### PR TITLE
Added functions to print jacobian matrix in COO to matrix market

### DIFF
--- a/examples/PowerElectronics/ScaleMicrogrid/CMakeLists.txt
+++ b/examples/PowerElectronics/ScaleMicrogrid/CMakeLists.txt
@@ -3,11 +3,18 @@
 
 
 add_executable(scalemicrogrid ScaleMicrogrid.cpp)
+add_executable(scalemicrogridarbitrary ScaleMicrogridArbitrary.cpp)
 target_link_libraries(scalemicrogrid GRIDKIT::power_elec_disgen
                                      GRIDKIT::power_elec_microline
                                      GRIDKIT::power_elec_microload
                                      GRIDKIT::solvers_dyn
                                      GRIDKIT::power_elec_microbusdq)
+
+target_link_libraries(scalemicrogridarbitrary GRIDKIT::power_elec_disgen
+                                        GRIDKIT::power_elec_microline
+                                        GRIDKIT::power_elec_microload
+                                        GRIDKIT::solvers_dyn
+                                        GRIDKIT::power_elec_microbusdq)
 								
 add_test(NAME ScaleMicrogrid    COMMAND $<TARGET_FILE:scalemicrogrid>)
 install(TARGETS scalemicrogrid RUNTIME DESTINATION bin)

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
@@ -321,6 +321,9 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
 
   sys_model->updateTime(0.0, 1.0e-8);
   sys_model->evaluateJacobian();
+  sys_model->printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + std::to_string(Nsize) + ".mtx", "ScaleMicrogrid Jacobian N" + std::to_string(Nsize));
+  // print the jacobian in matrix market format
+  
   if (debug_output)
     std::cout << "Intial Jacobian with alpha:\n";
 

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
@@ -324,7 +324,7 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
   sys_model->evaluateJacobian();
   sys_model->printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + std::to_string(Nsize) + ".mtx", "ScaleMicrogrid Jacobian N" + std::to_string(Nsize));
   // print the jacobian in matrix market format
-  
+
   if (debug_output)
     std::cout << "Intial Jacobian with alpha:\n";
 

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
@@ -307,7 +307,8 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
 
   sys_model->initialize();
   sys_model->evaluateResidual();
-
+  // print the residual in matrix market format
+  sys_model->printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + std::to_string(Nsize) + ".mtx", "ScaleMicrogrid Residual N" + std::to_string(Nsize));
   std::vector<real_type>& fres = sys_model->getResidual();
   if (debug_output)
   {

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
@@ -1,0 +1,305 @@
+
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
+#include <Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp>
+#include <Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp>
+#include <Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp>
+#include <Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp>
+#include <Model/PowerElectronics/SystemModelPowerElectronics.hpp>
+#include <Solver/Dynamic/DynamicSolver.hpp>
+#include <Solver/Dynamic/Ida.hpp>
+#include <Utilities/Testing.hpp>
+
+using index_type = size_t;
+using real_type  = double;
+
+// Include solution keys for the three test cases N = (2, 4, 8) plus tolerances here:
+#include "SolutionKeys.hpp"
+
+int printMicrogridSystems(index_type N_size);
+
+/**
+ * @brief Run Scale Microgrid for a specific N given by the user.
+ *
+ * @param[in] argc should be 1 if no N given, 2 if N given
+ * @param[in] argv can contain the N value (argv[1])
+ * @return int
+ */
+int main(int argc, char const* argv[])
+{
+  // Default value
+  index_type N_size = 4;
+  
+  // Parse command line arguments if provided
+  if (argc > 1) {
+    try {
+      N_size = std::stoi(argv[1]);
+    } catch (const std::exception& e) {
+      std::cerr << "Error parsing grid size argument: " << e.what() << std::endl;
+      std::cerr << "Using default grid size = " << N_size << std::endl;
+    }
+  }
+
+  return printMicrogridSystems(N_size);
+}
+
+/**
+ * @brief Tests network of distributed generators.
+ *
+ * @param[in] N_size - The number of DG line load cobinations to generate for scale
+ * @return int returns 0 if successful, >0 otherwise
+ */
+int printMicrogridSystems(index_type N_size)
+{
+  using namespace GridKit;
+
+  bool use_jac = true;
+
+  real_type t_init  = 0.0;
+  real_type t_final = 1.0;
+
+  real_type rel_tol = SCALE_MICROGRID_REL_TOL;
+  real_type abs_tol = SCALE_MICROGRID_ABS_TOL;
+
+  // Create circuit model
+  auto* sys_model = new PowerElectronicsModel<real_type, index_type>(rel_tol,
+                                                                    abs_tol,
+                                                                    use_jac,
+                                                                    SCALE_MICROGRID_MAX_STEPS);
+
+  // Ensure minimum size requirement
+  if (N_size < 1) {
+    std::cout << "N_size must be at least 1.\n";
+    return 1;
+  }
+
+  // Modeled after the problem in the paper
+  // Every Bus has the same virtual resistance. This is due to numerical stability as mentioned in the paper.
+  real_type RN = 1.0e4;
+
+  // DG Params Vector
+  // All DGs have the same set of parameters except for the first two.
+  GridKit::DistributedGeneratorParameters<real_type, index_type> DG_parms1;
+  DG_parms1.wb_  = 2.0 * M_PI * 50.0;
+  DG_parms1.wc_  = 31.41;
+  DG_parms1.mp_  = 9.4e-5;
+  DG_parms1.Vn_  = 380.0;
+  DG_parms1.nq_  = 1.3e-3;
+  DG_parms1.F_   = 0.75;
+  DG_parms1.Kiv_ = 420.0;
+  DG_parms1.Kpv_ = 0.1;
+  DG_parms1.Kic_ = 2.0e4;
+  DG_parms1.Kpc_ = 15.0;
+  DG_parms1.Cf_  = 5.0e-5;
+  DG_parms1.rLf_ = 0.1;
+  DG_parms1.Lf_  = 1.35e-3;
+  DG_parms1.rLc_ = 0.03;
+  DG_parms1.Lc_  = 0.35e-3;
+
+  GridKit::DistributedGeneratorParameters<real_type, index_type> DG_parms2;
+  DG_parms2.wb_  = 2.0 * M_PI * 50.0;
+  DG_parms2.wc_  = 31.41;
+  DG_parms2.mp_  = 12.5e-5;
+  DG_parms2.Vn_  = 380.0;
+  DG_parms2.nq_  = 1.5e-3;
+  DG_parms2.F_   = 0.75;
+  DG_parms2.Kiv_ = 390.0;
+  DG_parms2.Kpv_ = 0.05;
+  DG_parms2.Kic_ = 16.0e3;
+  DG_parms2.Kpc_ = 10.5;
+  DG_parms2.Cf_  = 50.0e-6;
+  DG_parms2.rLf_ = 0.1;
+  DG_parms2.Lf_  = 1.35e-3;
+  DG_parms2.rLc_ = 0.03;
+  DG_parms2.Lc_  = 0.35e-3;
+
+  std::vector<GridKit::DistributedGeneratorParameters<real_type, index_type>> DGParams_list(2 * N_size, DG_parms2);
+
+  // First two generators use parameters 1
+  if (DGParams_list.size() >= 1) DGParams_list[0] = DG_parms1;
+  if (DGParams_list.size() >= 2) DGParams_list[1] = DG_parms1;
+
+  // line vector params
+  // Every odd line has the same parameters and every even line has the same parameters
+  real_type              rline1 = 0.23;
+  real_type              Lline1 = 0.1 / (2.0 * M_PI * 50.0);
+  real_type              rline2 = 0.35;
+  real_type              Lline2 = 0.58 / (2.0 * M_PI * 50.0);
+  std::vector<real_type> rline_list(2 * N_size - 1, 0.0);
+  std::vector<real_type> Lline_list(2 * N_size - 1, 0.0);
+  for (index_type i = 0; i < rline_list.size(); i++)
+  {
+    rline_list[i] = (i % 2) ? rline2 : rline1;
+    Lline_list[i] = (i % 2) ? Lline2 : Lline1;
+  }
+
+  // load parms
+  // Only the first load has the same paramaters.
+  real_type rload1 = 3.0;
+  real_type Lload1 = 2.0 / (2.0 * M_PI * 50.0);
+  real_type rload2 = 2.0;
+  real_type Lload2 = 1.0 / (2.0 * M_PI * 50.0);
+
+  std::vector<real_type> rload_list(N_size, rload2);
+  std::vector<real_type> Lload_list(N_size, Lload2);
+  if (rload_list.size() >= 1) {
+    rload_list[0] = rload1;
+    Lload_list[0] = Lload1;
+  }
+
+  //							DGs	+		- refframe	   Lines +				Loads
+  index_type vec_size_internals = 13 * (2 * N_size) - 1 + (2 + 4 * (N_size - 1)) + 2 * N_size;
+  //							\omegaref + BusDQ
+  index_type vec_size_externals = 1 + 2 * (2 * N_size);
+
+  std::vector<index_type> vdqbus_index(2 * N_size, 0);
+  vdqbus_index[0] = vec_size_internals + 1;
+  for (index_type i = 1; i < vdqbus_index.size(); i++)
+  {
+    vdqbus_index[i] = vdqbus_index[i - 1] + 2;
+  }
+
+  // Total size of the vector setup
+  index_type vec_size_total = vec_size_internals + vec_size_externals;
+
+  // Create the reference DG
+  auto* dg_ref = new DistributedGenerator<real_type, index_type>(0,
+                                                                 DGParams_list[0],
+                                                                 true);
+  // ref motor
+  dg_ref->setExternalConnectionNodes(0, vec_size_internals);
+  // outputs
+  dg_ref->setExternalConnectionNodes(1, vdqbus_index[0]);
+  dg_ref->setExternalConnectionNodes(2, vdqbus_index[0] + 1);
+  //"grounding" of the difference
+  dg_ref->setExternalConnectionNodes(3, -1);
+  // internal connections
+  for (index_type i = 0; i < 12; i++)
+  {
+    dg_ref->setExternalConnectionNodes(4 + i, i);
+  }
+  sys_model->addComponent(dg_ref);
+
+  // Keep track of models and index location
+  index_type indexv   = 12;
+  index_type model_id = 1;
+  // Add all other DGs
+  for (index_type i = 1; i < 2 * N_size; i++)
+  {
+    // current DG to add
+    auto* dg = new DistributedGenerator<real_type, index_type>(model_id++,
+                                                               DGParams_list[i],
+                                                               false);
+    // ref motor
+    dg->setExternalConnectionNodes(0, vec_size_internals);
+    // outputs
+    dg->setExternalConnectionNodes(1, vdqbus_index[i]);
+    dg->setExternalConnectionNodes(2, vdqbus_index[i] + 1);
+    // internal connections
+    for (index_type j = 0; j < 13; j++)
+    {
+      dg->setExternalConnectionNodes(3 + j, indexv + j);
+    }
+    indexv += 13;
+    sys_model->addComponent(dg);
+  }
+
+  // Load all the Line components
+  for (index_type i = 0; i < 2 * N_size - 1; i++)
+  {
+    // line
+    auto* line_model = new MicrogridLine<real_type, index_type>(model_id++,
+                                                                rline_list[i],
+                                                                Lline_list[i]);
+    // ref motor
+    line_model->setExternalConnectionNodes(0, vec_size_internals);
+    // input connections
+    line_model->setExternalConnectionNodes(1, vdqbus_index[i]);
+    line_model->setExternalConnectionNodes(2, vdqbus_index[i] + 1);
+    // output connections
+    line_model->setExternalConnectionNodes(3, vdqbus_index[i + 1]);
+    line_model->setExternalConnectionNodes(4, vdqbus_index[i + 1] + 1);
+    // internal connections
+    for (index_type j = 0; j < 2; j++)
+    {
+      line_model->setExternalConnectionNodes(5 + j, indexv + j);
+    }
+    indexv += 2;
+    sys_model->addComponent(line_model);
+  }
+
+  //  Load all the Load components
+  for (index_type i = 0; i < N_size; i++)
+  {
+    auto* load_model = new MicrogridLoad<real_type, index_type>(model_id++,
+                                                                rload_list[i],
+                                                                Lload_list[i]);
+    // ref motor
+    load_model->setExternalConnectionNodes(0, vec_size_internals);
+    // input connections
+    load_model->setExternalConnectionNodes(1, vdqbus_index[2 * i]);
+    load_model->setExternalConnectionNodes(2, vdqbus_index[2 * i] + 1);
+    // internal connections
+    for (index_type j = 0; j < 2; j++)
+    {
+      load_model->setExternalConnectionNodes(3 + j, indexv + j);
+    }
+    indexv += 2;
+    sys_model->addComponent(load_model);
+  }
+
+  // Add all the microgrid Virtual DQ Buses
+  for (index_type i = 0; i < 2 * N_size; i++)
+  {
+    auto* virDQbus_model = new MicrogridBusDQ<real_type, index_type>(model_id++, RN);
+
+    virDQbus_model->setExternalConnectionNodes(0, vdqbus_index[i]);
+    virDQbus_model->setExternalConnectionNodes(1, vdqbus_index[i] + 1);
+    sys_model->addComponent(virDQbus_model);
+  }
+
+  // allocate all the initial conditions
+  sys_model->allocate(vec_size_total);
+
+
+  // Create Initial points for states. Every state is set to zero initially
+  for (index_type i = 0; i < vec_size_total; i++)
+  {
+    sys_model->y()[i]  = 0.0;
+    sys_model->yp()[i] = 0.0;
+  }
+
+  // Create Initial derivatives specifics generated in MATLAB
+  for (index_type i = 0; i < 2 * N_size; i++)
+  {
+    sys_model->yp()[13 * i - 1 + 3] = DGParams_list[i].Vn_;
+    sys_model->yp()[13 * i - 1 + 5] = DGParams_list[i].Kpv_ * DGParams_list[i].Vn_;
+    sys_model->yp()[13 * i - 1 + 7] = (DGParams_list[i].Kpc_ * DGParams_list[i].Kpv_ * DGParams_list[i].Vn_) / DGParams_list[i].Lf_;
+  }
+
+  // since the initial P_com = 0, set the initial vector to the reference frame
+  sys_model->y()[vec_size_internals] = DG_parms1.wb_;
+
+  sys_model->initialize();
+  sys_model->evaluateResidual();
+  
+  // Output file names based on grid size
+  std::string size_suffix = std::to_string(N_size);
+  
+  // print the residual in matrix market format
+  sys_model->printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + size_suffix + ".mtx", 
+                                       "ScaleMicrogrid Residual N" + size_suffix);
+  
+  std::vector<real_type>& fres = sys_model->getResidual();
+
+  sys_model->updateTime(0.0, 1.0e-8);
+  sys_model->evaluateJacobian();
+  sys_model->printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + size_suffix + ".mtx", 
+                                      "ScaleMicrogrid Jacobian N" + size_suffix);
+  return 0;
+}

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
@@ -68,10 +68,10 @@ int printMicrogridSystems(index_type N_size)
   real_type abs_tol = SCALE_MICROGRID_ABS_TOL;
 
   // Create circuit model
