### PR TITLE
Enzyme support example

### DIFF
--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -66,7 +66,8 @@ jobs:
                 gcc \
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
-          RUN curl -fsSL - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
+          RUN apt-get install -y --no-install-recommends wget && \
+              wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
               apt-get install -y --no-install-recommends \
                 llvm-18 \
                 clang-18 \

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -91,13 +91,13 @@ jobs:
     permissions:
       packages: write
       contents: read
-    timeout-minutes: 30
+    timeout-minutes: 500
 
     strategy:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - gridkit@develop +enzyme ^ llvm@18
+          - gridkit@develop +enzyme ^ llvm@19
 
     name: Build gridkit with Spack
     steps:
@@ -108,22 +108,11 @@ jobs:
           # Also need to change build script to use spack from base image
           submodules: true
 
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: "18.1"
-
-      - name: Check LLVM install
-        run: ls $PWD/llvm
-
-      - name: Check LLVM install bin
-        run: ls $PWD/llvm/bin
-
-      - name: Check LLVM install lib
-        run: ls $PWD/llvm/lib
-
       - name: Setup Spack
         run: echo "$PWD/Buildsystem/spack/spack/bin" >> "$GITHUB_PATH"
+
+      - name: Clean Spack
+        run: spack -e . clean -a
 
       - name: Create heredoc spack.yaml
         run: |
@@ -140,11 +129,6 @@ jobs:
             mirrors:
               local-buildcache: oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
               spack: https://binaries.spack.io/develop
-            packages:
-              llvm:
-                externals:
-                - spec: llvm@18
-                  prefix: $PWD/llvm
           EOF
 
       - name: Configure GHCR mirror

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -7,7 +7,7 @@ env:
   # Our repo name contains upper case characters, so we can't use ${{ github.repository }}
   IMAGE_NAME: gridkit
   USERNAME: gridkit-bot
-  BASE_VERSION: ubuntu-22.04-fortran-v0.2.0
+  BASE_VERSION: ubuntu-22.04-fortran-v0.2.1
 
 # Until we remove the need to clone submodules to build, this should on be in PRs
 on: [pull_request]
@@ -74,7 +74,10 @@ jobs:
               apt-get update && \
               apt-get install -y --no-install-recommends \
                 llvm-18 \
