### PR TITLE
Add dependency-tracking variable data type.

### DIFF
--- a/src/LinearAlgebra/SparsityPattern/Variable.hpp
+++ b/src/LinearAlgebra/SparsityPattern/Variable.hpp
@@ -35,8 +35,8 @@ namespace Sparse
         */
         Variable()
             : value_(0.0),
-              variableNumber_(INVALID_VAR_NUMBER),
-              isFixed_(false),
+              variable_number_(INVALID_VAR_NUMBER),
+              is_fixed_(false),
               dependencies_(new DependencyMap)
         {
         }
@@ -46,8 +46,8 @@ namespace Sparse
         */
         explicit Variable(double value)
             : value_(value),
-              variableNumber_(INVALID_VAR_NUMBER),
-              isFixed_(false),
+              variable_number_(INVALID_VAR_NUMBER),
+              is_fixed_(false),
               dependencies_(new DependencyMap)
         {
         }
@@ -57,13 +57,13 @@ namespace Sparse
             number.
 
         */
-        Variable(double value, size_t variableNumber)
+        Variable(double value, size_t variable_number)
             : value_(value),
-              variableNumber_(variableNumber),
-              isFixed_(false),
+              variable_number_(variable_number),
+              is_fixed_(false),
               dependencies_(new DependencyMap)
         {
-            (*dependencies_)[variableNumber_] = 1.0;
+            (*dependencies_)[variable_number_] = 1.0;
         }
     
         /*!
@@ -71,8 +71,8 @@ namespace Sparse
         */
         Variable(const Variable& v)
             : value_(v.value_),
-              variableNumber_(INVALID_VAR_NUMBER),
-              isFixed_(false),
+              variable_number_(INVALID_VAR_NUMBER),
+              is_fixed_(false),
               dependencies_(new DependencyMap(*v.dependencies_))
         {
         }
@@ -115,7 +115,7 @@ namespace Sparse
             value_ = rhs.value_;
 
             // if rhs is a constant so is *this
-            setFixed(rhs.isFixed());
+            setFixed(rhs.is_fixed());
 
             // set dependencies from rhs
             dependencies_->clear(); // clear map just in case
@@ -181,17 +181,17 @@ namespace Sparse
         */
         size_t getVariableNumber() const
         {
-            return variableNumber_;
+            return variable_number_;
         }
     
         /*!
             \brief Sets the variable number.
         */
-        void setVariableNumber(size_t variableNumber)
+        void setVariableNumber(size_t variable_number)
         {
             dependencies_->clear();
-            variableNumber_ = variableNumber;
-            (*dependencies_)[variableNumber_] = 1.0;
+            variable_number_ = variable_number;
+            (*dependencies_)[variable_number_] = 1.0;
         }
     
         /*!
@@ -203,15 +203,15 @@ namespace Sparse
         */
         bool isRegistered() const
         {
-            return variableNumber_ != INVALID_VAR_NUMBER;
+            return variable_number_ != INVALID_VAR_NUMBER;
         }
     
         /*!
             \brief Checks whether the variable is fixed or not.
         */
-        bool isFixed() const
+        bool is_fixed() const
         {
-            return isFixed_;
+            return is_fixed_;
         }
     
         /*
@@ -219,7 +219,7 @@ namespace Sparse
         */
         void setFixed(bool b = false)
         {
-            isFixed_ = b;
+            is_fixed_ = b;
         }
         
 
@@ -259,8 +259,8 @@ namespace Sparse
         
     private:
         double value_;           ///< Value of the variable.        
-        size_t variableNumber_;  ///< Independent variable ID
-        bool isFixed_;           ///< Constant parameter flag.
+        size_t variable_number_;  ///< Independent variable ID
+        bool is_fixed_;           ///< Constant parameter flag.
         
         mutable DependencyMap* dependencies_;
         static const size_t INVALID_VAR_NUMBER = static_cast<const size_t>(-1);

