### PR TITLE
Verify Branch and Load Jacobians computed with Sparse::Variable

### DIFF
--- a/src/LinearAlgebra/SparsityPattern/Variable.hpp
+++ b/src/LinearAlgebra/SparsityPattern/Variable.hpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <ScalarTraits.hpp>
 
 namespace GridKit
 {
@@ -324,6 +325,19 @@ namespace GridKit
     inline std::istream& operator>>(std::istream& is, Variable& v);
 
   } // namespace Sparse
+} // namespace GridKit
+
+namespace GridKit
+{
+  template <>
+  class ScalarTraits<Sparse::Variable>
+  {
+  public:
+    typedef double real_type;
+    typedef double norm_type;
+    typedef double scalar_type;
+  };
+
 } // namespace GridKit
 
 #include "VariableImplementation.hpp"

--- a/src/LinearAlgebra/SparsityPattern/Variable.hpp
+++ b/src/LinearAlgebra/SparsityPattern/Variable.hpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <string>
 #include <vector>
+
 #include <ScalarTraits.hpp>
 
 namespace GridKit

--- a/src/Model/PhasorDynamics/Branch/Branch.cpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.cpp
@@ -221,6 +221,8 @@ namespace GridKit
     // Available template instantiations
     template class Branch<double, long int>;
     template class Branch<double, size_t>;
+    template class Branch<Sparse::Variable, long int>;
+    template class Branch<Sparse::Variable, size_t>;
 
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/Bus.cpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.cpp
@@ -215,6 +215,8 @@ namespace GridKit
     // Available template instantiations
     template class Bus<double, long int>;
     template class Bus<double, size_t>;
+    template class Bus<Sparse::Variable, long int>;
+    template class Bus<Sparse::Variable, size_t>;
 
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/BusInfinite.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusInfinite.cpp
@@ -195,6 +195,7 @@ namespace GridKit
     // Available template instantiations
     template class BusInfinite<double, long int>;
     template class BusInfinite<double, size_t>;
+    template class BusInfinite<Sparse::Variable, size_t>;
 
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/BusInfinite.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusInfinite.cpp
@@ -195,6 +195,7 @@ namespace GridKit
     // Available template instantiations
     template class BusInfinite<double, long int>;
     template class BusInfinite<double, size_t>;
