### PR TITLE
Fix max number of backward steps in IDA solver.

### DIFF
--- a/Solver/Dynamic/Ida.cpp
+++ b/Solver/Dynamic/Ida.cpp
@@ -415,7 +415,7 @@ namespace AnalysisManager
             checkOutput(retval, "IDASetUserDataB");
 
             /// \todo Need to set max number of steps based on user input!
-            retval = IDASetMaxNumStepsB(solver_, backwardID_, 200);
+            retval = IDASetMaxNumStepsB(solver_, backwardID_, 2000);
             checkOutput(retval, "IDASetMaxNumSteps");
 
             // Set up linear solver


### PR DESCRIPTION
In branch `composer-dev` the default number of backward steps for adjoint sensitivity analysis was reduced from 2000 to 200. That caused some tests to fail. This PR reverts this (accidental?) change.

Fixes #3 