--- a/src/LinearAlgebra/SparsityPattern/Variable.hpp
+++ b/src/LinearAlgebra/SparsityPattern/Variable.hpp
@@ -1,0 +1,339 @@
+/*!
+    \file Variable.hpp
+*/
+#ifndef SAD_VARIABLE_HPP
+#define SAD_VARIABLE_HPP
+
+#include <map>
+#include <vector>
+#include <cstdlib>
+#include <cmath>
+#include <fstream>
+
+#include <cassert>
+#include <limits>
+#include <iostream>
+#include <iomanip>
+#include <string>
+
+namespace GridKit
+{
+namespace Sparse
+{
+    
+    /*!
+        \brief The Variable class is used to store the unknowns of the 
+        system and define abstract elementary algebra.
+        
+        \author Stefan Klus
+        \author Slaven Peles
+    */
+    class Variable
+    {
+    public:
+        /*!
+            \brief Default constructor.
+        */
+        Variable()
+            : value_(0.0),
+              variableNumber_(INVALID_VAR_NUMBER),
+              isFixed_(false),
+              dependencies_(new DependencyMap)
+        {
+        }
+
+        /*!
+            \brief Constructor which initializes the value.
+        */
+        explicit Variable(double value)
+            : value_(value),
+              variableNumber_(INVALID_VAR_NUMBER),
+              isFixed_(false),
+              dependencies_(new DependencyMap)
+        {
+        }
+
+        /*!
+            \brief Constructor which initializes the value and variable 
+            number.
+
+        */
+        Variable(double value, size_t variableNumber)
+            : value_(value),
+              variableNumber_(variableNumber),
+              isFixed_(false),
+              dependencies_(new DependencyMap)
+        {
+            (*dependencies_)[variableNumber_] = 1.0;
+        }
+    
+        /*!
+            \brief Copy constructor.
+        */
+        Variable(const Variable& v)
+            : value_(v.value_),
+              variableNumber_(INVALID_VAR_NUMBER),
+              isFixed_(false),
+              dependencies_(new DependencyMap(*v.dependencies_))
+        {
+        }
+    
+        /*!
+            \brief Destructor deletes the dependency map.
+        */
+        ~Variable()
+        {
+            delete dependencies_;
+        }
+    
+        /*!
+            \brief Assignment operator. Assigning double value to 
+            Variable removes its dependencies. Use only if you know 
+            what you are doing.
+        */
+        Variable& operator=(const double& rhs)
+        {
+            value_ = rhs;
+        
+            dependencies_->clear();
+            return *this;
+        }
+    
+        /*!
+            \brief Assignment operator.
+
+            This operator: 
+            - assigns value from the right hand side
+            - leaves variable ID unchanged 
+            - clears any existing and adds new dependencies from rhs
+        */
+        Variable& operator=(const Variable& rhs)
+        {
+            if (this == &rhs)  // self-assignment
+                return *this;
+        
+            // set value from rhs
+            value_ = rhs.value_;
+
+            // if rhs is a constant so is *this
+            setFixed(rhs.isFixed());
+
+            // set dependencies from rhs
+            dependencies_->clear(); // clear map just in case
+            addDependencies(rhs);   // use only dependencies from the rhs
+        
+            return *this;
+        }
+    
+        
+        /*!
+            \brief Operator () returns the value of a variable.
+
+            This is just short notation to avoid using 
+            getValue and setValue.
+        */
+        double& operator()()
+        {
+            return value_;
+        }
+    
+        /*!
+            \brief Operator() returns the value of a variable 
+            (const version).
+
+            This is just short notation to avoid using getValue. 
+        */
+        const double& operator()() const
+        {
+            return value_;
+        }
+
+        /*!
+            \brief Return the current value of the variable.
+        */
+        double getValue() const
+        {
+            return value_;
+        }
+    
+        /*!
+            \brief Overwrite the current value of the variable.
+        */
+        void setValue(double value)
+        {
+            value_ = value;
+        }
+    
+        /*!
+            \brief Return derivative of *this with respect to 
+            dependency i.
+        */
+        double der(size_t i) const
+        {
+            return (*dependencies_)[i];
+        }
+
+        
+        /*!
+            \brief Returns the variable number.
+
+            This number is assigned to state variables (variables 
+            updated directly by the solver) only.
+        */
+        size_t getVariableNumber() const
+        {
+            return variableNumber_;
+        }
+    
+        /*!
+            \brief Sets the variable number.
+        */
+        void setVariableNumber(size_t variableNumber)
+        {
+            dependencies_->clear();
+            variableNumber_ = variableNumber;
+            (*dependencies_)[variableNumber_] = 1.0;
+        }
+    
+        /*!
+            \brief Checks whether the variable was registered as 
+            an unknown of the system.
+
+            INVALID_VAR_NUMBER is used to mark parameters and 
+            temporary variables
+        */
+        bool isRegistered() const
+        {
+            return variableNumber_ != INVALID_VAR_NUMBER;
+        }
+    
+        /*!
+            \brief Checks whether the variable is fixed or not.
+        */
+        bool isFixed() const
+        {
+            return isFixed_;
+        }
+    
+        /*
+            \brief Turns variable into parameter, or vice versa.
+        */
+        void setFixed(bool b = false)
+        {
+            isFixed_ = b;
+        }
+        
+
+        // get the 'input set' of a variable
+        using DependencyMap = std::map<size_t, double>;
+        inline const DependencyMap& getDependencies() const;
+        
+        // set as the independent state variable and assign ID to it
+        inline void registerVariable(std::vector<Variable*>& x, 
+                                     const size_t& offset);
+
+        // adds all dependencies of v to *this
+        inline void addDependencies(const Variable& v);
+
+        // scale dependencies (derivatives) by scalar @a c.
+        inline void scaleDependencies(double c);
+
+        // print to output stream
+        inline void print(std::ostream& os) const;
+        
+        // +=
+        inline Variable& operator+=(const double& rhs);
+        inline Variable& operator+=(const Variable& rhs);
+        
+        // -=
+        inline Variable& operator-=(const double& rhs);
+        inline Variable& operator-=(const Variable& rhs);
+        
+        // *=
+        inline Variable& operator*=(const double& rhs);
+        inline Variable& operator*=(const Variable& rhs);
+        
+        // /=
+        inline Variable& operator/=(const double& rhs);
+        inline Variable& operator/=(const Variable& rhs);
+        
+        
+    private:
+        double value_;           ///< Value of the variable.        
+        size_t variableNumber_;  ///< Independent variable ID
+        bool isFixed_;           ///< Constant parameter flag.
+        
+        mutable DependencyMap* dependencies_;
+        static const size_t INVALID_VAR_NUMBER = -1;
+    };
+    
+    //------------------------------------
+    // non-member operators and functions
+    //------------------------------------
+    
+    // unary -
+    inline const Variable operator-(const Variable& v);
+    
+    // +
+    inline const Variable operator+(const Variable& lhs, const Variable& rhs);
+    inline const Variable operator+(const Variable& lhs, const double& rhs);
+    inline const Variable operator+(const double& lhs, const Variable& rhs);
+    
+    // -
+    inline const Variable operator-(const Variable& lhs, const Variable& rhs);
+    inline const Variable operator-(const Variable& lhs, const double& rhs);
+    inline const Variable operator-(const double& lhs, const Variable& rhs);
+    
+    // *
+    inline const Variable operator*(const Variable& lhs, const Variable& rhs);
+    inline const Variable operator*(const Variable& lhs, const double& rhs);
+    inline const Variable operator*(const double& lhs, const Variable& rhs);
+    
+    // /
+    inline const Variable operator/(const Variable& lhs, const Variable& rhs);
+    inline const Variable operator/(const Variable& lhs, const double& rhs);
+    inline const Variable operator/(const double& lhs, const Variable& rhs);
+    
+    // ==
+    inline bool operator==(const Variable& lhs, const Variable& rhs);
+    inline bool operator==(const Variable& lhs, const double& rhs);
+    inline bool operator==(const double& lhs, const Variable& rhs);
+    
+    // !=
+    inline bool operator!=(const Variable& lhs, const Variable& rhs);
+    inline bool operator!=(const Variable& lhs, const double& rhs);
+    inline bool operator!=(const double& lhs, const Variable& rhs);
+    
+    // <
+    inline bool operator<(const Variable& lhs, const Variable& rhs);
+    inline bool operator<(const Variable& lhs, const double& rhs);
+    inline bool operator<(const double& lhs, const Variable& rhs);
+    
+    // >
+    inline bool operator>(const Variable& lhs, const Variable& rhs);
+    inline bool operator>(const Variable& lhs, const double& rhs);
+    inline bool operator>(const double& lhs, const Variable& rhs);
+    
+    // <=
+    inline bool operator<=(const Variable& lhs, const Variable& rhs);
+    inline bool operator<=(const Variable& lhs, const double& rhs);
+    inline bool operator<=(const double& lhs, const Variable& rhs);
+    
+    // >=
+    inline bool operator>=(const Variable& lhs, const Variable& rhs);
+    inline bool operator>=(const Variable& lhs, const double& rhs);
+    inline bool operator>=(const double& lhs, const Variable& rhs);
+    
+    inline std::ostream& operator<<(std::ostream& os, const Variable& v);
+    inline Variable& operator<<(Variable& u, const Variable& v);
+    
+    inline std::istream& operator>>(std::istream& is, Variable& v);
+    
+
+} // namespace Sparse
+} // namespace GridKit
+
+#include "VariableImplementation.hpp"
+#include "VariableOperators.hpp"
+
+#endif // SAD_VARIABLE_HPP