+    template class BusInfinite<Sparse::Variable, long int>;
     template class BusInfinite<Sparse::Variable, size_t>;
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/BusBase.hpp
+++ b/src/Model/PhasorDynamics/BusBase.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include <Model/Evaluator.hpp>
+#include <LinearAlgebra/SparsityPattern/Variable.hpp>
 
 namespace GridKit
 {

--- a/src/Model/PhasorDynamics/BusBase.hpp
+++ b/src/Model/PhasorDynamics/BusBase.hpp
@@ -2,8 +2,8 @@
 
 #include <vector>
 
-#include <Model/Evaluator.hpp>
 #include <LinearAlgebra/SparsityPattern/Variable.hpp>
+#include <Model/Evaluator.hpp>
 
 namespace GridKit
 {

--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include <LinearAlgebra/SparsityPattern/Variable.hpp>
 #include <Model/Evaluator.hpp>
 
 namespace GridKit

--- a/src/Model/PhasorDynamics/Load/Load.cpp
+++ b/src/Model/PhasorDynamics/Load/Load.cpp
@@ -173,6 +173,8 @@ namespace GridKit
     // Available template instantiations
     template class Load<double, long int>;
     template class Load<double, size_t>;
+    template class Load<Sparse::Variable, long int>;
+    template class Load<Sparse::Variable, size_t>;
 
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -232,7 +232,6 @@ namespace GridKit
       for (const auto& pair_a : a)
       {
         auto it = b.find(pair_a.first);
-        std::cout << pair_a.second << ", " << it->second << std::endl;
         fail += !isEqual(pair_a.second, it->second);
       }
 

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -243,7 +243,7 @@ namespace GridKit
       for (const auto& pair_a : a)
       {
         auto it  = b.find(pair_a.first);
-        fail    += !isEqual(pair_a.second, it->second);
+        fail    += !isEqual(pair_a.second, it->second, tol);
       }
 
       return fail == 0;

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -228,7 +228,7 @@ namespace GridKit
      *
      * @param[in] std::map<IdxT, RealT> - first map
      * @param[in] std::map<IdxT, RealT> - second map
-     * @param[in] RealT - tolerance 
+     * @param[in] RealT - tolerance
      * @return bool - true if the maps are equal; false otherwise
      */
     template <typename IdxT = size_t, typename RealT = double>

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -223,7 +223,7 @@ namespace GridKit
     template <typename IdxT = size_t, typename RealT = double>
     inline bool isEqual(std::map<IdxT, RealT> a,
                         std::map<IdxT, RealT> b,
-                        const RealT tol = std::numeric_limits<RealT>::epsilon())
+                        const RealT           tol = std::numeric_limits<RealT>::epsilon())
     {
       int fail = 0;
 
@@ -231,8 +231,8 @@ namespace GridKit
 
       for (const auto& pair_a : a)
       {
-        auto it = b.find(pair_a.first);
-        fail += !isEqual(pair_a.second, it->second);
+        auto it  = b.find(pair_a.first);
+        fail    += !isEqual(pair_a.second, it->second);
       }
 
       return fail == 0;

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -249,13 +249,22 @@ namespace GridKit
       for (const auto& pair_a : a)
       {
         auto it = b.find(pair_a.first);
-        if (!isEqual(pair_a.second, it->second, tol))
+        if (it != b.end())
+        {
+          if (!isEqual(pair_a.second, it->second, tol))
+          {
+            fail++;
+            errs() << "Mismatching map values! "
+                   << "a.first = " << pair_a.first << ", "
+                   << "a.second = " << pair_a.second << ", and "
+                   << "b.second = " << it->second << "\n";
+          }
+        }
+        else
         {
           fail++;
-          errs() << "Mismatching map values! "
-                 << "a.first = " << pair_a.first << ", "
-                 << "a.second = " << pair_a.second << ", and "
-                 << "b.second = " << it->second << "\n";
+          errs() << "Entry not found in the second container! "
+                 << "a.first = " << pair_a.first << "\n";
         }
       }
 

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -10,6 +10,8 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <map>
+#include <vector>
 
 #include <PowerSystemData.hpp>
 

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -226,9 +226,9 @@ namespace GridKit
      * @tparam IdxT
      * @tparam RealT
      *
-     * @param[in] std::map<IdxT, RealT> - first map
-     * @param[in] std::map<IdxT, RealT> - second map
-     * @param[in] RealT - tolerance
+     * @param[in] a - first map to compare
+     * @param[in] b - second map to compare
+     * @param[in] tol - tolerance
      * @return bool - true if the maps are equal; false otherwise
      */
     template <typename IdxT = size_t, typename RealT = double>

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -238,12 +238,25 @@ namespace GridKit
     {
       int fail = 0;
 
-      fail += a.size() != b.size();
+      if (a.size() != b.size())
+      {
+        fail++;
+        errs() << "Containers do not have the same size! "
+               << "a.size() = " << a.size() << ", and "
+               << "b.size() = " << b.size() << "\n";
+      }
 
       for (const auto& pair_a : a)
       {
-        auto it  = b.find(pair_a.first);
-        fail    += !isEqual(pair_a.second, it->second, tol);
+        auto it = b.find(pair_a.first);
+        if (!isEqual(pair_a.second, it->second, tol))
+        {
+          fail++;
+          errs() << "Mismatching map values! "
+                 << "a.first = " << pair_a.first << ", "
+                 << "a.second = " << pair_a.second << ", and "
+                 << "b.second = " << it->second << "\n";
+        }
       }
 
       return fail == 0;

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -220,6 +220,17 @@ namespace GridKit
       return fail == 0;
     }
 
+    /**
+     * @brief Equatlity comparison between maps with a tolerance for the scalar value
+     *
+     * @tparam IdxT
+     * @tparam RealT
+     *
+     * @param[in] std::map<IdxT, RealT> - first map
+     * @param[in] std::map<IdxT, RealT> - second map
+     * @param[in] RealT - tolerance 
+     * @return bool - true if the maps are equal; false otherwise
+     */
     template <typename IdxT = size_t, typename RealT = double>
     inline bool isEqual(std::map<IdxT, RealT> a,
                         std::map<IdxT, RealT> b,

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -220,6 +220,25 @@ namespace GridKit
       return fail == 0;
     }
 
+    template <typename IdxT = size_t, typename RealT = double>
+    inline bool isEqual(std::map<IdxT, RealT> a,
+                        std::map<IdxT, RealT> b,
+                        const RealT tol = std::numeric_limits<RealT>::epsilon())
+    {
+      int fail = 0;
+
+      fail += a.size() != b.size();
+
+      for (const auto& pair_a : a)
+      {
+        auto it = b.find(pair_a.first);
+        std::cout << pair_a.second << ", " << it->second << std::endl;
+        fail += !isEqual(pair_a.second, it->second);
+      }
+
+      return fail == 0;
+    }
+
   } // namespace Testing
 
 } // namespace GridKit

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -1,6 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
+#include <LinearAlgebra/SparsityPattern/Variable.hpp>
 #include <Model/PhasorDynamics/Branch/Branch.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
