### PR TITLE
Fix runtime path setting when using clang++ and gfortran compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ option(GRIDKIT_BUILD_STATIC "Build static libraries" OFF)
 
 if(GRIDKIT_ENABLE_IPOPT)
   include(FindIpopt)
+  enable_language(Fortran) # Needed for linking to HSL
 endif()
 if(GRIDKIT_ENABLE_SUNDIALS)
   find_package(SUNDIALS 7.0.0 REQUIRED CONFIG 

--- a/Examples/DynamicConstrainedOpt/CMakeLists.txt
+++ b/Examples/DynamicConstrainedOpt/CMakeLists.txt
@@ -58,10 +58,18 @@
 # [[
 #  Author(s):
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
+#    - Slaven Peles <peless@ornl.gov>
 #]]
 
 add_executable(dynconopt DynamicConstrainedOpt.cpp)
-target_link_libraries(dynconopt GRIDKIT::generator4 GRIDKIT::generator2 GRIDKIT::bus GRIDKIT::solvers_dyn GRIDKIT::solvers_opt)
+target_link_libraries(dynconopt 
+    GRIDKIT::generator4
+    GRIDKIT::generator2
+    GRIDKIT::bus GRIDKIT::solvers_dyn
+    GRIDKIT::solvers_opt
+)
+# Fortran linker needed to link to HSL solvers
+set_property(TARGET dynconopt PROPERTY LINKER_LANGUAGE Fortran)
 install(TARGETS dynconopt DESTINATION bin)
 
 add_test(NAME DynamicConOpt COMMAND $<TARGET_FILE:dynconopt>)

--- a/Examples/GenConstLoad/CMakeLists.txt
+++ b/Examples/GenConstLoad/CMakeLists.txt
@@ -58,10 +58,18 @@
 # [[
 #  Author(s):
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
+#    - Slaven Peles <peless@ornl.gov>
 #]]
 
 add_executable(genconstload GenConstLoad.cpp)
-target_link_libraries(genconstload GRIDKIT::generator4governor GRIDKIT::bus GRIDKIT::load GRIDKIT::solvers_dyn GRIDKIT::solvers_opt)
+target_link_libraries(genconstload
+    GRIDKIT::generator4governor
+    GRIDKIT::bus GRIDKIT::load
+    GRIDKIT::solvers_dyn
+    GRIDKIT::solvers_opt
+)
+# Fortran linker needed to link to HSL solvers
+set_property(TARGET genconstload PROPERTY LINKER_LANGUAGE Fortran)
 install(TARGETS genconstload DESTINATION bin)
 
 add_test(NAME GenConstLoad COMMAND $<TARGET_FILE:genconstload>)

--- a/Examples/GenInfiniteBus/CMakeLists.txt
+++ b/Examples/GenInfiniteBus/CMakeLists.txt
@@ -58,10 +58,18 @@
 # [[
 #  Author(s):
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
+#    - Slaven Peles <peless@ornl.gov>
 #]]
 
 add_executable(geninfbus GenInfiniteBus.cpp)
-target_link_libraries(geninfbus GRIDKIT::bus GRIDKIT::generator4 GRIDKIT::solvers_opt GRIDKIT::solvers_dyn)
+target_link_libraries(geninfbus
+    GRIDKIT::bus
+    GRIDKIT::generator4
+    GRIDKIT::solvers_opt
+    GRIDKIT::solvers_dyn
+)
+# Fortran linker needed to link to HSL solvers
+set_property(TARGET geninfbus PROPERTY LINKER_LANGUAGE Fortran)
 install(TARGETS geninfbus DESTINATION bin)
 
 add_test(NAME GenInfiniteBus COMMAND $<TARGET_FILE:geninfbus>)

--- a/Examples/ParameterEstimation/CMakeLists.txt
+++ b/Examples/ParameterEstimation/CMakeLists.txt
@@ -58,6 +58,7 @@
 # [[
 #  Author(s):
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
+#    - Slaven Peles <peless@ornl.gov>
 #]]
 
 add_executable(paramest ParameterEstimation.cpp)
@@ -67,7 +68,9 @@ target_link_libraries(paramest
   GRIDKIT::solvers_opt
   GRIDKIT::solvers_dyn
   GRIDKIT::Utilities
-  )
+)
+# Fortran linker needed to link to HSL solvers
+set_property(TARGET paramest PROPERTY LINKER_LANGUAGE Fortran)
 install(TARGETS paramest RUNTIME DESTINATION bin)
 install(FILES lookup_table.dat DESTINATION bin)
 


### PR DESCRIPTION
If METIS and/or HSL libraries are built with gfortran and the Ipopt and GridKit with gcc/g++, the code will build but the runtime path may not be correctly set for gfortran library. It seems that linking mixed clang/gfortran code with gfortran rather than with clang fixes this issue.