--- a/src/LinearAlgebra/SparsityPattern/Variable.hpp
+++ b/src/LinearAlgebra/SparsityPattern/Variable.hpp
@@ -1,4 +1,4 @@
-/*!
+/**
     \file Variable.hpp
 */
 #pragma once
@@ -20,8 +20,8 @@ namespace GridKit
 namespace Sparse
 {
     
-    /*!
-        \brief The Variable class is used to store the unknowns of the 
+    /**
+        @brief The Variable class is used to store the unknowns of the 
         system and define abstract elementary algebra.
         
         \author Stefan Klus
@@ -30,8 +30,8 @@ namespace Sparse
     class Variable
     {
     public:
-        /*!
-            \brief Default constructor.
+        /**
+            @brief Default constructor.
         */
         Variable()
             : value_(0.0),
@@ -41,8 +41,8 @@ namespace Sparse
         {
         }
 
-        /*!
-            \brief Constructor which initializes the value.
+        /**
+            @brief Constructor which initializes the value.
         */
         explicit Variable(double value)
             : value_(value),
@@ -52,8 +52,8 @@ namespace Sparse
         {
         }
 
-        /*!
-            \brief Constructor which initializes the value and variable 
+        /**
+            @brief Constructor which initializes the value and variable 
             number.
 
         */
@@ -66,8 +66,8 @@ namespace Sparse
             (*dependencies_)[variable_number_] = 1.0;
         }
     
-        /*!
-            \brief Copy constructor.
+        /**
+            @brief Copy constructor.
         */
         Variable(const Variable& v)
             : value_(v.value_),
@@ -77,16 +77,16 @@ namespace Sparse
         {
         }
     
-        /*!
-            \brief Destructor deletes the dependency map.
+        /**
+            @brief Destructor deletes the dependency map.
         */
         ~Variable()
         {
             delete dependencies_;
         }
     
-        /*!
-            \brief Assignment operator. Assigning double value to 
+        /**
+            @brief Assignment operator. Assigning double value to 
             Variable removes its dependencies. Use only if you know 
             what you are doing.
         */
@@ -98,8 +98,8 @@ namespace Sparse
             return *this;
         }
     
-        /*!
-            \brief Assignment operator.
+        /**
+            @brief Assignment operator.
 
             This operator: 
             - assigns value from the right hand side
@@ -125,8 +125,8 @@ namespace Sparse
         }
     
         
-        /*!
-            \brief Operator () returns the value of a variable.
+        /**
+            @brief Operator () returns the value of a variable.
 
             This is just short notation to avoid using 
             getValue and setValue.
@@ -136,8 +136,8 @@ namespace Sparse
             return value_;
         }
     
-        /*!
-            \brief Operator() returns the value of a variable 
+        /**
+            @brief Operator() returns the value of a variable 
             (const version).
 
             This is just short notation to avoid using getValue. 
@@ -147,24 +147,24 @@ namespace Sparse
             return value_;
         }
 
-        /*!
-            \brief Return the current value of the variable.
+        /**
+            @brief Return the current value of the variable.
         */
         double getValue() const
         {
             return value_;
         }
     
-        /*!
-            \brief Overwrite the current value of the variable.
+        /**
+            @brief Overwrite the current value of the variable.
         */
         void setValue(double value)
         {
             value_ = value;
         }
     
-        /*!
-            \brief Return derivative of *this with respect to 
+        /**
+            @brief Return derivative of *this with respect to 
             dependency i.
         */
         double der(size_t i) const
@@ -173,8 +173,8 @@ namespace Sparse
         }
 
         
-        /*!
-            \brief Returns the variable number.
+        /**
+            @brief Returns the variable number.
 
             This number is assigned to state variables (variables 
             updated directly by the solver) only.
@@ -184,8 +184,8 @@ namespace Sparse
             return variable_number_;
         }
     
-        /*!
-            \brief Sets the variable number.
+        /**
+            @brief Sets the variable number.
         */
         void setVariableNumber(size_t variable_number)
         {
@@ -194,8 +194,8 @@ namespace Sparse
             (*dependencies_)[variable_number_] = 1.0;
         }
     
-        /*!
-            \brief Checks whether the variable was registered as 
+        /**
+            @brief Checks whether the variable was registered as 
             an unknown of the system.
 
             INVALID_VAR_NUMBER is used to mark parameters and 
@@ -206,17 +206,17 @@ namespace Sparse
             return variable_number_ != INVALID_VAR_NUMBER;
         }
     
-        /*!
-            \brief Checks whether the variable is fixed or not.
+        /**
+            @brief Checks whether the variable is fixed or not.
         */
         bool is_fixed() const
         {
             return is_fixed_;
         }
     
-        /*
-            \brief Turns variable into parameter, or vice versa.
-        */
+        /**
+            @brief Turns variable into parameter, or vice versa.
+         */
         void setFixed(bool b = false)
         {
             is_fixed_ = b;

--- a/src/LinearAlgebra/SparsityPattern/Variable.hpp
+++ b/src/LinearAlgebra/SparsityPattern/Variable.hpp
@@ -1,8 +1,7 @@
 /*!
     \file Variable.hpp
 */
-#ifndef SAD_VARIABLE_HPP
-#define SAD_VARIABLE_HPP
+#pragma once
 
 #include <map>
 #include <vector>
@@ -264,7 +263,7 @@ namespace Sparse
         bool isFixed_;           ///< Constant parameter flag.
         
         mutable DependencyMap* dependencies_;
-        static const size_t INVALID_VAR_NUMBER = -1;
+        static const size_t INVALID_VAR_NUMBER = static_cast<const size_t>(-1);
     };
     
     //------------------------------------
@@ -336,4 +335,3 @@ namespace Sparse
 #include "VariableImplementation.hpp"
 #include "VariableOperators.hpp"
 
-#endif // SAD_VARIABLE_HPP

