### PR TITLE
v0.23.1 Spack buildcache.

### DIFF
--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -149,7 +149,7 @@ jobs:
         run: ls -ltrh $(pwd)/*/*/
 
       - name: Concretize
-        run: spack -d -e . concretize
+        run: spack -e . concretize
 
       - name: Install dependencies
         run: spack -e . install --no-check-signature --only dependencies

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -7,7 +7,7 @@ env:
   # Our repo name contains upper case characters, so we can't use ${{ github.repository }}
   IMAGE_NAME: gridkit
   USERNAME: gridkit-bot
-  BASE_VERSION: ubuntu-24.04-fortran-v0.2.2
+  BASE_VERSION: ubuntu-24.04-fortran-v0.2.8
 
 # Until we remove the need to clone submodules to build, this should on be in PRs
 on: [pull_request]
@@ -125,7 +125,7 @@ jobs:
                 padded_length: 128
             mirrors:
               local-buildcache: oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-              spack: https://binaries.spack.io/develop
+              spack: https://binaries.spack.io/v0.23.1
             packages:
               llvm:
                 externals:
@@ -149,7 +149,7 @@ jobs:
         run: ls -ltrh $(pwd)/*/*/
 
       - name: Concretize
-        run: spack -e . concretize
+        run: spack -d -e . concretize
 
       - name: Install dependencies
         run: spack -e . install --no-check-signature --only dependencies


### PR DESCRIPTION
Set CI to use the v0.23.1 Spack buildcache as a workaround for breaking changes in develop (and upcoming v1.0.0 release.). 

Created issue #77 to look for a more permanent solution. 