### PR TITLE
Fix #17

### DIFF
--- a/Solver/Optimization/DynamicConstraint.cpp
+++ b/Solver/Optimization/DynamicConstraint.cpp
@@ -279,7 +279,7 @@ bool DynamicConstraint<ScalarT, IdxT>::eval_h(Index n, const Number* x, bool new
                                               bool new_lambda, Index nele_hess, Index* iRow,
                                               Index* jCol, Number* values)
 {
-    return false;
+    return true;
 }
 
 

--- a/Solver/Optimization/DynamicObjective.cpp
+++ b/Solver/Optimization/DynamicObjective.cpp
@@ -200,7 +200,7 @@ bool DynamicObjective<ScalarT, IdxT>::eval_grad_f(Index n, const Number* x, bool
 template <class ScalarT, typename IdxT>
 bool DynamicObjective<ScalarT, IdxT>::eval_g(Index n, const Number* x, bool new_x, Index m, Number* g)
 {
-    return false;
+    return true;
 }
 
 
@@ -209,7 +209,7 @@ bool DynamicObjective<ScalarT, IdxT>::eval_jac_g(Index n, const Number* x, bool 
                                                  Index m, Index nele_jac, Index* iRow, Index *jCol,
                                                  Number* values)
 {
-    return false;
+    return true;
 }
 
 
@@ -219,7 +219,7 @@ bool DynamicObjective<ScalarT, IdxT>::eval_h(Index n, const Number* x, bool new_
                                              bool new_lambda, Index nele_hess, Index* iRow,
                                              Index* jCol, Number* values)
 {
-    return false;
+    return true;
 }
 
 


### PR DESCRIPTION
Optimization model functions return `true` even when empty. Originally, these functions were set to return `false` to signify they don't do anything but it was a poor design choice. Ipopt may call these functions even if they are empty, there should not be a reason to report a failure in that case.