--- a/src/LinearAlgebra/SparsityPattern/VariableImplementation.hpp
+++ b/src/LinearAlgebra/SparsityPattern/VariableImplementation.hpp
@@ -59,15 +59,15 @@ namespace Sparse
     {
         os << value_;
         
-        if (isFixed_)
+        if (is_fixed_)
         {
             os << " (fixed)";
             return;
         }
         
-        if (variableNumber_ != INVALID_VAR_NUMBER)
+        if (variable_number_ != INVALID_VAR_NUMBER)
         {
-            os << " (variable " << variableNumber_ << ")";
+            os << " (variable " << variable_number_ << ")";
             return;
         }
         
@@ -113,7 +113,7 @@ namespace Sparse
     
     // -=
     /*!
-        \brief Compound substraction-assignment operator. Right hand 
+        \brief Compound subtraction-assignment operator. Right hand 
         side is a built-in double type.
     */
     Variable& Variable::operator-=(const double& rhs)
@@ -123,7 +123,7 @@ namespace Sparse
     }
     
     /*!
-        \brief Compound substraction-assignment operator. Right hand 
+        \brief Compound subtraction-assignment operator. Right hand 
         side is a Variable type.
     */
     Variable& Variable::operator-=(const Variable& rhs)

--- a/src/LinearAlgebra/SparsityPattern/VariableImplementation.hpp
+++ b/src/LinearAlgebra/SparsityPattern/VariableImplementation.hpp
@@ -2,8 +2,7 @@
     \file VariableImplementation.hpp
 */
 
-#ifndef SAD_VARIABLE_IMPLEMENTATION_HPP
-#define SAD_VARIABLE_IMPLEMENTATION_HPP
+#pragma once
 
 namespace GridKit
 {
@@ -213,5 +212,3 @@ namespace Sparse
 } // namespace Sparse
 } // namespace GridKit
 
-
-#endif // SAD_VARIABLE_IMPLEMENTATION_HPP

--- a/src/LinearAlgebra/SparsityPattern/VariableImplementation.hpp
+++ b/src/LinearAlgebra/SparsityPattern/VariableImplementation.hpp
@@ -1,4 +1,4 @@
-/*!
+/**
     \file VariableImplementation.hpp
 */
 
@@ -8,8 +8,8 @@ namespace GridKit
 {
 namespace Sparse
 {
-    /*!
-        \brief Returns the list of derivatives.
+    /**
+        @brief Returns the list of derivatives.
     */
     const Variable::DependencyMap& Variable::getDependencies() const
     {
@@ -18,8 +18,8 @@ namespace Sparse
     }
     
 
-    /*!
-        \brief Registers a variable as an unknown of the system and 
+    /**
+        @brief Registers a variable as an unknown of the system and 
         adds a pointer to the global @a x vector.
     */
     void Variable::registerVariable(std::vector<Variable*>& x, 
@@ -32,8 +32,8 @@ namespace Sparse
     }
     
 
-    /*!
-        \brief Adds all dependencies of v to *this.
+    /**
+        @brief Adds all dependencies of v to *this.
     */
     void Variable::addDependencies(const Variable& v)
     {
@@ -42,8 +42,8 @@ namespace Sparse
     }
     
 
-    /*!
-        \brief Multiplies each partial derivative of @a this by @a c. 
+    /**
+        @brief Multiplies each partial derivative of @a this by @a c. 
     */
     void Variable::scaleDependencies(double c)
     {
@@ -52,8 +52,8 @@ namespace Sparse
     }
     
     
-    /*!
-        \brief Prints the value and input set of the variable.
+    /**
+        @brief Prints the value and input set of the variable.
     */
     void Variable::print(std::ostream& os) const
     {
@@ -85,8 +85,8 @@ namespace Sparse
     // compound assignment operators
     //------------------------------------
     
-    /*!
-        \brief Compound addition-assignment operator. Right hand 
+    /**
+        @brief Compound addition-assignment operator. Right hand 
         side is a built-in double type.
     */
     Variable& Variable::operator+=(const double& rhs)
@@ -95,8 +95,8 @@ namespace Sparse
         return *this;
     }
     
-    /*!
-        \brief Compound addition-assignment operator. Right hand side 
+    /**
+        @brief Compound addition-assignment operator. Right hand side 
         is Variable type.
     */
     Variable& Variable::operator+=(const Variable& rhs)
@@ -112,8 +112,8 @@ namespace Sparse
     }
     
     // -=
-    /*!
-        \brief Compound subtraction-assignment operator. Right hand 
+    /**
+        @brief Compound subtraction-assignment operator. Right hand 
         side is a built-in double type.
     */
     Variable& Variable::operator-=(const double& rhs)
@@ -122,8 +122,8 @@ namespace Sparse
         return *this;
     }
     
-    /*!
-        \brief Compound subtraction-assignment operator. Right hand 
+    /**
+        @brief Compound subtraction-assignment operator. Right hand 
         side is a Variable type.
     */
     Variable& Variable::operator-=(const Variable& rhs)
@@ -139,8 +139,8 @@ namespace Sparse
     }
     
     // *=
-    /*!
-        \brief Compound multiplication-assignment operator. Right hand 
+    /**
+        @brief Compound multiplication-assignment operator. Right hand 
         side is a built-in double type.
     */
     Variable& Variable::operator*=(const double& rhs)
@@ -154,8 +154,8 @@ namespace Sparse
         return *this;
     }
     
-    /*!
-        \brief Compound multiplication-assignment operator. Right 
+    /**
+        @brief Compound multiplication-assignment operator. Right 
         hand side is a Variable type.
     */
     Variable& Variable::operator*=(const Variable& rhs)
@@ -174,8 +174,8 @@ namespace Sparse
     }
     
     // /=
-    /*!
-        \brief Compound division-assignment operator. Right hand side 
+    /**
+        @brief Compound division-assignment operator. Right hand side 
         is a built-in double type.
     */
     Variable& Variable::operator/=(const double& rhs)
@@ -189,8 +189,8 @@ namespace Sparse
         return *this;
     }
     
-    /*!
-        \brief Compound division-assignment operator. Right hand 
+    /**
+        @brief Compound division-assignment operator. Right hand 
         side is a Variable type.
     */
     Variable& Variable::operator/=(const Variable& rhs)

