### PR TITLE
A few changes need to compile for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,12 @@ set(PACKAGE_VERSION_PATCH "0")
 set(PACKAGE_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH}")
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wconversion -Wpedantic")
+
+if (MSVC)
+  set(CMAKE_CXX_FLAGS "/Wall")
+else()
+  set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wconversion -Wpedantic")
+endif()
 
 # Ipopt support is disabled by default
 option(GRIDKIT_ENABLE_IPOPT "Enable Ipopt support" OFF)

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
@@ -6,15 +6,13 @@
  *
  *
  */
-
+#define _USE_MATH_DEFINES
 #include "GenClassical.hpp"
 
 #include <cmath>
 #include <iostream>
 
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
-
-#define _USE_MATH_DEFINES
 
 namespace GridKit
 {

--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -5,6 +5,7 @@
  * @brief Tests for classical generator model.
  *
  */
+#define _USE_MATH_DEFINES  /* need this since directly including GenClassical.cpp for MSVC compiler */
 #include <iomanip>
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
## Description
 
A few little changes are needed to compile on MSVC -- recently I got my new computer set up to compile GridKit.
 
 ## Proposed changes
 
- If MSVC compiler, don't include unsupported compile flags.
- Ensure _USE_MATH_DEFINES is defined before first instance of #include<cmath> any time M_PI is used.
 
 ## Checklist
 
N/A
 
- [ ] All tests pass.
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [ ] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 

