### PR TITLE
Fix lookup install and downgrade to LLVM 16

### DIFF
--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -145,6 +145,9 @@ jobs:
       - name: Spack develop gridkit
         run: spack -e . develop --path=$(pwd) gridkit@develop
 
+      - name: List working directory
+        run: ls -ltrh $(pwd)/*/*/
+
       - name: Concretize
         run: spack -e . concretize
 

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -129,8 +129,8 @@ jobs:
             packages:
               llvm:
                 externals:
-                - spec: llvm@18
-                  prefix: /usr/lib/llvm-18
+                - spec: llvm@16
+                  prefix: /usr/lib/llvm-16
           EOF
 
       - name: Configure GHCR mirror

--- a/Examples/ParameterEstimation/CMakeLists.txt
+++ b/Examples/ParameterEstimation/CMakeLists.txt
@@ -72,6 +72,5 @@ target_link_libraries(paramest
 # Fortran linker needed to link to HSL solvers
 set_property(TARGET paramest PROPERTY LINKER_LANGUAGE Fortran)
 install(TARGETS paramest RUNTIME DESTINATION bin)
-install(FILES lookup_table.dat DESTINATION bin)
 
 add_test(NAME ParameterEst COMMAND $<TARGET_FILE:paramest>)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You should have all of the following installed before installing GridKit™
 	- [Suitesparse](https://github.com/DrTimothyAldenDavis/SuiteSparse) >= 5.x (optional)
 	- [Ipopt](https://github.com/coin-or/Ipopt) >= 3.x (optional)
     - [Enzyme](https://github.com/EnzymeAD/Enzyme) >=0.0.131 (optional)
-        - [LLVM](https://github.com/llvm/llvm-project) 16.x 
+        - [LLVM](https://github.com/llvm/llvm-project) >= 15.x 
 - [CMake](https://cmake.org/) >= 3.12
 - C++ 17 compliant compiler
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You should have all of the following installed before installing GridKit™
 	- [Suitesparse](https://github.com/DrTimothyAldenDavis/SuiteSparse) >= 5.x (optional)
 	- [Ipopt](https://github.com/coin-or/Ipopt) >= 3.x (optional)
     - [Enzyme](https://github.com/EnzymeAD/Enzyme) >=0.0.131 (optional)
-        - [LLVM](https://github.com/llvm/llvm-project) >= 18.x 
+        - [LLVM](https://github.com/llvm/llvm-project) 16.x 
 - [CMake](https://cmake.org/) >= 3.12
 - C++ 17 compliant compiler
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ You should have all of the following installed before installing GridKit™
 	- [Suitesparse](https://github.com/DrTimothyAldenDavis/SuiteSparse) >= 5.x (optional)
 	- [Ipopt](https://github.com/coin-or/Ipopt) >= 3.x (optional)
     - [Enzyme](https://github.com/EnzymeAD/Enzyme) >=0.0.131 (optional)
-        - [LLVM](https://github.com/llvm/llvm-project) >= 15.x 
+        - [LLVM](https://github.com/llvm/llvm-project) >= 15.x. GridKit is
+          currently tested with LLVM 16. 
 - [CMake](https://cmake.org/) >= 3.12
 - C++ 17 compliant compiler
 


### PR DESCRIPTION
#44 moved `Examples/ParameterEstimation/lookup_table.dat` to `Examples/ParameterEstimation/lookup_table.hpp`, but was still trying to install `lookup_table.dat` in the `CMakeLists.txt.`. Surprised CI didn't catch it.

This also downgrades LLVM from 18 to 16 in CI. While Gridkit tests currently work with later versions of LLVM, many tests fail within Enzyme itself. (Enzyme CI currently tests LLVM 15 and 16.)