--- a/src/LinearAlgebra/SparsityPattern/VariableImplementation.hpp
+++ b/src/LinearAlgebra/SparsityPattern/VariableImplementation.hpp
@@ -1,0 +1,217 @@
+/*!
+    \file VariableImplementation.hpp
+*/
+
+#ifndef SAD_VARIABLE_IMPLEMENTATION_HPP
+#define SAD_VARIABLE_IMPLEMENTATION_HPP
+
+namespace GridKit
+{
+namespace Sparse
+{
+    /*!
+        \brief Returns the list of derivatives.
+    */
+    const Variable::DependencyMap& Variable::getDependencies() const
+    {
+        assert(dependencies_ != 0);
+        return *dependencies_;
+    }
+    
+
+    /*!
+        \brief Registers a variable as an unknown of the system and 
+        adds a pointer to the global @a x vector.
+    */
+    void Variable::registerVariable(std::vector<Variable*>& x, 
+                                    const size_t& offset)
+    {
+        setVariableNumber(offset);  // define global variable number
+        setFixed(false);            // not a constant
+
+        x[offset] = this;
+    }
+    
+
+    /*!
+        \brief Adds all dependencies of v to *this.
+    */
+    void Variable::addDependencies(const Variable& v)
+    {
+        for (auto& p : *(v.dependencies_))
+            (*dependencies_)[p.first] = p.second;
+    }
+    
+
+    /*!
+        \brief Multiplies each partial derivative of @a this by @a c. 
+    */
+    void Variable::scaleDependencies(double c)
+    {
+        for (auto& p : *dependencies_)
+            (*dependencies_)[p.first] *= c;
+    }
+    
+    
+    /*!
+        \brief Prints the value and input set of the variable.
+    */
+    void Variable::print(std::ostream& os) const
+    {
+        os << value_;
+        
+        if (isFixed_)
+        {
+            os << " (fixed)";
+            return;
+        }
+        
+        if (variableNumber_ != INVALID_VAR_NUMBER)
+        {
+            os << " (variable " << variableNumber_ << ")";
+            return;
+        }
+        
+        if (dependencies_!= NULL && !dependencies_->empty())
+        {
+            os << " dependencies: [ ";
+            for (auto& p : *dependencies_)
+                os << "(" << p.first << ", " << p.second << ") ";
+            os << "]";
+        }
+    }
+    
+    
+    //------------------------------------
+    // compound assignment operators
+    //------------------------------------
+    
+    /*!
+        \brief Compound addition-assignment operator. Right hand 
+        side is a built-in double type.
+    */
+    Variable& Variable::operator+=(const double& rhs)
+    {
+        value_ += rhs;
+        return *this;
+    }
+    
+    /*!
+        \brief Compound addition-assignment operator. Right hand side 
+        is Variable type.
+    */
+    Variable& Variable::operator+=(const Variable& rhs)
+    {
+        // compute partial derivatives of *this
+        for (auto& p : *(rhs.dependencies_))
+            (*dependencies_)[p.first] += (p.second);
+
+        // compute value of *this
+        value_ += rhs.value_;
+
+        return *this;
+    }
+    
+    // -=
+    /*!
+        \brief Compound substraction-assignment operator. Right hand 
+        side is a built-in double type.
+    */
+    Variable& Variable::operator-=(const double& rhs)
+    {
+        value_ -= rhs;
+        return *this;
+    }
+    
+    /*!
+        \brief Compound substraction-assignment operator. Right hand 
+        side is a Variable type.
+    */
+    Variable& Variable::operator-=(const Variable& rhs)
+    {
+        // compute partial derivatives of *this
+        for (auto& p : *(rhs.dependencies_))
+            (*dependencies_)[p.first] -= (p.second);
+
+        // compute value of *this
+        value_ -= rhs.value_;
+
+        return *this;
+    }
+    
+    // *=
+    /*!
+        \brief Compound multiplication-assignment operator. Right hand 
+        side is a built-in double type.
+    */
+    Variable& Variable::operator*=(const double& rhs)
+    {
+        // Compute derivatives of this
+        scaleDependencies(rhs);
+
+        // compute value
+        value_ *= rhs;
+
+        return *this;
+    }
+    
+    /*!
+        \brief Compound multiplication-assignment operator. Right 
+        hand side is a Variable type.
+    */
+    Variable& Variable::operator*=(const Variable& rhs)
+    {
+        // derivation by parts of @ *this
+        scaleDependencies(rhs.value_);
+
+        // compute partial derivatives of rhs and add them to *this
+        for (auto& p : *(rhs.dependencies_))
+            (*dependencies_)[p.first] += (p.second * value_);
+
+        // compute value of this
+        value_ *= rhs.value_;
+
+        return *this;
+    }
+    
+    // /=
+    /*!
+        \brief Compound division-assignment operator. Right hand side 
+        is a built-in double type.
+    */
+    Variable& Variable::operator/=(const double& rhs)
+    {
+        double inverseRhs = 1.0/rhs;
+
+        // compute derivatives of @a *this
+        scaleDependencies(inverseRhs);
+
+        value_ *= inverseRhs;
+        return *this;
+    }
+    
+    /*!
+        \brief Compound division-assignment operator. Right hand 
+        side is a Variable type.
+    */
+    Variable& Variable::operator/=(const Variable& rhs)
+    {
+        double inverseRhs        = 1.0/rhs.value_;
+        double inverseRhsSq = inverseRhs * inverseRhs;
+
+        // derivation by parts of @a *this
+        scaleDependencies(inverseRhs);
+        for (auto& p : *(rhs.dependencies_))
+            (*dependencies_)[p.first] -= (p.second * value_ * inverseRhsSq);
+
+        // compute value of this
+        value_ *= inverseRhs;
+
+        return *this;
+    }
+    
+} // namespace Sparse
+} // namespace GridKit
+
+
+#endif // SAD_VARIABLE_IMPLEMENTATION_HPP