@@ -73,6 +74,42 @@ namespace GridKit
         success *= isEqual(bus1.Ii(), Ii1);
         success *= isEqual(bus2.Ir(), Ir2);
         success *= isEqual(bus2.Ii(), Ii2);
+
+        return success.report(__func__);
+      }
+
+      TestOutcome jacobian()
+      {
+        TestStatus success = true;
+
+        real_type R{2.0}; ///< Branch series resistance
+        real_type X{4.0}; ///< Branch series reactance
+        real_type G{0.2}; ///< Branch shunt conductance
+        real_type B{1.2}; ///< Branch shunt charging
+
+        Sparse::Variable Vr1{10.0}; ///< Bus-1 real voltage
+        Sparse::Variable Vi1{20.0}; ///< Bus-1 imaginary voltage
+        Sparse::Variable Vr2{30.0}; ///< Bus-2 real voltage
+        Sparse::Variable Vi2{40.0}; ///< Bus-2 imaginary voltage
+
+        const Sparse::Variable Ir1{17.0};  ///< Solution: real current entering bus-1
+        const Sparse::Variable Ii1{-10.0}; ///< Solution: imaginary current entering bus-1
+        const Sparse::Variable Ir2{15.0};  ///< Solution: real current entering bus-2
+        const Sparse::Variable Ii2{-20.0}; ///< Solution: imaginary current entering bus-2
+
+        PhasorDynamics::BusInfinite<Sparse::Variable, IdxT> bus1(Vr1, Vi1);
+        PhasorDynamics::BusInfinite<Sparse::Variable, IdxT> bus2(Vr2, Vi2);
+
+        PhasorDynamics::Branch<Sparse::Variable, IdxT> branch(&bus1, &bus2, R, X, G, B);
+        branch.evaluateResidual();
+
+        {
+          Sparse::Variable res = bus1.Ir();
+          const Sparse::Variable::DependencyMap& dependencies =
+              res.getDependencies();
+
+          std::cout << "Dependency size: " << dependencies.size() << "\n";
+        }
 
         return success.report(__func__);
       }

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -106,12 +106,13 @@ namespace GridKit
 
         std::vector<Sparse::Variable> residuals{bus1.Ir(), bus1.Ii(), bus2.Ir(), bus2.Ii()};
         std::vector<Sparse::Variable::DependencyMap> ref = analyticalJacobian(R, X, G, B);
