### PR TITLE
Create phasor dynamics model data structures (take two)

### DIFF
--- a/examples/PowerFlow/Grid3Bus/Grid3BusSys.cpp
+++ b/examples/PowerFlow/Grid3Bus/Grid3BusSys.cpp
@@ -22,7 +22,7 @@
 #include <Model/PowerFlow/Load/Load.hpp>
 #include <Model/PowerFlow/MatpowerParser.hpp>
 #include <Model/PowerFlow/MiniGrid/MiniGrid.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 #include <Model/PowerFlow/SystemModelPowerFlow.hpp>
 #include <Solver/SteadyState/Kinsol.hpp>
 #include <Utilities/Testing.hpp>
@@ -79,7 +79,7 @@ using namespace GridKit;
 using namespace AnalysisManager::Sundials;
 using namespace AnalysisManager;
 using namespace GridKit::Testing;
-using namespace GridKit::PowerSystemData;
+using namespace GridKit::PowerFlowData;
 
 constexpr double theta2_ref = -4.87979; // [deg]
 constexpr double V2_ref     = 1.08281;  // [p.u.]
@@ -149,7 +149,7 @@ int parserCase()
   std::cout << "Solving same problem, but assembled from components via a parser ...\n\n";
 
   // Data File Reading
-  GridKit::PowerSystemData::SystemModelData<double, size_t> mp;
+  GridKit::PowerFlowData::SystemModelData<double, size_t> mp;
 
   std::istringstream iss(BUS3_DATA_STRING);
   GridKit::readMatPower(mp, iss);

--- a/examples/PowerFlow/MatPowerTesting/MatPowerTesting.hpp
+++ b/examples/PowerFlow/MatPowerTesting/MatPowerTesting.hpp
@@ -12,7 +12,7 @@
 #include <limits>
 #include <vector>
 
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 #include <Utilities/Testing.hpp>
 
 namespace