-  auto* sys_model = new PowerElectronicsModel<real_type, index_type>(rel_tol,
-                                                                     abs_tol,
-                                                                     use_jac,
-                                                                     SCALE_MICROGRID_MAX_STEPS);
+  PowerElectronicsModel<real_type, index_type> sys_model(rel_tol,
+                                                         abs_tol,
+                                                         use_jac,
+                                                         SCALE_MICROGRID_MAX_STEPS);
 
   // Ensure minimum size requirement
   if (N_size < 1)
@@ -188,7 +188,7 @@ int printMicrogridSystems(index_type N_size)
   {
     dg_ref->setExternalConnectionNodes(4 + i, i);
   }
-  sys_model->addComponent(dg_ref);
+  sys_model.addComponent(dg_ref);
 
   // Keep track of models and index location
   index_type indexv   = 12;
@@ -211,7 +211,7 @@ int printMicrogridSystems(index_type N_size)
       dg->setExternalConnectionNodes(3 + j, indexv + j);
     }
     indexv += 13;
-    sys_model->addComponent(dg);
+    sys_model.addComponent(dg);
   }
 
   // Load all the Line components
@@ -235,7 +235,7 @@ int printMicrogridSystems(index_type N_size)
       line_model->setExternalConnectionNodes(5 + j, indexv + j);
     }
     indexv += 2;
-    sys_model->addComponent(line_model);
+    sys_model.addComponent(line_model);
   }
 
   //  Load all the Load components
@@ -255,7 +255,7 @@ int printMicrogridSystems(index_type N_size)
       load_model->setExternalConnectionNodes(3 + j, indexv + j);
     }
     indexv += 2;
-    sys_model->addComponent(load_model);
+    sys_model.addComponent(load_model);
   }
 
   // Add all the microgrid Virtual DQ Buses
@@ -265,43 +265,44 @@ int printMicrogridSystems(index_type N_size)
 
     virDQbus_model->setExternalConnectionNodes(0, vdqbus_index[i]);
     virDQbus_model->setExternalConnectionNodes(1, vdqbus_index[i] + 1);
-    sys_model->addComponent(virDQbus_model);
+    sys_model.addComponent(virDQbus_model);
   }
 
   // allocate all the initial conditions
-  sys_model->allocate(vec_size_total);
+  sys_model.allocate(vec_size_total);
 
   // Create Initial points for states. Every state is set to zero initially
   for (index_type i = 0; i < vec_size_total; i++)
   {
-    sys_model->y()[i]  = 0.0;
-    sys_model->yp()[i] = 0.0;
+    sys_model.y()[i]  = 0.0;
+    sys_model.yp()[i] = 0.0;
   }
 
   // Create Initial derivatives specifics generated in MATLAB
   for (index_type i = 0; i < 2 * N_size; i++)
   {
-    sys_model->yp()[13 * i - 1 + 3] = DGParams_list[i].Vn_;
-    sys_model->yp()[13 * i - 1 + 5] = DGParams_list[i].Kpv_ * DGParams_list[i].Vn_;
-    sys_model->yp()[13 * i - 1 + 7] = (DGParams_list[i].Kpc_ * DGParams_list[i].Kpv_ * DGParams_list[i].Vn_) / DGParams_list[i].Lf_;
+    sys_model.yp()[13 * i - 1 + 3] = DGParams_list[i].Vn_;
+    sys_model.yp()[13 * i - 1 + 5] = DGParams_list[i].Kpv_ * DGParams_list[i].Vn_;
+    sys_model.yp()[13 * i - 1 + 7] = (DGParams_list[i].Kpc_ * DGParams_list[i].Kpv_ * DGParams_list[i].Vn_) / DGParams_list[i].Lf_;
   }
 
   // since the initial P_com = 0, set the initial vector to the reference frame
-  sys_model->y()[vec_size_internals] = DG_parms1.wb_;
+  sys_model.y()[vec_size_internals] = DG_parms1.wb_;
 
-  sys_model->initialize();
-  sys_model->evaluateResidual();
+  sys_model.initialize();
+  sys_model.evaluateResidual();
 
   // Output file names based on grid size
   std::string size_suffix = std::to_string(N_size);
 
   // print the residual in matrix market format
-  sys_model->printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + size_suffix + ".mtx",
-                                       "ScaleMicrogrid Residual N" + size_suffix);
+  sys_model.printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + size_suffix + ".mtx",
+                                      "ScaleMicrogrid Residual N" + size_suffix);
 