+        
+        /// Compare dependencies computed automatically to the ones computed analytically
         for (size_t i = 0; i < residuals.size(); ++i)
         {
           Sparse::Variable res = residuals[i];
           const Sparse::Variable::DependencyMap& dependencies = res.getDependencies();
-          success *= (dependencies == ref[i]); ///< Compare dependencies computed automatically
-                                               ///< to the ones computed analytically
+          success *= (GridKit::Testing::isEqual(dependencies, ref[i])); 
         }
 
         return success.report(__func__);

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -81,7 +81,7 @@ namespace GridKit
       TestOutcome jacobian()
       {
         TestStatus success = true;
-
+        
         real_type R{2.0}; ///< Branch series resistance
         real_type X{4.0}; ///< Branch series reactance
         real_type G{0.2}; ///< Branch shunt conductance
@@ -95,12 +95,7 @@ namespace GridKit
         Vr1.setVariableNumber(0);
         Vi1.setVariableNumber(1);
         Vr2.setVariableNumber(2);
-        Vi1.setVariableNumber(3);
-
-        const Sparse::Variable Ir1{17.0};  ///< Solution: real current entering bus-1
-        const Sparse::Variable Ii1{-10.0}; ///< Solution: imaginary current entering bus-1
-        const Sparse::Variable Ir2{15.0};  ///< Solution: real current entering bus-2
-        const Sparse::Variable Ii2{-20.0}; ///< Solution: imaginary current entering bus-2
+        Vi2.setVariableNumber(3);
 
         PhasorDynamics::BusInfinite<Sparse::Variable, IdxT> bus1(Vr1, Vi1);
         PhasorDynamics::BusInfinite<Sparse::Variable, IdxT> bus2(Vr2, Vi2);
@@ -114,6 +109,51 @@ namespace GridKit
               res.getDependencies();
 
           std::cout << "Dependency size: " << dependencies.size() << "\n";
+          success *= (dependencies.size() == 4);
+          for (const auto& [key, value] : dependencies)
+          {
+            std::cout << '[' << key << "] = " << value << "; ";
+          }
+          std::cout << std::endl;
+        }
+        {
+          Sparse::Variable res = bus1.Ii();
+          const Sparse::Variable::DependencyMap& dependencies =
+              res.getDependencies();
+
+          std::cout << "Dependency size: " << dependencies.size() << "\n";
+          success *= (dependencies.size() == 4);
+          for (const auto& [key, value] : dependencies)
+          {
+            std::cout << '[' << key << "] = " << value << "; ";
+          }
+          std::cout << std::endl;
+        }
+        {
+          Sparse::Variable res = bus2.Ir();
+          const Sparse::Variable::DependencyMap& dependencies =
+              res.getDependencies();
+
+          std::cout << "Dependency size: " << dependencies.size() << "\n";
+          success *= (dependencies.size() == 4);
+          for (const auto& [key, value] : dependencies)
+          {
+            std::cout << '[' << key << "] = " << value << "; ";
+          }
+          std::cout << std::endl;
+        }
+        {
+          Sparse::Variable res = bus2.Ii();
+          const Sparse::Variable::DependencyMap& dependencies =
+              res.getDependencies();
+
+          std::cout << "Dependency size: " << dependencies.size() << "\n";
+          success *= (dependencies.size() == 4);
+          for (const auto& [key, value] : dependencies)
+          {
+            std::cout << '[' << key << "] = " << value << "; ";
+          }
+          std::cout << std::endl;
         }
 
         return success.report(__func__);

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -81,7 +81,7 @@ namespace GridKit
       TestOutcome jacobian()
       {
         TestStatus success = true;
-        
+
         real_type R{2.0}; ///< Branch series resistance
         real_type X{4.0}; ///< Branch series reactance
         real_type G{0.2}; ///< Branch shunt conductance
@@ -91,7 +91,7 @@ namespace GridKit
         Sparse::Variable Vi1{20.0}; ///< Bus-1 imaginary voltage
         Sparse::Variable Vr2{30.0}; ///< Bus-2 real voltage
         Sparse::Variable Vi2{40.0}; ///< Bus-2 imaginary voltage
-          
+
         Vr1.setVariableNumber(0); ///< Independent variables: first
         Vi1.setVariableNumber(1); ///< Independent variables: second
         Vr2.setVariableNumber(2); ///< Independent variables: third
@@ -101,18 +101,18 @@ namespace GridKit
         PhasorDynamics::BusInfinite<Sparse::Variable, IdxT> bus2(Vr2, Vi2);
 
         PhasorDynamics::Branch<Sparse::Variable, IdxT> branch(&bus1, &bus2, R, X, G, B);
-        branch.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking 
+        branch.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
                                    ///< the dependencies
 
-        std::vector<Sparse::Variable> residuals{bus1.Ir(), bus1.Ii(), bus2.Ir(), bus2.Ii()};
+        std::vector<Sparse::Variable>                residuals{bus1.Ir(), bus1.Ii(), bus2.Ir(), bus2.Ii()};
         std::vector<Sparse::Variable::DependencyMap> ref = analyticalJacobian(R, X, G, B);
-        
+
         /// Compare dependencies computed automatically to the ones computed analytically
         for (size_t i = 0; i < residuals.size(); ++i)
         {
-          Sparse::Variable res = residuals[i];
-          const Sparse::Variable::DependencyMap& dependencies = res.getDependencies();
-          success *= (GridKit::Testing::isEqual(dependencies, ref[i])); 
+          Sparse::Variable                       res           = residuals[i];
+          const Sparse::Variable::DependencyMap& dependencies  = res.getDependencies();
+          success                                             *= (GridKit::Testing::isEqual(dependencies, ref[i]));
         }
 
         return success.report(__func__);
@@ -180,6 +180,7 @@ namespace GridKit
 
         return success.report(__func__);
       }