-                clang-18 \
+                llvm-18-dev \
+                clang-18 \ 
+                libclang-18-dev \
+                libomp-18-dev \
               && rm -rf /var/lib/apt/lists/*
           EOF
 
@@ -107,7 +110,7 @@ jobs:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - gridkit@develop +enzyme ^ llvm@18
+          - gridkit@develop +enzyme
 
     name: Build gridkit with Spack
     steps:

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -147,8 +147,8 @@ jobs:
       - name: Trust keys
         run: spack -e . buildcache keys --install --trust
 
-      - name: Check llvm
-        run: ls -ltrh /usr/lib/llvm*
+      - name: Check usr/bin
+        run: ls -ltrh /usr/bin/
 
       - name: Find external packages
         run: spack -e . external find --all

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -128,6 +128,9 @@ jobs:
               spack: https://binaries.spack.io/develop
           EOF
 
+      - name: Check /usr/lib/cmake/
+        run: ls -ltrh /usr/lib/cmake/
+
       - name: Configure GHCR mirror
         run: spack -e . mirror set --oci-username ${{ env.USERNAME }} --oci-password "${{ secrets.GITHUB_TOKEN }}" local-buildcache
 

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - gridkit@develop +enzyme
+          - gridkit@develop +enzyme ^ llvm@19
 
     name: Build gridkit with Spack
     steps:

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -111,9 +111,6 @@ jobs:
       - name: Setup Spack
         run: echo "$PWD/Buildsystem/spack/spack/bin" >> "$GITHUB_PATH"
 
-      - name: Clean Spack
-        run: spack -e . clean -a
-
       - name: Create heredoc spack.yaml
         run: |
           cat << EOF > spack.yaml

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -66,7 +66,8 @@ jobs:
                 gcc \
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
-          RUN apt-get install -y --no-install-recommends wget && \
+          RUN apt-get update && \
+              apt-get install -y --no-install-recommends wget && \
               wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
               apt-get install -y --no-install-recommends \
                 llvm-18 \

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -135,7 +135,7 @@ jobs:
         run: spack -e . buildcache keys --install --trust
 
       - name: Check storage locations
-        run: du -h --max-depth=1 /
+        run: du -h --max-depth=1 /opt/
 
       - name: Find external packages
         run: spack -e . external find --all

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -66,8 +66,7 @@ jobs:
                 gcc \
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
-          RUN apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-18 main" && \
-              apt-get update &&
+          RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
               apt-get install -y --no-install-recommends \
                 llvm-18 \
                 clang-18 \

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -131,6 +131,11 @@ jobs:
             mirrors:
               local-buildcache: oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
               spack: https://binaries.spack.io/develop
+            packages:
+              llvm:
+                externals:
+                - spec llvm@18
+                  prefix: $PWD/llvm
           EOF
 
       - name: Configure GHCR mirror

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -135,10 +135,7 @@ jobs:
         run: spack -e . buildcache keys --install --trust
 
       - name: Check storage locations
-        run: df -h
-
-      - name: Check Spack storage
-        run: du -h --max-depth=1 /opt/spack
+        run: du -h --max-depth=1 /
 
       - name: Find external packages
         run: spack -e . external find --all

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -105,7 +105,7 @@ jobs:
         run: df -h
 
       - name: Check Spack storage
-        run: du -h -max-depth=1 /opt/spack
+        run: du -h --max-depth=1 /opt/spack
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -140,7 +140,7 @@ jobs:
         run: spack -e . buildcache keys --install --trust
 
       - name: Find external packages
-        run: spack -e . external find --all
+        run: spack -e . external find --all --exclude llvm
 
       - name: Spack develop gridkit
         run: spack -e . develop --path=$(pwd) gridkit@develop

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -66,7 +66,7 @@ jobs:
                 gcc \
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
-          RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
+          RUN curl -fsSL - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
               apt-get install -y --no-install-recommends \
                 llvm-18 \
                 clang-18 \

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -134,7 +134,7 @@ jobs:
             packages:
               llvm:
                 externals:
-                - spec llvm@18
+                  - spec: llvm@18
                   prefix: $PWD/llvm
           EOF
 

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -91,7 +91,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    timeout-minutes: 500
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -101,6 +101,12 @@ jobs:
 
     name: Build gridkit with Spack
     steps:
+      - name: Check storage locations
+        run: df -h
+
+      - name: Check Spack storage
+        run: du -h -max-depth=1 /opt/spack
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -144,7 +150,7 @@ jobs:
         run: spack -e . concretize
 
       - name: Install dependencies
-        run: spack -e . install -v --no-check-signature --only dependencies
+        run: spack -e . install -j16 --no-check-signature --only dependencies
 
       - name: Install package
         run: spack -e . install --keep-stage --no-check-signature --no-cache --fresh

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -66,7 +66,9 @@ jobs:
                 gcc \
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
-          RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+          RUN apt-get install -y --no-install-recommends \
+                llvm-18 \
+              && rm -rf /var/lib/apt/lists/*
           EOF
 
       - name: Extract metadata (tags, labels) for Docker
@@ -98,7 +100,7 @@ jobs:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - gridkit@develop +enzyme
+          - gridkit@develop +enzyme ^ llvm@18
 
     name: Build gridkit with Spack
     steps:

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -134,9 +134,6 @@ jobs:
       - name: Trust keys
         run: spack -e . buildcache keys --install --trust
 
-      - name: Check storage locations
-        run: du -h --max-depth=1 /opt/
-
       - name: Find external packages
         run: spack -e . external find --all
 
@@ -147,7 +144,7 @@ jobs:
         run: spack -e . concretize
 
       - name: Install dependencies
-        run: spack -e . install -j16 --no-check-signature --only dependencies
+        run: spack -e . install --no-check-signature --only dependencies
 
       - name: Install package
         run: spack -e . install --keep-stage --no-check-signature --no-cache --fresh

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -97,14 +97,14 @@ jobs:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - gridkit@develop +enzyme ^ llvm@19
+          - gridkit@develop +enzyme ^ llvm@18
 
     name: Build gridkit with Spack
     steps:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1"
+          version: "18.1"
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -66,9 +66,11 @@ jobs:
                 gcc \
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
-          RUN apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-$LLVM_VERSION main" && \
+          RUN apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-18 main" && \
+              apt-get update &&
               apt-get install -y --no-install-recommends \
                 llvm-18 \
+                clang-18 \
               && rm -rf /var/lib/apt/lists/*
           EOF
 

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -101,17 +101,26 @@ jobs:
 
     name: Build gridkit with Spack
     steps:
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: "18.1"
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Once we move submodule deps into spack, we can do some more builds
           # Also need to change build script to use spack from base image
           submodules: true
+
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "18.1"
+
+      - name: Check LLVM install
+        run: ls $PWD/llvm
+
+      - name: Check LLVM install bin
+        run: ls $PWD/llvm/bin
+
+      - name: Check LLVM install lib
+        run: ls $PWD/llvm/lib
 
       - name: Setup Spack
         run: echo "$PWD/Buildsystem/spack/spack/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -54,7 +54,6 @@ jobs:
         if: ${{ env.IMAGE_EXISTS == 'false' }}
         run: |
           cat << EOF > Dockerfile
-          ARG LLVM_VERSION=18
           FROM ubuntu:22.04
           RUN apt-get update && \
               apt-get install -y --no-install-recommends \
@@ -71,7 +70,7 @@ jobs:
           RUN apt-get update && \
               apt-get install -y --no-install-recommends wget && \
               wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-              apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-$LLVM_VERSION main" \
+              apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-18 main" \
               apt-get update && \
               apt-get install -y --no-install-recommends \
                 llvm-18 \

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -126,10 +126,12 @@ jobs:
             mirrors:
               local-buildcache: oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
               spack: https://binaries.spack.io/develop
+            packages:
+              llvm:
+                externals:
+                - spec: llvm@18
+                  prefix: /usr/lib/llvm-18
           EOF
-
-      - name: Check /usr/lib/cmake/
-        run: ls -ltrh /usr/lib/cmake/
 
       - name: Configure GHCR mirror
         run: spack -e . mirror set --oci-username ${{ env.USERNAME }} --oci-password "${{ secrets.GITHUB_TOKEN }}" local-buildcache

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -7,7 +7,7 @@ env:
   # Our repo name contains upper case characters, so we can't use ${{ github.repository }}
   IMAGE_NAME: gridkit
   USERNAME: gridkit-bot
-  BASE_VERSION: ubuntu-22.04-fortran-v0.1.0
+  BASE_VERSION: ubuntu-22.04-fortran-v0.2.0
 
 # Until we remove the need to clone submodules to build, this should on be in PRs
 on: [pull_request]
@@ -66,6 +66,9 @@ jobs:
                 gcc \
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
+          RUN apt-get install -y --no-install-recommends \
+                llvm-18 \
+              && rm -rf /var/lib/apt/lists/*
           EOF
 
       - name: Extract metadata (tags, labels) for Docker
@@ -97,7 +100,7 @@ jobs:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - gridkit@develop +enzyme ^ llvm@19
+          - gridkit@develop +enzyme ^ llvm@18
 
     name: Build gridkit with Spack
     steps:

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -66,7 +66,8 @@ jobs:
                 gcc \
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
-          RUN apt-get install -y --no-install-recommends \
+          RUN apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-$LLVM_VERSION main" && \
+              apt-get install -y --no-install-recommends \
                 llvm-18 \
               && rm -rf /var/lib/apt/lists/*
           EOF

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - gridkit@develop
+          - gridkit@develop +enzyme
 
     name: Build gridkit with Spack
     steps:

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -147,6 +147,9 @@ jobs:
       - name: Trust keys
         run: spack -e . buildcache keys --install --trust
 
+      - name: Check llvm
+        run: ls -ltrh /usr/lib/llvm*
+
       - name: Find external packages
         run: spack -e . external find --all
 

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -66,9 +66,7 @@ jobs:
                 gcc \
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
-          RUN apt-get install -y --no-install-recommends \
-                llvm-18 \
-              && rm -rf /var/lib/apt/lists/*
+          RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
           EOF
 
       - name: Extract metadata (tags, labels) for Docker
@@ -100,7 +98,7 @@ jobs:
       matrix:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
-          - gridkit@develop +enzyme ^ llvm@18
+          - gridkit@develop +enzyme
 
     name: Build gridkit with Spack
     steps:

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -91,7 +91,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -134,7 +134,7 @@ jobs:
             packages:
               llvm:
                 externals:
-                  - spec: llvm@18
+                - spec: llvm@18
                   prefix: $PWD/llvm
           EOF
 

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -101,12 +101,6 @@ jobs:
 
     name: Build gridkit with Spack
     steps:
-      - name: Check storage locations
-        run: df -h
-
-      - name: Check Spack storage
-        run: du -h --max-depth=1 /opt/spack
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -139,6 +133,12 @@ jobs:
 
       - name: Trust keys
         run: spack -e . buildcache keys --install --trust
+
+      - name: Check storage locations
+        run: df -h
+
+      - name: Check Spack storage
+        run: du -h --max-depth=1 /opt/spack
 
       - name: Find external packages
         run: spack -e . external find --all

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -7,7 +7,7 @@ env:
   # Our repo name contains upper case characters, so we can't use ${{ github.repository }}
   IMAGE_NAME: gridkit
   USERNAME: gridkit-bot
-  BASE_VERSION: ubuntu-22.04-fortran-v0.2.1
+  BASE_VERSION: ubuntu-24.04-fortran-v0.2.2
 
 # Until we remove the need to clone submodules to build, this should on be in PRs
 on: [pull_request]
@@ -15,7 +15,7 @@ on: [pull_request]
 jobs:
   base_image_build:
     name: Build base image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -49,12 +49,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Need to build custom base image with gfortran
-      # For LLVM build setup, see https://github.com/EnzymeAD/enzyme-dev-docker/blob/main/Dockerfile
       - name: Create Dockerfile heredoc
         if: ${{ env.IMAGE_EXISTS == 'false' }}
         run: |
           cat << EOF > Dockerfile
-          FROM ubuntu:22.04
+          FROM ubuntu:24.04
           RUN apt-get update && \
               apt-get install -y --no-install-recommends \
                 software-properties-common \
@@ -66,18 +65,6 @@ jobs:
               apt-get install -y --no-install-recommends \
                 gcc \
                 libstdc++6 \
-              && rm -rf /var/lib/apt/lists/*
-          RUN apt-get update && \
-              apt-get install -y --no-install-recommends wget && \
-              wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-              apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-18 main" \
-              apt-get update && \
-              apt-get install -y --no-install-recommends \
-                llvm-18 \
-                llvm-18-dev \
-                clang-18 \ 
-                libclang-18-dev \
-                libomp-18-dev \
               && rm -rf /var/lib/apt/lists/*
           EOF
 
@@ -100,7 +87,7 @@ jobs:
 
   gridkit_spack_builds:
     needs: base_image_build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
       contents: read
@@ -146,9 +133,6 @@ jobs:
 
       - name: Trust keys
         run: spack -e . buildcache keys --install --trust
-
-      - name: Check usr/bin
-        run: ls -ltrh /usr/bin/
 
       - name: Find external packages
         run: spack -e . external find --all

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -144,7 +144,7 @@ jobs:
         run: spack -e . concretize
 
       - name: Install dependencies
-        run: spack -e . install --no-check-signature --only dependencies
+        run: spack -e . install -v --no-check-signature --only dependencies
 
       - name: Install package
         run: spack -e . install --keep-stage --no-check-signature --no-cache --fresh

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -49,10 +49,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Need to build custom base image with gfortran
+      # For LLVM build setup, see https://github.com/EnzymeAD/enzyme-dev-docker/blob/main/Dockerfile
       - name: Create Dockerfile heredoc
         if: ${{ env.IMAGE_EXISTS == 'false' }}
         run: |
           cat << EOF > Dockerfile
+          ARG LLVM_VERSION=18
           FROM ubuntu:22.04
           RUN apt-get update && \
               apt-get install -y --no-install-recommends \
@@ -69,6 +71,8 @@ jobs:
           RUN apt-get update && \
               apt-get install -y --no-install-recommends wget && \
               wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+              apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-$LLVM_VERSION main" \
+              apt-get update && \
               apt-get install -y --no-install-recommends \
                 llvm-18 \
                 clang-18 \

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -100,6 +100,11 @@ jobs:
 
     name: Build gridkit with Spack
     steps:
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "19.1"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -91,6 +91,7 @@ jobs:
     permissions:
       packages: write
       contents: read
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Buildsystem/spack/spack"]
 	path = Buildsystem/spack/spack
 	url = https://github.com/nkoukpaizan/spack.git
-	branch = Gridkit-package-dev
+	branch = Gridkit-package-dev+enzyme

--- a/CMake/FindEnzyme.cmake
+++ b/CMake/FindEnzyme.cmake
@@ -1,0 +1,186 @@
+# 
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by Slaven Peles <peles2@llnl.gov>.
+# LLNL-CODE-718378.
+# All rights reserved.
+# 
+# This file is part of GridKit™. For details, see github.com/LLNL/GridKit 
+# Please also read the LICENSE file. 
+# 
+# Redistribution and use in source and binary forms, with or without 
+# modification, are permitted provided that the following conditions are met:
+# - Redistributions of source code must retain the above copyright notice, 
+#   this list of conditions and the disclaimer below.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the disclaimer (as noted below) in the 
+#   documentation and/or other materials provided with the distribution.
+# - Neither the name of the LLNS/LLNL nor the names of its contributors may 
+#   be used to endorse or promote products derived from this software without 
+#   specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL
+# SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISINGIN ANY 
+# WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+# 
+# Lawrence Livermore National Laboratory is operated by Lawrence Livermore 
+# National Security, LLC, for the U.S. Department of Energy, National 
+# Nuclear Security Administration under Contract DE-AC52-07NA27344.
+# 
+# This document was prepared as an account of work sponsored by an agency 
+# of the United States government. Neither the United States government nor 
+# Lawrence Livermore National Security, LLC, nor any of their employees 
+# makes any warranty, expressed or implied, or assumes any legal liability 
+# or responsibility for the accuracy, completeness, or usefulness of any 
+# information, apparatus, product, or process disclosed, or represents that 
+# its use would not infringe privately owned rights. Reference herein to 
+# any specific commercial product, process, or service by trade name, 
+# trademark, manufacturer, or otherwise does not necessarily constitute or 
+# imply its endorsement, recommendation, or favoring by the United States 
+# government or Lawrence Livermore National Security, LLC. The views and 
+# opinions of authors expressed herein do not necessarily state or reflect 
+# those of the United States government or Lawrence Livermore National 
+# Security, LLC, and shall not be used for advertising or product 
+# endorsement purposes. 
+# 
+
+#[[
+
+Finds Enzyme Clang plugin
+
+User may set:
+- ENZYME_DIR
+
+Author(s):
+- Asher Mancinelli <ashermancinelli@gmail.com>
+
+]]
+
+if(NOT ${CMAKE_C_COMPILER_ID} STREQUAL "Clang" OR NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+  message(FATAL_ERROR "Enzyme may only be enabled if building with Clang")
+endif()
+
+find_library(ENZYME_LLVM_PLUGIN_LIBRARY
+  NAMES
+  LLVMEnzyme-15.so
+  LLVMEnzyme-14.so
+  LLVMEnzyme-13.so
+  LLVMEnzyme-12.so
+  LLVMEnzyme-11.so
+  LLVMEnzyme-10.so
+  LLVMEnzyme-9.so
+  PATHS
+  ${ENZYME_DIR} $ENV{ENZYME_DIR}
+  ENV LD_LIBRARY_PATH ENV DYLD_LIBRARY_PATH
+  PATH_SUFFIXES
+  lib64 lib)
+
+find_library(ENZYME_CLANG_PLUGIN_LIBRARY
+  NAMES
+  ClangEnzyme-15.so
+  ClangEnzyme-14.so
+  ClangEnzyme-13.so
+  ClangEnzyme-12.so
+  ClangEnzyme-11.so
+  ClangEnzyme-10.so
+  ClangEnzyme-9.so
+  PATHS
+  ${ENZYME_DIR} $ENV{ENZYME_DIR}
+  ENV LD_LIBRARY_PATH ENV DYLD_LIBRARY_PATH
+  PATH_SUFFIXES
+  lib64 lib)
+
+find_program(GRIDKIT_LLVM_LINK llvm-link)
+find_program(GRIDKIT_OPT opt)
+
+if("${GRIDKIT_LLVM_LINK}" STREQUAL "GRIDKIT_LLVM_LINK-NOTFOUND")
+  message(FATAL_ERROR "Could not find llvm-link! Will not be able to build Enzyme targets.")
+endif()
+
+if("${GRIDKIT_OPT}" STREQUAL "GRIDKIT_OPT-NOTFOUND")
+  message(FATAL_ERROR "Could not find opt! Will not be able to build Enzyme targets.")
+endif()
+
+message(STATUS "${ENZYME_CLANG_PLUGIN_LIBRARY};${ENZYME_LLVM_PLUGIN_LIBRARY}")
+if((NOT ${ENZYME_LLVM_PLUGIN_LIBRARY}) OR (NOT ${ENZYME_CLANG_PLUGIN_LIBRARY}))
+  set(ENZYME_CLANG_PLUGIN_LIBRARY CACHE FILEPATH "Path to Enzyme Clang plugin library")
+  set(ENZYME_LLVM_PLUGIN_LIBRARY CACHE FILEPATH "Path to Enzyme LLVM plugin library")
+  message(STATUS "Found Enzyme clang plugin: ${ENZYME_CLANG_PLUGIN_LIBRARY}")
+  message(STATUS "Found Enzyme LLVM plugin: ${ENZYME_LLVM_PLUGIN_LIBRARY}")
+  get_filename_component(ENZYME_LIBRARY_DIR ${ENZYME_CLANG_PLUGIN_LIBRARY} DIRECTORY CACHE "Enzyme library directory")
+else()
+  message(FATAL_ERROR "Enzyme library not found!"
+    " Set ENZYME_DIR to Enzyme's installation prefix.")
+endif()
+
+macro(enzyme_add_executable)
+  set(options)
+  set(oneValueArgs NAME)
+  set(multiValueArgs SOURCES LINK_LIBRARIES)
+  cmake_parse_arguments(enzyme_add_executable "${options}" "${oneValueArgs}"
+    "${multiValueArgs}" ${ARGN})
+
+  set(PHASE2 "${CMAKE_CURRENT_BINARY_DIR}/${enzyme_add_executable_NAME}.bc")
+  set(PHASE3 "${CMAKE_CURRENT_BINARY_DIR}/${enzyme_add_executable_NAME}_enzyme.ll")
+  set(PHASE4 "${CMAKE_CURRENT_BINARY_DIR}/${enzyme_add_executable_NAME}_opt.ll")
+  set(PHASE5 "${CMAKE_CURRENT_BINARY_DIR}/${enzyme_add_executable_NAME}")
+
+  set(OBJS "")
+
+  foreach(SRC ${enzyme_add_executable_SOURCES})
+    set(PHASE0 "${CMAKE_CURRENT_SOURCE_DIR}/${SRC}")
+    set(PHASE1 "${CMAKE_CURRENT_BINARY_DIR}/${enzyme_add_executable_NAME}_${SRC}_compile.o")
+    add_custom_command(
+      DEPENDS ${PHASE0}
+      OUTPUT ${PHASE1}
+      COMMAND ${CMAKE_CXX_COMPILER} -flto -c ${PHASE0} -O2 -fno-vectorize -ffast-math -fno-unroll-loops -o ${PHASE1}
+      COMMENT "Compiling ${SRC} to object file for target ${enzyme_add_executable_NAME}"
+      )
+    set(OBJS "${OBJS} ${PHASE1}")
+  endforeach()
+
+  cmake_language(EVAL CODE "
+  add_custom_command(
+    DEPENDS ${OBJS}
+    OUTPUT ${PHASE2}
+    COMMAND ${GRIDKIT_LLVM_LINK} ${OBJS} -o ${PHASE2}
+    COMMENT \"Linking object files to LLVM bytecode for target ${enzyme_add_executable_NAME}\"
+    )
+  ")
+
+  add_custom_command(
+    DEPENDS ${PHASE2}
+    OUTPUT ${PHASE3}
+    COMMAND ${GRIDKIT_OPT} ${PHASE2} --enable-new-pm=0 -load=${ENZYME_LLVM_PLUGIN_LIBRARY} -enzyme -o ${PHASE3} -S
+    COMMENT "Running Enzyme opt pass on target ${enzyme_add_executable_NAME}"
+    )
+
+  add_custom_command(
+    DEPENDS ${PHASE3}
+    OUTPUT ${PHASE4}
+    COMMAND ${GRIDKIT_OPT} ${PHASE3} -O2 -o ${PHASE4} -S
+    COMMENT "Running remaining opt passes on target ${enzyme_add_executable_NAME}"
+    )
+
+  add_custom_command(
+    DEPENDS ${PHASE4}
+    OUTPUT ${PHASE5}
+    COMMAND ${CMAKE_CXX_COMPILER} ${PHASE4} -o ${PHASE5}
+    )
+
+  add_custom_target(
+    ${enzyme_add_executable_NAME} ALL
+    DEPENDS ${PHASE5}
+    )
+endmacro()

--- a/CMake/FindEnzyme.cmake
+++ b/CMake/FindEnzyme.cmake
@@ -188,7 +188,7 @@ macro(enzyme_add_executable)
     )
 
   add_custom_target(
-    ${enzyme_add_executable_NAME} ALL
+    "${enzyme_add_executable_NAME}_target" ALL
     DEPENDS ${PHASE5}
     )
 endmacro()

--- a/CMake/FindEnzyme.cmake
+++ b/CMake/FindEnzyme.cmake
@@ -170,7 +170,7 @@ macro(enzyme_add_executable)
   add_custom_command(
     DEPENDS ${PHASE2}
     OUTPUT ${PHASE3}
-    COMMAND ${GRIDKIT_OPT} ${PHASE2} --enable-new-pm=0 -load=${ENZYME_LLVM_PLUGIN_LIBRARY} -enzyme -o ${PHASE3} -S
+    COMMAND ${GRIDKIT_OPT} ${PHASE2} -load-pass-plugin=${ENZYME_LLVM_PLUGIN_LIBRARY} -passes=enzyme -o ${PHASE3} -S
     COMMENT "Running Enzyme opt pass on target ${enzyme_add_executable_NAME}"
     )
 

--- a/CMake/FindEnzyme.cmake
+++ b/CMake/FindEnzyme.cmake
@@ -73,6 +73,10 @@ endif()
 
 find_library(ENZYME_LLVM_PLUGIN_LIBRARY
   NAMES
+  LLVMEnzyme-19.so
+  LLVMEnzyme-18.so
+  LLVMEnzyme-17.so
+  LLVMEnzyme-16.so
   LLVMEnzyme-15.so
   LLVMEnzyme-14.so
   LLVMEnzyme-13.so
@@ -88,6 +92,10 @@ find_library(ENZYME_LLVM_PLUGIN_LIBRARY
 
 find_library(ENZYME_CLANG_PLUGIN_LIBRARY
   NAMES
+  ClangEnzyme-19.so
+  ClangEnzyme-18.so
+  ClangEnzyme-17.so
+  ClangEnzyme-16.so
   ClangEnzyme-15.so
   ClangEnzyme-14.so
   ClangEnzyme-13.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ set(PACKAGE_VERSION_PATCH "7")
 set(PACKAGE_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH}")
 
 # Ipopt support is disabled by default
-option(GRIDKIT_ENABLE_IPOPT "Enable Ipopt support" ON)
+option(GRIDKIT_ENABLE_IPOPT "Enable Ipopt support" OFF)
 
 # SUNDIALS support is enabled by default
 option(GRIDKIT_ENABLE_SUNDIALS "Enable SUNDIALS support" ON)
@@ -84,6 +84,8 @@ option(GRIDKIT_ENABLE_SUNDIALS "Enable SUNDIALS support" ON)
 # Enable KLU
 option(GRIDKIT_ENABLE_SUNDIALS_SPARSE "Enable SUNDIALS sparse linear solvers" ON)
 
+# Enzyme support is disabled by default
+option(GRIDKIT_ENABLE_ENZYME "Enable automatic differentiation with Enzyme" OFF)
 
 set(CMAKE_MACOSX_RPATH 1)
 
@@ -131,6 +133,10 @@ if(GRIDKIT_ENABLE_SUNDIALS)
 endif()
 if(GRIDKIT_ENABLE_SUNDIALS_SPARSE)
   include(FindSuiteSparse)
+endif()
+
+if(${GRIDKIT_ENABLE_ENZYME})
+  include(FindEnzyme)
 endif()
 
 # Macro that adds libraries

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -75,3 +75,7 @@ if(TARGET SUNDIALS::idas)
     add_subdirectory(ParameterEstimation)
   endif()
 endif()
+
+if(GRIDKIT_ENABLE_ENZYME)
+  add_subdirectory(Enzyme)
+endif()

--- a/Examples/Enzyme/CMakeLists.txt
+++ b/Examples/Enzyme/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(Standalone)
+add_subdirectory(Library)

--- a/Examples/Enzyme/Library/CMakeLists.txt
+++ b/Examples/Enzyme/Library/CMakeLists.txt
@@ -1,4 +1,4 @@
-enzyme_add_executable(
-  NAME LibraryEnzymeCheck
-  SOURCES main.cpp library.cpp
-  )
+enzyme_add_executable(NAME libcheck SOURCES main.cpp library.cpp)
+#install(TARGETS ${CMAKE_CURRENT_BINARY_DIR}/libcheck DESTINATION bin)
+
+add_test(NAME "libcheck" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/libcheck)

--- a/Examples/Enzyme/Library/CMakeLists.txt
+++ b/Examples/Enzyme/Library/CMakeLists.txt
@@ -1,0 +1,4 @@
+enzyme_add_executable(
+  NAME LibraryEnzymeCheck
+  SOURCES main.cpp library.cpp
+  )

--- a/Examples/Enzyme/Library/CMakeLists.txt
+++ b/Examples/Enzyme/Library/CMakeLists.txt
@@ -1,4 +1,4 @@
-enzyme_add_executable(NAME libcheck SOURCES main.cpp library.cpp)
-#install(TARGETS ${CMAKE_CURRENT_BINARY_DIR}/libcheck DESTINATION bin)
+enzyme_add_executable(NAME EnzymeLibCheck SOURCES main.cpp library.cpp)
+#install(TARGETS ${CMAKE_CURRENT_BINARY_DIR}/EnzymeLibCheck DESTINATION bin)
 
-add_test(NAME "libcheck" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/libcheck)
+add_test(NAME "EnzymeLibCheck" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/EnzymeLibCheck)

--- a/Examples/Enzyme/Library/library.cpp
+++ b/Examples/Enzyme/Library/library.cpp
@@ -1,0 +1,3 @@
+int square(int x) {
+  return x * x;
+}

--- a/Examples/Enzyme/Library/library.cpp
+++ b/Examples/Enzyme/Library/library.cpp
@@ -1,3 +1,3 @@
-int square(int x) {
+double square(double x) {
   return x * x;
 }

--- a/Examples/Enzyme/Library/library.hpp
+++ b/Examples/Enzyme/Library/library.hpp
@@ -1,0 +1,2 @@
+#pragma once
+int square(int x);

--- a/Examples/Enzyme/Library/library.hpp
+++ b/Examples/Enzyme/Library/library.hpp
@@ -1,2 +1,2 @@
 #pragma once
-int square(int x);
+double square(double x);

--- a/Examples/Enzyme/Library/main.cpp
+++ b/Examples/Enzyme/Library/main.cpp
@@ -1,10 +1,23 @@
+#include <iostream>
 #include "library.hpp"
 
 int __enzyme_autodiff(int (*)(int), ...);
 
 int main() {
   int fail = 0;
-  if (__enzyme_autodiff(square, 5) != 25)
-    fail++;
+  int sq = square(5);
+  int dersq = __enzyme_autodiff(square, 5);
+
+  std::cout << "x = 5, x^2 = " << sq << ", d(x^2)/dx = " << dersq << "\n"; 
+  if (__enzyme_autodiff(square, 5) != 10)
+  {
+    --fail;
+    // std::cout << "Incorrect result\n";
+  }
+  if(fail < 0)
+    std::cout << "Result incorrect\n\n";
+  else
+    std::cout << "Bingo!!\n\n";
+  std:: cout << fail << "\n";
   return fail;
 }

--- a/Examples/Enzyme/Library/main.cpp
+++ b/Examples/Enzyme/Library/main.cpp
@@ -1,0 +1,10 @@
+#include "library.hpp"
+
+int __enzyme_autodiff(int (*)(int), ...);
+
+int main() {
+  int fail = 0;
+  if (__enzyme_autodiff(square, 5) != 25)
+    fail++;
+  return fail;
+}

--- a/Examples/Enzyme/Library/main.cpp
+++ b/Examples/Enzyme/Library/main.cpp
@@ -1,23 +1,20 @@
 #include <iostream>
+#include <limits>
 #include "library.hpp"
 
-int __enzyme_autodiff(int (*)(int), ...);
+double __enzyme_autodiff(double (*)(double), ...);
 
 int main() {
   int fail = 0;
-  int sq = square(5);
-  int dersq = __enzyme_autodiff(square, 5);
+  double sq = square(5.0);
+  double dsq = __enzyme_autodiff(square, 5.0);
 
-  std::cout << "x = 5, x^2 = " << sq << ", d(x^2)/dx = " << dersq << "\n"; 
-  if (__enzyme_autodiff(square, 5) != 10)
+  std::cout << "x = 5, x^2 = " << sq << ", d(x^2)/dx = " << dsq << "\n"; 
+  if (std::abs(dsq - 10.0) > std::numeric_limits<double>::epsilon())
   {
-    --fail;
-    // std::cout << "Incorrect result\n";
+    fail++;
+    std::cout << "Result incorrect\n";
   }
-  if(fail < 0)
-    std::cout << "Result incorrect\n\n";
-  else
-    std::cout << "Bingo!!\n\n";
-  std:: cout << fail << "\n";
+  std::cout << "Status: " << fail << "\n";
   return fail;
 }

--- a/Examples/Enzyme/Standalone/CMakeLists.txt
+++ b/Examples/Enzyme/Standalone/CMakeLists.txt
@@ -2,3 +2,5 @@ enzyme_add_executable(
   NAME StandaloneEnzymeCheck
   SOURCES main.cpp
   )
+
+  add_test(NAME "standalonecheck" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/StandaloneEnzymeCheck)

--- a/Examples/Enzyme/Standalone/CMakeLists.txt
+++ b/Examples/Enzyme/Standalone/CMakeLists.txt
@@ -1,0 +1,4 @@
+enzyme_add_executable(
+  NAME StandaloneEnzymeCheck
+  SOURCES main.cpp
+  )

--- a/Examples/Enzyme/Standalone/CMakeLists.txt
+++ b/Examples/Enzyme/Standalone/CMakeLists.txt
@@ -1,6 +1,6 @@
 enzyme_add_executable(
-  NAME StandaloneEnzymeCheck
+  NAME EnzymeStandaloneCheck
   SOURCES main.cpp
   )
 
-  add_test(NAME "standalonecheck" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/StandaloneEnzymeCheck)
+add_test(NAME "EnzymeStandaloneCheck" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/EnzymeStandaloneCheck)

--- a/Examples/Enzyme/Standalone/main.cpp
+++ b/Examples/Enzyme/Standalone/main.cpp
@@ -9,9 +9,14 @@ int dsquare(int x) {
   return __enzyme_autodiff(square, x);
 }
 
-int main() {
+int sq  = square(5);
+int dsq = dsquare(5);
+
+int main()
+{
   int fail = 0;
-  if (dsquare(5) != 25)
+  std::cout << "x = 5, x^2 = " << sq << ", d(x^2)/dx = " << __enzyme_autodiff(square, 5) << "\n"; 
+  if (dsq != 10)
     fail++;
   return fail;
 }

--- a/Examples/Enzyme/Standalone/main.cpp
+++ b/Examples/Enzyme/Standalone/main.cpp
@@ -1,17 +1,17 @@
 #include <iostream>
 
-int foo(int x) {
+int square(int x) {
   return x * x;
 }
 
 int __enzyme_autodiff(int(*)(int), ...);
-int dfoo(int x) {
-  return __enzyme_autodiff(foo, x);
+int dsquare(int x) {
+  return __enzyme_autodiff(square, x);
 }
 
 int main() {
   int fail = 0;
-  if (dfoo(5) != 25)
+  if (dsquare(5) != 25)
     fail++;
   return fail;
 }

--- a/Examples/Enzyme/Standalone/main.cpp
+++ b/Examples/Enzyme/Standalone/main.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+
+int foo(int x) {
+  return x * x;
+}
+
+int __enzyme_autodiff(int(*)(int), ...);
+int dfoo(int x) {
+  return __enzyme_autodiff(foo, x);
+}
+
+int main() {
+  int fail = 0;
+  if (dfoo(5) != 25)
+    fail++;
+  return fail;
+}

--- a/Examples/Enzyme/Standalone/main.cpp
+++ b/Examples/Enzyme/Standalone/main.cpp
@@ -1,22 +1,27 @@
 #include <iostream>
+#include <limits>
 
-int square(int x) {
+double square(double x) {
   return x * x;
 }
 
-int __enzyme_autodiff(int(*)(int), ...);
-int dsquare(int x) {
+double __enzyme_autodiff(double(*)(double), ...);
+double dsquare(double x) {
   return __enzyme_autodiff(square, x);
 }
 
-int sq  = square(5);
-int dsq = dsquare(5);
+double sq  = square(5.0);
+double dsq = dsquare(5.0);
 
 int main()
 {
   int fail = 0;
-  std::cout << "x = 5, x^2 = " << sq << ", d(x^2)/dx = " << __enzyme_autodiff(square, 5) << "\n"; 
-  if (dsq != 10)
+  std::cout << "x = 5, x^2 = " << sq << ", d(x^2)/dx = " << dsq << "\n"; 
+  if (std::abs(dsq - 10.0) > std::numeric_limits<double>::epsilon())
+  {
     fail++;
+    std::cout << "Result incorrect\n";
+  }
+  std::cout << "Status: " << fail << "\n";
   return fail;
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You should have all of the following installed before installing GridKit™
 	- [SUNDIALS](https://github.com/LLNL/sundials) >= 7.0.0
 	- [Suitesparse](https://github.com/DrTimothyAldenDavis/SuiteSparse) >= 5.x (optional)
 	- [Ipopt](https://github.com/coin-or/Ipopt) >= 3.x (optional)
+    - [Enzyme](https://github.com/EnzymeAD/Enzyme) >=0.0.131 (optional)
+        - [LLVM](https://github.com/llvm/llvm-project) >= 18.x 
 - [CMake](https://cmake.org/) >= 3.12
 - C++ 17 compliant compiler
 


### PR DESCRIPTION
This builds on earlier work from Asher and Slaven to add examples using the Enzyme automatic differentiation library. 
There are two new tests compared to `develop` that should pass.

Building Enzyme from source is discussed in #23. I tested that approach as well as building LLVM and Enzyme through Spack, and both approaches work for this use-case.