--- a/src/LinearAlgebra/SparsityPattern/VariableOperators.hpp
+++ b/src/LinearAlgebra/SparsityPattern/VariableOperators.hpp
@@ -1,0 +1,365 @@
+/*!
+    \file VariableOperators.hpp
+    
+*/
+#ifndef SAD_VARIABLE_OPERATORS_HPP
+#define SAD_VARIABLE_OPERATORS_HPP
+
+// Define derivatives of standard library mathematical functions here.
+// These definitions could be used to add smoothing in cases where 
+// derivatives are discontinuous.
+namespace GridKit
+{
+namespace Sparse
+{
+    //------------------------------------
+    // non-member operators and functions
+    //------------------------------------
+    
+    // unary -
+    const Variable operator-(const Variable& v)
+    {
+        return -1.0*v;
+    }
+    
+    // +
+    const Variable operator+(const Variable& lhs, const Variable& rhs)
+    {
+        return Variable(lhs) += rhs;
+    }
+    
+    const Variable operator+(const Variable& lhs, const double& rhs)
+    {
+        return Variable(lhs) += rhs;
+    }
+    
+    const Variable operator+(const double& lhs, const Variable& rhs)
+    {
+        return Variable(rhs) += lhs;
+    }
+    
+    // -
+    const Variable operator-(const Variable& lhs, const Variable& rhs)
+    {
+        return Variable(lhs) -= rhs;
+    }
+    
+    const Variable operator-(const Variable& lhs, const double& rhs)
+    {
+        return Variable(lhs) -= rhs;
+    }
+    
+    const Variable operator-(const double& lhs, const Variable& rhs)
+    {
+        return Variable(lhs) -= rhs;
+    }
+    
+    // *
+    const Variable operator*(const Variable& lhs, const Variable& rhs)
+    {
+        return Variable(lhs) *= rhs;
+    }
+    
+    const Variable operator*(const Variable& lhs, const double& rhs)
+    {
+        return Variable(lhs) *= rhs;
+    }
+    
+    const Variable operator*(const double& lhs, const Variable& rhs)
+    {
+        return Variable(lhs) *= rhs;
+    }
+    
+    // /
+    const Variable operator/(const Variable& lhs, const Variable& rhs)
+    {
+        return Variable(lhs) /= rhs;
+    }
+    
+    const Variable operator/(const Variable& lhs, const double& rhs)
+    {
+        return Variable(lhs) /= rhs;
+    }
+    
+    const Variable operator/(const double& lhs, const Variable& rhs)
+    {
+        return Variable(lhs) /= rhs;
+    }
+    
+    // ==
+    bool operator==(const Variable& lhs, const Variable& rhs)
+    {
+        return lhs.getValue() == rhs.getValue();
+    }
+    
+    bool operator==(const Variable& lhs, const double& rhs)
+    {
+        return lhs.getValue() == rhs;
+    }
+    
+    bool operator==(const double& lhs, const Variable& rhs)
+    {
+        return lhs == rhs.getValue();
+    }
+    
+    // !=
+    bool operator!=(const Variable& lhs, const Variable& rhs)
+    {
+        return !(lhs.getValue() == rhs.getValue());
+    }
+    
+    bool operator!=(const Variable& lhs, const double& rhs)
+    {
+        return !(lhs.getValue() == rhs);
+    }
+    
+    bool operator!=(const double& lhs, const Variable& rhs)
+    {
+        return !(lhs == rhs.getValue());
+    }
+    
+    // <
+    bool operator<(const Variable& lhs, const Variable& rhs)
+    {
+        return lhs.getValue() < rhs.getValue();
+    }
+    
+    bool operator<(const Variable& lhs, const double& rhs)
+    {
+        return lhs.getValue() < rhs;
+    }
+    
+    bool operator<(const double& lhs, const Variable& rhs)
+    {
+        return lhs < rhs.getValue();
+    }
+    
+    // >
+    bool operator>(const Variable& lhs, const Variable& rhs)
+    {
+        return lhs.getValue() > rhs.getValue();
+    }
+    
+    bool operator>(const Variable& lhs, const double& rhs)
+    {
+        return lhs.getValue() > rhs;
+    }
+    
+    bool operator>(const double& lhs, const Variable& rhs)
+    {
+        return lhs > rhs.getValue();
+    }
+    
+    // <=
+    bool operator<=(const Variable& lhs, const Variable& rhs)
+    {
+        return lhs < rhs || lhs == rhs;
+    }
+    
+    bool operator<=(const Variable& lhs, const double& rhs)
+    {
+        return lhs < rhs || lhs == rhs;
+    }
+    
+    bool operator<=(const double& lhs, const Variable& rhs)
+    {
+        return lhs < rhs || lhs == rhs;
+    }
+    
+    // >=
+    bool operator>=(const Variable& lhs, const Variable& rhs)
+    {
+        return lhs > rhs || lhs == rhs;
+    }
+    
+    bool operator>=(const Variable& lhs, const double& rhs)
+    {
+        return lhs > rhs || lhs == rhs;
+    }
+    
+    bool operator>=(const double& lhs, const Variable& rhs)
+    {
+        return lhs > rhs || lhs == rhs;
+    }
+    
+    //------------------------------------
+    // non-member operators
+    //------------------------------------
+    
+    /*
+        \brief Stream insertion operator for variables.
+    */
+    std::ostream& operator<<(std::ostream& os, const Variable& v)
+    {
+        v.print(os);
+        return os;
+    }
+    
+    /*
+        \brief Adds all dependencies of a variable, i.e. v << u means 
+        that v depends on u.
+
+        \attention Use only if you know what you are doing!
+    */
+    Variable& operator<<(Variable& u, const Variable& v)
+    {
+        u.addDependencies(v);
+        return u;
+    }
+    
+    /*
+        \brief Stream extraction operator for variables.
+    */
+    std::istream& operator>>(std::istream& is, Variable& v)
+    {
+        return is >> v();
+    }
+    
+
+    //-------------------------------------------
+    // definitions of cmath functions derivatives
+    //-------------------------------------------
+    
+
+    /// Derivative of sine
+    inline double sin_derivative(double x)
+    {
+        return std::cos(x);
+    }
+
+    /// Derivative of cosine
+    inline double cos_derivative(double x)
+    {
+        return -std::sin(x);
+    }
+
+    /// Derivative of tangent
+    inline double tan_derivative(double x)
+    {
+        return 1.0/(std::cos(x)*std::cos(x));
+    }
+
+    /// Derivative of arc sine
+    inline double asin_derivative(double x)
+    {
+        return std::sqrt(1.0 - x*x);
+    }
+
+    /// Derivative of arc cosine
+    inline double acos_derivative(double x)
+    {
+        return -std::sqrt(1.0 - x*x);
+    }
+
+    /// Derivative of arc tangent
+    inline double atan_derivative(double x)
+    {
+        return 1.0/(1.0 + x*x);
+    }
+
+    /// Derivative of hyperbolic sine
+    inline double sinh_derivative(double x)
+    {
+        return std::cosh(x);
+    }
+
+    /// Derivative of hyperbolic cosine
+    inline double cosh_derivative(double x)
+    {
+        return std::sinh(x);
+    }
+
+    /// Derivative of hyperbolic tangent
+    inline double tanh_derivative(double x)
+    {
+        return 1.0/(std::cosh(x)*std::cosh(x));
+    }
+
+    /// Derivative of hyperbolic arc sine
+    inline double asinh_derivative(double x)
+    {
+        return std::sqrt(1.0 + x*x);
+    }
+
+    /// Derivative of hyperbolic arc cosine
+    inline double acosh_derivative(double x)
+    {
+        return std::sqrt(x*x - 1.0);
+    }
+
+    /// Derivative of hyperbolic arc tangent
+    inline double atanh_derivative(double x)
+    {
+        return 1.0/(1.0 - x*x);
+    }
+
+    /// Derivative of exponential function.
+    inline double exp_derivative(double x)
+    {
+        return std::exp(x);
+    }
+
+    /// Derivative of natural logarithm function.
+    inline double log_derivative(double x)
+    {
+        return 1.0/x;
+    }
+
+    /// Derivative of logarithm to base 10 function: 1/(x*log(10)).
+    inline double log10_derivative(double x)
+    {
+        return 0.4342944819032518/x;
+    }
+
+    /// Derivative of square root function.
+    inline double sqrt_derivative(double x)
+    {
+        return 0.5/std::sqrt(x);
+    }
+
+    /// Derivative of absolute value function.
+    inline double abs_derivative(double x)
+    {
+        return x > 0.0 ? 1.0 : -1.0;
+    }
+
+} // namespace Sparse
+} // namespace GridKit
+
+// Add all mathematical functions to the namespace std so that, 
+// for instance, std::sin(x) also works with objects of type Variable.
+namespace std
+{
+    
+#define IMPL_FUN_1(FUN,DER)                                            \
+    inline GridKit::Sparse::Variable FUN(const GridKit::Sparse::Variable& x)             \
+    {                                                                  \
+        double val = FUN(x());                                         \
+        double der = DER(x());                                         \
+        GridKit::Sparse::Variable res(x);       /* copy derivatives of x*/      \
+        res.setValue(val);          /* set function value f(x) */      \
+        res.scaleDependencies(der); /* compute derivatives of f(x) */  \
+        return res;                                                    \
+    }
+
+    IMPL_FUN_1(sin,   GridKit::Sparse::sin_derivative)
+    IMPL_FUN_1(cos,   GridKit::Sparse::cos_derivative)
+    IMPL_FUN_1(tan,   GridKit::Sparse::tan_derivative)
+    IMPL_FUN_1(asin,  GridKit::Sparse::asin_derivative)
+    IMPL_FUN_1(acos,  GridKit::Sparse::acos_derivative)
+    IMPL_FUN_1(atan,  GridKit::Sparse::atan_derivative)
+    IMPL_FUN_1(sinh,  GridKit::Sparse::sinh_derivative)
+    IMPL_FUN_1(cosh,  GridKit::Sparse::cosh_derivative)
+    IMPL_FUN_1(tanh,  GridKit::Sparse::tanh_derivative)
+    IMPL_FUN_1(exp,   GridKit::Sparse::exp_derivative)
+    IMPL_FUN_1(log,   GridKit::Sparse::log_derivative)
+    IMPL_FUN_1(log10, GridKit::Sparse::log10_derivative)
+    IMPL_FUN_1(sqrt,  GridKit::Sparse::sqrt_derivative)
+    IMPL_FUN_1(abs,   GridKit::Sparse::abs_derivative)
+    
+#undef IMPL_FUN_1
+
+} // namespace std
+
+
+#endif // SAD_VARIABLE_OPERATORS_HPP