+
     private:
       std::vector<Sparse::Variable::DependencyMap> analyticalJacobian(const real_type R,
                                                                       const real_type X,
@@ -188,23 +189,23 @@ namespace GridKit
       {
         const real_type b = -X / (R * R + X * X);
         const real_type g = R / (R * R + X * X);
-        
+
         real_type dIr1_dVr1 = -(g + 0.5 * G);
         real_type dIr1_dVi1 = (b + 0.5 * B);
         real_type dIr1_dVr2 = g;
         real_type dIr1_dVi2 = -b;
 
-        real_type dIi1_dVr1 = -(b + 0.5 * B); 
+        real_type dIi1_dVr1 = -(b + 0.5 * B);
         real_type dIi1_dVi1 = -(g + 0.5 * G);
         real_type dIi1_dVr2 = b;
         real_type dIi1_dVi2 = g;
-                              
-        real_type dIr2_dVr1 = g; 
+
+        real_type dIr2_dVr1 = g;
         real_type dIr2_dVi1 = -b;
         real_type dIr2_dVr2 = -(g + 0.5 * G);
         real_type dIr2_dVi2 = (b + 0.5 * B);
-                              
-        real_type dIi2_dVr1 = b; 
+
+        real_type dIi2_dVr1 = b;
         real_type dIi2_dVi1 = g;
         real_type dIi2_dVr2 = -(b + 0.5 * B);
         real_type dIi2_dVi2 = -(g + 0.5 * G);

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -91,6 +91,11 @@ namespace GridKit
         Sparse::Variable Vi1{20.0}; ///< Bus-1 imaginary voltage
         Sparse::Variable Vr2{30.0}; ///< Bus-2 real voltage
         Sparse::Variable Vi2{40.0}; ///< Bus-2 imaginary voltage
+          
+        Vr1.setVariableNumber(0);
+        Vi1.setVariableNumber(1);
+        Vr2.setVariableNumber(2);
+        Vi1.setVariableNumber(3);
 
         const Sparse::Variable Ir1{17.0};  ///< Solution: real current entering bus-1
         const Sparse::Variable Ii1{-10.0}; ///< Solution: imaginary current entering bus-1

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -92,68 +92,26 @@ namespace GridKit
         Sparse::Variable Vr2{30.0}; ///< Bus-2 real voltage
         Sparse::Variable Vi2{40.0}; ///< Bus-2 imaginary voltage
           
-        Vr1.setVariableNumber(0);
-        Vi1.setVariableNumber(1);
-        Vr2.setVariableNumber(2);
-        Vi2.setVariableNumber(3);
+        Vr1.setVariableNumber(0); ///< Independent variables: first
+        Vi1.setVariableNumber(1); ///< Independent variables: second
+        Vr2.setVariableNumber(2); ///< Independent variables: third
+        Vi2.setVariableNumber(3); ///< Independent variables: fourth
 
         PhasorDynamics::BusInfinite<Sparse::Variable, IdxT> bus1(Vr1, Vi1);
         PhasorDynamics::BusInfinite<Sparse::Variable, IdxT> bus2(Vr2, Vi2);
 
         PhasorDynamics::Branch<Sparse::Variable, IdxT> branch(&bus1, &bus2, R, X, G, B);
-        branch.evaluateResidual();
+        branch.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking 
+                                   ///< the dependencies
 
+        std::vector<Sparse::Variable> residuals{bus1.Ir(), bus1.Ii(), bus2.Ir(), bus2.Ii()};
+        std::vector<Sparse::Variable::DependencyMap> ref = analyticalJacobian(R, X, G, B);
+        for (size_t i = 0; i < residuals.size(); ++i)
         {
-          Sparse::Variable res = bus1.Ir();
-          const Sparse::Variable::DependencyMap& dependencies =
-              res.getDependencies();
-
-          std::cout << "Dependency size: " << dependencies.size() << "\n";
-          success *= (dependencies.size() == 4);
-          for (const auto& [key, value] : dependencies)
-          {
-            std::cout << '[' << key << "] = " << value << "; ";
-          }
-          std::cout << std::endl;
-        }
-        {
-          Sparse::Variable res = bus1.Ii();
-          const Sparse::Variable::DependencyMap& dependencies =
-              res.getDependencies();
-
-          std::cout << "Dependency size: " << dependencies.size() << "\n";
-          success *= (dependencies.size() == 4);
-          for (const auto& [key, value] : dependencies)
-          {
-            std::cout << '[' << key << "] = " << value << "; ";
-          }
-          std::cout << std::endl;
-        }
-        {
-          Sparse::Variable res = bus2.Ir();
-          const Sparse::Variable::DependencyMap& dependencies =
-              res.getDependencies();
-
-          std::cout << "Dependency size: " << dependencies.size() << "\n";
-          success *= (dependencies.size() == 4);
-          for (const auto& [key, value] : dependencies)
-          {
-            std::cout << '[' << key << "] = " << value << "; ";
-          }
-          std::cout << std::endl;
-        }
-        {
-          Sparse::Variable res = bus2.Ii();
-          const Sparse::Variable::DependencyMap& dependencies =
-              res.getDependencies();
-
-          std::cout << "Dependency size: " << dependencies.size() << "\n";
-          success *= (dependencies.size() == 4);
-          for (const auto& [key, value] : dependencies)
-          {
-            std::cout << '[' << key << "] = " << value << "; ";
-          }
-          std::cout << std::endl;
+          Sparse::Variable res = residuals[i];
+          const Sparse::Variable::DependencyMap& dependencies = res.getDependencies();
+          success *= (dependencies == ref[i]); ///< Compare dependencies computed automatically
+                                               ///< to the ones computed analytically
         }
 
         return success.report(__func__);
@@ -220,6 +178,43 @@ namespace GridKit
         branch.setB(zero);
 
         return success.report(__func__);
+      }
+    private:
+      std::vector<Sparse::Variable::DependencyMap> analyticalJacobian(const real_type R,
+                                                                      const real_type X,
+                                                                      const real_type G,
+                                                                      const real_type B)
+      {
+        const real_type b = -X / (R * R + X * X);
+        const real_type g = R / (R * R + X * X);
+        
+        real_type dIr1_dVr1 = -(g + 0.5 * G);
+        real_type dIr1_dVi1 = (b + 0.5 * B);
+        real_type dIr1_dVr2 = g;
+        real_type dIr1_dVi2 = -b;
+
+        real_type dIi1_dVr1 = -(b + 0.5 * B); 
+        real_type dIi1_dVi1 = -(g + 0.5 * G);
+        real_type dIi1_dVr2 = b;
+        real_type dIi1_dVi2 = g;
+                              
+        real_type dIr2_dVr1 = g; 
+        real_type dIr2_dVi1 = -b;
+        real_type dIr2_dVr2 = -(g + 0.5 * G);
+        real_type dIr2_dVi2 = (b + 0.5 * B);
+                              
+        real_type dIi2_dVr1 = b; 
+        real_type dIi2_dVi1 = g;
+        real_type dIi2_dVr2 = -(b + 0.5 * B);
+        real_type dIi2_dVi2 = -(g + 0.5 * G);
+
+        std::vector<Sparse::Variable::DependencyMap> dependencies(4);
+        dependencies[0] = {{0, dIr1_dVr1}, {1, dIr1_dVi1}, {2, dIr1_dVr2}, {3, dIr1_dVi2}};
+        dependencies[1] = {{0, dIi1_dVr1}, {1, dIi1_dVi1}, {2, dIi1_dVr2}, {3, dIi1_dVi2}};
+        dependencies[2] = {{0, dIr2_dVr1}, {1, dIr2_dVi1}, {2, dIr2_dVr2}, {3, dIr2_dVi2}};
+        dependencies[3] = {{0, dIi2_dVr1}, {1, dIi2_dVi1}, {2, dIi2_dVr2}, {3, dIi2_dVi2}};
+
+        return dependencies;
       }
     }; // class BranchTest
 

