### PR TITLE
fix remaining warnings (on-repo)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,6 @@ set(PACKAGE_VERSION_PATCH "0")
 
 set(PACKAGE_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH}")
 
-# TODO: Probably beter to set a debug interface target
-# set(CMAKE_CXX_FLAGS_DEBUG "-Wall -O0 -g -DDEBUG")
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wconversion -Wpedantic")
 

--- a/examples/PowerElectronics/Microgrid/Microgrid.cpp
+++ b/examples/PowerElectronics/Microgrid/Microgrid.cpp
@@ -106,7 +106,7 @@ int main(int /* argc */, char const** /* argv */)
   dg1->setExternalConnectionNodes(1, dqbus1);
   dg1->setExternalConnectionNodes(2, dqbus1 + 1);
   //"grounding" of the difference
-  dg1->setExternalConnectionNodes(3, -1);
+  dg1->setExternalConnectionNodes(3, static_cast<size_t>(-1));
   // internal connections
   for (size_t i = 0; i < 12; i++)
   {

--- a/examples/PowerElectronics/RLCircuit/RLCircuit.cpp
+++ b/examples/PowerElectronics/RLCircuit/RLCircuit.cpp
@@ -37,7 +37,7 @@ int main(int /* argc */, char const** /* argv */)
   //  input
   induct->setExternalConnectionNodes(0, 1);
   // output
-  induct->setExternalConnectionNodes(1, -1);
+  induct->setExternalConnectionNodes(1, static_cast<size_t>(-1));
   // internal
   induct->setExternalConnectionNodes(2, 2);
   // add component
@@ -59,7 +59,7 @@ int main(int /* argc */, char const** /* argv */)
   GridKit::VoltageSource<double, size_t>* vsource = new GridKit::VoltageSource<double, size_t>(idoff, vinit);
   // Form index to node uid realations
   // input
-  vsource->setExternalConnectionNodes(0, -1);
+  vsource->setExternalConnectionNodes(0, static_cast<size_t>(-1));
   // output
   vsource->setExternalConnectionNodes(1, 0);
   // internal

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
@@ -192,7 +192,7 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
   dg_ref->setExternalConnectionNodes(1, vdqbus_index[0]);
   dg_ref->setExternalConnectionNodes(2, vdqbus_index[0] + 1);
   //"grounding" of the difference
-  dg_ref->setExternalConnectionNodes(3, -1);
+  dg_ref->setExternalConnectionNodes(3, static_cast<index_type>(-1));
   // internal connections
   for (index_type i = 0; i < 12; i++)
   {

--- a/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -190,14 +190,13 @@ inline std::vector<IdxT> COO_Matrix<ScalarT, IdxT>::getCSRRowData()
   if (!this->isSorted())
     this->sortSparse();
   std::vector<IdxT> row_size_vec(static_cast<size_t>(this->rows_size_ + 1), 0);
-  IdxT              counter = 0;
-  for (IdxT i = 0; i < static_cast<IdxT>(row_size_vec.size() - 1); i++)
+  size_t            counter = 0;
+  for (size_t i = 0; i < row_size_vec.size() - 1; i++)
   {
-    row_size_vec[static_cast<size_t>(i + 1)] = row_size_vec[static_cast<size_t>(i)];
-    while (counter < static_cast<IdxT>(this->row_indices_.size())
-           && i == this->row_indices_[static_cast<size_t>(counter)])
+    row_size_vec[i + 1] = row_size_vec[i];
+    while (counter < this->row_indices_.size() && i == static_cast<size_t>(this->row_indices_[counter]))
     {
-      row_size_vec[static_cast<size_t>(i + 1)]++;
+      row_size_vec[i + 1]++;
       counter++;
     }
   }
@@ -227,38 +226,39 @@ inline void COO_Matrix<ScalarT, IdxT>::setValues(std::vector<IdxT> r, std::vecto
   this->sortSparseCOO(r, c, v);
 
   // Duplicated with axpy. Could replace with function depdent on lambda expression
-  IdxT a_iter = 0;
+  size_t a_iter = 0;
   // iterate for all current values_ in matrix
-  for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
+  for (size_t i = 0; i < this->row_indices_.size(); i++)
   {
     // pushback values_ when they are not in current matrix
-    while (a_iter < static_cast<IdxT>(r.size()) && (r[static_cast<size_t>(a_iter)] < this->row_indices_[static_cast<size_t>(i)] || (r[static_cast<size_t>(a_iter)] == this->row_indices_[static_cast<size_t>(i)] && c[static_cast<size_t>(a_iter)] < this->column_indices_[static_cast<size_t>(i)])))
+    while (a_iter < r.size() && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
     {
-      this->row_indices_.push_back(r[static_cast<size_t>(a_iter)]);
-      this->column_indices_.push_back(c[static_cast<size_t>(a_iter)]);
-      this->values_.push_back(v[static_cast<size_t>(a_iter)]);
-      this->checkIncreaseSize(r[static_cast<size_t>(a_iter)], c[static_cast<size_t>(a_iter)]);
+      this->row_indices_.push_back(r[a_iter]);
+      this->column_indices_.push_back(c[a_iter]);
+      this->values_.push_back(v[a_iter]);
+      this->checkIncreaseSize(r[a_iter], c[a_iter]);
       a_iter++;
     }
-    if (a_iter >= static_cast<IdxT>(r.size()))
+
+    if (a_iter >= r.size())
     {
       break;
     }
 
-    if (r[static_cast<size_t>(a_iter)] == this->row_indices_[static_cast<size_t>(i)] && c[static_cast<size_t>(a_iter)] == this->column_indices_[static_cast<size_t>(i)])
+    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
     {
-      this->values_[static_cast<size_t>(i)] = v[static_cast<size_t>(a_iter)];
+      this->values_[i] = v[a_iter];
       a_iter++;
     }
   }
   // push back rest that was not found sorted
-  for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
+  for (size_t i = a_iter; i < r.size(); i++)
   {
-    this->row_indices_.push_back(r[static_cast<size_t>(i)]);
-    this->column_indices_.push_back(c[static_cast<size_t>(i)]);
-    this->values_.push_back(v[static_cast<size_t>(i)]);
+    this->row_indices_.push_back(r[i]);
+    this->column_indices_.push_back(c[i]);
+    this->values_.push_back(v[i]);
 
-    this->checkIncreaseSize(r[static_cast<size_t>(i)], c[static_cast<size_t>(i)]);
+    this->checkIncreaseSize(r[i], c[i]);
   }
 
   this->sorted_ = false;
@@ -300,39 +300,39 @@ inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, COO_Matrix<ScalarT, I
   this->rows_size_    = this->rows_size_ > m ? this->rows_size_ : m;
   this->columns_size_ = this->columns_size_ > n ? this->columns_size_ : n;
 
-  IdxT a_iter = 0;
+  size_t a_iter = 0;
   // iterate for all current values in matrix
-  for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
+  for (size_t i = 0; i < this->row_indices_.size(); i++)
   {
     // pushback values when they are not in current matrix
-    while (a_iter < static_cast<IdxT>(r.size()) && (r[static_cast<size_t>(a_iter)] < this->row_indices_[static_cast<size_t>(i)] || (r[static_cast<size_t>(a_iter)] == this->row_indices_[static_cast<size_t>(i)] && c[static_cast<size_t>(a_iter)] < this->column_indices_[static_cast<size_t>(i)])))
+    while (a_iter < r.size() && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
     {
-      this->row_indices_.push_back(r[static_cast<size_t>(a_iter)]);
-      this->column_indices_.push_back(c[static_cast<size_t>(a_iter)]);
-      this->values_.push_back(alpha * val[static_cast<size_t>(a_iter)]);
+      this->row_indices_.push_back(r[a_iter]);
+      this->column_indices_.push_back(c[a_iter]);
+      this->values_.push_back(alpha * val[a_iter]);
 
-      this->checkIncreaseSize(r[static_cast<size_t>(a_iter)], c[static_cast<size_t>(a_iter)]);
+      this->checkIncreaseSize(r[a_iter], c[a_iter]);
       a_iter++;
     }
-    if (a_iter >= static_cast<IdxT>(r.size()))
+    if (a_iter >= r.size())
     {
       break;
     }
 
-    if (r[static_cast<size_t>(a_iter)] == this->row_indices_[static_cast<size_t>(i)] && c[static_cast<size_t>(a_iter)] == this->column_indices_[static_cast<size_t>(i)])
+    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
     {
-      this->values_[static_cast<size_t>(i)] += alpha * val[static_cast<size_t>(a_iter)];
+      this->values_[i] += alpha * val[a_iter];
       a_iter++;
     }
   }
   // push back rest that was not found sorted_
-  for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
+  for (size_t i = a_iter; i < r.size(); i++)
   {
-    this->row_indices_.push_back(r[static_cast<size_t>(i)]);
-    this->column_indices_.push_back(c[static_cast<size_t>(i)]);
-    this->values_.push_back(alpha * val[static_cast<size_t>(i)]);
+    this->row_indices_.push_back(r[i]);
+    this->column_indices_.push_back(c[i]);
+    this->values_.push_back(alpha * val[i]);
 
-    this->checkIncreaseSize(r[static_cast<size_t>(i)], c[static_cast<size_t>(i)]);
+    this->checkIncreaseSize(r[i], c[i]);
   }
 
   this->sorted_ = false;
@@ -367,12 +367,12 @@ inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, std::vector<IdxT> r, 
   // sort input
   this->sortSparseCOO(r, c, v);
 
-  IdxT a_iter = 0;
+  size_t a_iter = 0;
   // iterate for all current values_ in matrix
-  for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
+  for (size_t i = 0; i < this->row_indices_.size(); i++)
   {
     // pushback values_ when they are not in current matrix
-    while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
+    while (a_iter < r.size() && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
     {
       this->row_indices_.push_back(r[a_iter]);
       this->column_indices_.push_back(c[a_iter]);
@@ -381,7 +381,7 @@ inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, std::vector<IdxT> r, 
       this->checkIncreaseSize(r[a_iter], c[a_iter]);
       a_iter++;
     }
-    if (a_iter >= static_cast<IdxT>(r.size()))
+    if (a_iter >= r.size())
     {
       break;
     }
@@ -393,7 +393,7 @@ inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, std::vector<IdxT> r, 
     }
   }
   // push back rest that was not found sorted_
-  for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
+  for (IdxT i = a_iter; i < r.size(); i++)
   {
     this->row_indices_.push_back(r[i]);
     this->column_indices_.push_back(c[i]);
@@ -490,7 +490,7 @@ inline void COO_Matrix<ScalarT, IdxT>::permutationSizeMap(std::vector<IdxT> row_
   this->rows_size_    = m;
   this->columns_size_ = n;
 
-  for (int i = 0; i < this->values_.size(); i++)
+  for (size_t i = 0; i < this->values_.size(); i++)
   {
     if (row_perm[this->row_indices_[i]] == -1 || col_perm[this->column_indices_[i]] == -1)
     {
@@ -780,10 +780,8 @@ inline void COO_Matrix<ScalarT, IdxT>::sortSparseCOO(std::vector<IdxT>& rows, st
   // Sort by row first then column.
   std::sort(std::begin(ordervec),
             std::end(ordervec),
-            [&](int i1, int i2)
-            { return (rows[static_cast<size_t>(i1)] < rows[static_cast<size_t>(i2)])
-                     || (rows[static_cast<size_t>(i1)] == rows[static_cast<size_t>(i2)]
-                         && columns[static_cast<size_t>(i1)] < columns[static_cast<size_t>(i2)]); });
+            [&](auto i1, auto i2)
+            { return (rows[i1] < rows[i2]) || (rows[i1] == rows[i2] && columns[i1] < columns[i2]); });
 
   // reorder based of index-sorting. Only swap cost no extra memory.
   //  @todo see if extra memory creation is fine

--- a/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -515,7 +515,7 @@ inline void COO_Matrix<ScalarT, IdxT>::permutationSizeMap(std::vector<IdxT> row_
 template <class ScalarT, typename IdxT>
 inline void COO_Matrix<ScalarT, IdxT>::zeroMatrix()
 {
-  // resize doesn't effect capacity if smaller
+  // resize doesn't affect capacity if smaller
   this->column_indices_.resize(0);
   this->row_indices_.resize(0);
   this->values_.resize(0);

--- a/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -189,14 +189,15 @@ inline std::vector<IdxT> COO_Matrix<ScalarT, IdxT>::getCSRRowData()
 {
   if (!this->isSorted())
     this->sortSparse();
-  std::vector<IdxT> row_size_vec(this->rows_size_ + 1, 0);
+  std::vector<IdxT> row_size_vec(static_cast<size_t>(this->rows_size_ + 1), 0);
   IdxT              counter = 0;
   for (IdxT i = 0; i < static_cast<IdxT>(row_size_vec.size() - 1); i++)
   {
-    row_size_vec[i + 1] = row_size_vec[i];
-    while (counter < static_cast<IdxT>(this->row_indices_.size()) && i == this->row_indices_[counter])
+    row_size_vec[static_cast<size_t>(i + 1)] = row_size_vec[static_cast<size_t>(i)];
+    while (counter < static_cast<IdxT>(this->row_indices_.size())
+           && i == this->row_indices_[static_cast<size_t>(counter)])
     {
-      row_size_vec[i + 1]++;
+      row_size_vec[static_cast<size_t>(i + 1)]++;
       counter++;
     }
   }
@@ -231,12 +232,12 @@ inline void COO_Matrix<ScalarT, IdxT>::setValues(std::vector<IdxT> r, std::vecto
   for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
   {
     // pushback values_ when they are not in current matrix
-    while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
+    while (a_iter < static_cast<IdxT>(r.size()) && (r[static_cast<size_t>(a_iter)] < this->row_indices_[static_cast<size_t>(i)] || (r[static_cast<size_t>(a_iter)] == this->row_indices_[static_cast<size_t>(i)] && c[static_cast<size_t>(a_iter)] < this->column_indices_[static_cast<size_t>(i)])))
     {
-      this->row_indices_.push_back(r[a_iter]);
-      this->column_indices_.push_back(c[a_iter]);
-      this->values_.push_back(v[a_iter]);
-      this->checkIncreaseSize(r[a_iter], c[a_iter]);
+      this->row_indices_.push_back(r[static_cast<size_t>(a_iter)]);
+      this->column_indices_.push_back(c[static_cast<size_t>(a_iter)]);
+      this->values_.push_back(v[static_cast<size_t>(a_iter)]);
+      this->checkIncreaseSize(r[static_cast<size_t>(a_iter)], c[static_cast<size_t>(a_iter)]);
       a_iter++;
     }
     if (a_iter >= static_cast<IdxT>(r.size()))
@@ -244,20 +245,20 @@ inline void COO_Matrix<ScalarT, IdxT>::setValues(std::vector<IdxT> r, std::vecto
       break;
     }
 
-    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
+    if (r[static_cast<size_t>(a_iter)] == this->row_indices_[static_cast<size_t>(i)] && c[static_cast<size_t>(a_iter)] == this->column_indices_[static_cast<size_t>(i)])
     {
-      this->values_[i] = v[a_iter];
+      this->values_[static_cast<size_t>(i)] = v[static_cast<size_t>(a_iter)];
       a_iter++;
     }
   }
   // push back rest that was not found sorted
   for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
   {
-    this->row_indices_.push_back(r[i]);
-    this->column_indices_.push_back(c[i]);
-    this->values_.push_back(v[i]);
+    this->row_indices_.push_back(r[static_cast<size_t>(i)]);
+    this->column_indices_.push_back(c[static_cast<size_t>(i)]);
+    this->values_.push_back(v[static_cast<size_t>(i)]);
 
-    this->checkIncreaseSize(r[i], c[i]);
+    this->checkIncreaseSize(r[static_cast<size_t>(i)], c[static_cast<size_t>(i)]);
   }
 
   this->sorted_ = false;
@@ -304,13 +305,13 @@ inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, COO_Matrix<ScalarT, I
   for (IdxT i = 0; i < static_cast<IdxT>(this->row_indices_.size()); i++)
   {
     // pushback values when they are not in current matrix
-    while (a_iter < static_cast<IdxT>(r.size()) && (r[a_iter] < this->row_indices_[i] || (r[a_iter] == this->row_indices_[i] && c[a_iter] < this->column_indices_[i])))
+    while (a_iter < static_cast<IdxT>(r.size()) && (r[static_cast<size_t>(a_iter)] < this->row_indices_[static_cast<size_t>(i)] || (r[static_cast<size_t>(a_iter)] == this->row_indices_[static_cast<size_t>(i)] && c[static_cast<size_t>(a_iter)] < this->column_indices_[static_cast<size_t>(i)])))
     {
-      this->row_indices_.push_back(r[a_iter]);
-      this->column_indices_.push_back(c[a_iter]);
-      this->values_.push_back(alpha * val[a_iter]);
+      this->row_indices_.push_back(r[static_cast<size_t>(a_iter)]);
+      this->column_indices_.push_back(c[static_cast<size_t>(a_iter)]);
+      this->values_.push_back(alpha * val[static_cast<size_t>(a_iter)]);
 
-      this->checkIncreaseSize(r[a_iter], c[a_iter]);
+      this->checkIncreaseSize(r[static_cast<size_t>(a_iter)], c[static_cast<size_t>(a_iter)]);
       a_iter++;
     }
     if (a_iter >= static_cast<IdxT>(r.size()))
@@ -318,20 +319,20 @@ inline void COO_Matrix<ScalarT, IdxT>::axpy(ScalarT alpha, COO_Matrix<ScalarT, I
       break;
     }
 
-    if (r[a_iter] == this->row_indices_[i] && c[a_iter] == this->column_indices_[i])
+    if (r[static_cast<size_t>(a_iter)] == this->row_indices_[static_cast<size_t>(i)] && c[static_cast<size_t>(a_iter)] == this->column_indices_[static_cast<size_t>(i)])
     {
-      this->values_[i] += alpha * val[a_iter];
+      this->values_[static_cast<size_t>(i)] += alpha * val[static_cast<size_t>(a_iter)];
       a_iter++;
     }
   }
   // push back rest that was not found sorted_
   for (IdxT i = a_iter; i < static_cast<IdxT>(r.size()); i++)
   {
-    this->row_indices_.push_back(r[i]);
-    this->column_indices_.push_back(c[i]);
-    this->values_.push_back(alpha * val[i]);
+    this->row_indices_.push_back(r[static_cast<size_t>(i)]);
+    this->column_indices_.push_back(c[static_cast<size_t>(i)]);
+    this->values_.push_back(alpha * val[static_cast<size_t>(i)]);
 
-    this->checkIncreaseSize(r[i], c[i]);
+    this->checkIncreaseSize(r[static_cast<size_t>(i)], c[static_cast<size_t>(i)]);
   }
 
   this->sorted_ = false;
@@ -780,7 +781,9 @@ inline void COO_Matrix<ScalarT, IdxT>::sortSparseCOO(std::vector<IdxT>& rows, st
   std::sort(std::begin(ordervec),
             std::end(ordervec),
             [&](int i1, int i2)
-            { return (rows[i1] < rows[i2]) || (rows[i1] == rows[i2] && columns[i1] < columns[i2]); });
+            { return (rows[static_cast<size_t>(i1)] < rows[static_cast<size_t>(i2)])
+                     || (rows[static_cast<size_t>(i1)] == rows[static_cast<size_t>(i2)]
+                         && columns[static_cast<size_t>(i1)] < columns[static_cast<size_t>(i2)]); });
 
   // reorder based of index-sorting. Only swap cost no extra memory.
   //  @todo see if extra memory creation is fine

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
@@ -8,10 +8,11 @@
  */
 
 #define _USE_MATH_DEFINES
+#include "Genrou.hpp"
+
 #include <cmath>
 #include <iostream>
 
-#include "Genrou.hpp"
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 
 #define _USE_MATH_DEFINES

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
@@ -8,11 +8,10 @@
  */
 
 #define _USE_MATH_DEFINES
-#include "Genrou.hpp"
-
 #include <cmath>
 #include <iostream>
 
+#include "Genrou.hpp"
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 
 #define _USE_MATH_DEFINES
@@ -136,13 +135,13 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int Genrou<ScalarT, IdxT>::allocate()
     {
-      f_.resize(size_);
-      y_.resize(size_);
-      yp_.resize(size_);
-      tag_.resize(size_);
-      fB_.resize(size_);
-      yB_.resize(size_);
-      ypB_.resize(size_);
+      f_.resize(static_cast<size_t>(size_));
+      y_.resize(static_cast<size_t>(size_));
+      yp_.resize(static_cast<size_t>(size_));
+      tag_.resize(static_cast<size_t>(size_));
+      fB_.resize(static_cast<size_t>(size_));
+      yB_.resize(static_cast<size_t>(size_));
+      ypB_.resize(static_cast<size_t>(size_));
       return 0;
     }
 
@@ -209,7 +208,7 @@ namespace GridKit
                + G_ * (vd * -cos(delta) + vq * sin(delta)); /* inort, imag */
 
       for (IdxT i = 0; i < size_; ++i)
-        yp_[i] = 0.0;
+        yp_[static_cast<size_t>(i)] = 0.0;
 
       return 0;
     }
@@ -222,7 +221,7 @@ namespace GridKit
     {
       for (IdxT i = 0; i < size_; ++i)
       {
-        tag_[i] = i < 6;
+        tag_[static_cast<size_t>(i)] = i < 6;
       }
       return 0;
     }

--- a/src/Model/PowerElectronics/Capacitor/Capacitor.cpp
+++ b/src/Model/PowerElectronics/Capacitor/Capacitor.cpp
@@ -39,9 +39,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int Capacitor<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerElectronics/CircuitGraph.hpp
+++ b/src/Model/PowerElectronics/CircuitGraph.hpp
@@ -105,7 +105,7 @@ size_t CircuitGraph<N, E>::amountHyperEdges()
  */
 
 template <typename N, typename E>
-void CircuitGraph<N, E>::printBiPartiteGraph(bool verbose)
+void CircuitGraph<N, E>::printBiPartiteGraph([[maybe_unused]] bool verbose)
 {
 
   std::cout << "Amount of HyperNodes: " << this->amountHyperNodes() << std::endl;

--- a/src/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
+++ b/src/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
@@ -57,9 +57,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int DistributedGenerator<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
 
     return 0;
   }
@@ -186,7 +186,7 @@ namespace GridKit
     std::vector<ScalarT> valsder(13, -1.0);
     for (int i = 0; i < 13; i++)
     {
-      rcordder[i] = i + 3;
+      rcordder[static_cast<size_t>(i)] = static_cast<IdxT>(i + 3);
     }
     COO_Matrix<ScalarT, IdxT> Jacder = COO_Matrix<ScalarT, IdxT>(rcordder, rcordder, valsder, 16, 16);
 

--- a/src/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
+++ b/src/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
@@ -51,9 +51,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int InductionMotor<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
     return 0;
   }
 

--- a/src/Model/PowerElectronics/Inductor/Inductor.cpp
+++ b/src/Model/PowerElectronics/Inductor/Inductor.cpp
@@ -38,9 +38,9 @@ namespace GridKit
   int Inductor<ScalarT, IdxT>::allocate()
   {
 
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
+++ b/src/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
@@ -53,9 +53,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int LinearTransformer<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
     return 0;
   }
 

--- a/src/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
+++ b/src/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
@@ -42,9 +42,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridBusDQ<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
+++ b/src/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
@@ -46,9 +46,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridLine<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
+++ b/src/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
@@ -44,9 +44,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridLoad<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerElectronics/Resistor/Resistor.cpp
+++ b/src/Model/PowerElectronics/Resistor/Resistor.cpp
@@ -37,9 +37,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int Resistor<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
+++ b/src/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
@@ -69,9 +69,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int SynchronousMachine<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
     return 0;
   }
 

--- a/src/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
+++ b/src/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
@@ -50,9 +50,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int TransmissionLine<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
+++ b/src/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
@@ -37,9 +37,9 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int VoltageSource<ScalarT, IdxT>::allocate()
   {
-    y_.resize(size_);
-    yp_.resize(size_);
-    f_.resize(size_);
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    f_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerFlow/Bus/BusPQ.cpp
+++ b/src/Model/PowerFlow/Bus/BusPQ.cpp
@@ -70,14 +70,14 @@ namespace GridKit
   int BusPQ<ScalarT, IdxT>::allocate()
   {
     // std::cout << "Allocate PQ bus ..." << std::endl;
-    f_.resize(size_);
-    y_.resize(size_);
-    yp_.resize(size_);
-    tag_.resize(size_);
+    f_.resize(static_cast<size_t>(size_));
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    tag_.resize(static_cast<size_t>(size_));
 
-    fB_.resize(size_);
-    yB_.resize(size_);
-    ypB_.resize(size_);
+    fB_.resize(static_cast<size_t>(size_));
+    yB_.resize(static_cast<size_t>(size_));
+    ypB_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerFlow/Bus/BusPV.cpp
+++ b/src/Model/PowerFlow/Bus/BusPV.cpp
@@ -68,14 +68,14 @@ namespace GridKit
   int BusPV<ScalarT, IdxT>::allocate()
   {
     // std::cout << "Allocate PV bus ..." << std::endl;
-    f_.resize(size_);
-    y_.resize(size_);
-    yp_.resize(size_);
-    tag_.resize(size_);
+    f_.resize(static_cast<size_t>(size_));
+    y_.resize(static_cast<size_t>(size_));
+    yp_.resize(static_cast<size_t>(size_));
+    tag_.resize(static_cast<size_t>(size_));
 
-    fB_.resize(size_);
-    yB_.resize(size_);
-    ypB_.resize(size_);
+    fB_.resize(static_cast<size_t>(size_));
+    yB_.resize(static_cast<size_t>(size_));
+    ypB_.resize(static_cast<size_t>(size_));
 
     return 0;
   }

--- a/src/Model/PowerFlow/Generator2/Generator2.cpp
+++ b/src/Model/PowerFlow/Generator2/Generator2.cpp
@@ -48,7 +48,7 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int Generator2<ScalarT, IdxT>::allocate()
   {
-    tag_.resize(size_);
+    tag_.resize(static_cast<size_t>(size_));
     return 0;
   }
 

--- a/src/Model/PowerFlow/Generator4/Generator4.cpp
+++ b/src/Model/PowerFlow/Generator4/Generator4.cpp
@@ -1,10 +1,9 @@
 
 #define _USE_MATH_DEFINES
-#include "Generator4.hpp"
-
 #include <cmath>
 #include <iostream>
 
+#include "Generator4.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
 namespace GridKit
@@ -57,7 +56,7 @@ namespace GridKit
   int Generator4<ScalarT, IdxT>::allocate()
   {
     // std::cout << "Allocate Generator4..." << std::endl;
-    tag_.resize(size_);
+    tag_.resize(static_cast<size_t>(size_));
 
     return 0;
   }
@@ -143,7 +142,7 @@ namespace GridKit
 
     for (IdxT i = 4; i < size_; ++i)
     {
-      tag_[i] = false;
+      tag_[static_cast<size_t>(i)] = false;
     }
 
     return 0;
@@ -217,8 +216,8 @@ namespace GridKit
     // std::cout << "Initialize adjoint for Generator4..." << std::endl;
     for (IdxT i = 0; i < size_; ++i)
     {
-      yB_[i]  = 0.0;
-      ypB_[i] = 0.0;
+      yB_[static_cast<size_t>(i)]  = 0.0;
+      ypB_[static_cast<size_t>(i)] = 0.0;
     }
     ypB_[1] = frequencyPenaltyDer(y_[1]);
 

--- a/src/Model/PowerFlow/Generator4/Generator4.cpp
+++ b/src/Model/PowerFlow/Generator4/Generator4.cpp
@@ -1,9 +1,10 @@
 
 #define _USE_MATH_DEFINES
+#include "Generator4.hpp"
+
 #include <cmath>
 #include <iostream>
 
-#include "Generator4.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
 namespace GridKit

--- a/src/Model/PowerFlow/Generator4Governor/Generator4Governor.cpp
+++ b/src/Model/PowerFlow/Generator4Governor/Generator4Governor.cpp
@@ -1,9 +1,10 @@
 
 #define _USE_MATH_DEFINES
+#include "Generator4Governor.hpp"
+
 #include <cmath>
 #include <iostream>
 
-#include "Generator4Governor.hpp"
 #include "Model/PowerFlow/Bus/BaseBus.hpp"
 
 namespace GridKit
@@ -297,15 +298,15 @@ namespace GridKit
     // Generator adjoint
     fB_[static_cast<size_t>(offsetGen_ + 0)] = ypB_[static_cast<size_t>(offsetGen_ + 0)] - yB_[static_cast<size_t>(offsetGen_ + 4)] * V() * cosPhi + yB_[static_cast<size_t>(offsetGen_ + 5)] * V() * sinPhi;
     fB_[static_cast<size_t>(offsetGen_ + 1)] = 2.0 * H_ / omega_s_ * ypB_[static_cast<size_t>(offsetGen_ + 1)] + yB_[static_cast<size_t>(offsetGen_ + 0)] * omega_b_ - yB_[static_cast<size_t>(offsetGen_ + 1)] * D_ + frequencyPenaltyDer(omega())
-                          + yB_[static_cast<size_t>(offsetGov_ + 1)] * (1.0 - T2() / T1()) - yB_[static_cast<size_t>(offsetGov_ + 2)] * K() * T2() / T1();
+                                               + yB_[static_cast<size_t>(offsetGov_ + 1)] * (1.0 - T2() / T1()) - yB_[static_cast<size_t>(offsetGov_ + 2)] * K() * T2() / T1();
     fB_[static_cast<size_t>(offsetGen_ + 2)] = Tq0p_ * ypB_[static_cast<size_t>(offsetGen_ + 2)] - yB_[static_cast<size_t>(offsetGen_ + 1)] * Id() - yB_[static_cast<size_t>(offsetGen_ + 2)] + yB_[static_cast<size_t>(offsetGen_ + 4)]
-                          + lambdaP() * Id() - lambdaQ() * Iq();
+                                               + lambdaP() * Id() - lambdaQ() * Iq();
     fB_[static_cast<size_t>(offsetGen_ + 3)] = Td0p_ * ypB_[static_cast<size_t>(offsetGen_ + 3)] - yB_[static_cast<size_t>(offsetGen_ + 1)] * Iq() - yB_[static_cast<size_t>(offsetGen_ + 3)] + yB_[static_cast<size_t>(offsetGen_ + 5)]
-                          + lambdaP() * Iq() + lambdaQ() * Id();
+                                               + lambdaP() * Iq() + lambdaQ() * Id();
     fB_[static_cast<size_t>(offsetGen_ + 4)] = -yB_[static_cast<size_t>(offsetGen_ + 1)] * (Edp() + (Xqp_ - Xdp_) * Iq()) - yB_[static_cast<size_t>(offsetGen_ + 3)] * (Xd_ - Xdp_) - yB_[static_cast<size_t>(offsetGen_ + 4)] * Rs_ - yB_[static_cast<size_t>(offsetGen_ + 5)] * Xdp_
-                          + lambdaP() * (Edp() + (Xqp_ - Xdp_) * Iq() - 2.0 * Rs_ * Id()) + lambdaQ() * (Eqp() - 2.0 * Xdp_ * Id());
+                                               + lambdaP() * (Edp() + (Xqp_ - Xdp_) * Iq() - 2.0 * Rs_ * Id()) + lambdaQ() * (Eqp() - 2.0 * Xdp_ * Id());
     fB_[static_cast<size_t>(offsetGen_ + 5)] = -yB_[static_cast<size_t>(offsetGen_ + 1)] * (Eqp() + (Xqp_ - Xdp_) * Id()) + yB_[static_cast<size_t>(offsetGen_ + 2)] * (Xq_ - Xqp_) + yB_[static_cast<size_t>(offsetGen_ + 4)] * Xqp_ - yB_[static_cast<size_t>(offsetGen_ + 5)] * Rs_
-                          + lambdaP() * (Eqp() + (Xqp_ - Xdp_) * Id() - 2.0 * Rs_ * Iq()) - lambdaQ() * (Edp() + 2.0 * Xqp_ * Iq());
+                                               + lambdaP() * (Eqp() + (Xqp_ - Xdp_) * Id() - 2.0 * Rs_ * Iq()) - lambdaQ() * (Edp() + 2.0 * Xqp_ * Iq());
 
     // Bus adjoint
     PB() += (-yB_[static_cast<size_t>(offsetGen_ + 4)] * sinPhi - yB_[static_cast<size_t>(offsetGen_ + 5)] * cosPhi);

--- a/src/Model/PowerFlow/Generator4Governor/Generator4Governor.cpp
+++ b/src/Model/PowerFlow/Generator4Governor/Generator4Governor.cpp
@@ -1,10 +1,9 @@
 
 #define _USE_MATH_DEFINES
-#include "Generator4Governor.hpp"
-
 #include <cmath>
 #include <iostream>
 
+#include "Generator4Governor.hpp"
 #include "Model/PowerFlow/Bus/BaseBus.hpp"
 
 namespace GridKit
@@ -66,7 +65,7 @@ namespace GridKit
   int Generator4Governor<ScalarT, IdxT>::allocate()
   {
     // std::cout << "Allocate Gen2..." << std::endl;
-    tag_.resize(size_);
+    tag_.resize(static_cast<size_t>(size_));
 
     return 0;
   }
@@ -111,29 +110,29 @@ namespace GridKit
     const ScalarT Eqp = V() * cos(delta - theta()) + Rs_ * Iq + Xdp_ * Id;
 
     // Initialize generator
-    y_[offsetGen_ + 0]  = delta;
-    y_[offsetGen_ + 1]  = omega_s_ + 0.2; // <~ this is hack to perturb omega
-    y_[offsetGen_ + 2]  = Edp;
-    y_[offsetGen_ + 3]  = Eqp;
-    y_[offsetGen_ + 4]  = Id;
-    y_[offsetGen_ + 5]  = Iq;
-    yp_[offsetGen_ + 0] = 0.0;
-    yp_[offsetGen_ + 1] = 0.0;
-    yp_[offsetGen_ + 2] = 0.0;
-    yp_[offsetGen_ + 3] = 0.0;
-    yp_[offsetGen_ + 4] = 0.0;
-    yp_[offsetGen_ + 5] = 0.0;
+    y_[static_cast<size_t>(offsetGen_ + 0)]  = delta;
+    y_[static_cast<size_t>(offsetGen_ + 1)]  = omega_s_ + 0.2; // <~ this is hack to perturb omega
+    y_[static_cast<size_t>(offsetGen_ + 2)]  = Edp;
+    y_[static_cast<size_t>(offsetGen_ + 3)]  = Eqp;
+    y_[static_cast<size_t>(offsetGen_ + 4)]  = Id;
+    y_[static_cast<size_t>(offsetGen_ + 5)]  = Iq;
+    yp_[static_cast<size_t>(offsetGen_ + 0)] = 0.0;
+    yp_[static_cast<size_t>(offsetGen_ + 1)] = 0.0;
+    yp_[static_cast<size_t>(offsetGen_ + 2)] = 0.0;
+    yp_[static_cast<size_t>(offsetGen_ + 3)] = 0.0;
+    yp_[static_cast<size_t>(offsetGen_ + 4)] = 0.0;
+    yp_[static_cast<size_t>(offsetGen_ + 5)] = 0.0;
 
     Pm0_ = Edp * Id + Eqp * Iq + (Xqp_ - Xdp_) * Id * Iq; // <~ set to steady state value
     Ef0_ = Eqp + (Xd_ - Xdp_) * Id;                       // <~ set to steady state value
 
     // Initialize governor
-    y_[offsetGov_ + 0]  = Pm0_;
-    y_[offsetGov_ + 1]  = 0.0;
-    y_[offsetGov_ + 2]  = 0.0;
-    yp_[offsetGov_ + 0] = 0.0;
-    yp_[offsetGov_ + 1] = 0.0;
-    yp_[offsetGov_ + 2] = 0.0;
+    y_[static_cast<size_t>(offsetGov_ + 0)]  = Pm0_;
+    y_[static_cast<size_t>(offsetGov_ + 1)]  = 0.0;
+    y_[static_cast<size_t>(offsetGov_ + 2)]  = 0.0;
+    yp_[static_cast<size_t>(offsetGov_ + 0)] = 0.0;
+    yp_[static_cast<size_t>(offsetGov_ + 1)] = 0.0;
+    yp_[static_cast<size_t>(offsetGov_ + 2)] = 0.0;
 
     param_[1]    = K_;
     param_up_[1] = 20.0;
@@ -153,16 +152,16 @@ namespace GridKit
   int Generator4Governor<ScalarT, IdxT>::tagDifferentiable()
   {
     // std::cout << "size of tag vector is " << tag_.size() << "\n";
-    tag_[offsetGen_ + 0] = true;
-    tag_[offsetGen_ + 1] = true;
-    tag_[offsetGen_ + 2] = true;
-    tag_[offsetGen_ + 3] = true;
-    tag_[offsetGen_ + 4] = false;
-    tag_[offsetGen_ + 5] = false;
+    tag_[static_cast<size_t>(offsetGen_ + 0)] = true;
+    tag_[static_cast<size_t>(offsetGen_ + 1)] = true;
+    tag_[static_cast<size_t>(offsetGen_ + 2)] = true;
+    tag_[static_cast<size_t>(offsetGen_ + 3)] = true;
+    tag_[static_cast<size_t>(offsetGen_ + 4)] = false;
+    tag_[static_cast<size_t>(offsetGen_ + 5)] = false;
 
-    tag_[offsetGov_ + 0] = true;
-    tag_[offsetGov_ + 1] = true;
-    tag_[offsetGov_ + 2] = false;
+    tag_[static_cast<size_t>(offsetGov_ + 0)] = true;
+    tag_[static_cast<size_t>(offsetGov_ + 1)] = true;
+    tag_[static_cast<size_t>(offsetGov_ + 2)] = false;
 
     return 0;
   }
@@ -207,21 +206,21 @@ namespace GridKit
   int Generator4Governor<ScalarT, IdxT>::evaluateResidual()
   {
     // Generator equations
-    f_[offsetGen_ + 0] = dotDelta() - omega_b_ * (omega() - omega_s_);
-    f_[offsetGen_ + 1] = (2.0 * H_) / omega_s_ * dotOmega() - Lm(y_[offsetGov_ + 0]) + Eqp() * Iq() + Edp() * Id() + (-Xdp_ + Xqp_) * Id() * Iq() + D_ * (omega() - omega_s_);
-    f_[offsetGen_ + 2] = Tq0p_ * dotEdp() + Edp() - (Xq_ - Xqp_) * Iq();
-    f_[offsetGen_ + 3] = Td0p_ * dotEqp() + Eqp() + (Xd_ - Xdp_) * Id() - Ef0_;
-    f_[offsetGen_ + 4] = Rs_ * Id() - Xqp_ * Iq() + V() * sin(delta() - theta()) - Edp();
-    f_[offsetGen_ + 5] = Xdp_ * Id() + Rs_ * Iq() + V() * cos(delta() - theta()) - Eqp();
+    f_[static_cast<size_t>(offsetGen_ + 0)] = dotDelta() - omega_b_ * (omega() - omega_s_);
+    f_[static_cast<size_t>(offsetGen_ + 1)] = (2.0 * H_) / omega_s_ * dotOmega() - Lm(y_[static_cast<size_t>(offsetGov_ + 0)]) + Eqp() * Iq() + Edp() * Id() + (-Xdp_ + Xqp_) * Id() * Iq() + D_ * (omega() - omega_s_);
+    f_[static_cast<size_t>(offsetGen_ + 2)] = Tq0p_ * dotEdp() + Edp() - (Xq_ - Xqp_) * Iq();
+    f_[static_cast<size_t>(offsetGen_ + 3)] = Td0p_ * dotEqp() + Eqp() + (Xd_ - Xdp_) * Id() - Ef0_;
+    f_[static_cast<size_t>(offsetGen_ + 4)] = Rs_ * Id() - Xqp_ * Iq() + V() * sin(delta() - theta()) - Edp();
+    f_[static_cast<size_t>(offsetGen_ + 5)] = Xdp_ * Id() + Rs_ * Iq() + V() * cos(delta() - theta()) - Eqp();
 
     // Bus equations
     P() += Pg();
     Q() += Qg();
 
     // Governor equations
-    f_[offsetGov_ + 0] = yp_[offsetGov_ + 0] - Ln(y_[offsetGov_ + 2]);
-    f_[offsetGov_ + 1] = T1() * yp_[offsetGov_ + 1] + y_[offsetGov_ + 1] - (1.0 - T2() / T1()) * (omega() - omega_s_);
-    f_[offsetGov_ + 2] = T3() * y_[offsetGov_ + 2] - Pm0_ + Lm(y_[offsetGov_ + 0]) + K() * y_[offsetGov_ + 1] + K() * T2() / T1() * (omega() - omega_s_);
+    f_[static_cast<size_t>(offsetGov_ + 0)] = yp_[static_cast<size_t>(offsetGov_ + 0)] - Ln(y_[static_cast<size_t>(offsetGov_ + 2)]);
+    f_[static_cast<size_t>(offsetGov_ + 1)] = T1() * yp_[static_cast<size_t>(offsetGov_ + 1)] + y_[static_cast<size_t>(offsetGov_ + 1)] - (1.0 - T2() / T1()) * (omega() - omega_s_);
+    f_[static_cast<size_t>(offsetGov_ + 2)] = T3() * y_[static_cast<size_t>(offsetGov_ + 2)] - Pm0_ + Lm(y_[static_cast<size_t>(offsetGov_ + 0)]) + K() * y_[static_cast<size_t>(offsetGov_ + 1)] + K() * T2() / T1() * (omega() - omega_s_);
 
     return 0;
   }
@@ -253,10 +252,10 @@ namespace GridKit
     // std::cout << "Initialize adjoint for Generator4Governor..." << std::endl;
     for (IdxT i = 0; i < size_; ++i)
     {
-      yB_[i]  = 0.0;
-      ypB_[i] = 0.0;
+      yB_[static_cast<size_t>(i)]  = 0.0;
+      ypB_[static_cast<size_t>(i)] = 0.0;
     }
-    ypB_[offsetGen_ + 1] = frequencyPenaltyDer(omega());
+    ypB_[static_cast<size_t>(offsetGen_ + 1)] = frequencyPenaltyDer(omega());
 
     return 0;
   }
@@ -296,26 +295,26 @@ namespace GridKit
     ScalarT cosPhi = cos(delta() - theta());
 
     // Generator adjoint
-    fB_[offsetGen_ + 0] = ypB_[offsetGen_ + 0] - yB_[offsetGen_ + 4] * V() * cosPhi + yB_[offsetGen_ + 5] * V() * sinPhi;
-    fB_[offsetGen_ + 1] = 2.0 * H_ / omega_s_ * ypB_[offsetGen_ + 1] + yB_[offsetGen_ + 0] * omega_b_ - yB_[offsetGen_ + 1] * D_ + frequencyPenaltyDer(omega())
-                          + yB_[offsetGov_ + 1] * (1.0 - T2() / T1()) - yB_[offsetGov_ + 2] * K() * T2() / T1();
-    fB_[offsetGen_ + 2] = Tq0p_ * ypB_[offsetGen_ + 2] - yB_[offsetGen_ + 1] * Id() - yB_[offsetGen_ + 2] + yB_[offsetGen_ + 4]
+    fB_[static_cast<size_t>(offsetGen_ + 0)] = ypB_[static_cast<size_t>(offsetGen_ + 0)] - yB_[static_cast<size_t>(offsetGen_ + 4)] * V() * cosPhi + yB_[static_cast<size_t>(offsetGen_ + 5)] * V() * sinPhi;
+    fB_[static_cast<size_t>(offsetGen_ + 1)] = 2.0 * H_ / omega_s_ * ypB_[static_cast<size_t>(offsetGen_ + 1)] + yB_[static_cast<size_t>(offsetGen_ + 0)] * omega_b_ - yB_[static_cast<size_t>(offsetGen_ + 1)] * D_ + frequencyPenaltyDer(omega())
+                          + yB_[static_cast<size_t>(offsetGov_ + 1)] * (1.0 - T2() / T1()) - yB_[static_cast<size_t>(offsetGov_ + 2)] * K() * T2() / T1();
+    fB_[static_cast<size_t>(offsetGen_ + 2)] = Tq0p_ * ypB_[static_cast<size_t>(offsetGen_ + 2)] - yB_[static_cast<size_t>(offsetGen_ + 1)] * Id() - yB_[static_cast<size_t>(offsetGen_ + 2)] + yB_[static_cast<size_t>(offsetGen_ + 4)]
                           + lambdaP() * Id() - lambdaQ() * Iq();
-    fB_[offsetGen_ + 3] = Td0p_ * ypB_[offsetGen_ + 3] - yB_[offsetGen_ + 1] * Iq() - yB_[offsetGen_ + 3] + yB_[offsetGen_ + 5]
+    fB_[static_cast<size_t>(offsetGen_ + 3)] = Td0p_ * ypB_[static_cast<size_t>(offsetGen_ + 3)] - yB_[static_cast<size_t>(offsetGen_ + 1)] * Iq() - yB_[static_cast<size_t>(offsetGen_ + 3)] + yB_[static_cast<size_t>(offsetGen_ + 5)]
                           + lambdaP() * Iq() + lambdaQ() * Id();
-    fB_[offsetGen_ + 4] = -yB_[offsetGen_ + 1] * (Edp() + (Xqp_ - Xdp_) * Iq()) - yB_[offsetGen_ + 3] * (Xd_ - Xdp_) - yB_[offsetGen_ + 4] * Rs_ - yB_[offsetGen_ + 5] * Xdp_
+    fB_[static_cast<size_t>(offsetGen_ + 4)] = -yB_[static_cast<size_t>(offsetGen_ + 1)] * (Edp() + (Xqp_ - Xdp_) * Iq()) - yB_[static_cast<size_t>(offsetGen_ + 3)] * (Xd_ - Xdp_) - yB_[static_cast<size_t>(offsetGen_ + 4)] * Rs_ - yB_[static_cast<size_t>(offsetGen_ + 5)] * Xdp_
                           + lambdaP() * (Edp() + (Xqp_ - Xdp_) * Iq() - 2.0 * Rs_ * Id()) + lambdaQ() * (Eqp() - 2.0 * Xdp_ * Id());
-    fB_[offsetGen_ + 5] = -yB_[offsetGen_ + 1] * (Eqp() + (Xqp_ - Xdp_) * Id()) + yB_[offsetGen_ + 2] * (Xq_ - Xqp_) + yB_[offsetGen_ + 4] * Xqp_ - yB_[offsetGen_ + 5] * Rs_
+    fB_[static_cast<size_t>(offsetGen_ + 5)] = -yB_[static_cast<size_t>(offsetGen_ + 1)] * (Eqp() + (Xqp_ - Xdp_) * Id()) + yB_[static_cast<size_t>(offsetGen_ + 2)] * (Xq_ - Xqp_) + yB_[static_cast<size_t>(offsetGen_ + 4)] * Xqp_ - yB_[static_cast<size_t>(offsetGen_ + 5)] * Rs_
                           + lambdaP() * (Eqp() + (Xqp_ - Xdp_) * Id() - 2.0 * Rs_ * Iq()) - lambdaQ() * (Edp() + 2.0 * Xqp_ * Iq());
 
     // Bus adjoint
-    PB() += (-yB_[offsetGen_ + 4] * sinPhi - yB_[offsetGen_ + 5] * cosPhi);
-    QB() += (yB_[offsetGen_ + 4] * V() * cosPhi - yB_[offsetGen_ + 5] * V() * sinPhi);
+    PB() += (-yB_[static_cast<size_t>(offsetGen_ + 4)] * sinPhi - yB_[static_cast<size_t>(offsetGen_ + 5)] * cosPhi);
+    QB() += (yB_[static_cast<size_t>(offsetGen_ + 4)] * V() * cosPhi - yB_[static_cast<size_t>(offsetGen_ + 5)] * V() * sinPhi);
 
     // Governor adjoint
-    fB_[offsetGov_ + 0] = ypB_[offsetGov_ + 0] - yB_[offsetGov_ + 2] * dLm(y_[offsetGov_ + 0]) + yB_[offsetGen_ + 1] * dLm(y_[offsetGov_ + 0]);
-    fB_[offsetGov_ + 1] = ypB_[offsetGov_ + 1] * T1() - yB_[offsetGov_ + 1] - yB_[offsetGov_ + 2] * K();
-    fB_[offsetGov_ + 2] = yB_[offsetGov_ + 0] * dLn(y_[offsetGov_ + 2]) - yB_[offsetGov_ + 2] * T3();
+    fB_[static_cast<size_t>(offsetGov_ + 0)] = ypB_[static_cast<size_t>(offsetGov_ + 0)] - yB_[static_cast<size_t>(offsetGov_ + 2)] * dLm(y_[static_cast<size_t>(offsetGov_ + 0)]) + yB_[static_cast<size_t>(offsetGen_ + 1)] * dLm(y_[static_cast<size_t>(offsetGov_ + 0)]);
+    fB_[static_cast<size_t>(offsetGov_ + 1)] = ypB_[static_cast<size_t>(offsetGov_ + 1)] * T1() - yB_[static_cast<size_t>(offsetGov_ + 1)] - yB_[static_cast<size_t>(offsetGov_ + 2)] * K();
+    fB_[static_cast<size_t>(offsetGov_ + 2)] = yB_[static_cast<size_t>(offsetGov_ + 0)] * dLn(y_[static_cast<size_t>(offsetGov_ + 2)]) - yB_[static_cast<size_t>(offsetGov_ + 2)] * T3();
 
     return 0;
   }
@@ -334,10 +333,10 @@ namespace GridKit
     // std::cout << "Evaluate adjoint Integrand for Gen2..." << std::endl;
 
     // K adjoint
-    gB_[1] = -yB_[offsetGov_ + 2] * (y_[offsetGov_ + 1] + T2() / T1() * (omega() - omega_s_));
+    gB_[1] = -yB_[static_cast<size_t>(offsetGov_ + 2)] * (y_[static_cast<size_t>(offsetGov_ + 1)] + T2() / T1() * (omega() - omega_s_));
 
     // T2 adjoint
-    gB_[0] = -yB_[offsetGov_ + 1] * (omega() - omega_s_) / T1() - yB_[offsetGov_ + 2] * K() / T1() * (omega() - omega_s_);
+    gB_[0] = -yB_[static_cast<size_t>(offsetGov_ + 1)] * (omega() - omega_s_) / T1() - yB_[static_cast<size_t>(offsetGov_ + 2)] * K() / T1() * (omega() - omega_s_);
 
     return 0;
   }

--- a/src/Model/PowerFlow/Generator4Governor/Generator4Governor.hpp
+++ b/src/Model/PowerFlow/Generator4Governor/Generator4Governor.hpp
@@ -151,52 +151,52 @@ namespace GridKit
 
     const ScalarT dotDelta() const
     {
-      return yp_[offsetGen_ + 0];
+      return yp_[static_cast<size_t>(offsetGen_ + 0)];
     }
 
     const ScalarT dotOmega() const
     {
-      return yp_[offsetGen_ + 1];
+      return yp_[static_cast<size_t>(offsetGen_ + 1)];
     }
 
     const ScalarT dotEdp() const
     {
-      return yp_[offsetGen_ + 2];
+      return yp_[static_cast<size_t>(offsetGen_ + 2)];
     }
 
     const ScalarT dotEqp() const
     {
-      return yp_[offsetGen_ + 3];
+      return yp_[static_cast<size_t>(offsetGen_ + 3)];
     }
 
     const ScalarT delta() const
     {
-      return y_[offsetGen_ + 0];
+      return y_[static_cast<size_t>(offsetGen_ + 0)];
     }
 
     const ScalarT omega() const
     {
-      return y_[offsetGen_ + 1];
+      return y_[static_cast<size_t>(offsetGen_ + 1)];
     }
 
     const ScalarT Edp() const
     {
-      return y_[offsetGen_ + 2];
+      return y_[static_cast<size_t>(offsetGen_ + 2)];
     }
 
     const ScalarT Eqp() const
     {
-      return y_[offsetGen_ + 3];
+      return y_[static_cast<size_t>(offsetGen_ + 3)];
     }
 
     const ScalarT Id() const
     {
-      return y_[offsetGen_ + 4];
+      return y_[static_cast<size_t>(offsetGen_ + 4)];
     }
 
     const ScalarT Iq() const
     {
-      return y_[offsetGen_ + 5];
+      return y_[static_cast<size_t>(offsetGen_ + 5)];
     }
 
     const ScalarT K() const

--- a/src/Model/PowerFlow/Generator4Param/Generator4Param.cpp
+++ b/src/Model/PowerFlow/Generator4Param/Generator4Param.cpp
@@ -1,9 +1,10 @@
 
 #define _USE_MATH_DEFINES
+#include "Generator4Param.hpp"
+
 #include <cmath>
 #include <iostream>
 
-#include "Generator4Param.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
 namespace GridKit

--- a/src/Model/PowerFlow/Generator4Param/Generator4Param.cpp
+++ b/src/Model/PowerFlow/Generator4Param/Generator4Param.cpp
@@ -1,10 +1,9 @@
 
 #define _USE_MATH_DEFINES
-#include "Generator4Param.hpp"
-
 #include <cmath>
 #include <iostream>
 
+#include "Generator4Param.hpp"
 #include <Model/PowerFlow/Bus/BaseBus.hpp>
 
 namespace GridKit
@@ -53,7 +52,7 @@ namespace GridKit
   int Generator4Param<ScalarT, IdxT>::allocate()
   {
     // std::cout << "Allocate Generator4Param..." << std::endl;
-    tag_.resize(size_);
+    tag_.resize(static_cast<size_t>(size_));
 
     return 0;
   }
@@ -143,7 +142,7 @@ namespace GridKit
 
     for (IdxT i = 4; i < size_; ++i)
     {
-      tag_[i] = false;
+      tag_[static_cast<size_t>(i)] = false;
     }
 
     return 0;
@@ -219,8 +218,8 @@ namespace GridKit
     // std::cout << "Initialize adjoint for Generator4Param..." << std::endl;
     for (IdxT i = 0; i < size_; ++i)
     {
-      yB_[i]  = 0.0;
-      ypB_[i] = 0.0;
+      yB_[static_cast<size_t>(i)]  = 0.0;
+      ypB_[static_cast<size_t>(i)] = 0.0;
     }
     // ypB_[1] = frequencyPenaltyDer(y_[1]);
     ypB_[2] = -trajectoryPenaltyDerEdp(time_) / Tq0p_;
@@ -325,16 +324,16 @@ namespace GridKit
     if (t >= ti && t < tf)
     {
       // Interpolate from look-up table
-      Edp_est = (table_[n + 1][3] - table_[n][3]) / (table_[n + 1][0] - table_[n][0]) * (t - table_[n][0]) + table_[n][3];
-      Eqp_est = (table_[n + 1][4] - table_[n][4]) / (table_[n + 1][0] - table_[n][0]) * (t - table_[n][0]) + table_[n][4];
+      Edp_est = (table_[static_cast<size_t>(n + 1)][3] - table_[static_cast<size_t>(n)][3]) / (table_[static_cast<size_t>(n + 1)][0] - table_[static_cast<size_t>(n)][0]) * (t - table_[static_cast<size_t>(n)][0]) + table_[static_cast<size_t>(n)][3];
+      Eqp_est = (table_[static_cast<size_t>(n + 1)][4] - table_[static_cast<size_t>(n)][4]) / (table_[static_cast<size_t>(n + 1)][0] - table_[static_cast<size_t>(n)][0]) * (t - table_[static_cast<size_t>(n)][0]) + table_[static_cast<size_t>(n)][4];
     }
     else
     {
       if (tf <= t && t < tf + dt)
       {
         // Extrapolate from look-up table
-        Edp_est = (table_[n][3] - table_[n - 1][3]) / (table_[n][0] - table_[n - 1][0]) * (t - table_[n - 1][0]) + table_[n - 1][3];
-        Eqp_est = (table_[n][4] - table_[n - 1][4]) / (table_[n][0] - table_[n - 1][0]) * (t - table_[n - 1][0]) + table_[n - 1][4];
+        Edp_est = (table_[static_cast<size_t>(n)][3] - table_[static_cast<size_t>(n - 1)][3]) / (table_[static_cast<size_t>(n)][0] - table_[static_cast<size_t>(n - 1)][0]) * (t - table_[static_cast<size_t>(n - 1)][0]) + table_[static_cast<size_t>(n - 1)][3];
+        Eqp_est = (table_[static_cast<size_t>(n)][4] - table_[static_cast<size_t>(n - 1)][4]) / (table_[static_cast<size_t>(n)][0] - table_[static_cast<size_t>(n - 1)][0]) * (t - table_[static_cast<size_t>(n - 1)][0]) + table_[static_cast<size_t>(n - 1)][4];
       }
       else
       {
@@ -360,13 +359,13 @@ namespace GridKit
 
     if (t >= ti && t < tf)
     {
-      Edp_est = (table_[n + 1][3] - table_[n][3]) / (table_[n + 1][0] - table_[n][0]) * (t - table_[n][0]) + table_[n][3];
+      Edp_est = (table_[static_cast<size_t>(n + 1)][3] - table_[static_cast<size_t>(n)][3]) / (table_[static_cast<size_t>(n + 1)][0] - table_[static_cast<size_t>(n)][0]) * (t - table_[static_cast<size_t>(n)][0]) + table_[static_cast<size_t>(n)][3];
     }
     else
     {
       if (tf <= t && t < tf + dt)
       {
-        Edp_est = (table_[n][3] - table_[n - 1][3]) / (table_[n][0] - table_[n - 1][0]) * (t - table_[n - 1][0]) + table_[n - 1][3];
+        Edp_est = (table_[static_cast<size_t>(n)][3] - table_[static_cast<size_t>(n - 1)][3]) / (table_[static_cast<size_t>(n)][0] - table_[static_cast<size_t>(n - 1)][0]) * (t - table_[static_cast<size_t>(n - 1)][0]) + table_[static_cast<size_t>(n - 1)][3];
       }
       else
       {
@@ -391,13 +390,13 @@ namespace GridKit
 
     if (t >= ti && t < tf)
     {
-      Eqp_est = (table_[n + 1][4] - table_[n][4]) / (table_[n + 1][0] - table_[n][0]) * (t - table_[n][0]) + table_[n][4];
+      Eqp_est = (table_[static_cast<size_t>(n + 1)][4] - table_[static_cast<size_t>(n)][4]) / (table_[static_cast<size_t>(n + 1)][0] - table_[static_cast<size_t>(n)][0]) * (t - table_[static_cast<size_t>(n)][0]) + table_[static_cast<size_t>(n)][4];
     }
     else
     {
       if (tf <= t && t < tf + dt)
       {
-        Eqp_est = (table_[n][4] - table_[n - 1][4]) / (table_[n][0] - table_[n - 1][0]) * (t - table_[n - 1][0]) + table_[n - 1][4];
+        Eqp_est = (table_[static_cast<size_t>(n)][4] - table_[static_cast<size_t>(n - 1)][4]) / (table_[static_cast<size_t>(n)][0] - table_[static_cast<size_t>(n - 1)][0]) * (t - table_[static_cast<size_t>(n - 1)][0]) + table_[static_cast<size_t>(n - 1)][4];
       }
       else
       {

--- a/src/Model/PowerFlow/ModelEvaluatorImpl.hpp
+++ b/src/Model/PowerFlow/ModelEvaluatorImpl.hpp
@@ -30,18 +30,18 @@ namespace GridKit
       : size_(size),
         size_quad_(size_quad),
         size_opt_(size_opt),
-        y_(size_),
-        yp_(size_),
-        f_(size_),
-        g_(size_quad_),
-        yB_(size_),
-        ypB_(size_),
-        fB_(size_),
-        gB_(size_opt_),
+        y_(static_cast<size_t>(size_)),
+        yp_(static_cast<size_t>(size_)),
+        f_(static_cast<size_t>(size_)),
+        g_(static_cast<size_t>(size_quad_)),
+        yB_(static_cast<size_t>(size_)),
+        ypB_(static_cast<size_t>(size_)),
+        fB_(static_cast<size_t>(size_)),
+        gB_(static_cast<size_t>(size_opt_)),
         jac_(COO_Matrix<ScalarT, IdxT>()),
-        param_(size_opt_),
-        param_up_(size_opt_),
-        param_lo_(size_opt_)
+        param_(static_cast<size_t>(size_opt_)),
+        param_up_(static_cast<size_t>(size_opt_)),
+        param_lo_(static_cast<size_t>(size_opt_))
     {
     }
 

--- a/src/Solver/Dynamic/Ida.cpp
+++ b/src/Solver/Dynamic/Ida.cpp
@@ -1,11 +1,12 @@
 
+#include "Ida.hpp"
+
 #include <iomanip>
 #include <iostream>
 
 #include <idas/idas.h>
 #include <idas/idas_ls.h>
 
-#include "Ida.hpp"
 #include "Model/Evaluator.hpp"
 
 namespace AnalysisManager

--- a/src/Solver/Dynamic/Ida.cpp
+++ b/src/Solver/Dynamic/Ida.cpp
@@ -1,12 +1,11 @@
 
-#include "Ida.hpp"
-
 #include <iomanip>
 #include <iostream>
 
 #include <idas/idas.h>
 #include <idas/idas_ls.h>
 
+#include "Ida.hpp"
 #include "Model/Evaluator.hpp"
 
 namespace AnalysisManager
@@ -51,7 +50,7 @@ namespace AnalysisManager
       int retval = 0;
 
       // Allocate solution vectors
-      yy_ = N_VNew_Serial(model_->size(), context_);
+      yy_ = N_VNew_Serial(static_cast<sunindextype>(model_->size()), context_);
       checkAllocation((void*) yy_, "N_VNew_Serial");
       yp_ = N_VClone(yy_);
       checkAllocation((void*) yp_, "N_VClone");
@@ -88,7 +87,7 @@ namespace AnalysisManager
       model_->setMaxSteps(msa);
 
       /// \todo Need to set max number of steps based on user input!
-      retval = IDASetMaxNumSteps(solver_, msa);
+      retval = IDASetMaxNumSteps(solver_, static_cast<long>(msa));
       checkOutput(retval, "IDASetMaxNumSteps");
 
       // Tag differential variables
@@ -116,7 +115,11 @@ namespace AnalysisManager
       int retval = 0;
       if (model_->hasJacobian())
       {
-        JacobianMat_ = SUNSparseMatrix(model_->size(), model_->size(), model_->size() * model_->size(), CSR_MAT, context_);
+        JacobianMat_ = SUNSparseMatrix(static_cast<sunindextype>(model_->size()),
+                                       static_cast<sunindextype>(model_->size()),
+                                       static_cast<sunindextype>(model_->size() * model_->size()),
+                                       CSR_MAT,
+                                       context_);
         checkAllocation((void*) JacobianMat_, "SUNSparseMatrix");
 
         linearSolver_ = SUNLinSol_KLU(yy_, JacobianMat_, context_);
@@ -130,7 +133,9 @@ namespace AnalysisManager
       }
       else
       {
-        JacobianMat_ = SUNDenseMatrix(model_->size(), model_->size(), context_);
+        JacobianMat_ = SUNDenseMatrix(static_cast<sunindextype>(model_->size()),
+                                      static_cast<sunindextype>(model_->size()),
+                                      context_);
         checkAllocation((void*) JacobianMat_, "SUNDenseMatrix");
 
         linearSolver_ = SUNLinSol_Dense(yy_, JacobianMat_, context_);
@@ -278,7 +283,7 @@ namespace AnalysisManager
       int retval = 0;
 
       // Create and initialize quadratures
-      q_ = N_VNew_Serial(model_->sizeQuadrature(), context_);
+      q_ = N_VNew_Serial(static_cast<sunindextype>(model_->sizeQuadrature()), context_);
       checkAllocation((void*) q_, "N_VNew_Serial");
 
       // Set integrand function and allocate quadrature workspace
@@ -364,13 +369,13 @@ namespace AnalysisManager
     int Ida<ScalarT, IdxT>::configureAdjoint()
     {
       // Allocate adjoint vector, derivatives and quadrature
-      yyB_ = N_VNew_Serial(model_->size(), context_);
+      yyB_ = N_VNew_Serial(static_cast<sunindextype>(model_->size()), context_);
       checkAllocation((void*) yyB_, "N_VNew_Serial");
 
       ypB_ = N_VClone(yyB_);
       checkAllocation((void*) ypB_, "N_VClone");
 
-      qB_ = N_VNew_Serial(model_->sizeParams(), context_);
+      qB_ = N_VNew_Serial(static_cast<sunindextype>(model_->sizeParams()), context_);
       checkAllocation((void*) qB_, "N_VNew_Serial");
 
       return 0;
@@ -382,7 +387,7 @@ namespace AnalysisManager
       int retval = 0;
 
       // Create adjoint workspace
-      retval = IDAAdjInit(solver_, steps, IDA_HERMITE);
+      retval = IDAAdjInit(solver_, static_cast<long>(steps), IDA_HERMITE);
       checkOutput(retval, "IDAAdjInit");
 
       return retval;
@@ -420,7 +425,9 @@ namespace AnalysisManager
       checkOutput(retval, "IDASetMaxNumSteps");
 
       // Set up linear solver
-      JacobianMatB_ = SUNDenseMatrix(model_->size(), model_->size(), context_);
+      JacobianMatB_ = SUNDenseMatrix(static_cast<sunindextype>(model_->size()),
+                                     static_cast<sunindextype>(model_->size()),
+                                     context_);
       checkAllocation((void*) JacobianMatB_, "SUNDenseMatrix");
 
       linearSolverB_ = SUNLinSol_Dense(yyB_, JacobianMatB_, context_);
@@ -450,7 +457,9 @@ namespace AnalysisManager
       int retval = 0;
 
       // Create Jacobian matrix
-      JacobianMatB_ = SUNDenseMatrix(model_->size(), model_->size(), context_);
+      JacobianMatB_ = SUNDenseMatrix(static_cast<sunindextype>(model_->size()),
+                                     static_cast<sunindextype>(model_->size()),
+                                     context_);
       checkAllocation((void*) JacobianMatB_, "SUNDenseMatrix");
 
       // Create linear solver

--- a/src/Solver/Optimization/DynamicConstraint.cpp
+++ b/src/Solver/Optimization/DynamicConstraint.cpp
@@ -64,8 +64,8 @@ namespace AnalysisManager
       // Get boundaries for the optimization parameters
       for (IdxT i = 0; i < model_->sizeParams(); ++i)
       {
-        x_l[i] = model_->param_lo()[i];
-        x_u[i] = model_->param_up()[i];
+        x_l[i] = model_->param_lo()[static_cast<size_t>(i)];
+        x_u[i] = model_->param_up()[static_cast<size_t>(i)];
       }
 
       // No boundaries for fictitious parameter x[n]
@@ -97,7 +97,7 @@ namespace AnalysisManager
 
       // Initialize optimization parameters x
       for (IdxT i = 0; i < model_->sizeParams(); ++i)
-        x[i] = model_->param()[i];
+        x[i] = model_->param()[static_cast<size_t>(i)];
 
       // Initialize fictitious parameter x[n-1] to zero
       x[model_->sizeParams()] = 0.0;
@@ -142,7 +142,7 @@ namespace AnalysisManager
       // Update optimization parameters
       for (IdxT i = 0; i < model_->sizeParams(); ++i)
       {
-        model_->param()[i] = x[i];
+        model_->param()[static_cast<size_t>(i)] = x[i];
         // std::cout << "x[" << i << "] = " << x[i] << "\n";
       }
 
@@ -191,7 +191,7 @@ namespace AnalysisManager
       {
         // Update optimization parameters
         for (IdxT i = 0; i < model_->sizeParams(); ++i)
-          model_->param()[i] = x[i];
+          model_->param()[static_cast<size_t>(i)] = x[i];
 
         // evaluate the gradient of the objective function grad_{x} f(x)
         // This is creating and deleting adjoint system for each iteration!

--- a/src/Solver/Optimization/DynamicConstraint.cpp
+++ b/src/Solver/Optimization/DynamicConstraint.cpp
@@ -1,8 +1,8 @@
 
+#include "DynamicConstraint.hpp"
+
 #include <cassert>
 #include <iostream>
-
-#include "DynamicConstraint.hpp"
 
 namespace AnalysisManager
 {

--- a/src/Solver/Optimization/DynamicConstraint.cpp
+++ b/src/Solver/Optimization/DynamicConstraint.cpp
@@ -1,8 +1,8 @@
 
-#include "DynamicConstraint.hpp"
-
 #include <cassert>
 #include <iostream>
+
+#include "DynamicConstraint.hpp"
 
 namespace AnalysisManager
 {
@@ -32,13 +32,13 @@ namespace AnalysisManager
 
       // Number of parameters is size of the system plus 1 fictitious parameter
       // to store the objective value.
-      n = model_->sizeParams() + 1;
+      n = static_cast<Index>(model_->sizeParams() + 1);
 
       // There is one constraint
       m = 1;
 
       // Jacobian is a dense row matrix of length n+1.
-      nnz_jac_g = model_->sizeParams() + 1;
+      nnz_jac_g = static_cast<Index>(model_->sizeParams() + 1);
 
       // Using numerical Hessian.
       nnz_h_lag = 0;
@@ -50,7 +50,12 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicConstraint<ScalarT, IdxT>::get_bounds_info(Index n, Number* x_l, Number* x_u, Index m, Number* g_l, Number* g_u)
+    bool DynamicConstraint<ScalarT, IdxT>::get_bounds_info([[maybe_unused]] Index n,
+                                                           Number*                x_l,
+                                                           Number*                x_u,
+                                                           [[maybe_unused]] Index m,
+                                                           Number*                g_l,
+                                                           Number*                g_u)
     {
       // Check if sizes are set correctly
       assert(n == (Index) (model_->sizeParams() + 1));
@@ -75,7 +80,15 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicConstraint<ScalarT, IdxT>::get_starting_point(Index n, bool init_x, Number* x, bool init_z, Number* z_L, Number* z_U, Index m, bool init_lambda, Number* lambda)
+    bool DynamicConstraint<ScalarT, IdxT>::get_starting_point([[maybe_unused]] Index   n,
+                                                              [[maybe_unused]] bool    init_x,
+                                                              Number*                  x,
+                                                              [[maybe_unused]] bool    init_z,
+                                                              [[maybe_unused]] Number* z_L,
+                                                              [[maybe_unused]] Number* z_U,
+                                                              [[maybe_unused]] Index   m,
+                                                              [[maybe_unused]] bool    init_lambda,
+                                                              [[maybe_unused]] Number* lambda)
     {
       // Only initial values for x provided.
       assert(init_x == true);
@@ -93,7 +106,10 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicConstraint<ScalarT, IdxT>::eval_f(Index n, const Number* x, bool new_x, Number& obj_value)
+    bool DynamicConstraint<ScalarT, IdxT>::eval_f([[maybe_unused]] Index n,
+                                                  const Number*          x,
+                                                  [[maybe_unused]] bool  new_x,
+                                                  Number&                obj_value)
     {
       // Set objective to fictitious optimization parameter x[n-1]
       obj_value = x[model_->sizeParams()];
@@ -102,7 +118,10 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicConstraint<ScalarT, IdxT>::eval_grad_f(Index n, const Number* x, bool new_x, Number* grad_f)
+    bool DynamicConstraint<ScalarT, IdxT>::eval_grad_f([[maybe_unused]] Index         n,
+                                                       [[maybe_unused]] const Number* x,
+                                                       [[maybe_unused]] bool          new_x,
+                                                       Number*                        grad_f)
     {
       // Objective function equals to the fictitious parameter x[n-1].
       // Gradient, then assumes the simple form:
@@ -114,7 +133,11 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicConstraint<ScalarT, IdxT>::eval_g(Index n, const Number* x, bool new_x, Index m, Number* g)
+    bool DynamicConstraint<ScalarT, IdxT>::eval_g([[maybe_unused]] Index n,
+                                                  const Number*          x,
+                                                  [[maybe_unused]] bool  new_x,
+                                                  [[maybe_unused]] Index m,
+                                                  Number*                g)
     {
       // Update optimization parameters
       for (IdxT i = 0; i < model_->sizeParams(); ++i)
@@ -143,7 +166,14 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicConstraint<ScalarT, IdxT>::eval_jac_g(Index n, const Number* x, bool new_x, Index m, Index nele_jac, Index* iRow, Index* jCol, Number* values)
+    bool DynamicConstraint<ScalarT, IdxT>::eval_jac_g([[maybe_unused]] Index n,
+                                                      const Number*          x,
+                                                      [[maybe_unused]] bool  new_x,
+                                                      [[maybe_unused]] Index m,
+                                                      [[maybe_unused]] Index nele_jac,
+                                                      Index*                 iRow,
+                                                      Index*                 jCol,
+                                                      Number*                values)
     {
       // Set Jacobian sparsity pattern ...
       if (!values)
@@ -151,10 +181,10 @@ namespace AnalysisManager
         for (IdxT i = 0; i < model_->sizeParams(); ++i)
         {
           iRow[i] = 0;
-          jCol[i] = i;
+          jCol[i] = static_cast<Index>(i);
         }
         iRow[model_->sizeParams()] = 0;
-        jCol[model_->sizeParams()] = model_->sizeParams();
+        jCol[model_->sizeParams()] = static_cast<Index>(model_->sizeParams());
       }
       // ... or compute Jacobian derivatives
       else
@@ -202,23 +232,33 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicConstraint<ScalarT, IdxT>::eval_h(Index n, const Number* x, bool new_x, Number obj_factor, Index m, const Number* lambda, bool new_lambda, Index nele_hess, Index* iRow, Index* jCol, Number* values)
+    bool DynamicConstraint<ScalarT, IdxT>::eval_h([[maybe_unused]] Index         n,
+                                                  [[maybe_unused]] const Number* x,
+                                                  [[maybe_unused]] bool          new_x,
+                                                  [[maybe_unused]] Number        obj_factor,
+                                                  [[maybe_unused]] Index         m,
+                                                  [[maybe_unused]] const Number* lambda,
+                                                  [[maybe_unused]] bool          new_lambda,
+                                                  [[maybe_unused]] Index         nele_hess,
+                                                  [[maybe_unused]] Index*        iRow,
+                                                  [[maybe_unused]] Index*        jCol,
+                                                  [[maybe_unused]] Number*       values)
     {
       return true;
     }
 
     template <class ScalarT, typename IdxT>
-    void DynamicConstraint<ScalarT, IdxT>::finalize_solution(SolverReturn               status,
-                                                             Index                      n,
-                                                             const Number*              x,
-                                                             const Number*              z_L,
-                                                             const Number*              z_U,
-                                                             Index                      m,
-                                                             const Number*              g,
-                                                             const Number*              lambda,
-                                                             Number                     obj_value,
-                                                             const IpoptData*           ip_data,
-                                                             IpoptCalculatedQuantities* ip_cq)
+    void DynamicConstraint<ScalarT, IdxT>::finalize_solution([[maybe_unused]] SolverReturn               status,
+                                                             [[maybe_unused]] Index                      n,
+                                                             [[maybe_unused]] const Number*              x,
+                                                             [[maybe_unused]] const Number*              z_L,
+                                                             [[maybe_unused]] const Number*              z_U,
+                                                             [[maybe_unused]] Index                      m,
+                                                             [[maybe_unused]] const Number*              g,
+                                                             [[maybe_unused]] const Number*              lambda,
+                                                             [[maybe_unused]] Number                     obj_value,
+                                                             [[maybe_unused]] const IpoptData*           ip_data,
+                                                             [[maybe_unused]] IpoptCalculatedQuantities* ip_cq)
     {
     }
 

--- a/src/Solver/Optimization/DynamicObjective.cpp
+++ b/src/Solver/Optimization/DynamicObjective.cpp
@@ -1,8 +1,8 @@
 
+#include "DynamicObjective.hpp"
+
 #include <cassert>
 #include <iostream>
-
-#include "DynamicObjective.hpp"
 
 namespace AnalysisManager
 {

--- a/src/Solver/Optimization/DynamicObjective.cpp
+++ b/src/Solver/Optimization/DynamicObjective.cpp
@@ -1,8 +1,8 @@
 
-#include "DynamicObjective.hpp"
-
 #include <cassert>
 #include <iostream>
+
+#include "DynamicObjective.hpp"
 
 namespace AnalysisManager
 {
@@ -31,7 +31,7 @@ namespace AnalysisManager
       assert(model_->sizeQuadrature() == 1);
 
       // Number of optimization variables.
-      n = model_->sizeParams();
+      n = static_cast<Index>(model_->sizeParams());
 
       // There are no constraints
       m = 0;
@@ -49,7 +49,12 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicObjective<ScalarT, IdxT>::get_bounds_info(Index n, Number* x_l, Number* x_u, Index m, Number* g_l, Number* g_u)
+    bool DynamicObjective<ScalarT, IdxT>::get_bounds_info([[maybe_unused]] Index   n,
+                                                          Number*                  x_l,
+                                                          Number*                  x_u,
+                                                          [[maybe_unused]] Index   m,
+                                                          [[maybe_unused]] Number* g_l,
+                                                          [[maybe_unused]] Number* g_u)
     {
       // Check if sizes are set correctly
       assert(n == (Index) model_->sizeParams());
@@ -66,7 +71,15 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicObjective<ScalarT, IdxT>::get_starting_point(Index n, bool init_x, Number* x, bool init_z, Number* z_L, Number* z_U, Index m, bool init_lambda, Number* lambda)
+    bool DynamicObjective<ScalarT, IdxT>::get_starting_point([[maybe_unused]] Index   n,
+                                                             [[maybe_unused]] bool    init_x,
+                                                             Number*                  x,
+                                                             [[maybe_unused]] bool    init_z,
+                                                             [[maybe_unused]] Number* z_L,
+                                                             [[maybe_unused]] Number* z_U,
+                                                             [[maybe_unused]] Index   m,
+                                                             [[maybe_unused]] bool    init_lambda,
+                                                             [[maybe_unused]] Number* lambda)
     {
       // Only initial values for x provided.
       assert(init_x == true);
@@ -81,7 +94,10 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicObjective<ScalarT, IdxT>::eval_f(Index n, const Number* x, bool new_x, Number& obj_value)
+    bool DynamicObjective<ScalarT, IdxT>::eval_f([[maybe_unused]] Index n,
+                                                 const Number*          x,
+                                                 [[maybe_unused]] bool  new_x,
+                                                 Number&                obj_value)
     {
       // Update optimization parameters
       for (IdxT i = 0; i < model_->sizeParams(); ++i)
@@ -100,7 +116,10 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicObjective<ScalarT, IdxT>::eval_grad_f(Index n, const Number* x, bool new_x, Number* grad_f)
+    bool DynamicObjective<ScalarT, IdxT>::eval_grad_f([[maybe_unused]] Index n,
+                                                      const Number*          x,
+                                                      [[maybe_unused]] bool  new_x,
+                                                      Number*                grad_f)
     {
       assert(model_->sizeParams() == static_cast<IdxT>(n));
       // Update optimization parameters
@@ -130,35 +149,56 @@ namespace AnalysisManager
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicObjective<ScalarT, IdxT>::eval_g(Index n, const Number* x, bool new_x, Index m, Number* g)
+    bool DynamicObjective<ScalarT, IdxT>::eval_g([[maybe_unused]] Index         n,
+                                                 [[maybe_unused]] const Number* x,
+                                                 [[maybe_unused]] bool          new_x,
+                                                 [[maybe_unused]] Index         m,
+                                                 [[maybe_unused]] Number*       g)
     {
       return true;
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicObjective<ScalarT, IdxT>::eval_jac_g(Index n, const Number* x, bool new_x, Index m, Index nele_jac, Index* iRow, Index* jCol, Number* values)
+    bool DynamicObjective<ScalarT, IdxT>::eval_jac_g([[maybe_unused]] Index         n,
+                                                     [[maybe_unused]] const Number* x,
+                                                     [[maybe_unused]] bool          new_x,
+                                                     [[maybe_unused]] Index         m,
+                                                     [[maybe_unused]] Index         nele_jac,
+                                                     [[maybe_unused]] Index*        iRow,
+                                                     [[maybe_unused]] Index*        jCol,
+                                                     [[maybe_unused]] Number*       values)
     {
       return true;
     }
 
     template <class ScalarT, typename IdxT>
-    bool DynamicObjective<ScalarT, IdxT>::eval_h(Index n, const Number* x, bool new_x, Number obj_factor, Index m, const Number* lambda, bool new_lambda, Index nele_hess, Index* iRow, Index* jCol, Number* values)
+    bool DynamicObjective<ScalarT, IdxT>::eval_h([[maybe_unused]] Index         n,
+                                                 [[maybe_unused]] const Number* x,
+                                                 [[maybe_unused]] bool          new_x,
+                                                 [[maybe_unused]] Number        obj_factor,
+                                                 [[maybe_unused]] Index         m,
+                                                 [[maybe_unused]] const Number* lambda,
+                                                 [[maybe_unused]] bool          new_lambda,
+                                                 [[maybe_unused]] Index         nele_hess,
+                                                 [[maybe_unused]] Index*        iRow,
+                                                 [[maybe_unused]] Index*        jCol,
+                                                 [[maybe_unused]] Number*       values)
     {
       return true;
     }
 
     template <class ScalarT, typename IdxT>
-    void DynamicObjective<ScalarT, IdxT>::finalize_solution(SolverReturn               status,
-                                                            Index                      n,
-                                                            const Number*              x,
-                                                            const Number*              z_L,
-                                                            const Number*              z_U,
-                                                            Index                      m,
-                                                            const Number*              g,
-                                                            const Number*              lambda,
-                                                            Number                     obj_value,
-                                                            const IpoptData*           ip_data,
-                                                            IpoptCalculatedQuantities* ip_cq)
+    void DynamicObjective<ScalarT, IdxT>::finalize_solution([[maybe_unused]] SolverReturn               status,
+                                                            [[maybe_unused]] Index                      n,
+                                                            [[maybe_unused]] const Number*              x,
+                                                            [[maybe_unused]] const Number*              z_L,
+                                                            [[maybe_unused]] const Number*              z_U,
+                                                            [[maybe_unused]] Index                      m,
+                                                            [[maybe_unused]] const Number*              g,
+                                                            [[maybe_unused]] const Number*              lambda,
+                                                            [[maybe_unused]] Number                     obj_value,
+                                                            [[maybe_unused]] const IpoptData*           ip_data,
+                                                            [[maybe_unused]] IpoptCalculatedQuantities* ip_cq)
     {
     }
 

--- a/src/Solver/Optimization/DynamicObjective.cpp
+++ b/src/Solver/Optimization/DynamicObjective.cpp
@@ -63,8 +63,8 @@ namespace AnalysisManager
       // Get boundaries for the optimization parameters
       for (IdxT i = 0; i < model_->sizeParams(); ++i)
       {
-        x_l[i] = model_->param_lo()[i];
-        x_u[i] = model_->param_up()[i];
+        x_l[i] = model_->param_lo()[static_cast<size_t>(i)];
+        x_u[i] = model_->param_up()[static_cast<size_t>(i)];
       }
 
       return true;
@@ -88,7 +88,7 @@ namespace AnalysisManager
 
       // Initialize optimization parameters x
       for (IdxT i = 0; i < model_->sizeParams(); ++i)
-        x[i] = model_->param()[i];
+        x[i] = model_->param()[static_cast<size_t>(i)];
 
       return true;
     }
@@ -101,7 +101,7 @@ namespace AnalysisManager
     {
       // Update optimization parameters
       for (IdxT i = 0; i < model_->sizeParams(); ++i)
-        model_->param()[i] = x[i];
+        model_->param()[static_cast<size_t>(i)] = x[i];
 
       // Evaluate objective function
       integrator_->getSavedInitialCondition();
@@ -124,7 +124,7 @@ namespace AnalysisManager
       assert(model_->sizeParams() == static_cast<IdxT>(n));
       // Update optimization parameters
       for (IdxT i = 0; i < model_->sizeParams(); ++i)
-        model_->param()[i] = x[i];
+        model_->param()[static_cast<size_t>(i)] = x[i];
 
       // evaluate the gradient of the objective function grad_{x} f(x)
       // This is creating and deleting adjoint system for each iteration!

--- a/src/Solver/SteadyState/Kinsol.cpp
+++ b/src/Solver/SteadyState/Kinsol.cpp
@@ -8,8 +8,6 @@
  *
  */
 
-#include "Kinsol.hpp"
-
 #include <iomanip>
 #include <iostream>
 
@@ -18,6 +16,7 @@
 #include <sunlinsol/sunlinsol_dense.h> // access to dense SUNLinearSolver
 #include <sunmatrix/sunmatrix_dense.h> // access to dense SUNMatrix
 
+#include "Kinsol.hpp"
 #include "Model/Evaluator.hpp"
 
 namespace AnalysisManager
@@ -53,7 +52,7 @@ namespace AnalysisManager
       int retval = 0;
 
       // Allocate solution vectors
-      yy_ = N_VNew_Serial(model_->size(), context_);
+      yy_ = N_VNew_Serial(static_cast<sunindextype>(model_->size()), context_);
       checkAllocation((void*) yy_, "N_VNew_Serial");
 
       // Allocate scaling vector
@@ -93,7 +92,9 @@ namespace AnalysisManager
       int retval = 0;
 
       // Set up linear solver
-      JacobianMat_ = SUNDenseMatrix(model_->size(), model_->size(), context_);
+      JacobianMat_ = SUNDenseMatrix(static_cast<sunindextype>(model_->size()),
+                                    static_cast<sunindextype>(model_->size()),
+                                    context_);
       checkAllocation((void*) JacobianMat_, "SUNDenseMatrix");
 
       linearSolver_ = SUNLinSol_Dense(yy_, JacobianMat_, context_);

--- a/src/Solver/SteadyState/Kinsol.cpp
+++ b/src/Solver/SteadyState/Kinsol.cpp
@@ -8,6 +8,8 @@
  *
  */
 
+#include "Kinsol.hpp"
+
 #include <iomanip>
 #include <iostream>
 
@@ -16,7 +18,6 @@
 #include <sunlinsol/sunlinsol_dense.h> // access to dense SUNLinearSolver
 #include <sunmatrix/sunmatrix_dense.h> // access to dense SUNMatrix
 
-#include "Kinsol.hpp"
 #include "Model/Evaluator.hpp"
 
 namespace AnalysisManager


### PR DESCRIPTION
this is just #123 but the branch is on the main repository. below is copied from the original pull request

this pull request fixes the remaining warnings resulting from the addition of `-Wall -Wextra -Wconversion -Wpedantic` to the default cxxflags. these were missed in the initial pull request due to the source files they're in being gated behind the `GRIDKIT_ENABLE_IPOPT` define.

this pull request also removes some unnecessary commented out flags in the root `CMakeLists.txt` file due to them being superseded by the default flag list and also being covered by the `RelWithDebInfo` and `Debug` `CMAKE_BUILD_TYPE` values (iirc).