-  sys_model->updateTime(0.0, 1.0e-8);
-  sys_model->evaluateJacobian();
-  sys_model->printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + size_suffix + ".mtx",
-                                       "ScaleMicrogrid Jacobian N" + size_suffix);
+  sys_model.updateTime(0.0, 1.0e-8);
+  sys_model.evaluateJacobian();
+  sys_model.printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + size_suffix + ".mtx",
+                                      "ScaleMicrogrid Jacobian N" + size_suffix);
+
   return 0;
 }

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
@@ -34,12 +34,16 @@ int main(int argc, char const* argv[])
 {
   // Default value
   index_type N_size = 4;
-  
+
   // Parse command line arguments if provided
-  if (argc > 1) {
-    try {
+  if (argc > 1)
+  {
+    try
+    {
       N_size = std::stoi(argv[1]);
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e)
+    {
       std::cerr << "Error parsing grid size argument: " << e.what() << std::endl;
       std::cerr << "Using default grid size = " << N_size << std::endl;
     }
@@ -68,12 +72,13 @@ int printMicrogridSystems(index_type N_size)
 
   // Create circuit model
   auto* sys_model = new PowerElectronicsModel<real_type, index_type>(rel_tol,
-                                                                    abs_tol,
-                                                                    use_jac,
-                                                                    SCALE_MICROGRID_MAX_STEPS);
+                                                                     abs_tol,
+                                                                     use_jac,
+                                                                     SCALE_MICROGRID_MAX_STEPS);
 
   // Ensure minimum size requirement
-  if (N_size < 1) {
+  if (N_size < 1)
+  {
     std::cout << "N_size must be at least 1.\n";
     return 1;
   }
@@ -121,8 +126,10 @@ int printMicrogridSystems(index_type N_size)
   std::vector<GridKit::DistributedGeneratorParameters<real_type, index_type>> DGParams_list(2 * N_size, DG_parms2);
 
   // First two generators use parameters 1
-  if (DGParams_list.size() >= 1) DGParams_list[0] = DG_parms1;
-  if (DGParams_list.size() >= 2) DGParams_list[1] = DG_parms1;
+  if (DGParams_list.size() >= 1)
+    DGParams_list[0] = DG_parms1;
+  if (DGParams_list.size() >= 2)
+    DGParams_list[1] = DG_parms1;
 
   // line vector params
   // Every odd line has the same parameters and every even line has the same parameters
@@ -147,7 +154,8 @@ int printMicrogridSystems(index_type N_size)
 
   std::vector<real_type> rload_list(N_size, rload2);
   std::vector<real_type> Lload_list(N_size, Lload2);
-  if (rload_list.size() >= 1) {
+  if (rload_list.size() >= 1)
+  {
     rload_list[0] = rload1;
     Lload_list[0] = Lload1;
   }
@@ -266,7 +274,6 @@ int printMicrogridSystems(index_type N_size)
   // allocate all the initial conditions
   sys_model->allocate(vec_size_total);
 
-
   // Create Initial points for states. Every state is set to zero initially
   for (index_type i = 0; i < vec_size_total; i++)
   {
@@ -287,19 +294,19 @@ int printMicrogridSystems(index_type N_size)
 
   sys_model->initialize();
   sys_model->evaluateResidual();
-  
+
   // Output file names based on grid size
   std::string size_suffix = std::to_string(N_size);
-  
+
   // print the residual in matrix market format
-  sys_model->printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + size_suffix + ".mtx", 
+  sys_model->printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + size_suffix + ".mtx",
                                        "ScaleMicrogrid Residual N" + size_suffix);
-  
+
   std::vector<real_type>& fres = sys_model->getResidual();
 
   sys_model->updateTime(0.0, 1.0e-8);
   sys_model->evaluateJacobian();
-  sys_model->printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + size_suffix + ".mtx", 
-                                      "ScaleMicrogrid Jacobian N" + size_suffix);
+  sys_model->printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + size_suffix + ".mtx",
+                                       "ScaleMicrogrid Jacobian N" + size_suffix);
   return 0;
 }

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
@@ -64,9 +64,6 @@ int printMicrogridSystems(index_type N_size)
 
   bool use_jac = true;
 
-  real_type t_init  = 0.0;
-  real_type t_final = 1.0;
-
   real_type rel_tol = SCALE_MICROGRID_REL_TOL;
   real_type abs_tol = SCALE_MICROGRID_ABS_TOL;
 
@@ -301,8 +298,6 @@ int printMicrogridSystems(index_type N_size)
   // print the residual in matrix market format
   sys_model->printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + size_suffix + ".mtx",
                                        "ScaleMicrogrid Residual N" + size_suffix);
-
-  std::vector<real_type>& fres = sys_model->getResidual();
 
   sys_model->updateTime(0.0, 1.0e-8);
   sys_model->evaluateJacobian();

--- a/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -9,7 +9,9 @@
 #include <iterator>
 #include <tuple>
 #include <vector>
-
+#include <fstream>
+#include <type_traits>
+#include <algorithm>
 /**
  * @brief Quick class to provide sparse matrices of COO type.
  *
@@ -22,7 +24,79 @@
  */
 namespace GridKit
 {
-  namespace LinearAlgebra
+private:
+  std::vector<ScalarT> values_;
+  std::vector<IdxT>    row_indices_;
+  std::vector<IdxT>    column_indices_;
+  IdxT                 rows_size_;
+  IdxT                 columns_size_;
+  bool                 sorted_;
+
+public:
+  // Constructors
+  COO_Matrix(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v, IdxT m, IdxT n);
+  COO_Matrix(IdxT m, IdxT n);
+  COO_Matrix();
+  ~COO_Matrix();
+
+  // Operations
+
+  // --- Functions which call sort ---
+  std::tuple<std::vector<IdxT>, std::vector<ScalarT>>                       getRowCopy(IdxT r);
+  std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<ScalarT>&> getEntries();
+  std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<ScalarT>>    getEntryCopies();
+  std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<ScalarT>>    getEntryCopiesSubMatrix(std::vector<IdxT> submap);
+
+  std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<ScalarT>> setDataToCSR();
+  std::vector<IdxT>                                                      getCSRRowData();
+
+  // BLAS. Will sort before running
+  void    setValues(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v);
+  void    axpy(ScalarT alpha, COO_Matrix<ScalarT, IdxT>& a);
+  void    axpy(ScalarT alpha, std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v);
+  void    scal(ScalarT alpha);
+  ScalarT frobNorm();
+
+  // --- Permutation Operations ---
+  // Sorting is only done if not already sorted.
+  void permutation(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm);
+  void permutationSizeMap(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm, IdxT m, IdxT n);
+
+  void zeroMatrix();
+
+  void identityMatrix(IdxT n);
+
+  // Resort values_
+  void sortSparse();
+  bool isSorted();
+  IdxT nnz();
+
+  std::tuple<IdxT, IdxT> getDimensions();
+
+  void printMatrix(std::string name = "");
+
+  void printMatrixMarket(const std::string& filename, const std::string& comment);
+
+  static void sortSparseCOO(std::vector<IdxT>& rows, std::vector<IdxT>& columns, std::vector<ScalarT>& values);
+
+private:
+  IdxT indexStartRow(const std::vector<IdxT>& rows, IdxT r);
+  IdxT sparseCordBinarySearch(const std::vector<IdxT>& rows, const std::vector<IdxT>& columns, IdxT ri, IdxT ci);
+  bool checkIncreaseSize(IdxT r, IdxT c);
+};
+
+/**
+ * @brief Get copy of row index
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ * @param[in] r row index
+ * @return std::tuple<std::vector<IdxT>, std::vector<ScalarT>>
+ */
+template <class ScalarT, typename IdxT>
+inline std::tuple<std::vector<IdxT>, std::vector<ScalarT>> COO_Matrix<ScalarT, IdxT>::getRowCopy(IdxT r)
+{
+  if (!this->sorted_)
   {
     template <class ScalarT, typename IdxT>
     class COO_Matrix
@@ -97,7 +171,537 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     inline std::tuple<std::vector<IdxT>, std::vector<ScalarT>> COO_Matrix<ScalarT, IdxT>::getRowCopy(IdxT r)
     {
-      if (!this->sorted_)
+      row_size_vec[i + 1]++;
+      counter++;
+    }
+  }
+  return row_size_vec;
+}
+
+/**
+ * @brief Set coordinates and values of the matrix.
+ *
+ * Matrix entries will be sorted in row-major order before the method returns.
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ * @param[in] r row indices of the matrix
+ * @param[in] c column indices of the matrix
+ * @param[in] v values of the matrix
+ *
+ * @pre r.size() == c.size() == v.size()
+ * @pre r,c,v represent an array in COO format
+ *
+ * @post Coordinates and values are set in the matrix.
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::setValues(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v)
+{
+  // sort input
+  this->sortSparseCOO(r, c, v);
+
+  // Duplicated with axpy. Could replace with function depdent on lambda expression
+  IdxT a_iter = 0;
+  // iterate for all current values_ in matrix
+  for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
+  {
+    // pushback values_ when they are not in current matrix
+    while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
+    {
+      this->row_indices_.push_back(r[a_iter]);
+      this->column_indices_.push_back(c[a_iter]);
+      this->values_.push_back(v[a_iter]);
+      this->checkIncreaseSize(r[a_iter], c[a_iter]);
+      a_iter++;
+    }
+    if (a_iter >= static_cast<IdxT>(r.size()))
+    {
+      break;
+    }
+
+    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
+    {
+      this->values_[i] = v[a_iter];
+      a_iter++;
+    }
+  }
+  // push back rest that was not found sorted
+  for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
+  {
+    this->row_indices_.push_back(r[i]);
+    this->column_indices_.push_back(c[i]);
+    this->values_.push_back(v[i]);
+
+    this->checkIncreaseSize(r[i], c[i]);
+  }
+
+  this->sorted_ = false;
+}
+
+/**
+ * @brief Implements axpy this += alpha * a. Will sort before running
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ * @param[in] alpha matrix to be added
+ * @param[in] a scalar to multiply by
+ *
+ * @post this = this + alpha * a
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, COO_Matrix<ScalarT, IdxT>& a)
+{
+  if (alpha == 0)
+  {
+    return;
+  }
+
+  if (!this->sorted_)
+  {
+    this->sortSparse();
+  }
+  if (!a.isSorted())
+  {
+    a.sortSparse();
+  }
+  IdxT                                                                      m   = 0;
+  IdxT                                                                      n   = 0;
+  std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<ScalarT>&> tpm = a.getEntries();
+  const auto& [r, c, val]                                                       = tpm;
+  std::tie(m, n)                                                                = a.getDimensions();
+
+  // Increase size as necessary
+  this->rows_size_    = this->rows_size_ > m ? this->rows_size_ : m;
+  this->columns_size_ = this->columns_size_ > n ? this->columns_size_ : n;
+
+  IdxT a_iter = 0;
+  // iterate for all current values in matrix
+  for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
+  {
+    // pushback values when they are not in current matrix
+    while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
+    {
+      this->row_indices_.push_back(r[a_iter]);
+      this->column_indices_.push_back(c[a_iter]);
+      this->values_.push_back(alpha * val[a_iter]);
+
+      this->checkIncreaseSize(r[a_iter], c[a_iter]);
+      a_iter++;
+    }
+    if (a_iter >= static_cast<IdxT>(r.size()))
+    {
+      break;
+    }
+
+    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
+    {
+      this->values_[i] += alpha * val[a_iter];
+      a_iter++;
+    }
+  }
+  // push back rest that was not found sorted_
+  for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
+  {
+    this->row_indices_.push_back(r[i]);
+    this->column_indices_.push_back(c[i]);
+    this->values_.push_back(alpha * val[i]);
+
+    this->checkIncreaseSize(r[i], c[i]);
+  }
+
+  this->sorted_ = false;
+}
+
+/**
+ * @brief axpy on a COO representation of a matrix. Will sort before running
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ * @param alpha scalar to multiply by
+ * @param r row indices
+ * @param c column indices
+ * @param v values
+ *
+ * @pre r.size() == c.size() == v.size()
+ * @pre r,c,v represent an array a in COO format
+ *
+ * @post this = this + alpha * a
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v)
+{
+  if (alpha == 0)
+    return;
+
+  if (!this->sorted_)
+  {
+    this->sortSparse();
+  }
+
+  // sort input
+  this->sortSparseCOO(r, c, v);
+
+  IdxT a_iter = 0;
+  // iterate for all current values_ in matrix
+  for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
+  {
+    // pushback values_ when they are not in current matrix
+    while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
+    {
+      this->row_indices_.push_back(r[a_iter]);
+      this->column_indices_.push_back(c[a_iter]);
+      this->values_.push_back(alpha * v[a_iter]);
+
+      this->checkIncreaseSize(r[a_iter], c[a_iter]);
+      a_iter++;
+    }
+    if (a_iter >= static_cast<IdxT>(r.size()))
+    {
+      break;
+    }
+
+    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
+    {
+      this->values_[i] += alpha * v[a_iter];
+      a_iter++;
+    }
+  }
+  // push back rest that was not found sorted_
+  for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
+  {
+    this->row_indices_.push_back(r[i]);
+    this->column_indices_.push_back(c[i]);
+    this->values_.push_back(alpha * v[i]);
+
+    this->checkIncreaseSize(r[i], c[i]);
+  }
+
+  this->sorted_ = false;
+}
+
+/**
+ * @brief Scale all values by alpha
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ * @param[in] alpha scalar to scale by
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::scal(ScalarT alpha)
+{
+  for (auto i = this->values_.begin(); i < this->values_.end(); i++)
+  {
+    *i *= alpha;
+  }
+}
+
+/**
+ * @brief Calculates the Frobenius Norm of the matrix
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ * @return ScalarT - Frobenius Norm of the matrix
+ */
+template <class ScalarT, typename IdxT>
+inline ScalarT COO_Matrix<ScalarT, IdxT>::frobNorm()
+{
+  ScalarT totsum = 0.0;
+  for (auto i = this->values_.begin(); i < this->values_.end(); i++)
+  {
+    totsum += abs(*i) ^ 2;
+  }
+  return totsum;
+}
+
+/**
+ * @brief Permutate the matrix to a different one. Only changes the coordinates
+ *
+ * @tparam ScalarT
+ * @param[in] row_perm
+ * @param[out] col_perm
+ *
+ * @pre row_perm.size() == this->rows_size_ = col_perm.size() == this->columns_size_
+ *
+ * @post this = this(row_perm, col_perm)
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::permutation(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm)
+{
+  assert(row_perm.size() = this->rows_size_);
+  assert(col_perm.size() = this->columns_size_);
+
+  for (int i = 0; i < this->values_.size(); i++)
+  {
+    this->row_indices_[i]    = row_perm[this->row_indices_[i]];
+    this->column_indices_[i] = col_perm[this->column_indices_[i]];
+  }
+  this->sorted_ = false;
+  // cycle sorting maybe useful since permutations are already known
+}
+
+/**
+ * @brief Permutes the matrix and can change its size efficently
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ * @param[in] row_perm row permutation
+ * @param[in] col_perm column permutation
+ * @param[in] m number of rows
+ * @param[in] n number of columns
+ *
+ * @pre row_perm.size() == this->rows_size_
+ * @pre col_perm.size() == this->columns_size_
+ * @pre indices are set to -1 if they are to be removed
+ *
+ * @post this = this(row_perm, col_perm) and removed indices have corresponding values set to 0
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::permutationSizeMap(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm, IdxT m, IdxT n)
+{
+  assert(row_perm.size() == this->rows_size_);
+  assert(col_perm.size() == this->columns_size_);
+
+  this->rows_size_    = m;
+  this->columns_size_ = n;
+
+  for (int i = 0; i < this->values_.size(); i++)
+  {
+    if (row_perm[this->row_indices_[i]] == -1 || col_perm[this->column_indices_[i]] == -1)
+    {
+      this->values_[i] = 0;
+    }
+    else
+    {
+      this->row_indices_[i]    = row_perm[this->row_indices_[i]];
+      this->column_indices_[i] = col_perm[this->column_indices_[i]];
+    }
+  }
+  this->sorted_ = false;
+}
+
+/**
+ * @brief Turn matrix into the zero matrix. Does not actually delete memory
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ *
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::zeroMatrix()
+{
+  // resize doesn't effect capacity if smaller
+  this->column_indices_.resize(0);
+  this->row_indices_.resize(0);
+  this->values_.resize(0);
+  this->sorted_ = true;
+}
+
+/**
+ * @brief Turn matrix into the identity matrix
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ *
+ * @param[in] n size of the identity matrix
+ *
+ * @post this = I_n
+ *
+ * @todo - it might be better to explicitly zero out the matrix and require to be so in preconditions
+ */
+
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::identityMatrix(IdxT n)
+{
+  // Reset Matrix
+  this->zeroMatrix();
+  for (IdxT i = 0; i < n; i++)
+  {
+    this->column_indices_[i] = i;
+    this->row_indices_[i]    = i;
+    this->values_[i]         = 1.0;
+  }
+  this->sorted_ = true;
+}
+
+/**
+ * @brief Restructure the sparse matrix for faster accesses and modifications
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::sortSparse()
+{
+  this->sortSparseCOO(this->row_indices_, this->column_indices_, this->values_);
+  this->sorted_ = true;
+}
+
+/**
+ * @brief Check if the matrix is sorted
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ *
+ * @param[out]  bool - true if sorted, false otherwise
+ */
+
+template <class ScalarT, typename IdxT>
+inline bool COO_Matrix<ScalarT, IdxT>::isSorted()
+{
+  return this->sorted_;
+}
+
+/**
+ * @brief Get the number of non-zero elements in the matrix
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ *
+ * @param[out] IdxT - number of non-zero elements in the matrix
+ */
+template <class ScalarT, typename IdxT>
+inline IdxT COO_Matrix<ScalarT, IdxT>::nnz()
+{
+  return static_cast<IdxT>(this->values_.size());
+}
+
+template <class ScalarT, typename IdxT>
+inline std::tuple<IdxT, IdxT> COO_Matrix<ScalarT, IdxT>::getDimensions()
+{
+  return std::tuple<IdxT, IdxT>(this->rows_size_, this->columns_size_);
+}
+
+/**
+ * @brief Print matrix in sorted order
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ *
+ * @param[in] name to identify the specific matrix printed
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::printMatrix(std::string name)
+{
+  if (this->sorted_ == false)
+  {
+    this->sortSparse();
+  }
+
+  std::cout << "Sparse COO Matrix: " << name << "\n";
+  std::cout << "(x , y, value)\n";
+  for (size_t i = 0; i < this->values_.size(); i++)
+  {
+    std::cout << "(" << this->row_indices_[i]
+              << ", " << this->column_indices_[i]
+              << ", " << this->values_[i] << ")\n";
+  }
+  std::cout << std::flush;
+}
+
+/**
+ * @brief Print matrix to file in Matrix Market format
+ *
+ * @tparam ScalarT
+ * @tparam IdxT
+ *
+ * @param[in] filename Output file path
+ * @param[in] comment Optional comment for the Matrix Market file
+ */
+template <class ScalarT, typename IdxT>
+inline void COO_Matrix<ScalarT, IdxT>::printMatrixMarket(const std::string& filename, const std::string& comment)
+{
+  if (this->sorted_ == false)
+  {
+    this->sortSparse();
+  }
+
+  std::ofstream outfile(filename);
+  if (!outfile.is_open())
+  {
+    std::cerr << "Error: Unable to open file " << filename << " for writing." << std::endl;
+    return;
+  }
+
+  // Write Matrix Market header
+  outfile << "%%MatrixMarket matrix coordinate ";
+
+  // Determine real/integer/pattern type
+  if (std::is_same<ScalarT, int>::value || std::is_same<ScalarT, long>::value)
+    outfile << "integer ";
+  else if (std::is_floating_point<ScalarT>::value)
+    outfile << "real ";
+  else
+    outfile << "pattern ";
+
+  // For simplicity, assume general (not symmetric/hermitian)
+  outfile << "general" << std::endl;
+
+  // Write comment if provided
+  if (!comment.empty())
+    outfile << "% " << comment << std::endl;
+
+  // Write dimensions and number of entries
+  // Get max row and column indices to determine matrix dimensions
+  IdxT max_row = 0;
+  IdxT max_col = 0;
+  for (size_t i = 0; i < this->values_.size(); i++)
+  {
+    max_row = std::max(max_row, this->row_indices_[i]);
+    max_col = std::max(max_col, this->column_indices_[i]);
+  }
+
+  // Matrix Market uses 1-based indexing, so add 1 to dimensions
+  outfile << (max_row + 1) << " " << (max_col + 1) << " " << this->values_.size() << std::endl;
+
+  // Write the matrix entries
+  for (size_t i = 0; i < this->values_.size(); i++)
+  {
+    // Matrix Market uses 1-based indexing, so add 1 to indices
+    outfile << (this->row_indices_[i] + 1) << " "
+            << (this->column_indices_[i] + 1) << " "
+            << this->values_[i] << std::endl;
+  }
+
+  outfile.close();
+
+  std::cout << "Matrix Market file written to: " << filename << std::endl;
+}
+
+/**
+ * @brief Find the lowest row cordinate from set of provided coordinates
+ *
+ * Assumes rows and columns are sorted
+ * @tparam ScalarT
+ * @tparam IdxT
+ *
+ * @param[in] rows - row indices
+ * @param[in] r - row index
+ *
+ * @return IdxT - index of lowest row
+ */
+template <class ScalarT, typename IdxT>
+inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& rows, IdxT r)
+{
+  // Specialized Binary Search for Lowest Row
+  IdxT i1         = 0;
+  IdxT i2         = rows->size() - 1;
+  IdxT m_smallest = -1;
+  IdxT m          = -1;
+  while (i1 <= i2)
+  {
+    m = (i2 + i1) / 2;
+    // rows
+    if (rows[m] < r)
+    {
+      i1 = m + 1;
+    }
+    else if (r < rows[m])
+    {
+      i2 = m - 1;
+    }
+    else
+    {
+      if (i1 == i2)
       {
         this->sortSparse();
       }

--- a/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -608,7 +608,7 @@ inline void COO_Matrix<ScalarT, IdxT>::printMatrix(std::string name)
  * @param[in] comment Optional comment for the Matrix Market file
  */
 template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::printMatrixMarket(const std::string& filename, const std::string& comment)
+void COO_Matrix<ScalarT, IdxT>::printMatrixMarket(const std::string& filename, const std::string& comment)
 {
   if (this->sorted_ == false)
   {
@@ -625,13 +625,11 @@ inline void COO_Matrix<ScalarT, IdxT>::printMatrixMarket(const std::string& file
   // Write Matrix Market header
   outfile << "%%MatrixMarket matrix coordinate ";
 
-  // Determine real/integer/pattern type
-  if (std::is_same<ScalarT, int>::value || std::is_same<ScalarT, long>::value)
-    outfile << "integer ";
-  else if (std::is_floating_point<ScalarT>::value)
-    outfile << "real ";
-  else
-    outfile << "pattern ";
+  if (!std::is_floating_point<ScalarT>::value)
+  {
+    // error message
+    return;
+  }
 
   // For simplicity, assume general (not symmetric/hermitian)
   outfile << "general" << std::endl;

--- a/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -5,13 +5,13 @@
 #include <assert.h>
 #include <cmath>
 #include <cstdio>
+#include <fstream>
 #include <iostream>
 #include <iterator>
 #include <tuple>
-#include <vector>
-#include <fstream>
 #include <type_traits>
-#include <algorithm>
+#include <vector>
+
 /**
  * @brief Quick class to provide sparse matrices of COO type.
  *

--- a/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -631,7 +631,6 @@ void COO_Matrix<ScalarT, IdxT>::printMatrixMarket(const std::string& filename, c
     return;
   }
 
-  // For simplicity, assume general (not symmetric/hermitian)
   outfile << "general" << std::endl;
 
   // Write comment if provided

--- a/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -1,5 +1,4 @@
-#ifndef COO_MATRIX_HPP
-#define COO_MATRIX_HPP
+#pragma once
 
 #include <algorithm>
 #include <assert.h>
@@ -12,92 +11,20 @@
 #include <type_traits>
 #include <vector>
 
-/**
- * @brief Quick class to provide sparse matrices of COO type.
- *
- * Simplifies data movement
- *
- * @todo add functionality to keep track of multiple sorted lists. Faster
- * adding of new entries and will have a threshold to sort completely.
- *
- * m x n sparse matrix
- */
 namespace GridKit
 {
-private:
-  std::vector<ScalarT> values_;
-  std::vector<IdxT>    row_indices_;
-  std::vector<IdxT>    column_indices_;
-  IdxT                 rows_size_;
-  IdxT                 columns_size_;
-  bool                 sorted_;
-
-public:
-  // Constructors
-  COO_Matrix(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v, IdxT m, IdxT n);
-  COO_Matrix(IdxT m, IdxT n);
-  COO_Matrix();
-  ~COO_Matrix();
-
-  // Operations
-
-  // --- Functions which call sort ---
-  std::tuple<std::vector<IdxT>, std::vector<ScalarT>>                       getRowCopy(IdxT r);
-  std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<ScalarT>&> getEntries();
-  std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<ScalarT>>    getEntryCopies();
-  std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<ScalarT>>    getEntryCopiesSubMatrix(std::vector<IdxT> submap);
-
-  std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<ScalarT>> setDataToCSR();
-  std::vector<IdxT>                                                      getCSRRowData();
-
-  // BLAS. Will sort before running
-  void    setValues(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v);
-  void    axpy(ScalarT alpha, COO_Matrix<ScalarT, IdxT>& a);
-  void    axpy(ScalarT alpha, std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v);
-  void    scal(ScalarT alpha);
-  ScalarT frobNorm();
-
-  // --- Permutation Operations ---
-  // Sorting is only done if not already sorted.
-  void permutation(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm);
-  void permutationSizeMap(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm, IdxT m, IdxT n);
-
-  void zeroMatrix();
-
-  void identityMatrix(IdxT n);
-
-  // Resort values_
-  void sortSparse();
-  bool isSorted();
-  IdxT nnz();
-
-  std::tuple<IdxT, IdxT> getDimensions();
-
-  void printMatrix(std::string name = "");
-
-  void printMatrixMarket(const std::string& filename, const std::string& comment);
-
-  static void sortSparseCOO(std::vector<IdxT>& rows, std::vector<IdxT>& columns, std::vector<ScalarT>& values);
-
-private:
-  IdxT indexStartRow(const std::vector<IdxT>& rows, IdxT r);
-  IdxT sparseCordBinarySearch(const std::vector<IdxT>& rows, const std::vector<IdxT>& columns, IdxT ri, IdxT ci);
-  bool checkIncreaseSize(IdxT r, IdxT c);
-};
-
-/**
- * @brief Get copy of row index
- *
- * @tparam ScalarT
- * @tparam IdxT
- * @param[in] r row index
- * @return std::tuple<std::vector<IdxT>, std::vector<ScalarT>>
- */
-template <class ScalarT, typename IdxT>
-inline std::tuple<std::vector<IdxT>, std::vector<ScalarT>> COO_Matrix<ScalarT, IdxT>::getRowCopy(IdxT r)
-{
-  if (!this->sorted_)
+  namespace LinearAlgebra
   {
+    /**
+     * @brief Quick class to provide sparse matrices of COO type.
+     *
+     * Simplifies data movement
+     *
+     * @todo add functionality to keep track of multiple sorted lists. Faster
+     * adding of new entries and will have a threshold to sort completely.
+     *
+     * m x n sparse matrix
+     */
     template <class ScalarT, typename IdxT>
     class COO_Matrix
     {
@@ -152,6 +79,8 @@ inline std::tuple<std::vector<IdxT>, std::vector<ScalarT>> COO_Matrix<ScalarT, I
 
       void printMatrix(std::string name = "");
 
+      void printMatrixMarket(const std::string& filename, const std::string& comment);
+
       static void sortSparseCOO(std::vector<IdxT>& rows, std::vector<IdxT>& columns, std::vector<ScalarT>& values);
 
     private:
@@ -171,534 +100,7 @@ inline std::tuple<std::vector<IdxT>, std::vector<ScalarT>> COO_Matrix<ScalarT, I
     template <class ScalarT, typename IdxT>
     inline std::tuple<std::vector<IdxT>, std::vector<ScalarT>> COO_Matrix<ScalarT, IdxT>::getRowCopy(IdxT r)
     {
-      row_size_vec[i + 1]++;
-      counter++;
-    }
-  }
-  return row_size_vec;
-}
-
-/**
- * @brief Set coordinates and values of the matrix.
- *
- * Matrix entries will be sorted in row-major order before the method returns.
- *
- * @tparam ScalarT
- * @tparam IdxT
- * @param[in] r row indices of the matrix
- * @param[in] c column indices of the matrix
- * @param[in] v values of the matrix
- *
- * @pre r.size() == c.size() == v.size()
- * @pre r,c,v represent an array in COO format
- *
- * @post Coordinates and values are set in the matrix.
- */
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::setValues(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v)
-{
-  // sort input
-  this->sortSparseCOO(r, c, v);
-
-  // Duplicated with axpy. Could replace with function depdent on lambda expression
-  IdxT a_iter = 0;
-  // iterate for all current values_ in matrix
-  for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
-  {
-    // pushback values_ when they are not in current matrix
-    while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
-    {
-      this->row_indices_.push_back(r[a_iter]);
-      this->column_indices_.push_back(c[a_iter]);
-      this->values_.push_back(v[a_iter]);
-      this->checkIncreaseSize(r[a_iter], c[a_iter]);
-      a_iter++;
-    }
-    if (a_iter >= static_cast<IdxT>(r.size()))
-    {
-      break;
-    }
-
-    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
-    {
-      this->values_[i] = v[a_iter];
-      a_iter++;
-    }
-  }
-  // push back rest that was not found sorted
-  for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
-  {
-    this->row_indices_.push_back(r[i]);
-    this->column_indices_.push_back(c[i]);
-    this->values_.push_back(v[i]);
-
-    this->checkIncreaseSize(r[i], c[i]);
-  }
-
-  this->sorted_ = false;
-}
-
-/**
- * @brief Implements axpy this += alpha * a. Will sort before running
- *
- * @tparam ScalarT
- * @tparam IdxT
- * @param[in] alpha matrix to be added
- * @param[in] a scalar to multiply by
- *
- * @post this = this + alpha * a
- */
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, COO_Matrix<ScalarT, IdxT>& a)
-{
-  if (alpha == 0)
-  {
-    return;
-  }
-
-  if (!this->sorted_)
-  {
-    this->sortSparse();
-  }
-  if (!a.isSorted())
-  {
-    a.sortSparse();
-  }
-  IdxT                                                                      m   = 0;
-  IdxT                                                                      n   = 0;
-  std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<ScalarT>&> tpm = a.getEntries();
-  const auto& [r, c, val]                                                       = tpm;
-  std::tie(m, n)                                                                = a.getDimensions();
-
-  // Increase size as necessary
-  this->rows_size_    = this->rows_size_ > m ? this->rows_size_ : m;
-  this->columns_size_ = this->columns_size_ > n ? this->columns_size_ : n;
-
-  IdxT a_iter = 0;
-  // iterate for all current values in matrix
-  for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
-  {
-    // pushback values when they are not in current matrix
-    while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
-    {
-      this->row_indices_.push_back(r[a_iter]);
-      this->column_indices_.push_back(c[a_iter]);
-      this->values_.push_back(alpha * val[a_iter]);
-
-      this->checkIncreaseSize(r[a_iter], c[a_iter]);
-      a_iter++;
-    }
-    if (a_iter >= static_cast<IdxT>(r.size()))
-    {
-      break;
-    }
-
-    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
-    {
-      this->values_[i] += alpha * val[a_iter];
-      a_iter++;
-    }
-  }
-  // push back rest that was not found sorted_
-  for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
-  {
-    this->row_indices_.push_back(r[i]);
-    this->column_indices_.push_back(c[i]);
-    this->values_.push_back(alpha * val[i]);
-
-    this->checkIncreaseSize(r[i], c[i]);
-  }
-
-  this->sorted_ = false;
-}
-
-/**
- * @brief axpy on a COO representation of a matrix. Will sort before running
- *
- * @tparam ScalarT
- * @tparam IdxT
- * @param alpha scalar to multiply by
- * @param r row indices
- * @param c column indices
- * @param v values
- *
- * @pre r.size() == c.size() == v.size()
- * @pre r,c,v represent an array a in COO format
- *
- * @post this = this + alpha * a
- */
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v)
-{
-  if (alpha == 0)
-    return;
-
-  if (!this->sorted_)
-  {
-    this->sortSparse();
-  }
-
-  // sort input
-  this->sortSparseCOO(r, c, v);
-
-  IdxT a_iter = 0;
-  // iterate for all current values_ in matrix
-  for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
-  {
-    // pushback values_ when they are not in current matrix
-    while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
-    {
-      this->row_indices_.push_back(r[a_iter]);
-      this->column_indices_.push_back(c[a_iter]);
-      this->values_.push_back(alpha * v[a_iter]);
-
-      this->checkIncreaseSize(r[a_iter], c[a_iter]);
-      a_iter++;
-    }
-    if (a_iter >= static_cast<IdxT>(r.size()))
-    {
-      break;
-    }
-
-    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
-    {
-      this->values_[i] += alpha * v[a_iter];
-      a_iter++;
-    }
-  }
-  // push back rest that was not found sorted_
-  for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
-  {
-    this->row_indices_.push_back(r[i]);
-    this->column_indices_.push_back(c[i]);
-    this->values_.push_back(alpha * v[i]);
-
-    this->checkIncreaseSize(r[i], c[i]);
-  }
-
-  this->sorted_ = false;
-}
-
-/**
- * @brief Scale all values by alpha
- *
- * @tparam ScalarT
- * @tparam IdxT
- * @param[in] alpha scalar to scale by
- */
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::scal(ScalarT alpha)
-{
-  for (auto i = this->values_.begin(); i < this->values_.end(); i++)
-  {
-    *i *= alpha;
-  }
-}
-
-/**
- * @brief Calculates the Frobenius Norm of the matrix
- *
- * @tparam ScalarT
- * @tparam IdxT
- * @return ScalarT - Frobenius Norm of the matrix
- */
-template <class ScalarT, typename IdxT>
-inline ScalarT COO_Matrix<ScalarT, IdxT>::frobNorm()
-{
-  ScalarT totsum = 0.0;
-  for (auto i = this->values_.begin(); i < this->values_.end(); i++)
-  {
-    totsum += abs(*i) ^ 2;
-  }
-  return totsum;
-}
-
-/**
- * @brief Permutate the matrix to a different one. Only changes the coordinates
- *
- * @tparam ScalarT
- * @param[in] row_perm
- * @param[out] col_perm
- *
- * @pre row_perm.size() == this->rows_size_ = col_perm.size() == this->columns_size_
- *
- * @post this = this(row_perm, col_perm)
- */
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::permutation(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm)
-{
-  assert(row_perm.size() = this->rows_size_);
-  assert(col_perm.size() = this->columns_size_);
-
-  for (int i = 0; i < this->values_.size(); i++)
-  {
-    this->row_indices_[i]    = row_perm[this->row_indices_[i]];
-    this->column_indices_[i] = col_perm[this->column_indices_[i]];
-  }
-  this->sorted_ = false;
-  // cycle sorting maybe useful since permutations are already known
-}
-
-/**
- * @brief Permutes the matrix and can change its size efficently
- *
- * @tparam ScalarT
- * @tparam IdxT
- * @param[in] row_perm row permutation
- * @param[in] col_perm column permutation
- * @param[in] m number of rows
- * @param[in] n number of columns
- *
- * @pre row_perm.size() == this->rows_size_
- * @pre col_perm.size() == this->columns_size_
- * @pre indices are set to -1 if they are to be removed
- *
- * @post this = this(row_perm, col_perm) and removed indices have corresponding values set to 0
- */
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::permutationSizeMap(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm, IdxT m, IdxT n)
-{
-  assert(row_perm.size() == this->rows_size_);
-  assert(col_perm.size() == this->columns_size_);
-
-  this->rows_size_    = m;
-  this->columns_size_ = n;
-
-  for (int i = 0; i < this->values_.size(); i++)
-  {
-    if (row_perm[this->row_indices_[i]] == -1 || col_perm[this->column_indices_[i]] == -1)
-    {
-      this->values_[i] = 0;
-    }
-    else
-    {
-      this->row_indices_[i]    = row_perm[this->row_indices_[i]];
-      this->column_indices_[i] = col_perm[this->column_indices_[i]];
-    }
-  }
-  this->sorted_ = false;
-}
-
-/**
- * @brief Turn matrix into the zero matrix. Does not actually delete memory
- *
- * @tparam ScalarT
- * @tparam IdxT
- *
- */
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::zeroMatrix()
-{
-  // resize doesn't effect capacity if smaller
-  this->column_indices_.resize(0);
-  this->row_indices_.resize(0);
-  this->values_.resize(0);
-  this->sorted_ = true;
-}
-
-/**
- * @brief Turn matrix into the identity matrix
- *
- * @tparam ScalarT
- * @tparam IdxT
- *
- * @param[in] n size of the identity matrix
- *
- * @post this = I_n
- *
- * @todo - it might be better to explicitly zero out the matrix and require to be so in preconditions
- */
-
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::identityMatrix(IdxT n)
-{
-  // Reset Matrix
-  this->zeroMatrix();
-  for (IdxT i = 0; i < n; i++)
-  {
-    this->column_indices_[i] = i;
-    this->row_indices_[i]    = i;
-    this->values_[i]         = 1.0;
-  }
-  this->sorted_ = true;
-}
-
-/**
- * @brief Restructure the sparse matrix for faster accesses and modifications
- *
- * @tparam ScalarT
- * @tparam IdxT
- */
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::sortSparse()
-{
-  this->sortSparseCOO(this->row_indices_, this->column_indices_, this->values_);
-  this->sorted_ = true;
-}
-
-/**
- * @brief Check if the matrix is sorted
- *
- * @tparam ScalarT
- * @tparam IdxT
- *
- * @param[out]  bool - true if sorted, false otherwise
- */
-
-template <class ScalarT, typename IdxT>
-inline bool COO_Matrix<ScalarT, IdxT>::isSorted()
-{
-  return this->sorted_;
-}
-
-/**
- * @brief Get the number of non-zero elements in the matrix
- *
- * @tparam ScalarT
- * @tparam IdxT
- *
- * @param[out] IdxT - number of non-zero elements in the matrix
- */
-template <class ScalarT, typename IdxT>
-inline IdxT COO_Matrix<ScalarT, IdxT>::nnz()
-{
-  return static_cast<IdxT>(this->values_.size());
-}
-
-template <class ScalarT, typename IdxT>
-inline std::tuple<IdxT, IdxT> COO_Matrix<ScalarT, IdxT>::getDimensions()
-{
-  return std::tuple<IdxT, IdxT>(this->rows_size_, this->columns_size_);
-}
-
-/**
- * @brief Print matrix in sorted order
- *
- * @tparam ScalarT
- * @tparam IdxT
- *
- * @param[in] name to identify the specific matrix printed
- */
-template <class ScalarT, typename IdxT>
-inline void COO_Matrix<ScalarT, IdxT>::printMatrix(std::string name)
-{
-  if (this->sorted_ == false)
-  {
-    this->sortSparse();
-  }
-
-  std::cout << "Sparse COO Matrix: " << name << "\n";
-  std::cout << "(x , y, value)\n";
-  for (size_t i = 0; i < this->values_.size(); i++)
-  {
-    std::cout << "(" << this->row_indices_[i]
-              << ", " << this->column_indices_[i]
-              << ", " << this->values_[i] << ")\n";
-  }
-  std::cout << std::flush;
-}
-
-/**
- * @brief Print matrix to file in Matrix Market format
- *
- * @tparam ScalarT
- * @tparam IdxT
- *
- * @param[in] filename Output file path
- * @param[in] comment Optional comment for the Matrix Market file
- */
-template <class ScalarT, typename IdxT>
-void COO_Matrix<ScalarT, IdxT>::printMatrixMarket(const std::string& filename, const std::string& comment)
-{
-  if (this->sorted_ == false)
-  {
-    this->sortSparse();
-  }
-
-  std::ofstream outfile(filename);
-  if (!outfile.is_open())
-  {
-    std::cerr << "Error: Unable to open file " << filename << " for writing." << std::endl;
-    return;
-  }
-
-  // Write Matrix Market header
-  outfile << "%%MatrixMarket matrix coordinate ";
-
-  if (!std::is_floating_point<ScalarT>::value)
-  {
-    // error message
-    return;
-  }
-
-  outfile << "general" << std::endl;
-
-  // Write comment if provided
-  if (!comment.empty())
-    outfile << "% " << comment << std::endl;
-
-  // Write dimensions and number of entries
-  // Get max row and column indices to determine matrix dimensions
-  IdxT max_row = 0;
-  IdxT max_col = 0;
-  for (size_t i = 0; i < this->values_.size(); i++)
-  {
-    max_row = std::max(max_row, this->row_indices_[i]);
-    max_col = std::max(max_col, this->column_indices_[i]);
-  }
-
-  // Matrix Market uses 1-based indexing, so add 1 to dimensions
-  outfile << (max_row + 1) << " " << (max_col + 1) << " " << this->values_.size() << std::endl;
-
-  // Write the matrix entries
-  for (size_t i = 0; i < this->values_.size(); i++)
-  {
-    // Matrix Market uses 1-based indexing, so add 1 to indices
-    outfile << (this->row_indices_[i] + 1) << " "
-            << (this->column_indices_[i] + 1) << " "
-            << this->values_[i] << std::endl;
-  }
-
-  outfile.close();
-
-  std::cout << "Matrix Market file written to: " << filename << std::endl;
-}
-
-/**
- * @brief Find the lowest row cordinate from set of provided coordinates
- *
- * Assumes rows and columns are sorted
- * @tparam ScalarT
- * @tparam IdxT
- *
- * @param[in] rows - row indices
- * @param[in] r - row index
- *
- * @return IdxT - index of lowest row
- */
-template <class ScalarT, typename IdxT>
-inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& rows, IdxT r)
-{
-  // Specialized Binary Search for Lowest Row
-  IdxT i1         = 0;
-  IdxT i2         = rows->size() - 1;
-  IdxT m_smallest = -1;
-  IdxT m          = -1;
-  while (i1 <= i2)
-  {
-    m = (i2 + i1) / 2;
-    // rows
-    if (rows[m] < r)
-    {
-      i1 = m + 1;
-    }
-    else if (r < rows[m])
-    {
-      i2 = m - 1;
-    }
-    else
-    {
-      if (i1 == i2)
+      if (!this->sorted_)
       {
         this->sortSparse();
       }
@@ -794,12 +196,12 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
     {
       if (!this->isSorted())
         this->sortSparse();
-      std::vector<IdxT> row_size_vec(static_cast<size_t>(this->rows_size_ + 1), 0);
-      size_t            counter = 0;
-      for (size_t i = 0; i < row_size_vec.size() - 1; i++)
+      std::vector<IdxT> row_size_vec(this->rows_size_ + 1, 0);
+      IdxT              counter = 0;
+      for (IdxT i = 0; i < static_cast<IdxT>(row_size_vec.size() - 1); i++)
       {
         row_size_vec[i + 1] = row_size_vec[i];
-        while (counter < this->row_indices_.size() && i == static_cast<size_t>(this->row_indices_[counter]))
+        while (counter < static_cast<IdxT>(this->row_indices_.size()) && i == this->row_indices_[counter])
         {
           row_size_vec[i + 1]++;
           counter++;
@@ -831,12 +233,12 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
       this->sortSparseCOO(r, c, v);
 
       // Duplicated with axpy. Could replace with function depdent on lambda expression
-      size_t a_iter = 0;
+      IdxT a_iter = 0;
       // iterate for all current values_ in matrix
-      for (size_t i = 0; i < this->row_indices_.size(); i++)
+      for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
       {
         // pushback values_ when they are not in current matrix
-        while (a_iter < r.size() && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
+        while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
         {
           this->row_indices_.push_back(r[a_iter]);
           this->column_indices_.push_back(c[a_iter]);
@@ -844,8 +246,7 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
           this->checkIncreaseSize(r[a_iter], c[a_iter]);
           a_iter++;
         }
-
-        if (a_iter >= r.size())
+        if (a_iter >= static_cast<IdxT>(r.size()))
         {
           break;
         }
@@ -857,7 +258,7 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
         }
       }
       // push back rest that was not found sorted
-      for (size_t i = a_iter; i < r.size(); i++)
+      for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
       {
         this->row_indices_.push_back(r[i]);
         this->column_indices_.push_back(c[i]);
@@ -905,12 +306,12 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
       this->rows_size_    = this->rows_size_ > m ? this->rows_size_ : m;
       this->columns_size_ = this->columns_size_ > n ? this->columns_size_ : n;
 
-      size_t a_iter = 0;
+      IdxT a_iter = 0;
       // iterate for all current values in matrix
-      for (size_t i = 0; i < this->row_indices_.size(); i++)
+      for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
       {
         // pushback values when they are not in current matrix
-        while (a_iter < r.size() && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
+        while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
         {
           this->row_indices_.push_back(r[a_iter]);
           this->column_indices_.push_back(c[a_iter]);
@@ -919,7 +320,7 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
           this->checkIncreaseSize(r[a_iter], c[a_iter]);
           a_iter++;
         }
-        if (a_iter >= r.size())
+        if (a_iter >= static_cast<IdxT>(r.size()))
         {
           break;
         }
@@ -931,7 +332,7 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
         }
       }
       // push back rest that was not found sorted_
-      for (size_t i = a_iter; i < r.size(); i++)
+      for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
       {
         this->row_indices_.push_back(r[i]);
         this->column_indices_.push_back(c[i]);
@@ -972,12 +373,12 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
       // sort input
       this->sortSparseCOO(r, c, v);
 
-      size_t a_iter = 0;
+      IdxT a_iter = 0;
       // iterate for all current values_ in matrix
-      for (size_t i = 0; i < this->row_indices_.size(); i++)
+      for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
       {
         // pushback values_ when they are not in current matrix
-        while (a_iter < r.size() && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
+        while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
         {
           this->row_indices_.push_back(r[a_iter]);
           this->column_indices_.push_back(c[a_iter]);
@@ -986,7 +387,7 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
           this->checkIncreaseSize(r[a_iter], c[a_iter]);
           a_iter++;
         }
-        if (a_iter >= r.size())
+        if (a_iter >= static_cast<IdxT>(r.size()))
         {
           break;
         }
@@ -998,7 +399,7 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
         }
       }
       // push back rest that was not found sorted_
-      for (IdxT i = a_iter; i < r.size(); i++)
+      for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
       {
         this->row_indices_.push_back(r[i]);
         this->column_indices_.push_back(c[i]);
@@ -1095,7 +496,7 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
       this->rows_size_    = m;
       this->columns_size_ = n;
 
-      for (size_t i = 0; i < this->values_.size(); i++)
+      for (int i = 0; i < this->values_.size(); i++)
       {
         if (row_perm[this->row_indices_[i]] == -1 || col_perm[this->column_indices_[i]] == -1)
         {
@@ -1120,7 +521,7 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
     template <class ScalarT, typename IdxT>
     inline void COO_Matrix<ScalarT, IdxT>::zeroMatrix()
     {
-      // resize doesn't affect capacity if smaller
+      // resize doesn't effect capacity if smaller
       this->column_indices_.resize(0);
       this->row_indices_.resize(0);
       this->values_.resize(0);
@@ -1227,6 +628,72 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
                   << ", " << this->values_[i] << ")\n";
       }
       std::cout << std::flush;
+    }
+
+    /**
+     * @brief Print matrix to file in Matrix Market format
+     *
+     * @tparam ScalarT
+     * @tparam IdxT
+     *
+     * @param[in] filename Output file path
+     * @param[in] comment Optional comment for the Matrix Market file
+     */
+    template <class ScalarT, typename IdxT>
+    void COO_Matrix<ScalarT, IdxT>::printMatrixMarket(const std::string& filename, const std::string& comment)
+    {
+      if (this->sorted_ == false)
+      {
+        this->sortSparse();
+      }
+
+      std::ofstream outfile(filename);
+      if (!outfile.is_open())
+      {
+        std::cerr << "Error: Unable to open file " << filename << " for writing." << std::endl;
+        return;
+      }
+
+      // Write Matrix Market header
+      outfile << "%%MatrixMarket matrix coordinate ";
+
+      if (!std::is_floating_point<ScalarT>::value)
+      {
+        // error message
+        return;
+      }
+
+      outfile << "general" << std::endl;
+
+      // Write comment if provided
+      if (!comment.empty())
+        outfile << "% " << comment << std::endl;
+
+      // Write dimensions and number of entries
+      // Get max row and column indices to determine matrix dimensions
+      IdxT max_row = 0;
+      IdxT max_col = 0;
+      for (size_t i = 0; i < this->values_.size(); i++)
+      {
+        max_row = std::max(max_row, this->row_indices_[i]);
+        max_col = std::max(max_col, this->column_indices_[i]);
+      }
+
+      // Matrix Market uses 1-based indexing, so add 1 to dimensions
+      outfile << (max_row + 1) << " " << (max_col + 1) << " " << this->values_.size() << std::endl;
+
+      // Write the matrix entries
+      for (size_t i = 0; i < this->values_.size(); i++)
+      {
+        // Matrix Market uses 1-based indexing, so add 1 to indices
+        outfile << (this->row_indices_[i] + 1) << " "
+                << (this->column_indices_[i] + 1) << " "
+                << this->values_[i] << std::endl;
+      }
+
+      outfile.close();
+
+      std::cout << "Matrix Market file written to: " << filename << std::endl;
     }
 
     /**
@@ -1385,7 +852,7 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
       // Sort by row first then column.
       std::sort(std::begin(ordervec),
                 std::end(ordervec),
-                [&](auto i1, auto i2)
+                [&](int i1, int i2)
                 { return (rows[i1] < rows[i2]) || (rows[i1] == rows[i2] && columns[i1] < columns[i2]); });
 
       // reorder based of index-sorting. Only swap cost no extra memory.
@@ -1482,7 +949,5 @@ inline IdxT COO_Matrix<ScalarT, IdxT>::indexStartRow(const std::vector<IdxT>& ro
     COO_Matrix<ScalarT, IdxT>::~COO_Matrix()
     {
     }
-
   } // namespace LinearAlgebra
 } // namespace GridKit
-#endif

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -21,12 +21,12 @@ namespace GridKit
    * @return true if the write was successful, false otherwise
    */
   template <typename T>
-  bool writeVectorToMatrixMarket(const std::vector<T>& vec, const std::string& filename, const std::string& header) {
+  void writeVectorToMatrixMarket(const std::vector<T>& vec, const std::string& filename, const std::string& header) {
       std::ofstream outFile(filename);
       
       if (!outFile.is_open()) {
           std::cerr << "Error: Could not open file " << filename << " for writing." << std::endl;
-          return false;
+          return;
       }
       
       // Write Matrix Market header
@@ -46,10 +46,8 @@ namespace GridKit
           outFile << val << std::endl;
       }
       
-      outFile.close();
-      
-      std::cout << "Vector successfully written to " << filename << std::endl;
-      return true;
+      outFile.close();      
+      return;
   }
 
 

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -3,9 +3,9 @@
 #pragma once
 
 #include <cassert>
+#include <iomanip>
 #include <iostream>
 #include <vector>
-#include <iomanip>
 
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 #include <Model/PowerElectronics/CircuitGraph.hpp>

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -324,10 +324,23 @@ namespace GridKit
       alpha_ = a;
     }
 
+    /**
+     * @brief print the system Jacobian in COO format
+     * 
+     * 
+     */
+
+    void printJacobianMatrixMarket(std::string filename, std::string title)
+    {
+      jac_.printMatrixMarket(filename, title);
+    }
+
     void addComponent(component_type* component)
     {
       components_.push_back(component);
     }
+
+
 
   private:
     static constexpr IdxT neg1_ = static_cast<IdxT>(-1);

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -14,42 +14,45 @@ namespace GridKit
 {
   /**
    * Writes a vector to a file in Matrix Market format
-   * 
+   *
    * @param vec The vector to write
    * @param filename The name of the output file
    * @param header Additional header information/comments
    * @return true if the write was successful, false otherwise
    */
   template <typename T>
-  void writeVectorToMatrixMarket(const std::vector<T>& vec, const std::string& filename, const std::string& header) {
-      std::ofstream outFile(filename);
-      
-      if (!outFile.is_open()) {
-          std::cerr << "Error: Could not open file " << filename << " for writing." << std::endl;
-          return;
-      }
-      
-      // Write Matrix Market header
-      outFile << "%%MatrixMarket vector array real general" << std::endl;
-      
-      // Write additional header information as comments
-      if (!header.empty()) {
-          outFile << "% " << header << std::endl;
-      }
-      
-      // Write the vector size
-      outFile << vec.size() << std::endl;
-      
-      // Write the vector elements
-      outFile << std::scientific << std::setprecision(16);
-      for (const auto& val : vec) {
-          outFile << val << std::endl;
-      }
-      
-      outFile.close();      
-      return;
-  }
+  void writeVectorToMatrixMarket(const std::vector<T>& vec, const std::string& filename, const std::string& header)
+  {
+    std::ofstream outFile(filename);
 
+    if (!outFile.is_open())
+    {
+      std::cerr << "Error: Could not open file " << filename << " for writing." << std::endl;
+      return;
+    }
+
+    // Write Matrix Market header
+    outFile << "%%MatrixMarket vector array real general" << std::endl;
+
+    // Write additional header information as comments
+    if (!header.empty())
+    {
+      outFile << "% " << header << std::endl;
+    }
+
+    // Write the vector size
+    outFile << vec.size() << std::endl;
+
+    // Write the vector elements
+    outFile << std::scientific << std::setprecision(16);
+    for (const auto& val : vec)
+    {
+      outFile << val << std::endl;
+    }
+
+    outFile.close();
+    return;
+  }
 
   template <class ScalarT, typename IdxT>
   class PowerElectronicsModel : public CircuitComponent<ScalarT, IdxT>
@@ -389,8 +392,6 @@ namespace GridKit
     {
       components_.push_back(component);
     }
-
-
 
   private:
     static constexpr IdxT neg1_ = static_cast<IdxT>(-1);

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -12,6 +12,46 @@
 
 namespace GridKit
 {
+  /**
+   * Writes a vector to a file in Matrix Market format
+   * 
+   * @param vec The vector to write
+   * @param filename The name of the output file
+   * @param header Additional header information/comments
+   * @return true if the write was successful, false otherwise
+   */
+  template <typename T>
+  bool writeVectorToMatrixMarket(const std::vector<T>& vec, const std::string& filename, const std::string& header) {
+      std::ofstream outFile(filename);
+      
+      if (!outFile.is_open()) {
+          std::cerr << "Error: Could not open file " << filename << " for writing." << std::endl;
+          return false;
+      }
+      
+      // Write Matrix Market header
+      outFile << "%%MatrixMarket vector array real general" << std::endl;
+      
+      // Write additional header information as comments
+      if (!header.empty()) {
+          outFile << "% " << header << std::endl;
+      }
+      
+      // Write the vector size
+      outFile << vec.size() << std::endl;
+      
+      // Write the vector elements
+      outFile << std::scientific << std::setprecision(16);
+      for (const auto& val : vec) {
+          outFile << val << std::endl;
+      }
+      
+      outFile.close();
+      
+      std::cout << "Vector successfully written to " << filename << std::endl;
+      return true;
+  }
+
 
   template <class ScalarT, typename IdxT>
   class PowerElectronicsModel : public CircuitComponent<ScalarT, IdxT>
@@ -322,6 +362,17 @@ namespace GridKit
       }
       time_  = t;
       alpha_ = a;
+    }
+
+    /**
+     * @brief print the system residual in COO format
+     *
+     * @param[in] filename
+     * @param[in] title
+     */
+    void printResidualMatrixMarket(std::string filename, std::string title)
+    {
+      writeVectorToMatrixMarket(f_, filename, title);
     }
 
     /**

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <iostream>
 #include <vector>
+#include <iomanip>
 
 #include <Model/PowerElectronics/CircuitComponent.hpp>
 #include <Model/PowerElectronics/CircuitGraph.hpp>

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -326,8 +326,9 @@ namespace GridKit
 
     /**
      * @brief print the system Jacobian in COO format
-     * 
-     * 
+     *
+     * @param[in] filename
+     * @param[in] title
      */
 
     void printJacobianMatrixMarket(std::string filename, std::string title)


### PR DESCRIPTION
## Description
 
 _This is a new feature that enables exporting `ScaleMicrogrid` examples of arbitrary size for testing._

 
 ## Proposed changes
 
 _The functions work as intended and the rest of the code is intact. This is a broad fix that can work for other Jacobians or COO matrices.
After running `make`, in your `build` directory, run_
```
./examples/ScaleMicrogrid/scalemicrogridarbitrary <N>
```
For example
```
./examples/ScaleMicrogrid/scalemicrogridarbitrary 1000
```

This will generate a linear system with $`36N-2`$ variables and constraints.
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [X] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc..._
 