--- a/tests/UnitTests/PhasorDynamics/LoadTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/LoadTests.hpp
@@ -76,29 +76,30 @@ namespace GridKit
 
         Sparse::Variable Vr{10.0}; ///< Bus real voltage
         Sparse::Variable Vi{20.0}; ///< Bus imaginary voltage
-                                   
+
         Vr.setVariableNumber(0); ///< Independent variables: first
         Vi.setVariableNumber(1); ///< Independent variables: second
 
         PhasorDynamics::BusInfinite<Sparse::Variable, IdxT> bus(Vr, Vi);
 
         PhasorDynamics::Load<Sparse::Variable, IdxT> load(&bus, R, X);
-        load.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking 
+        load.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
                                  ///< the dependencies
 
-        std::vector<Sparse::Variable> residuals{bus.Ir(), bus.Ii()};
+        std::vector<Sparse::Variable>                residuals{bus.Ir(), bus.Ii()};
         std::vector<Sparse::Variable::DependencyMap> ref = analyticalJacobian(R, X);
-        
+
         /// Compare dependencies computed automatically to the ones computed analytically
         for (size_t i = 0; i < residuals.size(); ++i)
         {
-          Sparse::Variable res = residuals[i];
-          const Sparse::Variable::DependencyMap& dependencies = res.getDependencies();
-          success *= (GridKit::Testing::isEqual(dependencies, ref[i])); 
+          Sparse::Variable                       res           = residuals[i];
+          const Sparse::Variable::DependencyMap& dependencies  = res.getDependencies();
+          success                                             *= (GridKit::Testing::isEqual(dependencies, ref[i]));
         }
 
         return success.report(__func__);
       }