@@ -34,8 +34,8 @@ namespace GridKit
   {
 
     template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::GenCostData<RealT, IdxT> a,
-                        PowerSystemData::GenCostData<RealT, IdxT> b,
+    inline bool isEqual(PowerFlowData::GenCostData<RealT, IdxT> a,
+                        PowerFlowData::GenCostData<RealT, IdxT> b,
                         RealT                                     tol = tol_)
     {
       (void) tol; // suppress warning
@@ -52,8 +52,8 @@ namespace GridKit
     }
 
     template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::GenData<RealT, IdxT> a,
-                        PowerSystemData::GenData<RealT, IdxT> b,
+    inline bool isEqual(PowerFlowData::GenData<RealT, IdxT> a,
+                        PowerFlowData::GenData<RealT, IdxT> b,
                         RealT                                 tol = tol_)
     {
       int fail = 0;
@@ -88,8 +88,8 @@ namespace GridKit
     }
 
     template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::BusData<RealT, IdxT> a,
-                        PowerSystemData::BusData<RealT, IdxT> b,
+    inline bool isEqual(PowerFlowData::BusData<RealT, IdxT> a,
+                        PowerFlowData::BusData<RealT, IdxT> b,
                         RealT                                 tol = tol_)
     {
       int fail = 0;
@@ -124,8 +124,8 @@ namespace GridKit
     }
 
     template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::LoadData<RealT, IdxT> a,
-                        PowerSystemData::LoadData<RealT, IdxT> b,
+    inline bool isEqual(PowerFlowData::LoadData<RealT, IdxT> a,
+                        PowerFlowData::LoadData<RealT, IdxT> b,
                         RealT                                  tol = tol_)
     {
       int fail = 0;
@@ -144,8 +144,8 @@ namespace GridKit
     }
 
     template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::BranchData<RealT, IdxT> a,
-                        PowerSystemData::BranchData<RealT, IdxT> b,
+    inline bool isEqual(PowerFlowData::BranchData<RealT, IdxT> a,
+                        PowerFlowData::BranchData<RealT, IdxT> b,
                         RealT                                    tol = tol_)
     {
       int fail = 0;
@@ -197,8 +197,8 @@ namespace GridKit
     }
 
     template <typename RealT = double, typename IdxT = int>
-    inline bool isEqual(PowerSystemData::SystemModelData<RealT, IdxT> a,
-                        PowerSystemData::SystemModelData<RealT, IdxT> b)
+    inline bool isEqual(PowerFlowData::SystemModelData<RealT, IdxT> a,
+                        PowerFlowData::SystemModelData<RealT, IdxT> b)
     {
       int fail = 0;
 

--- a/examples/PowerFlow/MatPowerTesting/MatPowerTesting.hpp
+++ b/examples/PowerFlow/MatPowerTesting/MatPowerTesting.hpp
@@ -36,7 +36,7 @@ namespace GridKit
     template <typename RealT = double, typename IdxT = int>
     inline bool isEqual(PowerFlowData::GenCostData<RealT, IdxT> a,
                         PowerFlowData::GenCostData<RealT, IdxT> b,
-                        RealT                                     tol = tol_)
+                        RealT                                   tol = tol_)
     {
       (void) tol; // suppress warning
       int fail  = 0;
@@ -54,7 +54,7 @@ namespace GridKit
     template <typename RealT = double, typename IdxT = int>
     inline bool isEqual(PowerFlowData::GenData<RealT, IdxT> a,
                         PowerFlowData::GenData<RealT, IdxT> b,
-                        RealT                                 tol = tol_)
+                        RealT                               tol = tol_)
     {
       int fail = 0;
 
@@ -90,7 +90,7 @@ namespace GridKit
     template <typename RealT = double, typename IdxT = int>
     inline bool isEqual(PowerFlowData::BusData<RealT, IdxT> a,
                         PowerFlowData::BusData<RealT, IdxT> b,
-                        RealT                                 tol = tol_)
+                        RealT                               tol = tol_)
     {
       int fail = 0;
 
@@ -126,7 +126,7 @@ namespace GridKit
     template <typename RealT = double, typename IdxT = int>
     inline bool isEqual(PowerFlowData::LoadData<RealT, IdxT> a,
                         PowerFlowData::LoadData<RealT, IdxT> b,
-                        RealT                                  tol = tol_)
+                        RealT                                tol = tol_)
     {
       int fail = 0;
 
@@ -146,7 +146,7 @@ namespace GridKit
     template <typename RealT = double, typename IdxT = int>
     inline bool isEqual(PowerFlowData::BranchData<RealT, IdxT> a,
                         PowerFlowData::BranchData<RealT, IdxT> b,
-                        RealT                                    tol = tol_)
+                        RealT                                  tol = tol_)
     {
       int fail = 0;
 

--- a/examples/PowerFlow/MatPowerTesting/test_parse_branch_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_branch_row.cpp
@@ -2,11 +2,11 @@
 
 #include "MatPowerTesting.hpp"
 #include <Model/PowerFlow/MatpowerParser.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 using namespace GridKit;
 using namespace GridKit::Testing;
-using namespace GridKit::PowerSystemData;
+using namespace GridKit::PowerFlowData;
 
 namespace
 {

--- a/examples/PowerFlow/MatPowerTesting/test_parse_bus_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_bus_row.cpp
@@ -2,11 +2,11 @@
 
 #include "MatPowerTesting.hpp"
 #include <Model/PowerFlow/MatpowerParser.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 using namespace GridKit;
 using namespace GridKit::Testing;
-using namespace GridKit::PowerSystemData;
+using namespace GridKit::PowerFlowData;
 
 namespace
 {

--- a/examples/PowerFlow/MatPowerTesting/test_parse_gen_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_gen_row.cpp
@@ -2,11 +2,11 @@
 
 #include "MatPowerTesting.hpp"
 #include <Model/PowerFlow/MatpowerParser.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 using namespace GridKit;
 using namespace GridKit::Testing;
-using namespace GridKit::PowerSystemData;
+using namespace GridKit::PowerFlowData;
 
 namespace
 {

--- a/examples/PowerFlow/MatPowerTesting/test_parse_gencost_row.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_gencost_row.cpp
@@ -2,11 +2,11 @@
 
 #include "MatPowerTesting.hpp"
 #include <Model/PowerFlow/MatpowerParser.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 using namespace GridKit;
 using namespace GridKit::Testing;
-using namespace GridKit::PowerSystemData;
+using namespace GridKit::PowerFlowData;
 
 namespace
 {

--- a/examples/PowerFlow/MatPowerTesting/test_parse_matpower.cpp
+++ b/examples/PowerFlow/MatPowerTesting/test_parse_matpower.cpp
@@ -2,11 +2,11 @@
 
 #include "MatPowerTesting.hpp"
 #include <Model/PowerFlow/MatpowerParser.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 using namespace GridKit;
 using namespace GridKit::Testing;
-using namespace GridKit::PowerSystemData;
+using namespace GridKit::PowerFlowData;
 
 namespace
 {

--- a/src/Model/PhasorDynamics/Branch/Branch.cpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PhasorDynamics/Branch/BranchData.hpp>
 
 namespace GridKit
 {
@@ -73,13 +73,13 @@ namespace GridKit
     }
 
     template <class ScalarT, typename IdxT>
-    Branch<ScalarT, IdxT>::Branch(bus_type* bus1, bus_type* bus2, BranchData& data)
+    Branch<ScalarT, IdxT>::Branch(bus_type* bus1, bus_type* bus2, model_data_type& data)
       : bus1_(bus1),
         bus2_(bus2),
-        R_(data.r),
-        X_(data.x),
-        G_(0.0),
-        B_(data.b),
+        R_(data.R),
+        X_(data.X),
+        G_(data.G),
+        B_(data.B),
         bus1ID_(data.fbus),
         bus2ID_(data.tbus)
     {

--- a/src/Model/PhasorDynamics/Branch/Branch.cpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.cpp
@@ -36,8 +36,8 @@ namespace GridKit
         X_(0.01),
         G_(0.0),
         B_(0.0),
-        bus1ID_(0),
-        bus2ID_(0)
+        bus1_id_(0),
+        bus2_id_(0)
     {
       size_ = 0;
     }
@@ -67,8 +67,8 @@ namespace GridKit
         X_(X),
         G_(G),
         B_(B),
-        bus1ID_(0),
-        bus2ID_(0)
+        bus1_id_(0),
+        bus2_id_(0)
     {
     }
 
@@ -80,8 +80,8 @@ namespace GridKit
         X_(data.X),
         G_(data.G),
         B_(data.B),
-        bus1ID_(data.fbus),
-        bus2ID_(data.tbus)
+        bus1_id_(data.bus1_id),
+        bus2_id_(data.bus2_id)
     {
       size_ = 0;
     }

--- a/src/Model/PhasorDynamics/Branch/Branch.cpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.cpp
@@ -12,8 +12,8 @@
 #include <cmath>
 #include <iostream>
 
-#include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Branch/BranchData.hpp>
+#include <Model/PhasorDynamics/Bus/Bus.hpp>
 
 namespace GridKit
 {

--- a/src/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.hpp
@@ -15,17 +15,11 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename RealT, typename IdxT>
-    struct BranchData;
-  }
-} // namespace GridKit
-
-namespace GridKit
-{
-  namespace PhasorDynamics
-  {
     template <class ScalarT, typename IdxT>
     class BusBase;
+
+    template <typename RealT, typename IdxT>
+    struct BranchData;
   }
 } // namespace GridKit
 
@@ -154,8 +148,8 @@ namespace GridKit
       real_type  X_;
       real_type  G_;
       real_type  B_;
-      const IdxT bus1ID_;
-      const IdxT bus2ID_;
+      const IdxT bus1_id_;
+      const IdxT bus2_id_;
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.hpp
@@ -20,7 +20,7 @@ namespace GridKit
 
     template <typename RealT, typename IdxT>
     struct BranchData;
-  }
+  } // namespace PhasorDynamics
 } // namespace GridKit
 
 namespace GridKit

--- a/src/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.hpp
@@ -13,7 +13,7 @@
 // Forward declarations.
 namespace GridKit
 {
-  namespace PowerSystemData
+  namespace PhasorDynamics
   {
     template <typename RealT, typename IdxT>
     struct BranchData;
@@ -51,21 +51,21 @@ namespace GridKit
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::g_;
-      using Component<ScalarT, IdxT>::yB_;
-      using Component<ScalarT, IdxT>::ypB_;
-      using Component<ScalarT, IdxT>::fB_;
-      using Component<ScalarT, IdxT>::gB_;
-      using Component<ScalarT, IdxT>::param_;
+      // using Component<ScalarT, IdxT>::g_;
+      // using Component<ScalarT, IdxT>::yB_;
+      // using Component<ScalarT, IdxT>::ypB_;
+      // using Component<ScalarT, IdxT>::fB_;
+      // using Component<ScalarT, IdxT>::gB_;
+      // using Component<ScalarT, IdxT>::param_;
 
-      using bus_type   = BusBase<ScalarT, IdxT>;
-      using real_type  = typename Component<ScalarT, IdxT>::real_type;
-      using BranchData = GridKit::PowerSystemData::BranchData<real_type, IdxT>;
+      using real_type       = typename Component<ScalarT, IdxT>::real_type;
+      using bus_type        = BusBase<ScalarT, IdxT>;
+      using model_data_type = BranchData<real_type, IdxT>;
 
     public:
       Branch(bus_type* bus1, bus_type* bus2);
       Branch(bus_type* bus1, bus_type* bus2, real_type R, real_type X, real_type G, real_type B);
-      Branch(bus_type* bus1, bus_type* bus2, BranchData& data);
+      Branch(bus_type* bus1, bus_type* bus2, model_data_type& data);
       virtual ~Branch();
 
       virtual int allocate() override;

--- a/src/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.hpp
@@ -45,12 +45,6 @@ namespace GridKit
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::f_;
-      // using Component<ScalarT, IdxT>::g_;
-      // using Component<ScalarT, IdxT>::yB_;
-      // using Component<ScalarT, IdxT>::ypB_;
-      // using Component<ScalarT, IdxT>::fB_;
-      // using Component<ScalarT, IdxT>::gB_;
-      // using Component<ScalarT, IdxT>::param_;
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;
       using bus_type        = BusBase<ScalarT, IdxT>;

--- a/src/Model/PhasorDynamics/Branch/BranchData.hpp
+++ b/src/Model/PhasorDynamics/Branch/BranchData.hpp
@@ -1,0 +1,36 @@
+/**
+ * @file BranchData.hpp
+ * @author Slaven Peles (peless@ornl.gov)
+ * @brief Modeling data for branches (transmission lines)
+ * 
+ */
+#pragma once
+
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    /**
+     * @brief Contains modeling data for a Branch
+     * 
+     * @tparam RealT Real parameter data type
+     * @tparam IdxT  Integer parameter data type
+     * 
+     * Integer parameters are of the same type as matrix and vector indices.
+     * 
+     * @todo Decide on naming scheme for model parameters.
+     */
+    template <typename RealT, typename IdxT>
+    struct BranchData
+    {
+      RealT R{0.0}; ///< line series resistance
+      RealT X{0.0}; ///< line series reactance
+      RealT G{0.0}; ///< line shunt conductance
+      RealT B{0.0}; ///< line shunt charging 
+
+      IdxT fbus{0}; ///< Unique ID of bus 1
+      IdxT tbus{0}; ///< Unique ID of bus 2
+    };
+  }
+}

--- a/src/Model/PhasorDynamics/Branch/BranchData.hpp
+++ b/src/Model/PhasorDynamics/Branch/BranchData.hpp
@@ -2,10 +2,9 @@
  * @file BranchData.hpp
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Modeling data for branches (transmission lines)
- * 
+ *
  */
 #pragma once
-
 
 namespace GridKit
 {
@@ -13,12 +12,12 @@ namespace GridKit
   {
     /**
      * @brief Contains modeling data for a Branch
-     * 
+     *
      * @tparam RealT Real parameter data type
      * @tparam IdxT  Integer parameter data type
-     * 
+     *
      * Integer parameters are of the same type as matrix and vector indices.
-     * 
+     *
      * @todo Decide on naming scheme for model parameters.
      */
     template <typename RealT, typename IdxT>
@@ -27,10 +26,10 @@ namespace GridKit
       RealT R{0.0}; ///< line series resistance
       RealT X{0.0}; ///< line series reactance
       RealT G{0.0}; ///< line shunt conductance
-      RealT B{0.0}; ///< line shunt charging 
+      RealT B{0.0}; ///< line shunt charging
 
       IdxT bus1_id{0}; ///< Unique ID of bus 1
       IdxT bus2_id{0}; ///< Unique ID of bus 2
     };
-  }
-}
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/Bus.cpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.cpp
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <iostream>
 
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PhasorDynamics/Bus/BusData.hpp>
 
 namespace GridKit
 {
@@ -61,10 +61,10 @@ namespace GridKit
      * @param[in] data - structure with bus data
      */
     template <class ScalarT, typename IdxT>
-    Bus<ScalarT, IdxT>::Bus(BusData& data)
-      : BusBase<ScalarT, IdxT>(data.bus_i),
-        Vr0_(data.Vm * cos(data.Va)),
-        Vi0_(data.Vm * sin(data.Va))
+    Bus<ScalarT, IdxT>::Bus(DataT& data)
+      : BusBase<ScalarT, IdxT>(data.bus_id),
+        Vr0_(data.Vr0),
+        Vi0_(data.Vi0)
     {
       // std::cout << "Create Bus..." << std::endl;
       // std::cout << "Number of equations is " << size_ << std::endl;

--- a/src/Model/PhasorDynamics/Bus/Bus.hpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.hpp
@@ -6,7 +6,7 @@
 // Forward declaration of BusData structure
 namespace GridKit
 {
-  namespace PowerSystemData
+  namespace PhasorDynamics
   {
     template <typename RealT, typename IdxT>
     struct BusData;
@@ -39,11 +39,11 @@ namespace GridKit
 
     public:
       using real_type = typename BusBase<ScalarT, IdxT>::real_type;
-      using BusData   = GridKit::PowerSystemData::BusData<real_type, IdxT>;
+      using DataT     = BusData<real_type, IdxT>;
 
       Bus();
       Bus(ScalarT Vr, ScalarT Vi);
-      Bus(BusData& data);
+      Bus(DataT& data);
       virtual ~Bus();
 
       virtual int allocate() override;
@@ -101,45 +101,6 @@ namespace GridKit
         return f_[1];
       }
 
-      // virtual ScalarT& VrB() override
-      // {
-      //     return yB_[0];
-      // }
-
-      // virtual const ScalarT& VrB() const override
-      // {
-      //     return yB_[0];
-      // }
-
-      // virtual ScalarT& ViB() override
-      // {
-      //     return yB_[1];
-      // }
-
-      // virtual const ScalarT& ViB() const override
-      // {
-      //     return yB_[1];
-      // }
-
-      // virtual ScalarT& IrB() override
-      // {
-      //     return fB_[0];
-      // }
-
-      // virtual const ScalarT& IrB() const override
-      // {
-      //     return fB_[0];
-      // }
-
-      // virtual ScalarT& IiB() override
-      // {
-      //     return fB_[1];
-      // }
-
-      // virtual const ScalarT& IiB() const override
-      // {
-      //     return fB_[1];
-      // }
 
     private:
       ScalarT Vr0_{0.0};

--- a/src/Model/PhasorDynamics/Bus/Bus.hpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.hpp
@@ -101,7 +101,6 @@ namespace GridKit
         return f_[1];
       }
 
-
     private:
       ScalarT Vr0_{0.0};
       ScalarT Vi0_{0.0};

--- a/src/Model/PhasorDynamics/Bus/BusData.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusData.hpp
@@ -1,0 +1,33 @@
+/**
+ * @file BusData.hpp
+ * @author Slaven Peles (peless@ornl.gov)
+ * @brief Modeling data for branches (transmission lines)
+ * 
+ */
+#pragma once
+
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    /**
+     * @brief Contains modeling data for a Bus
+     * 
+     * @tparam RealT Real parameter data type
+     * @tparam IdxT  Integer parameter data type
+     * 
+     * Integer parameters are of the same type as matrix and vector indices.
+     * 
+     * @todo Decide on naming scheme for model parameters.
+     */
+    template <typename RealT, typename IdxT>
+    struct BusData
+    {
+      RealT Vr0{0.0}; ///< Initial value for real bus voltage
+      RealT Vi0{0.0}; ///< Initial value for imaginary bus voltage
+
+      IdxT bus_id{0}; ///< Unique ID of bus 1
+    };
+  }
+}

--- a/src/Model/PhasorDynamics/Bus/BusData.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusData.hpp
@@ -1,7 +1,7 @@
 /**
  * @file BusData.hpp
  * @author Slaven Peles (peless@ornl.gov)
- * @brief Modeling data for branches (transmission lines)
+ * @brief Modeling data for buses (nodes)
  * 
  */
 #pragma once

--- a/src/Model/PhasorDynamics/Bus/BusData.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusData.hpp
@@ -2,10 +2,9 @@
  * @file BusData.hpp
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Modeling data for buses (nodes)
- * 
+ *
  */
 #pragma once
-
 
 namespace GridKit
 {
@@ -13,12 +12,12 @@ namespace GridKit
   {
     /**
      * @brief Contains modeling data for a Bus
-     * 
+     *
      * @tparam RealT Real parameter data type
      * @tparam IdxT  Integer parameter data type
-     * 
+     *
      * Integer parameters are of the same type as matrix and vector indices.
-     * 
+     *
      * @todo Decide on naming scheme for model parameters.
      */
     template <typename RealT, typename IdxT>
@@ -29,5 +28,5 @@ namespace GridKit
 
       IdxT bus_id{0}; ///< Unique ID of bus 1
     };
-  }
-}
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/BusInfinite.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusInfinite.cpp
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <iostream>
 
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PhasorDynamics/Bus/BusData.hpp>
 
 namespace GridKit
 {
@@ -66,10 +66,10 @@ namespace GridKit
      * @param[in] data - structure with bus data
      */
     template <class ScalarT, typename IdxT>
-    BusInfinite<ScalarT, IdxT>::BusInfinite(BusData& data)
-      : BusBase<ScalarT, IdxT>(data.bus_i),
-        Vr_(data.Vm * cos(data.Va)),
-        Vi_(data.Vm * sin(data.Va))
+    BusInfinite<ScalarT, IdxT>::BusInfinite(DataT& data)
+      : BusBase<ScalarT, IdxT>(data.bus_id),
+        Vr_(data.Vr0),
+        Vi_(data.Vi0)
     {
       size_ = 0;
     }

--- a/src/Model/PhasorDynamics/Bus/BusInfinite.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusInfinite.hpp
@@ -6,7 +6,7 @@
 // Forward declaration of BusData structure
 namespace GridKit
 {
-  namespace PowerSystemData
+  namespace PhasorDynamics
   {
     template <typename RealT, typename IdxT>
     struct BusData;
@@ -37,11 +37,11 @@ namespace GridKit
 
     public:
       using real_type = typename BusBase<ScalarT, IdxT>::real_type;
-      using BusData   = GridKit::PowerSystemData::BusData<real_type, IdxT>;
+      using DataT     = BusData<real_type, IdxT>;
 
       BusInfinite();
       BusInfinite(ScalarT Vr, ScalarT Vi);
-      BusInfinite(BusData& data);
+      BusInfinite(DataT& data);
       virtual ~BusInfinite();
 
       virtual int allocate() override;
@@ -98,46 +98,6 @@ namespace GridKit
       {
         return Ii_;
       }
-
-      // virtual ScalarT& VrB() override
-      // {
-      //     return VrB_;
-      // }
-
-      // virtual const ScalarT& VrB() const override
-      // {
-      //     return VrB_;
-      // }
-
-      // virtual ScalarT& ViB() override
-      // {
-      //     return ViB_;
-      // }
-
-      // virtual const ScalarT& ViB() const override
-      // {
-      //     return ViB_;
-      // }
-
-      // virtual ScalarT& IrB() override
-      // {
-      //     return IrB_;
-      // }
-
-      // virtual const ScalarT& IrB() const override
-      // {
-      //     return IrB_;
-      // }
-
-      // virtual ScalarT& IiB() override
-      // {
-      //     return IiB_;
-      // }
-
-      // virtual const ScalarT& IiB() const override
-      // {
-      //     return IiB_;
-      // }
 
     private:
       ScalarT Vr_{0.0};

--- a/src/Model/PhasorDynamics/BusFault/BusFault.cpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.cpp
@@ -13,7 +13,6 @@
 #include <iostream>
 
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
 
 namespace GridKit
 {

--- a/src/Model/PhasorDynamics/Load/Load.cpp
+++ b/src/Model/PhasorDynamics/Load/Load.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
+#include <Model/PhasorDynamics/Load/LoadData.hpp>
 
 namespace GridKit
 {
@@ -34,14 +35,12 @@ namespace GridKit
       : bus_(bus),
         R_(R),
         X_(X)
-
     {
     }
 
     template <class ScalarT, typename IdxT>
     Load<ScalarT, IdxT>::Load(bus_type* bus, IdxT component_id)
       : bus_(bus)
-
     {
       size_         = 0;
       component_id_ = component_id;

--- a/src/Model/PhasorDynamics/Load/Load.hpp
+++ b/src/Model/PhasorDynamics/Load/Load.hpp
@@ -11,7 +11,10 @@ namespace GridKit
   {
     template <class ScalarT, typename IdxT>
     class BusBase;
-  }
+
+    template <typename RealT, typename IdxT>
+    struct LoadData;
+  } // namespace PhasorDynamics
 } // namespace GridKit
 
 namespace GridKit
@@ -33,16 +36,17 @@ namespace GridKit
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::g_;
-      using Component<ScalarT, IdxT>::yB_;
-      using Component<ScalarT, IdxT>::ypB_;
-      using Component<ScalarT, IdxT>::fB_;
-      using Component<ScalarT, IdxT>::gB_;
-      using Component<ScalarT, IdxT>::param_;
+      // using Component<ScalarT, IdxT>::g_;
+      // using Component<ScalarT, IdxT>::yB_;
+      // using Component<ScalarT, IdxT>::ypB_;
+      // using Component<ScalarT, IdxT>::fB_;
+      // using Component<ScalarT, IdxT>::gB_;
+      // using Component<ScalarT, IdxT>::param_;
       using Component<ScalarT, IdxT>::component_id_;
 
-      using bus_type  = BusBase<ScalarT, IdxT>;
-      using real_type = typename Component<ScalarT, IdxT>::real_type;
+      using real_type       = typename Component<ScalarT, IdxT>::real_type;
+      using bus_type        = BusBase<ScalarT, IdxT>;
+      using model_data_type = LoadData<real_type, IdxT>;
 
     public:
       Load(bus_type* bus);

--- a/src/Model/PhasorDynamics/Load/Load.hpp
+++ b/src/Model/PhasorDynamics/Load/Load.hpp
@@ -36,12 +36,6 @@ namespace GridKit
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::f_;
-      // using Component<ScalarT, IdxT>::g_;
-      // using Component<ScalarT, IdxT>::yB_;
-      // using Component<ScalarT, IdxT>::ypB_;
-      // using Component<ScalarT, IdxT>::fB_;
-      // using Component<ScalarT, IdxT>::gB_;
-      // using Component<ScalarT, IdxT>::param_;
       using Component<ScalarT, IdxT>::component_id_;
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;

--- a/src/Model/PhasorDynamics/Load/LoadData.hpp
+++ b/src/Model/PhasorDynamics/Load/LoadData.hpp
@@ -1,7 +1,7 @@
 /**
- * @file BranchData.hpp
+ * @file LoadData.hpp
  * @author Slaven Peles (peless@ornl.gov)
- * @brief Modeling data for branches (transmission lines)
+ * @brief Modeling data for loads
  * 
  */
 #pragma once
@@ -12,7 +12,7 @@ namespace GridKit
   namespace PhasorDynamics
   {
     /**
-     * @brief Contains modeling data for a Branch
+     * @brief Contains modeling data for a Load
      * 
      * @tparam RealT Real parameter data type
      * @tparam IdxT  Integer parameter data type
@@ -22,15 +22,12 @@ namespace GridKit
      * @todo Decide on naming scheme for model parameters.
      */
     template <typename RealT, typename IdxT>
-    struct BranchData
+    struct LoadData
     {
-      RealT R{0.0}; ///< line series resistance
-      RealT X{0.0}; ///< line series reactance
-      RealT G{0.0}; ///< line shunt conductance
-      RealT B{0.0}; ///< line shunt charging 
+      RealT R{0.0}; ///< load resistance
+      RealT X{0.0}; ///< load reactance
 
-      IdxT bus1_id{0}; ///< Unique ID of bus 1
-      IdxT bus2_id{0}; ///< Unique ID of bus 2
+      IdxT bus_id{0}; ///< Unique ID of bus 1
     };
   }
 }

--- a/src/Model/PhasorDynamics/Load/LoadData.hpp
+++ b/src/Model/PhasorDynamics/Load/LoadData.hpp
@@ -2,10 +2,9 @@
  * @file LoadData.hpp
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Modeling data for loads
- * 
+ *
  */
 #pragma once
-
 
 namespace GridKit
 {
@@ -13,12 +12,12 @@ namespace GridKit
   {
     /**
      * @brief Contains modeling data for a Load
-     * 
+     *
      * @tparam RealT Real parameter data type
      * @tparam IdxT  Integer parameter data type
-     * 
+     *
      * Integer parameters are of the same type as matrix and vector indices.
-     * 
+     *
      * @todo Decide on naming scheme for model parameters.
      */
     template <typename RealT, typename IdxT>
@@ -29,5 +28,5 @@ namespace GridKit
 
       IdxT bus_id{0}; ///< Unique ID of bus 1
     };
-  }
-}
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
+++ b/src/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
@@ -101,7 +101,7 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int SynchronousMachine<ScalarT, IdxT>::evaluateResidual()
   {
-    ScalarT rkq1  = std::get<0>(Rkq_);
+    ScalarT rkq1 = std::get<0>(Rkq_);
     [[maybe_unused]]
     ScalarT rkq2  = std::get<1>(Rkq_);
     ScalarT llkq1 = std::get<0>(Llkq_);

--- a/src/Model/PowerFlow/Branch/Branch.cpp
+++ b/src/Model/PowerFlow/Branch/Branch.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {

--- a/src/Model/PowerFlow/Branch/Branch.hpp
+++ b/src/Model/PowerFlow/Branch/Branch.hpp
@@ -10,7 +10,7 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   class BaseBus;
 
-  namespace PowerSystemData
+  namespace PowerFlowData
   {
     template <class ScalarT, typename IdxT>
     struct BranchData;
@@ -43,7 +43,7 @@ namespace GridKit
 
     using bus_type   = BaseBus<ScalarT, IdxT>;
     using real_type  = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using BranchData = GridKit::PowerSystemData::BranchData<real_type, IdxT>;
+    using BranchData = GridKit::PowerFlowData::BranchData<real_type, IdxT>;
 
   public:
     Branch(bus_type* bus1, bus_type* bus2);

--- a/src/Model/PowerFlow/Bus/BusFactory.hpp
+++ b/src/Model/PowerFlow/Bus/BusFactory.hpp
@@ -4,7 +4,7 @@
 #include <Model/PowerFlow/Bus/BusPQ.hpp>
 #include <Model/PowerFlow/Bus/BusPV.hpp>
 #include <Model/PowerFlow/Bus/BusSlack.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
@@ -14,7 +14,7 @@ namespace GridKit
   {
   public:
     using real_type = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using BusData   = GridKit::PowerSystemData::BusData<real_type, IdxT>;
+    using BusData   = GridKit::PowerFlowData::BusData<real_type, IdxT>;
 
     BusFactory() = delete;
 

--- a/src/Model/PowerFlow/Bus/BusPQ.hpp
+++ b/src/Model/PowerFlow/Bus/BusPQ.hpp
@@ -3,7 +3,7 @@
 #define _BUS_PQ_HPP_
 
 #include "BaseBus.hpp"
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
@@ -29,7 +29,7 @@ namespace GridKit
 
   public:
     using real_type = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using BusData   = GridKit::PowerSystemData::BusData<real_type, IdxT>;
+    using BusData   = GridKit::PowerFlowData::BusData<real_type, IdxT>;
 
     BusPQ();
     BusPQ(ScalarT V, ScalarT theta);

--- a/src/Model/PowerFlow/Bus/BusPV.hpp
+++ b/src/Model/PowerFlow/Bus/BusPV.hpp
@@ -5,7 +5,7 @@
 #include <cassert>
 
 #include "BaseBus.hpp"
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
@@ -31,7 +31,7 @@ namespace GridKit
 
   public:
     using real_type = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using BusData   = GridKit::PowerSystemData::BusData<real_type, IdxT>;
+    using BusData   = GridKit::PowerFlowData::BusData<real_type, IdxT>;
 
     BusPV();
     BusPV(ScalarT V, ScalarT theta0);

--- a/src/Model/PowerFlow/Bus/BusSlack.hpp
+++ b/src/Model/PowerFlow/Bus/BusSlack.hpp
@@ -3,7 +3,7 @@
 #define _BUS_SLACK_HPP_
 
 #include "BaseBus.hpp"
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
@@ -29,7 +29,7 @@ namespace GridKit
 
   public:
     using real_type = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using BusData   = GridKit::PowerSystemData::BusData<real_type, IdxT>;
+    using BusData   = GridKit::PowerFlowData::BusData<real_type, IdxT>;
 
     BusSlack();
     BusSlack(ScalarT V, ScalarT theta);

--- a/src/Model/PowerFlow/Generator/GeneratorFactory.hpp
+++ b/src/Model/PowerFlow/Generator/GeneratorFactory.hpp
@@ -5,7 +5,7 @@
 #include <Model/PowerFlow/Generator/GeneratorPQ.hpp>
 #include <Model/PowerFlow/Generator/GeneratorPV.hpp>
 #include <Model/PowerFlow/Generator/GeneratorSlack.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
@@ -15,7 +15,7 @@ namespace GridKit
   {
   public:
     using real_type = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using GenData   = GridKit::PowerSystemData::GenData<real_type, IdxT>;
+    using GenData   = GridKit::PowerFlowData::GenData<real_type, IdxT>;
 
     GeneratorFactory() = delete;
 

--- a/src/Model/PowerFlow/Generator/GeneratorPQ.hpp
+++ b/src/Model/PowerFlow/Generator/GeneratorPQ.hpp
@@ -5,7 +5,7 @@
 
 #include "GeneratorBase.hpp"
 #include <Model/PowerFlow/ModelEvaluatorImpl.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
@@ -39,7 +39,7 @@ namespace GridKit
 
     using bus_type  = BaseBus<ScalarT, IdxT>;
     using real_type = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using GenData   = GridKit::PowerSystemData::GenData<real_type, IdxT>;
+    using GenData   = GridKit::PowerFlowData::GenData<real_type, IdxT>;
 
   public:
     GeneratorPQ(bus_type* bus, GenData& data);

--- a/src/Model/PowerFlow/Generator/GeneratorPV.hpp
+++ b/src/Model/PowerFlow/Generator/GeneratorPV.hpp
@@ -5,7 +5,7 @@
 
 #include "GeneratorBase.hpp"
 #include <Model/PowerFlow/ModelEvaluatorImpl.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
@@ -39,7 +39,7 @@ namespace GridKit
 
     using bus_type  = BaseBus<ScalarT, IdxT>;
     using real_type = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using GenData   = GridKit::PowerSystemData::GenData<real_type, IdxT>;
+    using GenData   = GridKit::PowerFlowData::GenData<real_type, IdxT>;
 
   public:
     GeneratorPV(bus_type* bus, GenData& data);

--- a/src/Model/PowerFlow/Generator/GeneratorSlack.hpp
+++ b/src/Model/PowerFlow/Generator/GeneratorSlack.hpp
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include "GeneratorBase.hpp"
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
@@ -38,7 +38,7 @@ namespace GridKit
 
     using bus_type  = BaseBus<ScalarT, IdxT>;
     using real_type = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using GenData   = GridKit::PowerSystemData::GenData<real_type, IdxT>;
+    using GenData   = GridKit::PowerFlowData::GenData<real_type, IdxT>;
     // typedef typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type real_type;
     // typedef BaseBus<ScalarT, IdxT> bus_type;
 

--- a/src/Model/PowerFlow/Generator4Param/Generator4Param.cpp
+++ b/src/Model/PowerFlow/Generator4Param/Generator4Param.cpp
@@ -1,9 +1,10 @@
 
 #define _USE_MATH_DEFINES
+#include "Generator4Param.hpp"
+
 #include <cmath>
 #include <iostream>
 
-#include "Generator4Param.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
 namespace GridKit

--- a/src/Model/PowerFlow/Load/Load.hpp
+++ b/src/Model/PowerFlow/Load/Load.hpp
@@ -3,7 +3,7 @@
 #define _LOAD_HPP_
 
 #include <Model/PowerFlow/ModelEvaluatorImpl.hpp>
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
@@ -39,7 +39,7 @@ namespace GridKit
     // typedef BaseBus<ScalarT, IdxT> bus_type;
     using bus_type  = BaseBus<ScalarT, IdxT>;
     using real_type = typename ModelEvaluatorImpl<ScalarT, IdxT>::real_type;
-    using LoadData  = GridKit::PowerSystemData::LoadData<real_type, IdxT>;
+    using LoadData  = GridKit::PowerFlowData::LoadData<real_type, IdxT>;
 
   public:
     Load(bus_type* bus, ScalarT P, ScalarT Q);

--- a/src/Model/PowerFlow/MatpowerParser.hpp
+++ b/src/Model/PowerFlow/MatpowerParser.hpp
@@ -17,11 +17,11 @@
 #include <sstream>
 #include <vector>
 
-#include <Model/PowerFlow/PowerSystemData.hpp>
+#include <Model/PowerFlow/PowerFlowData.hpp>
 
 namespace GridKit
 {
-  using namespace GridKit::PowerSystemData;
+  using namespace GridKit::PowerFlowData;
 
   static const std::string matlab_syntax_error{
       "Only a subset of Matlab syntax is supported."

--- a/src/Model/PowerFlow/PowerFlowData.hpp
+++ b/src/Model/PowerFlow/PowerFlowData.hpp
@@ -6,7 +6,7 @@
 
 /**
  *
- * @file PowerSystemData.hpp
+ * @file PowerFlowData.hpp
  * @author Asher Mancinelli <asher.mancinelli@pnnl.gov>
  *
  * @remark `std::stringstream` is preferred over `operator+(std::string, ...)`
@@ -17,7 +17,7 @@
 namespace GridKit
 {
 
-  namespace PowerSystemData
+  namespace PowerFlowData
   {
 
     template <typename RealT = double, typename IdxT = int>
@@ -238,5 +238,5 @@ namespace GridKit
       }
     }; // struct SystemModelData
 
-  } // namespace PowerSystemData
+  } // namespace PowerFlowData
 } // namespace GridKit

--- a/src/Model/PowerFlow/SystemModelPowerFlow.hpp
+++ b/src/Model/PowerFlow/SystemModelPowerFlow.hpp
@@ -75,7 +75,7 @@ namespace GridKit
      *
      * @param mp model data
      */
-    SystemSteadyStateModel(GridKit::PowerSystemData::SystemModelData<ScalarT, IdxT> mp)
+    SystemSteadyStateModel(GridKit::PowerFlowData::SystemModelData<ScalarT, IdxT> mp)
       : ModelEvaluatorImpl<ScalarT, IdxT>(0, 0, 0)
     {
       rel_tol_ = 1e-5;


### PR DESCRIPTION
## Description

Create data structures to store model data for each component model type, e.g. an electrical machine data structure. These data structures will contain a superset of parameters for each component model type.
 
@abirchfield @lukelowry @alexander-novo @reid-g @abdourahmanbarry 
 
 ## Proposed changes
 
The purpose of these data structures is to decouple data input from component models, so that:
- Multiple inputs (GUI, file input, etc.) can be used to enter system model data in GridKit.
- Multiple component model implementations can use the same data structures to instantiate the component.
- Analysis can be performed on these data structures to compute sparsity pattern of system Jacobian without even instantiating the component or system models.

The changes proposed in the  PR are the first step in this direction.
 
 ## Checklist
 
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