--- a/src/LinearAlgebra/SparsityPattern/VariableOperators.hpp
+++ b/src/LinearAlgebra/SparsityPattern/VariableOperators.hpp
@@ -2,8 +2,7 @@
     \file VariableOperators.hpp
     
 */
-#ifndef SAD_VARIABLE_OPERATORS_HPP
-#define SAD_VARIABLE_OPERATORS_HPP
+#pragma once
 
 // Define derivatives of standard library mathematical functions here.
 // These definitions could be used to add smoothing in cases where 
@@ -361,5 +360,3 @@ namespace std
 
 } // namespace std
 
-
-#endif // SAD_VARIABLE_OPERATORS_HPP

--- a/src/LinearAlgebra/SparsityPattern/VariableOperators.hpp
+++ b/src/LinearAlgebra/SparsityPattern/VariableOperators.hpp
@@ -1,12 +1,9 @@
-/*!
+/**
     \file VariableOperators.hpp
     
 */
 #pragma once
 
-// Define derivatives of standard library mathematical functions here.
-// These definitions could be used to add smoothing in cases where 
-// derivatives are discontinuous.
 namespace GridKit
 {
 namespace Sparse
@@ -185,8 +182,8 @@ namespace Sparse
     // non-member operators
     //------------------------------------
     
-    /*
-        \brief Stream insertion operator for variables.
+    /**
+        @brief Stream insertion operator for variables.
     */
     std::ostream& operator<<(std::ostream& os, const Variable& v)
     {
@@ -194,8 +191,8 @@ namespace Sparse
         return os;
     }
     
-    /*
-        \brief Adds all dependencies of a variable, i.e. v << u means 
+    /**
+        @brief Adds all dependencies of a variable, i.e. v << u means 
         that v depends on u.
 
         \attention Use only if you know what you are doing!
@@ -206,8 +203,8 @@ namespace Sparse
         return u;
     }
     
-    /*
-        \brief Stream extraction operator for variables.
+    /**
+        @brief Stream extraction operator for variables.
     */
     std::istream& operator>>(std::istream& is, Variable& v)
     {

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -99,6 +99,7 @@ inline bool isEqual(PowerSystemData::GenCostData<RealT, IdxT> a,
                     PowerSystemData::GenCostData<RealT, IdxT> b,
                     RealT tol = tol_)
 {
+  (void) tol; // suppress warning
   int fail = 0;
   fail += a.kind != b.kind;
   fail += a.startup != b.startup;
@@ -232,7 +233,7 @@ inline bool isEqual(std::vector<T> a, std::vector<T> b, double tol = tol_)
 
   int fail = 0;
   for (std::size_t i = 0; i < a.size(); i++) {
-    if (!isEqual(a[i], b[i])) {
+    if (!isEqual(a[i], b[i], tol)) {
       fail++;
       errs() << "[isEqual<vector<T>>]: Got failure with i=" << i << ".\n";
     }

--- a/tests/UnitTests/CMakeLists.txt
+++ b/tests/UnitTests/CMakeLists.txt
@@ -1,2 +1,3 @@
 #
 add_subdirectory(PhasorDynamics)
+add_subdirectory(SparsityPattern)

--- a/tests/UnitTests/SparsityPattern/CMakeLists.txt
+++ b/tests/UnitTests/SparsityPattern/CMakeLists.txt
@@ -1,0 +1,14 @@
+# [[
+#  Author(s):
+#    - Slaven Peles <peless@ornl.gov>
+#]]
+
+
+add_executable(test_sparsity_pattern runSparsityPatternTests.cpp)
+target_link_libraries(test_sparsity_pattern GRIDKIT::phasor_dynamics_bus)
+                                
+
+add_test(NAME SparsityPatternTest COMMAND $<TARGET_FILE:test_sparsity_pattern>)
+
+install(TARGETS test_sparsity_pattern 
+        RUNTIME DESTINATION bin)

--- a/tests/UnitTests/SparsityPattern/SparsityPatternTests.hpp
+++ b/tests/UnitTests/SparsityPattern/SparsityPatternTests.hpp
@@ -56,7 +56,7 @@ namespace Testing
             // Check dependencies of f[1] (depends on x[0], x[1], x[2])
             {
                 const Sparse::Variable::DependencyMap& dependencies = 
-                    (f[1]).getDependencies();
+                    (f[2]).getDependencies();
             
                 success *= (dependencies.size() == 3);
                 success *= (dependencies.find(0) != dependencies.end());

--- a/tests/UnitTests/SparsityPattern/SparsityPatternTests.hpp
+++ b/tests/UnitTests/SparsityPattern/SparsityPatternTests.hpp
@@ -53,7 +53,7 @@ namespace Testing
                 success *= (dependencies.find(2) == dependencies.end());    
             }
             
-            // Check dependencies of f[1] (depends on x[0], x[1], x[2])
+            // Check dependencies of f[2] (depends on x[0], x[1], x[2])
             {
                 const Sparse::Variable::DependencyMap& dependencies = 
                     (f[2]).getDependencies();
@@ -73,11 +73,11 @@ namespace Testing
                                   const std::vector<T>& x,
                                   const std::vector<T>& p)
             {
-                const T y = x[0]*x[1];
+                const T u = x[0]*x[1];
                 
                 f[0] = p[0]*(x[1] - x[0]);        // sigma*(y - x)
                 f[1] = x[0]*(p[1] - x[2]) - x[1]; // x*(rho - z) - y
-                f[2] = y - p[2]*x[2];             // x*y - beta*z
+                f[2] = u - p[2]*x[2];             // x*y - beta*z
             }
         
 

--- a/tests/UnitTests/SparsityPattern/SparsityPatternTests.hpp
+++ b/tests/UnitTests/SparsityPattern/SparsityPatternTests.hpp
@@ -1,0 +1,87 @@
+#include <iostream>
+#include <iomanip>
+
+#include <LinearAlgebra/SparsityPattern/Variable.hpp>
+#include <Utilities/Testing.hpp>
+#include <Utilities/TestHelpers.hpp>
+
+
+namespace GridKit
+{
+namespace Testing
+{
+    template<class ScalarT, typename IdxT>
+    class SparsityPatternTests
+    {
+    public:
+        SparsityPatternTests() = default;
+        ~SparsityPatternTests() = default;
+
+        /// Constructor, allocation, and initialization checks
+        TestOutcome variable()
+        {
+            TestStatus success = true;
+
+            const size_t n = 3;
+            std::vector<Sparse::Variable> x(n), p(n), f(n);
+            
+            // decide x, y, and z are variables
+            for (size_t i = 0; i < n; ++i)
+                x[i].setVariableNumber(i);
+            
+            // ...and sigma, rho, and beta are constant parameters
+            for (size_t i = 0; i < n; ++i)
+                p[i].setFixed(true);
+        
+            // initialize independent variables
+            x[0]() = 8.0; x[1]() = 20.0; x[2]() = 2.0/3.0;
+        
+            // set constant parameter values
+            p[0] = 10.0; p[1] = 8.0/3.0; p[2] = 28.0;
+            
+            // The residualFunction computes f
+            residualFunction(f, x, p);
+
+            // Check dependenices of f[0] (depends on x[0] and x[1])
+            {
+                const Sparse::Variable::DependencyMap& dependencies = 
+                    (f[0]).getDependencies();
+            
+                success *= (dependencies.size() == 2);
+                success *= (dependencies.find(0) != dependencies.end());
+                success *= (dependencies.find(1) != dependencies.end());
+                success *= (dependencies.find(2) == dependencies.end());    
+            }
+            
+            // Check dependencies of f[1] (depends on x[0], x[1], x[2])
+            {
+                const Sparse::Variable::DependencyMap& dependencies = 
+                    (f[1]).getDependencies();
+            
+                success *= (dependencies.size() == 3);
+                success *= (dependencies.find(0) != dependencies.end());
+                success *= (dependencies.find(1) != dependencies.end());
+                success *= (dependencies.find(2) != dependencies.end());    
+            }
+            
+            return success.report(__func__);
+        }
+
+        private:
+            template <typename T>
+            void residualFunction(std::vector<T>& f,
+                                  const std::vector<T>& x,
+                                  const std::vector<T>& p)
+            {
+                const T y = x[0]*x[1];
+                
+                f[0] = p[0]*(x[1] - x[0]);        // sigma*(y - x)
+                f[1] = x[0]*(p[1] - x[2]) - x[1]; // x*(rho - z) - y
+                f[2] = y - p[2]*x[2];             // x*y - beta*z
+            }
+        
+
+    };
+
+} // namespace Testing
+} // namespace GridKit

--- a/tests/UnitTests/SparsityPattern/runSparsityPatternTests.cpp
+++ b/tests/UnitTests/SparsityPattern/runSparsityPatternTests.cpp
@@ -1,0 +1,14 @@
+#include "SparsityPatternTests.hpp"
+
+int main()
+{
+    using namespace GridKit;
+    using namespace GridKit::Testing;
+
+    GridKit::Testing::TestingResults result; 
+    GridKit::Testing::SparsityPatternTests<double, size_t> test;
+
+    result += test.variable();
+
+    return result.summary();
+}


### PR DESCRIPTION
Add a definition for a variable type that tracks its dependencies. This dependency tracking is helpful when computing e.g. Jacobian sparsity pattern. 

For example, consider function template
```c++
            template <typename T>
            void residualFunction(std::vector<T>& f,
                                  const std::vector<T>& x,
                                  const std::vector<T>& p)
            {
                const T y = x[0]*x[1];
                
                f[0] = 10.0*(x[1] - x[0]); 
                f[1] = x[0]*(8.0/3.0 - x[2]) - x[1];
                f[2] = y - 28.0*x[2];
            }
```
Substituting template parameter `GridKit::Sparse::Variable<double>` would produce a function that computes vector `f` such that each element of `f` contains numerical value and the list of elements of `x` that are used to compute that value. For example, with values of `x` set as
```c++
  x[0]() = 8.0; x[1]() = 20.0; x[2]() = 2.0/3.0;
```
`f[0]` would contain double floating point value `120.0` and indices `0` and `1`. See [here](https://global-sci.com/article/83218/sparse-automatic-differentiation-for-complex-networks-of-differential-algebraic-equations-using-abstract-elementary-algebra) for more details.

This PR only provides dependency tracking data type and a simple unit test.

CC @sklus