+
     private:
       std::vector<Sparse::Variable::DependencyMap> analyticalJacobian(const real_type R,
                                                                       const real_type X)
@@ -109,9 +110,9 @@ namespace GridKit
         real_type dIr_dVr = -g;
         real_type dIr_dVi = -b;
 
-        real_type dIi_dVr = b; 
+        real_type dIi_dVr = b;
         real_type dIi_dVi = -g;
-                              
+
         std::vector<Sparse::Variable::DependencyMap> dependencies(2);
         dependencies[0] = {{0, dIr_dVr}, {1, dIr_dVi}};
         dependencies[1] = {{0, dIi_dVr}, {1, dIi_dVi}};

--- a/tests/UnitTests/PhasorDynamics/LoadTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/LoadTests.hpp
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <iostream>
 
+#include <LinearAlgebra/SparsityPattern/Variable.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <Model/PhasorDynamics/Load/Load.hpp>
@@ -64,6 +65,58 @@ namespace GridKit
         success *= isEqual(bus.Ii(), Ii);
 
         return success.report(__func__);
+      }
+
+      TestOutcome jacobian()
+      {
+        TestStatus success = true;
+
+        real_type R{2.0}; ///< Load resistance
+        real_type X{4.0}; ///< Load reactance
+
+        Sparse::Variable Vr{10.0}; ///< Bus real voltage
+        Sparse::Variable Vi{20.0}; ///< Bus imaginary voltage
+                                   
+        Vr.setVariableNumber(0); ///< Independent variables: first
+        Vi.setVariableNumber(1); ///< Independent variables: second
+
+        PhasorDynamics::BusInfinite<Sparse::Variable, IdxT> bus(Vr, Vi);
+
+        PhasorDynamics::Load<Sparse::Variable, IdxT> load(&bus, R, X);
+        load.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking 
+                                 ///< the dependencies
+
+        std::vector<Sparse::Variable> residuals{bus.Ir(), bus.Ii()};
+        std::vector<Sparse::Variable::DependencyMap> ref = analyticalJacobian(R, X);
+        
+        /// Compare dependencies computed automatically to the ones computed analytically
+        for (size_t i = 0; i < residuals.size(); ++i)
+        {
+          Sparse::Variable res = residuals[i];
+          const Sparse::Variable::DependencyMap& dependencies = res.getDependencies();
+          success *= (GridKit::Testing::isEqual(dependencies, ref[i])); 
+        }
+
+        return success.report(__func__);
+      }
+    private:
+      std::vector<Sparse::Variable::DependencyMap> analyticalJacobian(const real_type R,
+                                                                      const real_type X)
+      {
+        const real_type b = -X / (R * R + X * X);
+        const real_type g = R / (R * R + X * X);
+
+        real_type dIr_dVr = -g;
+        real_type dIr_dVi = -b;
+
+        real_type dIi_dVr = b; 
+        real_type dIi_dVi = -g;
+                              
+        std::vector<Sparse::Variable::DependencyMap> dependencies(2);
+        dependencies[0] = {{0, dIr_dVr}, {1, dIr_dVi}};
+        dependencies[1] = {{0, dIi_dVr}, {1, dIi_dVi}};
+
+        return dependencies;
       }
     };
 

--- a/tests/UnitTests/PhasorDynamics/runBranchTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runBranchTests.cpp
@@ -11,6 +11,7 @@ int main()
   result += test.constructor();
   result += test.accessors();
   result += test.residual();
+  result += test.jacobian();
 
   return result.summary();
 }

--- a/tests/UnitTests/PhasorDynamics/runLoadTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runLoadTests.cpp
@@ -10,6 +10,7 @@ int main()
 
   result += test.constructor();
   result += test.residual();
+  result += test.jacobian();
 
   return result.summary();
 }


### PR DESCRIPTION
## Description
 
This adds tests for Branch and Load Jacobians.
 
 ## Proposed changes

Added a Jacobian test for BranchTest and LoadTest. Using Gridkit::Sparse::Variable, we track model residual dependencies and compute the values of the Jacobian. The result is compared to the analytical Jacobian in std::map format. The Jacobians are constant matrices in these cases. 
 
 ## Checklist
 
- [x] All tests pass.
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
