### PR TITLE
Rename namespace ModelLib -> GridKit.

### DIFF
--- a/examples/AdjointSensitivity/AdjointSensitivity.cpp
+++ b/examples/AdjointSensitivity/AdjointSensitivity.cpp
@@ -79,7 +79,7 @@
  */
 int main()
 {
-    using namespace ModelLib;
+    using namespace GridKit;
     using namespace AnalysisManager::Sundials;
     using namespace AnalysisManager;
     using namespace GridKit::Testing;

--- a/examples/DistributedGeneratorTest/DGTest.cpp
+++ b/examples/DistributedGeneratorTest/DGTest.cpp
@@ -20,7 +20,7 @@
 int main(int argc, char const *argv[])
 {
 	
-	ModelLib::DistributedGeneratorParameters<double, size_t> parms;
+	GridKit::DistributedGeneratorParameters<double, size_t> parms;
 	//Parameters from MATLAB Microgrid code for first DG
 	parms.wb_ = 2.0*M_PI*50.0;
 	parms.wc_ = 31.41;
@@ -38,7 +38,7 @@ int main(int argc, char const *argv[])
 	parms.rLc_ = 0.03;
 	parms.Lc_ = 0.35e-3;
 
-	ModelLib::DistributedGenerator<double, size_t> *dg = new ModelLib::DistributedGenerator<double, size_t>(0, parms, true);
+	GridKit::DistributedGenerator<double, size_t> *dg = new GridKit::DistributedGenerator<double, size_t>(0, parms, true);
 
 	std::vector<double> t1(16,0.0);
 	std::vector<double> t2{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5};

--- a/examples/DynamicConstrainedOpt/DynamicConstrainedOpt.cpp
+++ b/examples/DynamicConstrainedOpt/DynamicConstrainedOpt.cpp
@@ -74,7 +74,7 @@
 
 int main()
 {
-    using namespace ModelLib;
+    using namespace GridKit;
     using namespace AnalysisManager::Sundials;
     using namespace AnalysisManager;
     using namespace GridKit::Testing;

--- a/examples/GenConstLoad/GenConstLoad.cpp
+++ b/examples/GenConstLoad/GenConstLoad.cpp
@@ -75,7 +75,7 @@
 
 int main()
 {
-    using namespace ModelLib;
+    using namespace GridKit;
     using namespace AnalysisManager::Sundials;
     using namespace AnalysisManager;
     using namespace GridKit::Testing;

--- a/examples/GenInfiniteBus/GenInfiniteBus.cpp
+++ b/examples/GenInfiniteBus/GenInfiniteBus.cpp
@@ -75,7 +75,7 @@
 
 int main()
 {
-    using namespace ModelLib;
+    using namespace GridKit;
     using namespace AnalysisManager::Sundials;
     using namespace AnalysisManager;
     using namespace GridKit::Testing;

--- a/examples/Grid3Bus/Grid3BusSys.cpp
+++ b/examples/Grid3Bus/Grid3BusSys.cpp
@@ -134,7 +134,7 @@ mpc.gencost = [
 )";
 
 
-using namespace ModelLib;
+using namespace GridKit;
 using namespace AnalysisManager::Sundials;
 using namespace AnalysisManager;
 using namespace GridKit::Testing;

--- a/examples/Microgrid/Microgrid.cpp
+++ b/examples/Microgrid/Microgrid.cpp
@@ -27,13 +27,13 @@ int main(int argc, char const *argv[])
     bool usejac = true;
 
     //Create model
-    ModelLib::PowerElectronicsModel<double, size_t>* sysmodel = new ModelLib::PowerElectronicsModel<double, size_t>(reltol, abstol, usejac, max_step_amount);
+    GridKit::PowerElectronicsModel<double, size_t>* sysmodel = new GridKit::PowerElectronicsModel<double, size_t>(reltol, abstol, usejac, max_step_amount);
 
     //Modeled after the problem in the paper
     double RN = 1.0e4;
 
     //DG Params
-    ModelLib::DistributedGeneratorParameters<double, size_t> parms1;
+    GridKit::DistributedGeneratorParameters<double, size_t> parms1;
     parms1.wb_ = 2.0*M_PI*50.0;
     parms1.wc_ = 31.41;
     parms1.mp_ = 9.4e-5;
@@ -50,7 +50,7 @@ int main(int argc, char const *argv[])
     parms1.rLc_ = 0.03;
     parms1.Lc_ = 0.35e-3;
 
-    ModelLib::DistributedGeneratorParameters<double, size_t> parms2;
+    GridKit::DistributedGeneratorParameters<double, size_t> parms2;
     //Parameters from MATLAB Microgrid code for first DG
     parms2.wb_ = 2.0*M_PI*50.0;
     parms2.wc_ = 31.41;
@@ -103,7 +103,7 @@ int main(int argc, char const *argv[])
     size_t indexv = 0;
 
     //dg 1
-    ModelLib::DistributedGenerator<double, size_t> *dg1 = new ModelLib::DistributedGenerator<double, size_t>(0, parms1, true);
+    GridKit::DistributedGenerator<double, size_t> *dg1 = new GridKit::DistributedGenerator<double, size_t>(0, parms1, true);
     //ref motor
     dg1->setExternalConnectionNodes(0,vec_size_internals);
     //outputs
@@ -121,7 +121,7 @@ int main(int argc, char const *argv[])
     sysmodel->addComponent(dg1);
 
     //dg 2
-    ModelLib::DistributedGenerator<double, size_t> *dg2 = new ModelLib::DistributedGenerator<double, size_t>(1, parms1, false);
+    GridKit::DistributedGenerator<double, size_t> *dg2 = new GridKit::DistributedGenerator<double, size_t>(1, parms1, false);
     //ref motor
     dg2->setExternalConnectionNodes(0,vec_size_internals);
     //outputs
@@ -138,7 +138,7 @@ int main(int argc, char const *argv[])
     
 
     //dg 3
-    ModelLib::DistributedGenerator<double, size_t> *dg3 = new ModelLib::DistributedGenerator<double, size_t>(2, parms2, false);
+    GridKit::DistributedGenerator<double, size_t> *dg3 = new GridKit::DistributedGenerator<double, size_t>(2, parms2, false);
     //ref motor
     dg3->setExternalConnectionNodes(0,vec_size_internals);
     //outputs
@@ -155,7 +155,7 @@ int main(int argc, char const *argv[])
 
 
     //dg 4
-    ModelLib::DistributedGenerator<double, size_t> *dg4 = new ModelLib::DistributedGenerator<double, size_t>(3, parms2, false);
+    GridKit::DistributedGenerator<double, size_t> *dg4 = new GridKit::DistributedGenerator<double, size_t>(3, parms2, false);
     //ref motor
     dg4->setExternalConnectionNodes(0,vec_size_internals);
     //outputs
@@ -174,7 +174,7 @@ int main(int argc, char const *argv[])
     // Lines
 
     //line 1
-    ModelLib::MicrogridLine<double, size_t> *l1 = new ModelLib::MicrogridLine<double, size_t>(4, rline1, Lline1);
+    GridKit::MicrogridLine<double, size_t> *l1 = new GridKit::MicrogridLine<double, size_t>(4, rline1, Lline1);
     //ref motor
     l1->setExternalConnectionNodes(0,vec_size_internals);
     //input connections
@@ -194,7 +194,7 @@ int main(int argc, char const *argv[])
 
 
     //line 2
-    ModelLib::MicrogridLine<double, size_t> *l2 = new ModelLib::MicrogridLine<double, size_t>(5, rline2, Lline2);
+    GridKit::MicrogridLine<double, size_t> *l2 = new GridKit::MicrogridLine<double, size_t>(5, rline2, Lline2);
     //ref motor
     l2->setExternalConnectionNodes(0,vec_size_internals);
     //input connections
@@ -213,7 +213,7 @@ int main(int argc, char const *argv[])
     sysmodel->addComponent(l2);
     
     //line 3
-    ModelLib::MicrogridLine<double, size_t> *l3 = new ModelLib::MicrogridLine<double, size_t>(6, rline3, Lline3);
+    GridKit::MicrogridLine<double, size_t> *l3 = new GridKit::MicrogridLine<double, size_t>(6, rline3, Lline3);
     //ref motor
     l3->setExternalConnectionNodes(0,vec_size_internals);
     //input connections
@@ -234,7 +234,7 @@ int main(int argc, char const *argv[])
     //  loads
 
     //load 1
-    ModelLib::MicrogridLoad<double, size_t> *load1 = new ModelLib::MicrogridLoad<double, size_t>(7, rload1, Lload1);
+    GridKit::MicrogridLoad<double, size_t> *load1 = new GridKit::MicrogridLoad<double, size_t>(7, rload1, Lload1);
     //ref motor
     load1->setExternalConnectionNodes(0,vec_size_internals);
     //input connections
@@ -250,7 +250,7 @@ int main(int argc, char const *argv[])
     sysmodel->addComponent(load1);
 
     //load 2
-    ModelLib::MicrogridLoad<double, size_t> *load2 = new ModelLib::MicrogridLoad<double, size_t>(8, rload2, Lload2);
+    GridKit::MicrogridLoad<double, size_t> *load2 = new GridKit::MicrogridLoad<double, size_t>(8, rload2, Lload2);
     //ref motor
     load2->setExternalConnectionNodes(0,vec_size_internals);
     //input connections
@@ -266,25 +266,25 @@ int main(int argc, char const *argv[])
     sysmodel->addComponent(load2);
 
     //Virtual PQ Buses
-    ModelLib::MicrogridBusDQ<double, size_t> *bus1 = new ModelLib::MicrogridBusDQ<double, size_t>(9, RN);
+    GridKit::MicrogridBusDQ<double, size_t> *bus1 = new GridKit::MicrogridBusDQ<double, size_t>(9, RN);
 
     bus1->setExternalConnectionNodes(0,dqbus1);
     bus1->setExternalConnectionNodes(1,dqbus1 + 1);
     sysmodel->addComponent(bus1);
 
-    ModelLib::MicrogridBusDQ<double, size_t> *bus2 = new ModelLib::MicrogridBusDQ<double, size_t>(10, RN);
+    GridKit::MicrogridBusDQ<double, size_t> *bus2 = new GridKit::MicrogridBusDQ<double, size_t>(10, RN);
 
     bus2->setExternalConnectionNodes(0,dqbus2);
     bus2->setExternalConnectionNodes(1,dqbus2 + 1);
     sysmodel->addComponent(bus2);
 
-    ModelLib::MicrogridBusDQ<double, size_t> *bus3 = new ModelLib::MicrogridBusDQ<double, size_t>(11, RN);
+    GridKit::MicrogridBusDQ<double, size_t> *bus3 = new GridKit::MicrogridBusDQ<double, size_t>(11, RN);
 
     bus3->setExternalConnectionNodes(0,dqbus3);
     bus3->setExternalConnectionNodes(1,dqbus3 + 1);
     sysmodel->addComponent(bus3);
 
-    ModelLib::MicrogridBusDQ<double, size_t> *bus4 = new ModelLib::MicrogridBusDQ<double, size_t>(12, RN);
+    GridKit::MicrogridBusDQ<double, size_t> *bus4 = new GridKit::MicrogridBusDQ<double, size_t>(12, RN);
 
     bus4->setExternalConnectionNodes(0,dqbus4);
     bus4->setExternalConnectionNodes(1,dqbus4 + 1);

--- a/examples/ParameterEstimation/ParameterEstimation.cpp
+++ b/examples/ParameterEstimation/ParameterEstimation.cpp
@@ -80,7 +80,7 @@
 
 int main()
 {
-    using namespace ModelLib;
+    using namespace GridKit;
     using namespace AnalysisManager::Sundials;
     using namespace AnalysisManager;
     using namespace GridKit::Testing;

--- a/examples/RLCircuit/RLCircuit.cpp
+++ b/examples/RLCircuit/RLCircuit.cpp
@@ -24,7 +24,7 @@ int main(int argc, char const *argv[])
 
     //TODO:setup as named parameters
     //Create circuit model
-    ModelLib::PowerElectronicsModel<double, size_t>* sysmodel = new ModelLib::PowerElectronicsModel<double, size_t>(reltol, abstol, usejac);
+    GridKit::PowerElectronicsModel<double, size_t>* sysmodel = new GridKit::PowerElectronicsModel<double, size_t>(reltol, abstol, usejac);
 
     size_t idoff = 0;
 
@@ -35,7 +35,7 @@ int main(int argc, char const *argv[])
 
 
     //inductor
-    ModelLib::Inductor<double, size_t>* induct = new ModelLib::Inductor(idoff,linit);
+    GridKit::Inductor<double, size_t>* induct = new GridKit::Inductor(idoff,linit);
     //Form index to node uid realations
     // input
     induct->setExternalConnectionNodes(0,1);
@@ -49,7 +49,7 @@ int main(int argc, char const *argv[])
 
     //resistor
     idoff++;
-    ModelLib::Resistor<double, size_t>* resis = new ModelLib::Resistor(idoff, rinit);
+    GridKit::Resistor<double, size_t>* resis = new GridKit::Resistor(idoff, rinit);
     //Form index to node uid realations
     //input
     resis->setExternalConnectionNodes(0,0);
@@ -60,7 +60,7 @@ int main(int argc, char const *argv[])
 
     //voltage source
     idoff++;
-    ModelLib::VoltageSource<double, size_t>* vsource = new ModelLib::VoltageSource(idoff, vinit);
+    GridKit::VoltageSource<double, size_t>* vsource = new GridKit::VoltageSource(idoff, vinit);
     //Form index to node uid realations
     //input
     vsource->setExternalConnectionNodes(0,-1);

--- a/examples/ScaleMicrogrid/ScaleMicrogrid.cpp
+++ b/examples/ScaleMicrogrid/ScaleMicrogrid.cpp
@@ -64,7 +64,7 @@ int main(int argc, char const *argv[])
  */
 int test(index_type Nsize, real_type error_tol, bool debug_output)
 {
-    using namespace ModelLib;
+    using namespace GridKit;
 
     bool usejac = true;
 
@@ -105,7 +105,7 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
 
     // DG Params Vector
     // All DGs have the same set of parameters except for the first two.
-    ModelLib::DistributedGeneratorParameters<real_type, index_type> DG_parms1;
+    GridKit::DistributedGeneratorParameters<real_type, index_type> DG_parms1;
     DG_parms1.wb_ = 2.0*M_PI*50.0;
     DG_parms1.wc_ = 31.41;
     DG_parms1.mp_ = 9.4e-5;
@@ -122,7 +122,7 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
     DG_parms1.rLc_ = 0.03;
     DG_parms1.Lc_ = 0.35e-3;
 
-    ModelLib::DistributedGeneratorParameters<real_type, index_type> DG_parms2;
+    GridKit::DistributedGeneratorParameters<real_type, index_type> DG_parms2;
     DG_parms2.wb_ = 2.0*M_PI*50.0;
     DG_parms2.wc_ = 31.41;
     DG_parms2.mp_ = 12.5e-5;
@@ -139,7 +139,7 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
     DG_parms2.rLc_ = 0.03;
     DG_parms2.Lc_ = 0.35e-3;
 
-    std::vector<ModelLib::DistributedGeneratorParameters<real_type, index_type>> DGParams_list(2*Nsize, DG_parms2);
+    std::vector<GridKit::DistributedGeneratorParameters<real_type, index_type>> DGParams_list(2*Nsize, DG_parms2);
 
     DGParams_list[0] = DG_parms1;
     DGParams_list[1] = DG_parms1;

--- a/src/Model/PhasorDynamics/Branch/Branch.cpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.cpp
@@ -64,7 +64,7 @@
 
 #include "Branch.hpp"
 
-namespace ModelLib { // change to GridKit
+namespace GridKit {
 namespace PhasorDynamics {
 
 /*!

--- a/src/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.hpp
@@ -70,7 +70,7 @@ namespace PowerSystemData
 }
 }
 
-namespace ModelLib
+namespace GridKit
 {
 namespace PhasorDynamics
 {
@@ -78,7 +78,7 @@ namespace PhasorDynamics
 }
 }
 
-namespace ModelLib
+namespace GridKit
 {
 namespace PhasorDynamics
 {

--- a/src/Model/PhasorDynamics/Bus/Bus.cpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.cpp
@@ -63,7 +63,7 @@
 #include <PowerSystemData.hpp>
 #include "Bus.hpp"
 
-namespace ModelLib // change to GridKit
+namespace GridKit
 {
 namespace PhasorDynamics 
 {
@@ -223,5 +223,5 @@ template class Bus<double, long int>;
 template class Bus<double, size_t>;
 
 } // namespace PhasorDynamic
-} // namespace ModelLib
+} // namespace GridKit
 

--- a/src/Model/PhasorDynamics/Bus/Bus.hpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.hpp
@@ -72,7 +72,7 @@ namespace PowerSystemData
 }
 }
 
-namespace ModelLib // change to GridKit
+namespace GridKit
 {
 namespace PhasorDynamics
 {

--- a/src/Model/PowerElectronics/Capacitor/Capacitor.cpp
+++ b/src/Model/PowerElectronics/Capacitor/Capacitor.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "Capacitor.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for Capacitor
@@ -141,5 +141,5 @@ template class Capacitor<double, long int>;
 template class Capacitor<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/Capacitor/Capacitor.hpp
+++ b/src/Model/PowerElectronics/Capacitor/Capacitor.hpp
@@ -8,13 +8,13 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a Capacitor class.

--- a/src/Model/PowerElectronics/CircuitComponent.hpp
+++ b/src/Model/PowerElectronics/CircuitComponent.hpp
@@ -9,7 +9,7 @@
 #include <set>
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a CircuitComponent class.

--- a/src/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
+++ b/src/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "DistributedGenerator.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 
 /*!
@@ -359,5 +359,5 @@ template class DistributedGenerator<double, long int>;
 template class DistributedGenerator<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
+++ b/src/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
@@ -8,7 +8,7 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 
@@ -34,7 +34,7 @@ namespace ModelLib
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a DistributedGenerator class.

--- a/src/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
+++ b/src/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
@@ -7,7 +7,7 @@
 #include "InductionMotor.hpp"
 
 
-namespace ModelLib {
+namespace GridKit {
 
 
 
@@ -141,5 +141,5 @@ template class InductionMotor<double, long int>;
 template class InductionMotor<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
+++ b/src/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
@@ -8,13 +8,13 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a InductionMotor class.

--- a/src/Model/PowerElectronics/Inductor/Inductor.cpp
+++ b/src/Model/PowerElectronics/Inductor/Inductor.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "Inductor.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a inductor
@@ -140,5 +140,5 @@ template class Inductor<double, long int>;
 template class Inductor<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/Inductor/Inductor.hpp
+++ b/src/Model/PowerElectronics/Inductor/Inductor.hpp
@@ -8,13 +8,13 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a Inductor class.

--- a/src/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
+++ b/src/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "LinearTransformer.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a LinearTransformer model
@@ -119,5 +119,5 @@ template class LinearTransformer<double, long int>;
 template class LinearTransformer<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
+++ b/src/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
@@ -8,13 +8,13 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a LinearTransformer class.

--- a/src/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
+++ b/src/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include "MicrogridBusDQ.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a constant MicrogridBusDQ model
@@ -134,5 +134,5 @@ template class MicrogridBusDQ<double, long int>;
 template class MicrogridBusDQ<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
+++ b/src/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
@@ -8,13 +8,13 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a MicrogridBusDQ class.

--- a/src/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
+++ b/src/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include "MicrogridLine.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a constant MicrogridLine model
@@ -171,5 +171,5 @@ template class MicrogridLine<double, long int>;
 template class MicrogridLine<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
+++ b/src/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
@@ -7,13 +7,13 @@
 #include <PowerSystemData.hpp>
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT>
     class BaseBus;
 }
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a MicrogridLine class.

--- a/src/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
+++ b/src/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include "MicrogridLoad.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a constant MicrogridLoad model
@@ -168,5 +168,5 @@ template class MicrogridLoad<double, long int>;
 template class MicrogridLoad<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
+++ b/src/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
@@ -8,13 +8,13 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a passive MicrogridLoad class.

--- a/src/Model/PowerElectronics/Resistor/Resistor.cpp
+++ b/src/Model/PowerElectronics/Resistor/Resistor.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "Resistor.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a resistor model
@@ -122,5 +122,5 @@ template class Resistor<double, long int>;
 template class Resistor<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/Resistor/Resistor.hpp
+++ b/src/Model/PowerElectronics/Resistor/Resistor.hpp
@@ -8,13 +8,13 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a Resistor class.

--- a/src/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
+++ b/src/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
@@ -7,7 +7,7 @@
 #include "SynchronousMachine.hpp"
 
 
-namespace ModelLib {
+namespace GridKit {
 
 
 
@@ -149,5 +149,5 @@ template class SynchronousMachine<double, long int>;
 template class SynchronousMachine<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
+++ b/src/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
@@ -9,13 +9,13 @@
 #include <tuple>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a SynchronousMachine class.

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -11,7 +11,7 @@
 #include <CircuitGraph.hpp>
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
 
     template <class ScalarT, typename IdxT>
@@ -329,4 +329,4 @@ namespace ModelLib
 
     }; // class PowerElectronicsModel
 
-} // namespace ModelLib
+} // namespace GridKit

--- a/src/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
+++ b/src/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include "TransmissionLine.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a TransmissionLine model
@@ -201,5 +201,5 @@ template class TransmissionLine<double, long int>;
 template class TransmissionLine<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
+++ b/src/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
@@ -8,13 +8,13 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a TransmissionLine class.

--- a/src/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
+++ b/src/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "VoltageSource.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a constant VoltageSource model
@@ -118,5 +118,5 @@ template class VoltageSource<double, long int>;
 template class VoltageSource<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
+++ b/src/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
@@ -8,13 +8,13 @@
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a VoltageSource class.

--- a/src/Model/PowerFlow/Branch/Branch.cpp
+++ b/src/Model/PowerFlow/Branch/Branch.cpp
@@ -64,7 +64,7 @@
 
 #include "Branch.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a pi-model branch
@@ -215,4 +215,4 @@ int Branch<ScalarT, IdxT>::evaluateAdjointIntegrand()
 template class Branch<double, long int>;
 template class Branch<double, size_t>;
 
-} //namespace ModelLib
+} //namespace GridKit

--- a/src/Model/PowerFlow/Branch/Branch.hpp
+++ b/src/Model/PowerFlow/Branch/Branch.hpp
@@ -62,12 +62,12 @@
 
 #include <ModelEvaluatorImpl.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Implementation of a pi-model branch between two buses.

--- a/src/Model/PowerFlow/Bus/BaseBus.hpp
+++ b/src/Model/PowerFlow/Bus/BaseBus.hpp
@@ -62,7 +62,7 @@
 
 #include <ModelEvaluatorImpl.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Base class for all power flow buses.
@@ -151,7 +151,7 @@ namespace ModelLib
         const IdxT busID_;
     }; // class BaseBus
 
-} // namespace ModelLib
+} // namespace GridKit
 
 
 #endif // _BASE_BUS_HPP_

--- a/src/Model/PowerFlow/Bus/BusFactory.hpp
+++ b/src/Model/PowerFlow/Bus/BusFactory.hpp
@@ -64,7 +64,7 @@
 #include <Model/PowerFlow/Bus/BusPV.hpp>
 #include <Model/PowerFlow/Bus/BusSlack.hpp>
 
-namespace ModelLib {
+namespace GridKit {
 
     template <typename ScalarT = double, typename IdxT = int>
     class BusFactory
@@ -97,4 +97,4 @@ namespace ModelLib {
         }
     };
 
-} // namespace ModelLib
+} // namespace GridKit

--- a/src/Model/PowerFlow/Bus/BusPQ.cpp
+++ b/src/Model/PowerFlow/Bus/BusPQ.cpp
@@ -61,7 +61,7 @@
 #include <cmath>
 #include "BusPQ.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a PQ bus
@@ -209,5 +209,5 @@ template class BusPQ<double, long int>;
 template class BusPQ<double, size_t>;
 
 
-} // namespace ModelLib
+} // namespace GridKit
 

--- a/src/Model/PowerFlow/Bus/BusPQ.hpp
+++ b/src/Model/PowerFlow/Bus/BusPQ.hpp
@@ -63,7 +63,7 @@
 #include "BaseBus.hpp"
 #include <PowerSystemData.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Implementation of a PQ bus.
@@ -193,7 +193,7 @@ namespace ModelLib
 
     };
 
-} // namespace ModelLib
+} // namespace GridKit
 
 
 #endif // _BUS_PQ_HPP_

--- a/src/Model/PowerFlow/Bus/BusPV.cpp
+++ b/src/Model/PowerFlow/Bus/BusPV.cpp
@@ -61,7 +61,7 @@
 #include <cmath>
 #include "BusPV.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a PV bus
@@ -202,5 +202,5 @@ template class BusPV<double, long int>;
 template class BusPV<double, size_t>;
 
 
-} // namespace ModelLib
+} // namespace GridKit
 

--- a/src/Model/PowerFlow/Bus/BusPV.hpp
+++ b/src/Model/PowerFlow/Bus/BusPV.hpp
@@ -64,7 +64,7 @@
 #include "BaseBus.hpp"
 #include <PowerSystemData.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Implementation of a PV bus.
@@ -207,7 +207,7 @@ namespace ModelLib
         ScalarT QB_;
     };
 
-} // namespace ModelLib
+} // namespace GridKit
 
 
 #endif // _BUS_PV_HPP_

--- a/src/Model/PowerFlow/Bus/BusSlack.cpp
+++ b/src/Model/PowerFlow/Bus/BusSlack.cpp
@@ -61,7 +61,7 @@
 #include <cmath>
 #include "BusSlack.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a slack bus
@@ -141,5 +141,5 @@ template class BusSlack<double, long int>;
 template class BusSlack<double, size_t>;
 
 
-} // namespace ModelLib
+} // namespace GridKit
 

--- a/src/Model/PowerFlow/Bus/BusSlack.hpp
+++ b/src/Model/PowerFlow/Bus/BusSlack.hpp
@@ -63,7 +63,7 @@
 #include "BaseBus.hpp"
 #include <PowerSystemData.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Implementation of a slack bus.
@@ -198,7 +198,7 @@ namespace ModelLib
 
     }; // class BusSlack
 
-} // namespace ModelLib
+} // namespace GridKit
 
 
 #endif // _BUS_SLACK_HPP_

--- a/src/Model/PowerFlow/Generator/GeneratorBase.hpp
+++ b/src/Model/PowerFlow/Generator/GeneratorBase.hpp
@@ -62,13 +62,13 @@
 #include <ModelEvaluatorImpl.hpp>
 #include <vector>
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /**
      * @brief Generator base class template

--- a/src/Model/PowerFlow/Generator/GeneratorFactory.hpp
+++ b/src/Model/PowerFlow/Generator/GeneratorFactory.hpp
@@ -66,7 +66,7 @@
 #include <Model/PowerFlow/Generator/GeneratorPV.hpp>
 
 
-namespace ModelLib {
+namespace GridKit {
 
     template <typename ScalarT = double, typename IdxT = int>
     class GeneratorFactory
@@ -99,4 +99,4 @@ namespace ModelLib {
         }
     };
 
-} // namespace ModelLib
+} // namespace GridKit

--- a/src/Model/PowerFlow/Generator/GeneratorPQ.cpp
+++ b/src/Model/PowerFlow/Generator/GeneratorPQ.cpp
@@ -64,7 +64,7 @@
 #include "GeneratorPQ.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a constant load model
@@ -164,5 +164,5 @@ template class GeneratorPQ<double, long int>;
 template class GeneratorPQ<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerFlow/Generator/GeneratorPQ.hpp
+++ b/src/Model/PowerFlow/Generator/GeneratorPQ.hpp
@@ -64,13 +64,13 @@
 #include <PowerSystemData.hpp>
 #include "GeneratorBase.hpp"
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
      /*!
      * @brief Implementation of a PV generator.

--- a/src/Model/PowerFlow/Generator/GeneratorPV.cpp
+++ b/src/Model/PowerFlow/Generator/GeneratorPV.cpp
@@ -64,7 +64,7 @@
 #include "GeneratorPV.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a constant load model
@@ -164,5 +164,5 @@ template class GeneratorPV<double, long int>;
 template class GeneratorPV<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerFlow/Generator/GeneratorPV.hpp
+++ b/src/Model/PowerFlow/Generator/GeneratorPV.hpp
@@ -64,13 +64,13 @@
 #include <PowerSystemData.hpp>
 #include "GeneratorBase.hpp"
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
      /*!
      * @brief Implementation of a PV generator.

--- a/src/Model/PowerFlow/Generator/GeneratorSlack.cpp
+++ b/src/Model/PowerFlow/Generator/GeneratorSlack.cpp
@@ -64,7 +64,7 @@
 #include "GeneratorSlack.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a constant load model
@@ -164,5 +164,5 @@ template class GeneratorSlack<double, long int>;
 template class GeneratorSlack<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerFlow/Generator/GeneratorSlack.hpp
+++ b/src/Model/PowerFlow/Generator/GeneratorSlack.hpp
@@ -64,13 +64,13 @@
 #include <PowerSystemData.hpp>
 #include <vector>
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
      /*!
      * @brief Implementation of a power grid.

--- a/src/Model/PowerFlow/Generator2/Generator2.cpp
+++ b/src/Model/PowerFlow/Generator2/Generator2.cpp
@@ -62,7 +62,7 @@
 #include <Model/PowerFlow/Bus/BusSlack.hpp>
 #include "Generator2.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a simple generator model
@@ -230,4 +230,4 @@ template class Generator2<double, long int>;
 template class Generator2<double, size_t>;
 
 
-} // namespace ModelLib
+} // namespace GridKit

--- a/src/Model/PowerFlow/Generator2/Generator2.hpp
+++ b/src/Model/PowerFlow/Generator2/Generator2.hpp
@@ -59,12 +59,12 @@
 
 #include <ModelEvaluatorImpl.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Implementation of a second order generator model.
@@ -156,4 +156,4 @@ namespace ModelLib
         bus_type* bus_;
     };
 
-} // namespace ModelLib
+} // namespace GridKit

--- a/src/Model/PowerFlow/Generator4/Generator4.cpp
+++ b/src/Model/PowerFlow/Generator4/Generator4.cpp
@@ -63,7 +63,7 @@
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 #include "Generator4.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a simple generator model
@@ -396,5 +396,5 @@ template class Generator4<double, long int>;
 template class Generator4<double, size_t>;
 
 
-} // namespace ModelLib
+} // namespace GridKit
 

--- a/src/Model/PowerFlow/Generator4/Generator4.hpp
+++ b/src/Model/PowerFlow/Generator4/Generator4.hpp
@@ -62,12 +62,12 @@
 
 #include <ModelEvaluatorImpl.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Implementation of a fourth order generator model.
@@ -256,7 +256,7 @@ namespace ModelLib
         bus_type* bus_;
     };
 
-} // namespace ModelLib
+} // namespace GridKit
 
 
 #endif // _GENERATOR_4_H_

--- a/src/Model/PowerFlow/Generator4Governor/Generator4Governor.cpp
+++ b/src/Model/PowerFlow/Generator4Governor/Generator4Governor.cpp
@@ -63,7 +63,7 @@
 #include "Generator4Governor.hpp"
 #include "Model/PowerFlow/Bus/BaseBus.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 
 /*!
@@ -501,4 +501,4 @@ template class Generator4Governor<double, long int>;
 template class Generator4Governor<double, size_t>;
 
 
-} // namespace ModelLib
+} // namespace GridKit

--- a/src/Model/PowerFlow/Generator4Governor/Generator4Governor.hpp
+++ b/src/Model/PowerFlow/Generator4Governor/Generator4Governor.hpp
@@ -62,12 +62,12 @@
 
 #include <ModelEvaluatorImpl.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Implementation of a fourth order generator model with
@@ -319,7 +319,7 @@ namespace ModelLib
         bus_type* bus_;
     };
 
-} // namespace ModelLib
+} // namespace GridKit
 
 
 #endif // _GENERATOR_4_GOVERNOR_B_HPP_

--- a/src/Model/PowerFlow/Generator4Param/Generator4Param.cpp
+++ b/src/Model/PowerFlow/Generator4Param/Generator4Param.cpp
@@ -63,7 +63,7 @@
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 #include "Generator4Param.hpp"
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a simple generator model
@@ -471,5 +471,5 @@ template class Generator4Param<double, long int>;
 template class Generator4Param<double, size_t>;
 
 
-} // namespace ModelLib
+} // namespace GridKit
 

--- a/src/Model/PowerFlow/Generator4Param/Generator4Param.hpp
+++ b/src/Model/PowerFlow/Generator4Param/Generator4Param.hpp
@@ -62,12 +62,12 @@
 
 #include <ModelEvaluatorImpl.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Implementation of a fourth order generator model.
@@ -273,7 +273,7 @@ namespace ModelLib
         std::vector<std::vector<ScalarT>> table_;
     };
 
-} // namespace ModelLib
+} // namespace GridKit
 
 
 #endif // _GENERATOR_4_H_

--- a/src/Model/PowerFlow/Load/Load.cpp
+++ b/src/Model/PowerFlow/Load/Load.cpp
@@ -64,7 +64,7 @@
 #include "Load.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a constant load model
@@ -178,5 +178,5 @@ template class Load<double, long int>;
 template class Load<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerFlow/Load/Load.hpp
+++ b/src/Model/PowerFlow/Load/Load.hpp
@@ -63,13 +63,13 @@
 #include <ModelEvaluatorImpl.hpp>
 #include <PowerSystemData.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
     template <class ScalarT, typename IdxT> class BaseBus;
 }
 
 
-namespace ModelLib
+namespace GridKit
 {
     /*!
      * @brief Declaration of a passive load class.

--- a/src/Model/PowerFlow/MiniGrid/MiniGrid.cpp
+++ b/src/Model/PowerFlow/MiniGrid/MiniGrid.cpp
@@ -64,7 +64,7 @@
 #include "MiniGrid.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
-namespace ModelLib {
+namespace GridKit {
 
 /*!
  * @brief Constructor for a constant load model
@@ -144,5 +144,5 @@ template class MiniGrid<double, long int>;
 template class MiniGrid<double, size_t>;
 
 
-} //namespace ModelLib
+} //namespace GridKit
 

--- a/src/Model/PowerFlow/MiniGrid/MiniGrid.hpp
+++ b/src/Model/PowerFlow/MiniGrid/MiniGrid.hpp
@@ -61,7 +61,7 @@
 #include <ModelEvaluatorImpl.hpp>
 #include <vector>
 
-namespace ModelLib
+namespace GridKit
 {
      /*!
      * @brief Implementation of a power grid.

--- a/src/Model/PowerFlow/SystemModelPowerFlow.hpp
+++ b/src/Model/PowerFlow/SystemModelPowerFlow.hpp
@@ -73,7 +73,7 @@
 #include <ScalarTraits.hpp>
 #include <ModelEvaluatorImpl.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
 
 /**
@@ -426,4 +426,4 @@ private:
 
 }; // class SystemSteadyStateModel
 
-} // namespace ModelLib
+} // namespace GridKit

--- a/src/ModelEvaluator.hpp
+++ b/src/ModelEvaluator.hpp
@@ -64,7 +64,7 @@
 #include <ScalarTraits.hpp>
 #include <LinearAlgebra/COO_Matrix.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
 
     /*!
@@ -152,6 +152,6 @@ namespace ModelLib
     };
 
 
-} // namespace ModelLib
+} // namespace GridKit
 
 #endif // _MODEL_EVALUATOR_HPP_

--- a/src/ModelEvaluatorImpl.hpp
+++ b/src/ModelEvaluatorImpl.hpp
@@ -63,7 +63,7 @@
 #include <vector>
 #include <ModelEvaluator.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
 
     /*!
@@ -318,6 +318,6 @@ namespace ModelLib
     };
 
 
-} // namespace ModelLib
+} // namespace GridKit
 
 #endif // _MODEL_EVALUATOR_IMPL_HPP_

--- a/src/Solver/Dynamic/DynamicSolver.hpp
+++ b/src/Solver/Dynamic/DynamicSolver.hpp
@@ -69,18 +69,18 @@ namespace AnalysisManager
     class DynamicSolver
     {
     public:
-        DynamicSolver(ModelLib::ModelEvaluator<ScalarT, IdxT>* model) : model_(model)
+        DynamicSolver(GridKit::ModelEvaluator<ScalarT, IdxT>* model) : model_(model)
         {
         }
         virtual ~DynamicSolver(){}
         
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* getModel()
+        GridKit::ModelEvaluator<ScalarT, IdxT>* getModel()
         {
             return model_;
         }
         
     protected:
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* model_;
+        GridKit::ModelEvaluator<ScalarT, IdxT>* model_;
     };
 
 }

--- a/src/Solver/Dynamic/Ida.cpp
+++ b/src/Solver/Dynamic/Ida.cpp
@@ -75,7 +75,7 @@ namespace Sundials
 {
 
     template <class ScalarT, typename IdxT>
-    Ida<ScalarT, IdxT>::Ida(ModelLib::ModelEvaluator<ScalarT, IdxT>* model) : DynamicSolver<ScalarT, IdxT>(model)
+    Ida<ScalarT, IdxT>::Ida(GridKit::ModelEvaluator<ScalarT, IdxT>* model) : DynamicSolver<ScalarT, IdxT>(model)
     {
         int retval = 0;
 
@@ -579,7 +579,7 @@ namespace Sundials
     template <class ScalarT, typename IdxT>
     int Ida<ScalarT, IdxT>::Residual(sunrealtype tres, N_Vector yy, N_Vector yp, N_Vector rr, void *user_data)
     {
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* model = static_cast<ModelLib::ModelEvaluator<ScalarT, IdxT>*>(user_data);
+        GridKit::ModelEvaluator<ScalarT, IdxT>* model = static_cast<GridKit::ModelEvaluator<ScalarT, IdxT>*>(user_data);
 
         model->updateTime(tres, 0.0);
         copyVec(yy, model->y());
@@ -596,7 +596,7 @@ namespace Sundials
     int Ida<ScalarT, IdxT>::Jac(sunrealtype t, sunrealtype cj, N_Vector yy, N_Vector yp, N_Vector resvec, SUNMatrix J, void *user_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3)
     {
 
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* model = static_cast<ModelLib::ModelEvaluator<ScalarT, IdxT>*>(user_data);
+        GridKit::ModelEvaluator<ScalarT, IdxT>* model = static_cast<GridKit::ModelEvaluator<ScalarT, IdxT>*>(user_data);
 
 
         model->updateTime(t, cj);
@@ -637,7 +637,7 @@ namespace Sundials
     template <class ScalarT, typename IdxT>
     int Ida<ScalarT, IdxT>::Integrand(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rhsQ, void *user_data)
     {
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* model = static_cast<ModelLib::ModelEvaluator<ScalarT, IdxT>*>(user_data);
+        GridKit::ModelEvaluator<ScalarT, IdxT>* model = static_cast<GridKit::ModelEvaluator<ScalarT, IdxT>*>(user_data);
 
         model->updateTime(tt, 0.0);
         copyVec(yy, model->y());
@@ -653,7 +653,7 @@ namespace Sundials
     template <class ScalarT, typename IdxT>
     int Ida<ScalarT, IdxT>::adjointResidual(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector yyB, N_Vector ypB, N_Vector rrB, void *user_data)
     {
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* model = static_cast<ModelLib::ModelEvaluator<ScalarT, IdxT>*>(user_data);
+        GridKit::ModelEvaluator<ScalarT, IdxT>* model = static_cast<GridKit::ModelEvaluator<ScalarT, IdxT>*>(user_data);
 
         model->updateTime(tt, 0.0);
         copyVec(yy, model->y());
@@ -672,7 +672,7 @@ namespace Sundials
     template <class ScalarT, typename IdxT>
     int Ida<ScalarT, IdxT>::adjointIntegrand(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector yyB, N_Vector ypB, N_Vector rhsQB, void *user_data)
     {
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* model = static_cast<ModelLib::ModelEvaluator<ScalarT, IdxT>*>(user_data);
+        GridKit::ModelEvaluator<ScalarT, IdxT>* model = static_cast<GridKit::ModelEvaluator<ScalarT, IdxT>*>(user_data);
 
         model->updateTime(tt, 0.0);
         copyVec(yy, model->y());

--- a/src/Solver/Dynamic/Ida.hpp
+++ b/src/Solver/Dynamic/Ida.hpp
@@ -83,7 +83,7 @@ namespace AnalysisManager
             typedef typename GridKit::ScalarTraits<ScalarT>::real_type real_type;
 
         public:
-            Ida(ModelLib::ModelEvaluator<ScalarT, IdxT>* model);
+            Ida(GridKit::ModelEvaluator<ScalarT, IdxT>* model);
             ~Ida();
 
             int configureSimulation();

--- a/src/Solver/Optimization/OptimizationSolver.hpp
+++ b/src/Solver/Optimization/OptimizationSolver.hpp
@@ -83,7 +83,7 @@ namespace AnalysisManager
         virtual ~OptimizationSolver(){}
 
     protected:
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* model_;
+        GridKit::ModelEvaluator<ScalarT, IdxT>* model_;
         Sundials::Ida<ScalarT, IdxT>* integrator_;
     };
 

--- a/src/Solver/SteadyState/Kinsol.cpp
+++ b/src/Solver/SteadyState/Kinsol.cpp
@@ -85,7 +85,7 @@ namespace Sundials
 {
 
     template <class ScalarT, typename IdxT>
-    Kinsol<ScalarT, IdxT>::Kinsol(ModelLib::ModelEvaluator<ScalarT, IdxT>* model) 
+    Kinsol<ScalarT, IdxT>::Kinsol(GridKit::ModelEvaluator<ScalarT, IdxT>* model) 
         : SteadyStateSolver<ScalarT, IdxT>(model)
     {
         int retval = 0;
@@ -216,8 +216,8 @@ namespace Sundials
     template <class ScalarT, typename IdxT>
     int Kinsol<ScalarT, IdxT>::Residual(N_Vector yy, N_Vector rr, void *user_data)
     {
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* model = 
-            static_cast<ModelLib::ModelEvaluator<ScalarT, IdxT>*>(user_data);
+        GridKit::ModelEvaluator<ScalarT, IdxT>* model = 
+            static_cast<GridKit::ModelEvaluator<ScalarT, IdxT>*>(user_data);
 
         copyVec(yy, model->y());
 

--- a/src/Solver/SteadyState/Kinsol.hpp
+++ b/src/Solver/SteadyState/Kinsol.hpp
@@ -90,7 +90,7 @@ namespace AnalysisManager
             typedef typename GridKit::ScalarTraits<ScalarT>::real_type real_type;
 
         public:
-            Kinsol(ModelLib::ModelEvaluator<ScalarT, IdxT>* model);
+            Kinsol(GridKit::ModelEvaluator<ScalarT, IdxT>* model);
             ~Kinsol();
 
             int configureSimulation();

--- a/src/Solver/SteadyState/SteadyStateSolver.hpp
+++ b/src/Solver/SteadyState/SteadyStateSolver.hpp
@@ -66,18 +66,18 @@ namespace AnalysisManager
     class SteadyStateSolver
     {
     public:
-        SteadyStateSolver(ModelLib::ModelEvaluator<ScalarT, IdxT>* model) : model_(model)
+        SteadyStateSolver(GridKit::ModelEvaluator<ScalarT, IdxT>* model) : model_(model)
         {
         }
         virtual ~SteadyStateSolver(){}
         
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* getModel()
+        GridKit::ModelEvaluator<ScalarT, IdxT>* getModel()
         {
             return model_;
         }
         
     protected:
-        ModelLib::ModelEvaluator<ScalarT, IdxT>* model_;
+        GridKit::ModelEvaluator<ScalarT, IdxT>* model_;
     };
 
 }

--- a/src/SystemModel.hpp
+++ b/src/SystemModel.hpp
@@ -67,7 +67,7 @@
 #include <ScalarTraits.hpp>
 #include <ModelEvaluatorImpl.hpp>
 
-namespace ModelLib
+namespace GridKit
 {
 
 /**
@@ -710,6 +710,6 @@ private:
 
 }; // class SystemModel
 
-} // namespace ModelLib
+} // namespace GridKit
 
 #endif // _SYSTEM_MODEL_HPP_


### PR DESCRIPTION
Use `GridKit` name space for all models rather than generic `ModelLib`. This is a wholesale name change of the existing namespaces.