### PR TITLE
Refactor examples

### DIFF
--- a/examples/PhasorDynamics/Example1/example1.cpp
+++ b/examples/PhasorDynamics/Example1/example1.cpp
@@ -126,6 +126,7 @@ int main()
   double stop = static_cast<double>(clock());
 
   double error_V = 0.0; // error in |V|
+  double error_w = 0.0; // error in rotor speed
 
   // Read through the simulation data stored in the buffer.
   // Since we captured by reference, output should be available
@@ -141,22 +142,37 @@ int main()
     if (err > error_V)
       error_V = err;
 
-    std::cout << "GridKit: t = " << data.ti
-              << ", |V| = " << std::sqrt(data.Vr * data.Vr + data.Vi * data.Vi)
-              << ", w = " << (1.0 + data.dw) << "\n";
-    std::cout << "Ref    : t = " << ref_sol[0]
-              << ", |V| = " << ref_sol[2]
-              << ", w = " << ref_sol[1]
-              << "\n";
-    std::cout << "Error in |V| = "
-              << err
-              << "\n";
-    std::cout << "\n";
+    err = std::abs(1.0 + data.dw - ref_sol[1])/(1.0 + ref_sol[1]);
+    if (err > error_w)
+      error_w = err;
+
+    // // Optional output
+    // std::cout << "GridKit: t = " << data.ti
+    //           << ", |V| = " << std::sqrt(data.Vr * data.Vr + data.Vi * data.Vi)
+    //           << ", w = " << (1.0 + data.dw) << "\n";
+    // std::cout << "Ref    : t = " << ref_sol[0]
+    //           << ", |V| = " << ref_sol[2]
+    //           << ", w = " << ref_sol[1]
+    //           << "\n";
+    // std::cout << "Error in |V| = "
+    //           << err
+    //           << "\n";
+    // std::cout << "\n";
   }
 
+  double error_V_allowed = 2e-4;
+  double error_w_allowed = 1e-4;
+
+  // Tolerances based on Powerworld reference accuracy
   int status = 0;
   std::cout << "Max error in |V| = " << error_V << "\n";
-  if (error_V > 2e-4)
+  if (error_V > error_V_allowed)
+  {
+    std::cout << "Test failed with error too large!\n";
+    status = 1;
+  }
+  std::cout << "Max error in  w  = " << error_w << "\n";
+  if (error_w > error_w_allowed)
   {
     std::cout << "Test failed with error too large!\n";
     status = 1;

--- a/examples/PhasorDynamics/Example1/example1.cpp
+++ b/examples/PhasorDynamics/Example1/example1.cpp
@@ -142,7 +142,7 @@ int main()
     if (err > error_V)
       error_V = err;
 
-    err = std::abs(1.0 + data.dw - ref_sol[1])/(1.0 + ref_sol[1]);
+    err = std::abs(1.0 + data.dw - ref_sol[1]) / (1.0 + ref_sol[1]);
     if (err > error_w)
       error_w = err;
 

--- a/examples/PhasorDynamics/Example2/example2.cpp
+++ b/examples/PhasorDynamics/Example2/example2.cpp
@@ -183,7 +183,7 @@ int main()
   }
   // fileout.close();
 
-  std::cout << "Worst error " << worst_error
+  std::cout << "Max error " << worst_error
             << " at time t = " << worst_error_time << "\n";
   std::cout << "\n\nComplete in " << (stop - start) / CLOCKS_PER_SEC << " seconds\n";
 

--- a/examples/PowerElectronics/DistributedGeneratorTest/DGTest.cpp
+++ b/examples/PowerElectronics/DistributedGeneratorTest/DGTest.cpp
@@ -75,7 +75,7 @@ int main(int /* argc */, char const** /* argv */)
                                2.684419146397466e+03};
 
   std::cout << "Testing the DistributedGenerator model ...\n";
