### PR TITLE
Fixing for file IO Parameter Estimation Example

### DIFF
--- a/Examples/ParameterEstimation/CMakeLists.txt
+++ b/Examples/ParameterEstimation/CMakeLists.txt
@@ -60,6 +60,8 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
+add_compile_definitions("PARAMETER_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+
 add_executable(paramest ParameterEstimation.cpp)
 target_link_libraries(paramest
   GRIDKIT::bus

--- a/Examples/ParameterEstimation/ParameterEstimation.cpp
+++ b/Examples/ParameterEstimation/ParameterEstimation.cpp
@@ -72,7 +72,10 @@
 #include <Solver/Optimization/DynamicConstraint.hpp>
 #include <Utilities/FileIO.hpp>
 #include <Utilities/Testing.hpp>
+#include <string>
 
+#define STRING(x) #x
+#define XSTRING(x) STRING(x)
 
 int main(int argc, char** argv)
 {
@@ -98,7 +101,8 @@ int main(int argc, char** argv)
     // Create numerical integrator and configure it for the generator model
     Ida<double, size_t>* idas = new Ida<double, size_t>(model);
 
-    const std::string input_data = (argc == 2) ? argv[1] : "lookup_table.dat";
+    const std::string input_data = (argc == 2) ? argv[1] : std::string(XSTRING(PARAMETER_DIR)) + "/lookup_table.dat";
+
     double t_init  = -1.0;
     double t_final = -1.0;
 

--- a/Utilities/FileIO.hpp
+++ b/Utilities/FileIO.hpp
@@ -70,6 +70,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <ostream>
 #include <regex>
 #include <sstream>
 #include <vector>
@@ -251,6 +252,18 @@ void readMatPowerBaseMVA(SystemModelData<RealT, IdxT>& mp, std::string& line)
 
 namespace GridKit
 {
+
+/**
+ * @brief Reads a file in for tabulated data
+ *
+ * @todo needs to return int for file error codes
+ * 
+ * @tparam ScalarT 
+ * @param table 
+ * @param filename 
+ * @param ti 
+ * @param tf 
+ */
 template <typename ScalarT>
 void setLookupTable(std::vector<std::vector<ScalarT>>& table,
                     std::string filename,
@@ -258,6 +271,12 @@ void setLookupTable(std::vector<std::vector<ScalarT>>& table,
                     ScalarT& tf)
 {
   std::ifstream idata(filename);
+  if (!idata.is_open()) {
+    ///@todo swap with returing error codes instead of crashing.
+    std::cerr << "Error. Given file name \"" << filename<< "\" does not exsist." << std::endl;
+    abort();
+  }
+
   std::string line;
   int oldwordcount = -1;
   while (std::getline(idata, line)) {
@@ -281,6 +300,12 @@ void setLookupTable(std::vector<std::vector<ScalarT>>& table,
   }
 
   size_t N = table.size();
+  if (N < 2) {
+    ///@todo swap with returing error codes instead of crashing.
+    std::cerr << "Error. Only " << N << " data points found in file " << filename << std::endl;
+    abort();
+  }
+
   ti = table[0][0];
   tf = table[N - 1][0];
 }


### PR DESCRIPTION
 - Crashes for file IO when the file is not found
 - ParameterEstimation can be run outside of its own directory without error