-  double error_allowed = 10*std::numeric_limits<double>::epsilon();
+  double error_allowed = 10 * std::numeric_limits<double>::epsilon();
   for (size_t i = 0; i < true_vec.size(); i++)
   {
     double error = std::abs(true_vec[i] - dg->getResidual()[i]) / std::abs(1.0 + true_vec[i]);

--- a/examples/PowerElectronics/DistributedGeneratorTest/DGTest.cpp
+++ b/examples/PowerElectronics/DistributedGeneratorTest/DGTest.cpp
@@ -16,7 +16,7 @@
  * @param argv
  * @return int
  */
-int main(int argc, char const* argv[])
+int main(int /* argc */, char const** /* argv */)
 {
 
   GridKit::DistributedGeneratorParameters<double, size_t> parms;
@@ -49,12 +49,12 @@ int main(int argc, char const* argv[])
 
   dg->evaluateResidual();
 
-  std::cout << "Output: {";
-  for (double i : dg->getResidual())
-  {
-    printf("%e ,", i);
-  }
-  std::cout << "}\n";
+  // std::cout << "Output: {";
+  // for (double i : dg->getResidual())
+  // {
+  //   printf("%e ,", i);
+  // }
+  // std::cout << "}\n";
 
   // Generated from matlab code with same parameters and inputs
   std::vector<double> true_vec{3.141592277589793e+02,
@@ -74,11 +74,20 @@ int main(int argc, char const* argv[])
                                3.337988298081817e+03,
                                2.684419146397466e+03};
 
-  std::cout << "Test the Relative Error\n";
+  std::cout << "Testing the DistributedGenerator model ...\n";
+  double error_allowed = 10*std::numeric_limits<double>::epsilon();
   for (size_t i = 0; i < true_vec.size(); i++)
   {
-    printf("%e ,\n", (true_vec[i] - dg->getResidual()[i]) / true_vec[i]);
+    double error = std::abs(true_vec[i] - dg->getResidual()[i]) / std::abs(1.0 + true_vec[i]);
+    if (error > error_allowed)
+    {
+      std::cout << "Model error for equation " << i << " is: " << error << "\n";
+      std::cout << "Maximum allowed error is: " << error_allowed << "\n";
+      std::cout << "Test FAILED!\n";
+      return 1;
+    }
   }
+  std::cout << "Test successful!\n";
 
   return 0;
 }

--- a/examples/PowerElectronics/Microgrid/Microgrid.cpp
+++ b/examples/PowerElectronics/Microgrid/Microgrid.cpp
@@ -15,16 +15,17 @@
 #include <Solver/Dynamic/DynamicSolver.hpp>
 #include <Solver/Dynamic/Ida.hpp>
 
-int main(int argc, char const* argv[])
+int main(int /* argc */, char const** /* argv */)
 {
-  ///@todo Needs to be modified. Some components are small relative to others thus there error is high (or could be matlab vector issue)
+  /// @todo Needs to be modified. Some components are small relative to others thus 
+  /// there error is high (or could be matlab vector issue)
   double abs_tol         = 1.0e-8;
   double rel_tol         = 1.0e-8;
-  size_t max_step_amount = 3000;
+  size_t max_step_number = 3000;
   bool   use_jac         = true;
 
   // Create model
-  GridKit::PowerElectronicsModel<double, size_t>* sysmodel = new GridKit::PowerElectronicsModel<double, size_t>(rel_tol, abs_tol, use_jac, max_step_amount);
+  auto* sysmodel = new GridKit::PowerElectronicsModel<double, size_t>(rel_tol, abs_tol, use_jac, max_step_number);
 
   // Modeled after the problem in the paper
   double RN = 1.0e4;
@@ -315,20 +316,21 @@ int main(int argc, char const* argv[])
   sysmodel->initialize();
   sysmodel->evaluateResidual();
 
-  std::vector<double>& fres = sysmodel->getResidual();
-  std::cout << "Verify Intial Resisdual is Zero: {\n";
-  for (size_t i = 0; i < fres.size(); i++)
-  {
-    printf("%lu : %e \n", i, fres[i]);
-  }
-  std::cout << "}\n";
+  // // Optional debugging output
+  // std::vector<double>& fres = sysmodel->getResidual();
+  // std::cout << "Verify Intial Resisdual is Zero: {\n";
+  // for (size_t i = 0; i < fres.size(); i++)
+  // {
+  //   printf("%lu : %e \n", i, fres[i]);
+  // }
+  // std::cout << "}\n";
 
   sysmodel->updateTime(0.0, 1.0e-8);
   sysmodel->evaluateJacobian();
   std::cout << "Intial Jacobian with alpha:\n";
 
   // Create numerical integrator and configure it for the generator model
-  AnalysisManager::Sundials::Ida<double, size_t>* idas = new AnalysisManager::Sundials::Ida<double, size_t>(sysmodel);
+  auto* idas = new AnalysisManager::Sundials::Ida<double, size_t>(sysmodel);
 
   double t_init  = 0.0;
   double t_final = 1.0;
@@ -342,13 +344,14 @@ int main(int argc, char const* argv[])
 
   std::vector<double>& yfinial = sysmodel->y();
 
-  std::cout << "Final Vector y\n";
-  for (size_t i = 0; i < yfinial.size(); i++)
-  {
-    std::cout << yfinial[i] << "\n";
-  }
+  // // Optional debugging output
+  // std::cout << "Final Vector y\n";
+  // for (size_t i = 0; i < yfinial.size(); i++)
+  // {
+  //   std::cout << yfinial[i] << "\n";
+  // }
 
-  // Generate from MATLAB code ODE form with tolerances of 1e-12
+  // Generated from MATLAB code ODE form with tolerances of 1e-12
   std::vector<double> true_vec{
       2.297543153595780e+04,
       1.275311524125022e+04,
@@ -421,11 +424,31 @@ int main(int argc, char const* argv[])
       3.604108939430972e+02,
       -3.492842627398574e+01};
 
-  std::cout << "Test the Relative Error\n";
+  // std::cout << "Test the Relative Error\n";
+  // for (size_t i = 0; i < true_vec.size(); i++)
+  // {
+  //   printf("%lu : %e ,\n", i, abs(true_vec[i] - yfinial[i]) / abs(true_vec[i]));
+  // }
+
+  std::cout << "Testing the DistributedGenerator model ...\n";
+  double error_allowed = 1e-4;
+  double max_error = 0.0;
   for (size_t i = 0; i < true_vec.size(); i++)
   {
-    printf("%lu : %e ,\n", i, abs(true_vec[i] - yfinial[i]) / abs(true_vec[i]));
+    double error = std::abs(true_vec[i] - yfinial[i]) / std::abs(1.0 + true_vec[i]);
+    if (error > max_error)
+      max_error = error;
+    if (error > error_allowed)
+    {
+      std::cout << "Model error for equation " << i << " is: " << error << "\n";
+      std::cout << "Maximum allowed error is: " << error_allowed << "\n";
+      std::cout << "Test FAILED!\n";
+      return 1;
+    }
   }
+  std::cout << "Max error     = " << max_error << "\n";
+  std::cout << "Allowed error = " << error_allowed << "\n";
+  std::cout << "Test successful!\n";
 
   delete idas;
   delete sysmodel;

--- a/examples/PowerElectronics/Microgrid/Microgrid.cpp
+++ b/examples/PowerElectronics/Microgrid/Microgrid.cpp
@@ -17,7 +17,7 @@
 
 int main(int /* argc */, char const** /* argv */)
 {
-  /// @todo Needs to be modified. Some components are small relative to others thus 
+  /// @todo Needs to be modified. Some components are small relative to others thus
   /// there error is high (or could be matlab vector issue)
   double abs_tol         = 1.0e-8;
   double rel_tol         = 1.0e-8;
@@ -432,7 +432,7 @@ int main(int /* argc */, char const** /* argv */)
 
   std::cout << "Testing the DistributedGenerator model ...\n";
   double error_allowed = 1e-4;
-  double max_error = 0.0;
+  double max_error     = 0.0;
   for (size_t i = 0; i < true_vec.size(); i++)
   {
     double error = std::abs(true_vec[i] - yfinial[i]) / std::abs(1.0 + true_vec[i]);

--- a/examples/PowerElectronics/RLCircuit/RLCircuit.cpp
+++ b/examples/PowerElectronics/RLCircuit/RLCircuit.cpp
@@ -14,7 +14,7 @@
 #include <Solver/Dynamic/DynamicSolver.hpp>
 #include <Solver/Dynamic/Ida.hpp>
 
-int main(int argc, char const* argv[])
+int main(int /* argc */, char const** /* argv */)
 {
   double abs_tol = 1.0e-8;
   double rel_tol = 1.0e-8;

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
@@ -31,7 +31,7 @@ static int test(index_type Nsize, real_type test_tolerance, bool error_tol = fal
  * @param argv unsued
  * @return int
  */
-int main(int argc, char const* argv[])
+int main(int /* argc */, char const** /* argv */)
 {
   int       retval    = 0;
   bool      debug_out = false;

--- a/examples/PowerFlow/Grid3Bus/README.md
+++ b/examples/PowerFlow/Grid3Bus/README.md
@@ -10,7 +10,7 @@ The mathematical model of the power flow problem is formulated as a set of nonli
 The model and its parameters are described in Figure 1:
 
 <div align="center">
-   <img align="center" src="../../docs/Figures/example1.jpg">
+   <img align="center" src="../../../docs/Figures/example1.jpg">
    
    
   Figure 1: A simple 3-bus grid example.

--- a/examples/PowerFlow/MatPowerTesting/MatPowerTesting.hpp
+++ b/examples/PowerFlow/MatPowerTesting/MatPowerTesting.hpp
@@ -1,0 +1,219 @@
+/**
+ * @file Testing.hpp
+ * @author Slaven Peles <slaven.peles@pnnl.gov>
+ *
+ * Contains utilies for testing.
+ *
+ */
+#pragma once
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <vector>
+
+#include <PowerSystemData.hpp>
+#include <Utilities/Testing.hpp>
+
+namespace
+{
+
+  static constexpr double tol_ = 1e-8;
+
+  inline std::ostream& errs()
+  {
+    std::cerr << "[examples/PowerFlow/MatPowerTesting.hpp]: ";
+    return std::cerr;
+  }
+
+} // namespace
+
+namespace GridKit
+{
+  namespace Testing
+  {
+
+    template <typename RealT = double, typename IdxT = int>
+    inline bool isEqual(PowerSystemData::GenCostData<RealT, IdxT> a,
+                        PowerSystemData::GenCostData<RealT, IdxT> b,
+                        RealT                                     tol = tol_)
+    {
+      (void) tol; // suppress warning
+      int fail  = 0;
+      fail     += a.kind != b.kind;
+      fail     += a.startup != b.startup;
+      fail     += a.shutdown != b.shutdown;
+      fail     += a.n != b.n;
+      if (fail)
+      {
+        errs() << "Got failure!\na=" << a.str() << "\nb=" << b.str();
+      }
+      return fail == 0;
+    }
+
+    template <typename RealT = double, typename IdxT = int>
+    inline bool isEqual(PowerSystemData::GenData<RealT, IdxT> a,
+                        PowerSystemData::GenData<RealT, IdxT> b,
+                        RealT                                 tol = tol_)
+    {
+      int fail = 0;
+
+      fail += a.bus != b.bus;
+      fail += !isEqual(a.Pg, b.Pg, tol);
+      fail += !isEqual(a.Qg, b.Qg, tol);
+      fail += !isEqual(a.Qmax, b.Qmax, tol);
+      fail += !isEqual(a.Qmin, b.Qmin, tol);
+      fail += !isEqual(a.Vg, b.Vg, tol);
+      fail += a.mBase != b.mBase;
+      fail += a.status != b.status;
+      fail += a.Pmax != b.Pmax;
+      fail += a.Pmin != b.Pmin;
+      fail += a.Pc1 != b.Pc1;
+      fail += a.Pc2 != b.Pc2;
+      fail += a.Qc1min != b.Qc1min;
+      fail += a.Qc1max != b.Qc1max;
+      fail += a.Qc2min != b.Qc2min;
+      fail += a.Qc2max != b.Qc2max;
+      fail += a.ramp_agc != b.ramp_agc;
+      fail += a.ramp_10 != b.ramp_10;
+      fail += a.ramp_30 != b.ramp_30;
+      fail += a.ramp_q != b.ramp_q;
+      fail += a.apf != b.apf;
+
+      if (fail)
+      {
+        errs() << "Got failure!\na=" << a.str() << "\nb=" << b.str();
+      }
+      return fail == 0;
+    }
+
+    template <typename RealT = double, typename IdxT = int>
+    inline bool isEqual(PowerSystemData::BusData<RealT, IdxT> a,
+                        PowerSystemData::BusData<RealT, IdxT> b,
+                        RealT                                 tol = tol_)
+    {
+      int fail = 0;
+
+      fail += a.bus_i != b.bus_i;
+      fail += a.type != b.type;
+      fail += a.Gs != b.Gs;
+      fail += a.Bs != b.Bs;
+      fail += a.area != b.area;
+      fail += !isEqual(a.Vm, b.Vm, tol);
+      fail += !isEqual(a.Va, b.Va, tol);
+      fail += a.baseKV != b.baseKV;
+      fail += a.zone != b.zone;
+      fail += !isEqual(a.Vmax, b.Vmax, tol);
+      fail += !isEqual(a.Vmin, b.Vmin, tol);
+
+      if (fail)
+      {
+        errs() << "bus_i: a=" << a.bus_i << ", b=" << b.bus_i << "\n"
+               << "type: a=" << a.type << ", b=" << b.type << "\n"
+               << "Gs: a=" << a.Gs << ", b=" << b.Gs << "\n"
+               << "Bs: a=" << a.Bs << ", b=" << b.Bs << "\n"
+               << "area: a=" << a.area << ", b=" << b.area << "\n"
+               << "Vm: a=" << a.Vm << ", b=" << b.Vm << "\n"
+               << "Va: a=" << a.Va << ", b=" << b.Va << "\n"
+               << "baseKV: a=" << a.baseKV << ", b=" << b.baseKV << "\n"
+               << "zone: a=" << a.zone << ", b=" << b.zone << "\n"
+               << "Vmax: a=" << a.Vmax << ", b=" << b.Vmax << "\n"
+               << "Vmin: a=" << a.Vmin << ", b=" << b.Vmin << "\n";
+      }
+      return fail == 0;
+    }
+
+    template <typename RealT = double, typename IdxT = int>
+    inline bool isEqual(PowerSystemData::LoadData<RealT, IdxT> a,
+                        PowerSystemData::LoadData<RealT, IdxT> b,
+                        RealT                                  tol = tol_)
+    {
+      int fail = 0;
+
+      fail += a.bus_i != b.bus_i;
+      fail += !isEqual(a.Pd, b.Pd, tol);
+      fail += !isEqual(a.Qd, b.Qd, tol);
+
+      if (fail)
+      {
+        errs() << "bus_i: a=" << a.bus_i << ", b=" << b.bus_i << "\n"
+               << "Pd: a=" << a.Pd << ", b=" << b.Pd << "\n"
+               << "Qd: a=" << a.Qd << ", b=" << b.Qd << "\n";
+      }
+      return fail == 0;
+    }
+
+    template <typename RealT = double, typename IdxT = int>
+    inline bool isEqual(PowerSystemData::BranchData<RealT, IdxT> a,
+                        PowerSystemData::BranchData<RealT, IdxT> b,
+                        RealT                                    tol = tol_)
+    {
+      int fail = 0;
+
+      fail += a.fbus != b.fbus;
+      fail += a.tbus != b.tbus;
+      fail += !isEqual(a.r, b.r, tol);
+      fail += !isEqual(a.x, b.x, tol);
+      fail += !isEqual(a.b, b.b, tol);
+      fail += a.rateA != b.rateA;
+      fail += a.rateB != b.rateB;
+      fail += a.rateC != b.rateC;
+      fail += a.ratio != b.ratio;
+      fail += a.angle != b.angle;
+      fail += a.status != b.status;
+      fail += a.angmin != b.angmin;
+      fail += a.angmax != b.angmax;
+
+      if (fail)
+      {
+        errs() << "Got failure!\na=" << a.str() << "\nb=" << b.str();
+      }
+      return fail == 0;
+    }
+
+    template <typename T>
+    inline bool isEqual(std::vector<T> a, std::vector<T> b, double tol = tol_)
+    {
+      if (a.size() != b.size())
+        throw std::runtime_error([&]
+                                 {
+      std::stringstream errs;
+      errs << "Containers do not have the same size!\n"
+           << "\tGot a.size() == " << a.size() << "\n"
+           << "\tGot b.size() == " << b.size() << "\n";
+      return errs.str(); }());
+
+      int fail = 0;
+      for (std::size_t i = 0; i < a.size(); i++)
+      {
+        if (!isEqual(a[i], b[i], tol))
+        {
+          fail++;
+          errs() << "[isEqual<vector<T>>]: Got failure with i=" << i << ".\n";
+        }
+      }
+
+      return fail == 0;
+    }
+
+    template <typename RealT = double, typename IdxT = int>
+    inline bool isEqual(PowerSystemData::SystemModelData<RealT, IdxT> a,
+                        PowerSystemData::SystemModelData<RealT, IdxT> b)
+    {
+      int fail = 0;
+
+      fail += a.version != b.version;
+      fail += a.baseMVA != b.baseMVA;
+      fail += !isEqual(a.bus, b.bus);
+      fail += !isEqual(a.gen, b.gen);
+      fail += !isEqual(a.gencost, b.gencost);
+      fail += !isEqual(a.branch, b.branch);
+      fail += !isEqual(a.load, b.load);
+
+      return fail == 0;
+    }
+
+  } // namespace Testing
+
+} // namespace GridKit

--- a/examples/PowerFlow/MatPowerTesting/MatPowerTesting.hpp
+++ b/examples/PowerFlow/MatPowerTesting/MatPowerTesting.hpp
@@ -1,8 +1,8 @@
 /**
- * @file Testing.hpp
+ * @file MatPowerTesting.hpp
  * @author Slaven Peles <slaven.peles@pnnl.gov>
  *
- * Contains utilies for testing.
+ * Contains utilities for testing Matpower parser for GridKit.
  *
  */
 #pragma once
@@ -10,7 +10,6 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
-#include <map>
 #include <vector>
 
 #include <PowerSystemData.hpp>

--- a/examples/PowerFlow/MatPowerTesting/test_parse_branch_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_branch_row.cpp
@@ -2,7 +2,7 @@
 
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include <Testing.hpp>
+#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/examples/PowerFlow/MatPowerTesting/test_parse_branch_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_branch_row.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
+#include "MatPowerTesting.hpp"
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/examples/PowerFlow/MatPowerTesting/test_parse_branch_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_branch_row.cpp
@@ -33,7 +33,7 @@ mpc.branch = [
 
 } // namespace
 
-int main(int argc, char** argv)
+int main(int /* argc */, char** /* argv */)
 {
   int                                  fail = 0;
   std::vector<BranchData<RealT, IdxT>> branch_answer{

--- a/examples/PowerFlow/MatPowerTesting/test_parse_bus_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_bus_row.cpp
@@ -2,7 +2,7 @@
 
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include <Testing.hpp>
+#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/examples/PowerFlow/MatPowerTesting/test_parse_bus_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_bus_row.cpp
@@ -28,7 +28,7 @@ mpc.bus = [
 
 } // namespace
 
-int main(int argc, char** argv)
+int main(int /* argc */, char** /* argv */)
 {
   int                               fail = 0;
   std::vector<BusData<RealT, IdxT>> bus_answer{

--- a/examples/PowerFlow/MatPowerTesting/test_parse_bus_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_bus_row.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
+#include "MatPowerTesting.hpp"
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/examples/PowerFlow/MatPowerTesting/test_parse_gen_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_gen_row.cpp
@@ -2,7 +2,7 @@
 
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include <Testing.hpp>
+#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/examples/PowerFlow/MatPowerTesting/test_parse_gen_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_gen_row.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
+#include "MatPowerTesting.hpp"
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/examples/PowerFlow/MatPowerTesting/test_parse_gen_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_gen_row.cpp
@@ -30,7 +30,7 @@ mpc.gen = [
 
 } // namespace
 
-int main(int argc, char** argv)
+int main(int /* argc */, char** /* argv */)
 {
   int                               fail = 0;
   std::vector<GenData<RealT, IdxT>> gen_answer{

--- a/examples/PowerFlow/MatPowerTesting/test_parse_gencost_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_gencost_row.cpp
@@ -2,7 +2,7 @@
 
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include <Testing.hpp>
+#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/examples/PowerFlow/MatPowerTesting/test_parse_gencost_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_gencost_row.cpp
@@ -33,7 +33,7 @@ mpc.gencost = [
 
 } // namespace
 
-int main(int argc, char** argv)
+int main(int /* argc */, char** /* argv */)
 {
   int                                   fail = 0;
   std::vector<GenCostData<RealT, IdxT>> gencost_answer{

--- a/examples/PowerFlow/MatPowerTesting/test_parse_gencost_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_gencost_row.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
+#include "MatPowerTesting.hpp"
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/examples/PowerFlow/MatPowerTesting/test_parse_matpower.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_matpower.cpp
@@ -2,7 +2,7 @@
 
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include <Testing.hpp>
+#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/examples/PowerFlow/MatPowerTesting/test_parse_matpower.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_matpower.cpp
@@ -83,7 +83,7 @@ mpc.gencost = [
 
 } // namespace
 
-int main(int argc, char** argv)
+int main(int /* argc */, char** /* argv */)
 {
   int fail = 0;
 

--- a/examples/PowerFlow/MatPowerTesting/test_parse_matpower.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_matpower.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
+#include "MatPowerTesting.hpp"
 #include <FileIO.hpp>
 #include <PowerSystemData.hpp>
-#include "MatPowerTesting.hpp"
 
 using namespace GridKit;
 using namespace GridKit::Testing;

--- a/src/LinearAlgebra/SparsityPattern/Variable.hpp
+++ b/src/LinearAlgebra/SparsityPattern/Variable.hpp
@@ -260,7 +260,7 @@ namespace GridKit
       bool   is_fixed_;        ///< Constant parameter flag.
 
       mutable DependencyMap* dependencies_;
-      static const size_t    INVALID_VAR_NUMBER = static_cast<const size_t>(-1);
+      static const size_t    INVALID_VAR_NUMBER = static_cast<size_t>(-1);
     };
 
     //------------------------------------

--- a/src/Model/PowerFlow/Branch/Branch.hpp
+++ b/src/Model/PowerFlow/Branch/Branch.hpp
@@ -63,7 +63,7 @@ namespace GridKit
     // int evaluateAdjointJacobian();
     int evaluateAdjointIntegrand();
 
-    void updateTime(real_type t, real_type a)
+    void updateTime(real_type /* t */, real_type /* a */)
     {
     }
 

--- a/src/Model/PowerFlow/Generator/GeneratorSlack.cpp
+++ b/src/Model/PowerFlow/Generator/GeneratorSlack.cpp
@@ -17,7 +17,7 @@ namespace GridKit
    */
 
   template <class ScalarT, typename IdxT>
-  GeneratorSlack<ScalarT, IdxT>::GeneratorSlack(bus_type* bus, GenData& data)
+  GeneratorSlack<ScalarT, IdxT>::GeneratorSlack(bus_type* bus, GenData& /* data */)
     : bus_(bus)
   {
     // std::cout << "Create a load model with " << size_ << " variables ...\n";

--- a/src/Model/PowerFlow/MiniGrid/MiniGrid.hpp
+++ b/src/Model/PowerFlow/MiniGrid/MiniGrid.hpp
@@ -59,7 +59,7 @@ namespace GridKit
       return -1;
     }
 
-    void updateTime(real_type t, real_type a)
+    void updateTime(real_type /* t */, real_type /* a */)
     {
     }
 

--- a/src/Model/PowerFlow/SystemModelPowerFlow.hpp
+++ b/src/Model/PowerFlow/SystemModelPowerFlow.hpp
@@ -348,7 +348,7 @@ namespace GridKit
       return 0;
     }
 
-    void updateTime(real_type t, real_type a)
+    void updateTime(real_type /* t */, real_type /* a */)
     {
     }
 

--- a/src/PowerSystemData.hpp
+++ b/src/PowerSystemData.hpp
@@ -197,7 +197,7 @@ namespace GridKit
       using LoadDataT    = LoadData<RealT, IdxT>;
 
       std::string               version;
-      IdxT                      baseMVA;
+      RealT                     baseMVA;
       std::vector<BusDataT>     bus;
       std::vector<GenDataT>     gen;
       std::vector<BranchDataT>  branch;

--- a/src/Utilities/FileIO.hpp
+++ b/src/Utilities/FileIO.hpp
@@ -189,7 +189,7 @@ namespace
     if (std::regex_match(line, matches, pat))
     {
       std::string s = matches[1];
-      mp.baseMVA    = std::atoi(s.c_str());
+      mp.baseMVA    = std::atof(s.c_str());
     }
     else
     {

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -15,7 +15,6 @@
 
 #include <PowerSystemData.hpp>
 
-
 namespace GridKit
 {
   namespace Testing
@@ -52,8 +51,8 @@ namespace GridKit
       {
         fail++;
         std::cerr << "Containers do not have the same size! "
-               << "a.size() = " << a.size() << ", and "
-               << "b.size() = " << b.size() << "\n";
+                  << "a.size() = " << a.size() << ", and "
+                  << "b.size() = " << b.size() << "\n";
       }
 
       for (const auto& pair_a : a)
@@ -65,22 +64,21 @@ namespace GridKit
           {
             fail++;
             std::cerr << "Mismatching map values! "
-                   << "a.first = " << pair_a.first << ", "
-                   << "a.second = " << pair_a.second << ", and "
-                   << "b.second = " << it->second << "\n";
+                      << "a.first = " << pair_a.first << ", "
+                      << "a.second = " << pair_a.second << ", and "
+                      << "b.second = " << it->second << "\n";
           }
         }
         else
         {
           fail++;
           std::cerr << "Entry not found in the second container! "
-                 << "a.first = " << pair_a.first << "\n";
+                    << "a.first = " << pair_a.first << "\n";
         }
       }
 
       return fail == 0;
     }
-
 
   } // namespace Testing
 

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -11,9 +11,6 @@
 #include <iostream>
 #include <limits>
 #include <map>
-#include <vector>
-
-#include <PowerSystemData.hpp>
 
 namespace GridKit
 {

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -15,18 +15,6 @@
 
 #include <PowerSystemData.hpp>
 
-namespace
-{
-
-  static constexpr double tol_ = 1e-8;
-
-  inline std::ostream& errs()
-  {
-    std::cerr << "[Utils/Testing.hpp]: ";
-    return std::cerr;
-  }
-
-} // namespace
 
 namespace GridKit
 {
@@ -40,186 +28,6 @@ namespace GridKit
     {
       T error = std::abs(value - ref) / (1.0 + std::abs(ref));
       return (error < tol);
-    }
-
-    template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::GenCostData<RealT, IdxT> a,
-                        PowerSystemData::GenCostData<RealT, IdxT> b,
-                        RealT                                     tol = tol_)
-    {
-      (void) tol; // suppress warning
-      int fail  = 0;
-      fail     += a.kind != b.kind;
-      fail     += a.startup != b.startup;
-      fail     += a.shutdown != b.shutdown;
-      fail     += a.n != b.n;
-      if (fail)
-      {
-        errs() << "Got failure!\na=" << a.str() << "\nb=" << b.str();
-      }
-      return fail == 0;
-    }
-
-    template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::GenData<RealT, IdxT> a,
-                        PowerSystemData::GenData<RealT, IdxT> b,
-                        RealT                                 tol = tol_)
-    {
-      int fail = 0;
-
-      fail += a.bus != b.bus;
-      fail += !isEqual(a.Pg, b.Pg, tol);
-      fail += !isEqual(a.Qg, b.Qg, tol);
-      fail += !isEqual(a.Qmax, b.Qmax, tol);
-      fail += !isEqual(a.Qmin, b.Qmin, tol);
-      fail += !isEqual(a.Vg, b.Vg, tol);
-      fail += a.mBase != b.mBase;
-      fail += a.status != b.status;
-      fail += a.Pmax != b.Pmax;
-      fail += a.Pmin != b.Pmin;
-      fail += a.Pc1 != b.Pc1;
-      fail += a.Pc2 != b.Pc2;
-      fail += a.Qc1min != b.Qc1min;
-      fail += a.Qc1max != b.Qc1max;
-      fail += a.Qc2min != b.Qc2min;
-      fail += a.Qc2max != b.Qc2max;
-      fail += a.ramp_agc != b.ramp_agc;
-      fail += a.ramp_10 != b.ramp_10;
-      fail += a.ramp_30 != b.ramp_30;
-      fail += a.ramp_q != b.ramp_q;
-      fail += a.apf != b.apf;
-
-      if (fail)
-      {
-        errs() << "Got failure!\na=" << a.str() << "\nb=" << b.str();
-      }
-      return fail == 0;
-    }
-
-    template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::BusData<RealT, IdxT> a,
-                        PowerSystemData::BusData<RealT, IdxT> b,
-                        RealT                                 tol = tol_)
-    {
-      int fail = 0;
-
-      fail += a.bus_i != b.bus_i;
-      fail += a.type != b.type;
-      fail += a.Gs != b.Gs;
-      fail += a.Bs != b.Bs;
-      fail += a.area != b.area;
-      fail += !isEqual(a.Vm, b.Vm, tol);
-      fail += !isEqual(a.Va, b.Va, tol);
-      fail += a.baseKV != b.baseKV;
-      fail += a.zone != b.zone;
-      fail += !isEqual(a.Vmax, b.Vmax, tol);
-      fail += !isEqual(a.Vmin, b.Vmin, tol);
-
-      if (fail)
-      {
-        errs() << "bus_i: a=" << a.bus_i << ", b=" << b.bus_i << "\n"
-               << "type: a=" << a.type << ", b=" << b.type << "\n"
-               << "Gs: a=" << a.Gs << ", b=" << b.Gs << "\n"
-               << "Bs: a=" << a.Bs << ", b=" << b.Bs << "\n"
-               << "area: a=" << a.area << ", b=" << b.area << "\n"
-               << "Vm: a=" << a.Vm << ", b=" << b.Vm << "\n"
-               << "Va: a=" << a.Va << ", b=" << b.Va << "\n"
-               << "baseKV: a=" << a.baseKV << ", b=" << b.baseKV << "\n"
-               << "zone: a=" << a.zone << ", b=" << b.zone << "\n"
-               << "Vmax: a=" << a.Vmax << ", b=" << b.Vmax << "\n"
-               << "Vmin: a=" << a.Vmin << ", b=" << b.Vmin << "\n";
-      }
-      return fail == 0;
-    }
-
-    template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::LoadData<RealT, IdxT> a,
-                        PowerSystemData::LoadData<RealT, IdxT> b,
-                        RealT                                  tol = tol_)
-    {
-      int fail = 0;
-
-      fail += a.bus_i != b.bus_i;
-      fail += !isEqual(a.Pd, b.Pd, tol);
-      fail += !isEqual(a.Qd, b.Qd, tol);
-
-      if (fail)
-      {
-        errs() << "bus_i: a=" << a.bus_i << ", b=" << b.bus_i << "\n"
-               << "Pd: a=" << a.Pd << ", b=" << b.Pd << "\n"
-               << "Qd: a=" << a.Qd << ", b=" << b.Qd << "\n";
-      }
-      return fail == 0;
-    }
-
-    template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::BranchData<RealT, IdxT> a,
-                        PowerSystemData::BranchData<RealT, IdxT> b,
-                        RealT                                    tol = tol_)
-    {
-      int fail = 0;
-
-      fail += a.fbus != b.fbus;
-      fail += a.tbus != b.tbus;
-      fail += !isEqual(a.r, b.r, tol);
-      fail += !isEqual(a.x, b.x, tol);
-      fail += !isEqual(a.b, b.b, tol);
-      fail += a.rateA != b.rateA;
-      fail += a.rateB != b.rateB;
-      fail += a.rateC != b.rateC;
-      fail += a.ratio != b.ratio;
-      fail += a.angle != b.angle;
-      fail += a.status != b.status;
-      fail += a.angmin != b.angmin;
-      fail += a.angmax != b.angmax;
-
-      if (fail)
-      {
-        errs() << "Got failure!\na=" << a.str() << "\nb=" << b.str();
-      }
-      return fail == 0;
-    }
-
-    template <typename T>
-    inline bool isEqual(std::vector<T> a, std::vector<T> b, double tol = tol_)
-    {
-      if (a.size() != b.size())
-        throw std::runtime_error([&]
-                                 {
-      std::stringstream errs;
-      errs << "Containers do not have the same size!\n"
-           << "\tGot a.size() == " << a.size() << "\n"
-           << "\tGot b.size() == " << b.size() << "\n";
-      return errs.str(); }());
-
-      int fail = 0;
-      for (std::size_t i = 0; i < a.size(); i++)
-      {
-        if (!isEqual(a[i], b[i], tol))
-        {
-          fail++;
-          errs() << "[isEqual<vector<T>>]: Got failure with i=" << i << ".\n";
-        }
-      }
-
-      return fail == 0;
-    }
-
-    template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::SystemModelData<RealT, IdxT> a,
-                        PowerSystemData::SystemModelData<RealT, IdxT> b)
-    {
-      int fail = 0;
-
-      fail += a.version != b.version;
-      fail += a.baseMVA != b.baseMVA;
-      fail += !isEqual(a.bus, b.bus);
-      fail += !isEqual(a.gen, b.gen);
-      fail += !isEqual(a.gencost, b.gencost);
-      fail += !isEqual(a.branch, b.branch);
-      fail += !isEqual(a.load, b.load);
-
-      return fail == 0;
     }
 
     /**
@@ -243,7 +51,7 @@ namespace GridKit
       if (a.size() != b.size())
       {
         fail++;
-        errs() << "Containers do not have the same size! "
+        std::cerr << "Containers do not have the same size! "
                << "a.size() = " << a.size() << ", and "
                << "b.size() = " << b.size() << "\n";
       }
@@ -256,7 +64,7 @@ namespace GridKit
           if (!isEqual(pair_a.second, it->second, tol))
           {
             fail++;
-            errs() << "Mismatching map values! "
+            std::cerr << "Mismatching map values! "
                    << "a.first = " << pair_a.first << ", "
                    << "a.second = " << pair_a.second << ", and "
                    << "b.second = " << it->second << "\n";
@@ -265,13 +73,14 @@ namespace GridKit
         else
         {
           fail++;
-          errs() << "Entry not found in the second container! "
+          std::cerr << "Entry not found in the second container! "
                  << "a.first = " << pair_a.first << "\n";
         }
       }
 
       return fail == 0;
     }
+
 
   } // namespace Testing
 


### PR DESCRIPTION
## Description
 
Several minor issues related to examples are addressed here:
- Some examples return redundant output, which may obscure important error messages.
- Distributed generator and microgrid examples did not test for result accuracy.
- Helper functions specific to Matpower parser testing were included in general GridKit testing utilities.
- Some examples built with compiler warnings.
 
 
@alexander-novo @abdourahmanbarry 
 
 ## Proposed changes
 
Comment out redundant output, add accuracy checks where missing and fix compiler warnings for all examples.

Move helper functions for Matpower parser tests to `examples/PowerFlow/MatPowerTesting/MatPowerTesting.hpp`.
 
 ## Checklist
 

- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- N/A There are unit tests for the new code.
- N/A The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
 None.