### PR TITLE
Add component data structures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,24 @@ double another_member;   // No, there is no trailing underscore to distinguish i
 double memberVariable_;  // No, using lowercase camel instead of C-style name format
 ```
 
+#### Ecxeption
+
+Public member variables that are accessed directly do not need trailing
+underscores. For example, consider this code:
+```c++
+struct ModelData
+{
+  int id;
+  double value;
+};
+
+ModelData data;
+data.id = 1;
+data.value = 2.0;
+```
+Member variables of struct `data` are accessed diorectly outside the struct
+and do not need to be denoted with trailing underscores `_`.
+
 ### Function names
 
 Use lowercase camel format for function names.

--- a/examples/PhasorDynamics/Example1/example1.cpp
+++ b/examples/PhasorDynamics/Example1/example1.cpp
@@ -15,8 +15,11 @@
 
 #include <Model/PhasorDynamics/Branch/Branch.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
+#include <Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <Model/PhasorDynamics/BusFault/BusFault.hpp>
+#include <Model/PhasorDynamics/BusFault/BusFaultData.hpp>
+#include <Model/PhasorDynamics/Bus/BusData.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
@@ -37,6 +40,20 @@ int main()
   //
   // Create model data
   //
+  BusData<real_type, index_type> bus_data_1;
+  bus_data_1.Vr0 = 0.9949877346411762;
+  bus_data_1.Vi0 = 0.09999703952427966;
+
+  BusData<real_type, index_type> bus_data_2;
+  bus_data_2.Vr0 = 1.0;
+  bus_data_2.Vi0 = 0.0;
+
+  BranchData<real_type, index_type> branch_data_1_2;
+  branch_data_1_2.R = 0.0;
+  branch_data_1_2.X = 0.1;
+  branch_data_1_2.G = 0.0;
+  branch_data_1_2.B = 0.0;  
+
   GenrouData<real_type, index_type> gen_data_1;
   gen_data_1.unit_id = 1;
   gen_data_1.p0      = 1.;
@@ -58,14 +75,19 @@ int main()
   gen_data_1.S10     = 0.;
   gen_data_1.S12     = 0.;
 
+  BusFaultData<real_type, index_type> bus_fault_data_1;
+  bus_fault_data_1.R = 0.0;
+  bus_fault_data_1.X = 1e-3;
+  bus_fault_data_1.status = 0;
+
   //
   // Instantiate model components
   //
 
-  Bus<scalar_type, size_t>         bus1(0.9949877346411762, 0.09999703952427966);
-  BusInfinite<scalar_type, size_t> bus2(1.0, 0.0);
-  Branch<scalar_type, size_t>      branch(&bus1, &bus2, 0, 0.1, 0, 0);
-  BusFault<scalar_type, size_t>    fault(&bus1, 0, 1e-3, 0);
+  Bus<scalar_type, size_t>         bus1(bus_data_1);
+  BusInfinite<scalar_type, size_t> bus2(bus_data_2);
+  Branch<scalar_type, size_t>      branch(&bus1, &bus2, branch_data_1_2);
+  BusFault<scalar_type, size_t>    fault(&bus1, bus_fault_data_1);
   Genrou<scalar_type, size_t>      gen(&bus1, gen_data_1);
 
   //

--- a/examples/PhasorDynamics/Example1/example1.cpp
+++ b/examples/PhasorDynamics/Example1/example1.cpp
@@ -78,7 +78,7 @@ int main()
   BusFaultData<real_type, index_type> bus_fault_data_1;
   bus_fault_data_1.R      = 0.0;
   bus_fault_data_1.X      = 1e-3;
-  bus_fault_data_1.status = 0;
+  bus_fault_data_1.status = false;
 
   //
   // Instantiate model components
@@ -102,6 +102,7 @@ int main()
   sys.addComponent(&gen);
   sys.allocate();
 
+  // Set time step to 1/4 of a 60Hz cycle
   real_type dt = 1.0 / 4.0 / 60.0;
 
   // A data structure to keep track of the data we want to
@@ -114,6 +115,8 @@ int main()
   // (plain ol' data), which have some benefits in C++.
   struct OutputData
   {
+    // Output variables are time, real and imaginary voltage and
+    // frequency deviation
     real_type ti, Vr, Vi, dw;
   };
 
@@ -132,9 +135,9 @@ int main()
   // push it into output, which is updated outside the callback.
   auto output_cb = [&](real_type t)
   {
-    std::vector<scalar_type>& yval = sys.y();
+    std::vector<scalar_type>& y_val = sys.y();
 
-    output.push_back(OutputData{t, yval[0], yval[1], yval[3]});
+    output.push_back(OutputData{t, y_val[0], y_val[1], y_val[3]});
   };
 
   // Set up simulation
@@ -150,13 +153,13 @@ int main()
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault and run for the next 0.1s
-  fault.setStatus(1);
+  fault.setStatus(true);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear the fault and run until t = 10s.
-  fault.setStatus(0);
+  fault.setStatus(false);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);
@@ -197,6 +200,7 @@ int main()
     // std::cout << "\n";
   }
 
+  // Errors allowed for agreement with Powerworld results
   real_type error_V_allowed = 2e-4;
   real_type error_w_allowed = 1e-4;
 

--- a/examples/PhasorDynamics/Example1/example1.cpp
+++ b/examples/PhasorDynamics/Example1/example1.cpp
@@ -18,6 +18,7 @@
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <Model/PhasorDynamics/BusFault/BusFault.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp>
+#include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Solver/Dynamic/Ida.hpp>
 #include <Utilities/Testing.hpp>
@@ -27,37 +28,51 @@ int main()
   using namespace GridKit::PhasorDynamics;
   using namespace AnalysisManager::Sundials;
 
+  using scalar_type = double;
+  using real_type   = double;
+  using index_type  = size_t;
+
   std::cout << "Example 1 version 2\n";
 
-  /* Create model parts */
-  SystemModel<double, size_t> sys;
-  Bus<double, size_t>         bus1(0.9949877346411762, 0.09999703952427966);
-  BusInfinite<double, size_t> bus2(1.0, 0.0);
-  Branch<double, size_t>      branch(&bus1, &bus2, 0, 0.1, 0, 0);
-  BusFault<double, size_t>    fault(&bus1, 0, 1e-3, 0);
+  //
+  // Create model data
+  //
+  GenrouData<real_type, index_type> gen_data_1;
+  gen_data_1.unit_id = 1;
+  gen_data_1.p0      = 1.;
+  gen_data_1.q0      = 0.05013;
+  gen_data_1.H       = 3.;
+  gen_data_1.D       = 0.;
+  gen_data_1.Ra      = 0.;
+  gen_data_1.Tdop    = 7.;
+  gen_data_1.Tdopp   = .04;
+  gen_data_1.Tqopp   = .05;
+  gen_data_1.Tqop    = .75;
+  gen_data_1.Xd      = 2.1;
+  gen_data_1.Xdp     = 0.2;
+  gen_data_1.Xdpp    = 0.18;
+  gen_data_1.Xq      = 0.5;
+  gen_data_1.Xqp     = 0.5;
+  gen_data_1.Xqpp    = 0.18;
+  gen_data_1.Xl      = 0.15;
+  gen_data_1.S10     = 0.;
+  gen_data_1.S12     = 0.;
 
-  Genrou<double, size_t> gen(&bus1,
-                             1,
-                             1.,
-                             0.05013,
-                             3.,
-                             0.,
-                             0.,
-                             7.,
-                             .04,
-                             .05,
-                             .75,
-                             2.1,
-                             0.2,
-                             0.18,
-                             0.5,
-                             0.5,
-                             0.18,
-                             0.15,
-                             0.,
-                             0.);
+  //
+  // Instantiate model components
+  //
 
-  /* Connect everything together */
+  Bus<scalar_type, size_t>         bus1(0.9949877346411762, 0.09999703952427966);
+  BusInfinite<scalar_type, size_t> bus2(1.0, 0.0);
+  Branch<scalar_type, size_t>      branch(&bus1, &bus2, 0, 0.1, 0, 0);
+  BusFault<scalar_type, size_t>    fault(&bus1, 0, 1e-3, 0);
+  Genrou<scalar_type, size_t>      gen(&bus1, gen_data_1);
+
+  //
+  // Create the 2-bus system
+  //
+
+  SystemModel<scalar_type, size_t> sys;
   sys.addBus(&bus1);
   sys.addBus(&bus2);
   sys.addComponent(&branch);
@@ -65,7 +80,7 @@ int main()
   sys.addComponent(&gen);
   sys.allocate();
 
-  double dt = 1.0 / 4.0 / 60.0;
+  real_type dt = 1.0 / 4.0 / 60.0;
 
   // A data structure to keep track of the data we want to
   // compare to the reference solution. Rather than keeping
@@ -77,7 +92,7 @@ int main()
   // (plain ol' data), which have some benefits in C++.
   struct OutputData
   {
-    double ti, Vr, Vi, dw;
+    real_type ti, Vr, Vi, dw;
   };
 
   // A list of output for each time step.
@@ -93,19 +108,19 @@ int main()
   // reference to that variable inside the callback). We select
   // the subset of the output we're interested in recording and
   // push it into output, which is updated outside the callback.
-  auto output_cb = [&](double t)
+  auto output_cb = [&](real_type t)
   {
-    std::vector<double>& yval = sys.y();
+    std::vector<scalar_type>& yval = sys.y();
 
     output.push_back(OutputData{t, yval[0], yval[1], yval[3]});
   };
 
   // Set up simulation
-  Ida<double, size_t> ida(&sys);
+  Ida<scalar_type, size_t> ida(&sys);
   ida.configureSimulation();
 
   // Run simulation - making sure to pass the callback to record output
-  double start = static_cast<double>(clock());
+  real_type start = static_cast<real_type>(clock());
 
   // Run for 1s
   ida.initializeSimulation(0.0, false);
@@ -123,20 +138,20 @@ int main()
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);
-  double stop = static_cast<double>(clock());
+  real_type stop = static_cast<real_type>(clock());
 
-  double error_V = 0.0; // error in |V|
-  double error_w = 0.0; // error in rotor speed
+  real_type error_V = 0.0; // error in |V|
+  real_type error_w = 0.0; // error in rotor speed
 
   // Read through the simulation data stored in the buffer.
   // Since we captured by reference, output should be available
   // for us to read here, outside the callback.
   for (size_t i = 0; i < output.size(); i++)
   {
-    OutputData           data    = output[i];
-    std::vector<double>& ref_sol = Example1::reference_solution[i + 1];
+    OutputData              data    = output[i];
+    std::vector<real_type>& ref_sol = Example1::reference_solution[i + 1];
 
-    double err =
+    real_type err =
         std::abs(std::sqrt(data.Vr * data.Vr + data.Vi * data.Vi) - ref_sol[2])
         / (1.0 + std::abs(ref_sol[2]));
     if (err > error_V)
@@ -160,8 +175,8 @@ int main()
     // std::cout << "\n";
   }
 
-  double error_V_allowed = 2e-4;
-  double error_w_allowed = 1e-4;
+  real_type error_V_allowed = 2e-4;
+  real_type error_w_allowed = 1e-4;
 
   // Tolerances based on Powerworld reference accuracy
   int status = 0;

--- a/examples/PhasorDynamics/Example1/example1.cpp
+++ b/examples/PhasorDynamics/Example1/example1.cpp
@@ -14,12 +14,12 @@
 #include <iostream>
 
 #include <Model/PhasorDynamics/Branch/Branch.hpp>
-#include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Branch/BranchData.hpp>
+#include <Model/PhasorDynamics/Bus/Bus.hpp>
+#include <Model/PhasorDynamics/Bus/BusData.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <Model/PhasorDynamics/BusFault/BusFault.hpp>
 #include <Model/PhasorDynamics/BusFault/BusFaultData.hpp>
-#include <Model/PhasorDynamics/Bus/BusData.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
@@ -52,7 +52,7 @@ int main()
   branch_data_1_2.R = 0.0;
   branch_data_1_2.X = 0.1;
   branch_data_1_2.G = 0.0;
-  branch_data_1_2.B = 0.0;  
+  branch_data_1_2.B = 0.0;
 
   GenrouData<real_type, index_type> gen_data_1;
   gen_data_1.unit_id = 1;
@@ -76,8 +76,8 @@ int main()
   gen_data_1.S12     = 0.;
 
   BusFaultData<real_type, index_type> bus_fault_data_1;
-  bus_fault_data_1.R = 0.0;
-  bus_fault_data_1.X = 1e-3;
+  bus_fault_data_1.R      = 0.0;
+  bus_fault_data_1.X      = 1e-3;
   bus_fault_data_1.status = 0;
 
   //

--- a/examples/PhasorDynamics/Example2/example2.cpp
+++ b/examples/PhasorDynamics/Example2/example2.cpp
@@ -16,9 +16,12 @@
 #include <vector>
 
 #include <Model/PhasorDynamics/Branch/Branch.hpp>
+#include <Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
+#include <Model/PhasorDynamics/Bus/BusData.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <Model/PhasorDynamics/BusFault/BusFault.hpp>
+#include <Model/PhasorDynamics/BusFault/BusFaultData.hpp>
 #include <Model/PhasorDynamics/Load/Load.hpp>
 #include <Model/PhasorDynamics/Load/LoadData.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp>
@@ -85,8 +88,44 @@ int main()
   std::cout << "Example 2 version 1\n";
 
   //
-  // Create model data
+  // Create (load) model data
   //
+
+  // Bus 1
+  BusData<real_type, index_type> bus_data_1;
+  bus_data_1.Vr0 = 1.06;
+  bus_data_1.Vi0 = 0.0;
+
+  // Bus 2
+  BusData<real_type, index_type> bus_data_2;
+  bus_data_2.Vr0 = 1.0599558398065716;
+  bus_data_2.Vi0 = -0.009675621941024773;
+
+  // Bus 3
+  BusData<real_type, index_type> bus_data_3;
+  bus_data_3.Vr0 = 0.9610827543495831;
+  bus_data_3.Vi0 = -0.13122476630506485;
+
+  // Branch 1-2
+  BranchData<real_type, index_type> branch_data_1_2;
+  branch_data_1_2.R = 0.05;
+  branch_data_1_2.X = 0.21;
+  branch_data_1_2.G = 0;
+  branch_data_1_2.B = 0.1;
+
+  // Branch 1-3
+  BranchData<real_type, index_type> branch_data_1_3;
+  branch_data_1_3.R = 0.06;
+  branch_data_1_3.X = 0.15;
+  branch_data_1_3.G = 0;
+  branch_data_1_3.B = 0.12;
+
+  // Branch 2-3
+  BranchData<real_type, index_type> branch_data_2_3;
+  branch_data_2_3.R = 0.08;
+  branch_data_2_3.X = 0.27;
+  branch_data_2_3.G = 0;
+  branch_data_2_3.B = 0.45;
 
   // Generator on bus 2
   GenrouData<real_type, index_type> gen_data_2;
@@ -138,23 +177,30 @@ int main()
   load_data_3.X      = 0.20330047265361242;
   load_data_3.bus_id = 3;
 
+  BusFaultData<real_type, index_type> bus_fault_data_3;
+  bus_fault_data_3.R = 0.0;
+  bus_fault_data_3.X = 1e-5;
+  bus_fault_data_3.status = 0;
+
   //
   // Instantiate model components
   //
 
-  SystemModel<scalar_type, index_type> sys;
-  BusInfinite<scalar_type, index_type> bus1(1.06, 0.0);
-  Bus<scalar_type, index_type>         bus2(1.0599558398065716, -0.009675621941024773);
-  Bus<scalar_type, index_type>         bus3(0.9610827543495831, -0.13122476630506485);
-  Branch<scalar_type, index_type>      branch12(&bus1, &bus2, 0.05, 0.21, 0, 0.1);
-  Branch<scalar_type, index_type>      branch13(&bus1, &bus3, 0.06, 0.15, 0, 0.12);
-  Branch<scalar_type, index_type>      branch23(&bus2, &bus3, 0.08, 0.27, 0, 0.45);
-  Genrou<scalar_type, index_type>      gen2(&bus2, gen_data_2);
-  Genrou<scalar_type, index_type>      gen3(&bus3, gen_data_3);
-  Load<scalar_type, index_type>        load3(&bus3, load_data_3);
-  BusFault<scalar_type, index_type>    fault(&bus3, 0, 1e-5, 0);
+  BusInfinite<scalar_type, index_type> bus1(bus_data_1);
+  Bus<scalar_type, index_type>         bus2(bus_data_2);
+  Bus<scalar_type, index_type>         bus3(bus_data_3);
+
+  Branch<scalar_type, index_type> branch12(&bus1, &bus2, branch_data_1_2);
+  Branch<scalar_type, index_type> branch13(&bus1, &bus3, branch_data_1_3);
+  Branch<scalar_type, index_type> branch23(&bus2, &bus3, branch_data_2_3);
+
+  Genrou<scalar_type, index_type>   gen2(&bus2, gen_data_2);
+  Genrou<scalar_type, index_type>   gen3(&bus3, gen_data_3);
+  Load<scalar_type, index_type>     load3(&bus3, load_data_3);
+  BusFault<scalar_type, index_type> fault(&bus3, bus_fault_data_3);
 
   /* Connect everything together */
+  SystemModel<scalar_type, index_type> sys;
   sys.addBus(&bus1);
   sys.addBus(&bus2);
   sys.addBus(&bus3);

--- a/examples/PhasorDynamics/Example2/example2.cpp
+++ b/examples/PhasorDynamics/Example2/example2.cpp
@@ -22,6 +22,7 @@
 #include <Model/PhasorDynamics/Load/Load.hpp>
 #include <Model/PhasorDynamics/Load/LoadData.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp>
+#include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Solver/Dynamic/Ida.hpp>
 #include <Utilities/Testing.hpp>
@@ -87,6 +88,50 @@ int main()
   // Create model data
   //
 
+  // Generator on bus 2
+  GenrouData<real_type, index_type> gen_data_2;
+  gen_data_2.unit_id = 1;
+  gen_data_2.p0      = 0.5;
+  gen_data_2.q0      = -0.07588;
+  gen_data_2.H       = 2.7;
+  gen_data_2.D       = 0.;
+  gen_data_2.Ra      = 0.;
+  gen_data_2.Tdop    = 7.;
+  gen_data_2.Tdopp   = .04;
+  gen_data_2.Tqopp   = .05;
+  gen_data_2.Tqop    = .75;
+  gen_data_2.Xd      = 1.9;
+  gen_data_2.Xdp     = 0.17;
+  gen_data_2.Xdpp    = 0.15;
+  gen_data_2.Xq      = 0.4;
+  gen_data_2.Xqp     = 0.35;
+  gen_data_2.Xqpp    = 0.15;
+  gen_data_2.Xl      = 0.14999;
+  gen_data_2.S10     = 0.;
+  gen_data_2.S12     = 0.;
+
+  // Generator on bus 3
+  GenrouData<real_type, index_type> gen_data_3;
+  gen_data_3.unit_id = 1;
+  gen_data_3.p0      = 0.25;
+  gen_data_3.q0      = 0.26587;
+  gen_data_3.H       = 1.6;
+  gen_data_3.D       = 0.;
+  gen_data_3.Ra      = 0.;
+  gen_data_3.Tdop    = 7.5;
+  gen_data_3.Tdopp   = .04;
+  gen_data_3.Tqopp   = .05;
+  gen_data_3.Tqop    = .75;
+  gen_data_3.Xd      = 2.3;
+  gen_data_3.Xdp     = 0.2;
+  gen_data_3.Xdpp    = 0.18;
+  gen_data_3.Xq      = 0.5;
+  gen_data_3.Xqp     = 0.5;
+  gen_data_3.Xqpp    = 0.18;
+  gen_data_3.Xl      = 0.15;
+  gen_data_3.S10     = 0.;
+  gen_data_3.S12     = 0.;
+
   // Load on bus 3
   LoadData<real_type, index_type> load_data_3;
   load_data_3.R      = 0.4447197839297772;
@@ -104,46 +149,8 @@ int main()
   Branch<scalar_type, index_type>      branch12(&bus1, &bus2, 0.05, 0.21, 0, 0.1);
   Branch<scalar_type, index_type>      branch13(&bus1, &bus3, 0.06, 0.15, 0, 0.12);
   Branch<scalar_type, index_type>      branch23(&bus2, &bus3, 0.08, 0.27, 0, 0.45);
-  Genrou<scalar_type, index_type>      gen2(&bus2,
-                                       1,
-                                       0.5,
-                                       -0.07588,
-                                       2.7,
-                                       0.,
-                                       0.,
-                                       7.,
-                                       .04,
-                                       .05,
-                                       .75,
-                                       1.9,
-                                       0.17,
-                                       0.15,
-                                       0.4,
-                                       0.35,
-                                       0.15,
-                                       0.14999,
-                                       0.,
-                                       0.);
-  Genrou<scalar_type, index_type>      gen3(&bus3,
-                                       1,
-                                       0.25,
-                                       0.26587,
-                                       1.6,
-                                       0.,
-                                       0.,
-                                       7.5,
-                                       .04,
-                                       .05,
-                                       .75,
-                                       2.3,
-                                       0.2,
-                                       0.18,
-                                       0.5,
-                                       0.5,
-                                       0.18,
-                                       0.15,
-                                       0.,
-                                       0.);
+  Genrou<scalar_type, index_type>      gen2(&bus2, gen_data_2);
+  Genrou<scalar_type, index_type>      gen3(&bus3, gen_data_3);
   Load<scalar_type, index_type>        load3(&bus3, load_data_3);
   BusFault<scalar_type, index_type>    fault(&bus3, 0, 1e-5, 0);
 

--- a/examples/PhasorDynamics/Example2/example2.cpp
+++ b/examples/PhasorDynamics/Example2/example2.cpp
@@ -180,7 +180,7 @@ int main()
   BusFaultData<real_type, index_type> bus_fault_data_3;
   bus_fault_data_3.R      = 0.0;
   bus_fault_data_3.X      = 1e-5;
-  bus_fault_data_3.status = 0;
+  bus_fault_data_3.status = false;
 
   //
   // Instantiate model components
@@ -219,13 +219,13 @@ int main()
 
   auto output_cb = [&](real_type t)
   {
-    std::vector<double>& yval = sys.y();
+    std::vector<double>& y_val = sys.y();
 
     output.push_back(OutputData{t,
-                                1.0 + yval[5],
-                                1.0 + yval[26],
-                                std::sqrt(yval[0] * yval[0] + yval[1] * yval[1]),
-                                std::sqrt(yval[2] * yval[2] + yval[3] * yval[3])});
+                                1.0 + y_val[5],
+                                1.0 + y_val[26],
+                                std::sqrt(y_val[0] * y_val[0] + y_val[1] * y_val[1]),
+                                std::sqrt(y_val[2] * y_val[2] + y_val[3] * y_val[3])});
   };
 
   // Set up simulation
@@ -241,13 +241,13 @@ int main()
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault to ground and run for 0.1s
-  fault.setStatus(1);
+  fault.setStatus(true);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear fault and run until t = 10s.
-  fault.setStatus(0);
+  fault.setStatus(false);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Example2/example2.cpp
+++ b/examples/PhasorDynamics/Example2/example2.cpp
@@ -20,6 +20,7 @@
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <Model/PhasorDynamics/BusFault/BusFault.hpp>
 #include <Model/PhasorDynamics/Load/Load.hpp>
+#include <Model/PhasorDynamics/Load/LoadData.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Solver/Dynamic/Ida.hpp>
@@ -82,7 +83,20 @@ int main()
 
   std::cout << "Example 2 version 1\n";
 
-  /* Create model parts */
+  //
+  // Create model data
+  //
+
+  // Load on bus 3
+  LoadData<real_type, index_type> load_data_3;
+  load_data_3.R      = 0.4447197839297772;
+  load_data_3.X      = 0.20330047265361242;
+  load_data_3.bus_id = 3;
+
+  //
+  // Instantiate model components
+  //
+
   SystemModel<scalar_type, index_type> sys;
   BusInfinite<scalar_type, index_type> bus1(1.06, 0.0);
   Bus<scalar_type, index_type>         bus2(1.0599558398065716, -0.009675621941024773);
@@ -90,9 +104,47 @@ int main()
   Branch<scalar_type, index_type>      branch12(&bus1, &bus2, 0.05, 0.21, 0, 0.1);
   Branch<scalar_type, index_type>      branch13(&bus1, &bus3, 0.06, 0.15, 0, 0.12);
   Branch<scalar_type, index_type>      branch23(&bus2, &bus3, 0.08, 0.27, 0, 0.45);
-  Genrou<scalar_type, index_type>      gen2(&bus2, 1, 0.5, -0.07588, 2.7, 0., 0., 7., .04, .05, .75, 1.9, 0.17, 0.15, 0.4, 0.35, 0.15, 0.14999, 0., 0.);
-  Genrou<scalar_type, index_type>      gen3(&bus3, 1, 0.25, 0.26587, 1.6, 0., 0., 7.5, .04, .05, .75, 2.3, 0.2, 0.18, 0.5, 0.5, 0.18, 0.15, 0., 0.);
-  Load<scalar_type, index_type>        load3(&bus3, 0.4447197839297772, 0.20330047265361242);
+  Genrou<scalar_type, index_type>      gen2(&bus2,
+                                       1,
+                                       0.5,
+                                       -0.07588,
+                                       2.7,
+                                       0.,
+                                       0.,
+                                       7.,
+                                       .04,
+                                       .05,
+                                       .75,
+                                       1.9,
+                                       0.17,
+                                       0.15,
+                                       0.4,
+                                       0.35,
+                                       0.15,
+                                       0.14999,
+                                       0.,
+                                       0.);
+  Genrou<scalar_type, index_type>      gen3(&bus3,
+                                       1,
+                                       0.25,
+                                       0.26587,
+                                       1.6,
+                                       0.,
+                                       0.,
+                                       7.5,
+                                       .04,
+                                       .05,
+                                       .75,
+                                       2.3,
+                                       0.2,
+                                       0.18,
+                                       0.5,
+                                       0.5,
+                                       0.18,
+                                       0.15,
+                                       0.,
+                                       0.);
+  Load<scalar_type, index_type>        load3(&bus3, load_data_3);
   BusFault<scalar_type, index_type>    fault(&bus3, 0, 1e-5, 0);
 
   /* Connect everything together */

--- a/examples/PhasorDynamics/Example2/example2.cpp
+++ b/examples/PhasorDynamics/Example2/example2.cpp
@@ -178,8 +178,8 @@ int main()
   load_data_3.bus_id = 3;
 
   BusFaultData<real_type, index_type> bus_fault_data_3;
-  bus_fault_data_3.R = 0.0;
-  bus_fault_data_3.X = 1e-5;
+  bus_fault_data_3.R      = 0.0;
+  bus_fault_data_3.X      = 1e-5;
   bus_fault_data_3.status = 0;
 
   //

--- a/src/Model/PhasorDynamics/BusFault/BusFault.cpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
+#include <Model/PhasorDynamics/BusFault/BusFaultData.hpp>
 
 namespace GridKit
 {
@@ -50,6 +51,25 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     BusFault<ScalarT, IdxT>::BusFault(bus_type* bus, real_type R, real_type X, int status)
       : bus_(bus), R_(R), X_(X), status_(status), busID_(0)
+    {
+      size_ = 0;
+    }
+
+    /**
+     * @brief Construct a new BusFault
+     *
+     * @tparam ScalarT - scalar type
+     * @tparam IdxT    - matrix/vector index type
+     * @param bus1 - pointer to bus-1
+     * @param bus2 - pointer to bus-2
+     */
+    template <class ScalarT, typename IdxT>
+    BusFault<ScalarT, IdxT>::BusFault(bus_type* bus, DataT& data)
+      : bus_(bus),
+        R_(data.R),
+        X_(data.X),
+        status_(data.status),
+        busID_(data.bus_id)
     {
       size_ = 0;
     }

--- a/src/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -98,10 +98,10 @@ namespace GridKit
       }
 
     private:
-      bus_type* bus_;
-      real_type R_;
-      real_type X_;
-      int       status_;
+      bus_type*  bus_;
+      real_type  R_;
+      real_type  X_;
+      int        status_;
       const IdxT busID_;
     };
 

--- a/src/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -71,7 +71,7 @@ namespace GridKit
         X_ = X;
       }
 
-      void setStatus(int status)
+      void setStatus(bool status)
       {
         status_ = status;
       }
@@ -101,7 +101,7 @@ namespace GridKit
       bus_type*  bus_;
       real_type  R_;
       real_type  X_;
-      int        status_;
+      bool       status_;
       const IdxT busID_;
     };
 

--- a/src/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -4,6 +4,16 @@
 #include <Model/PhasorDynamics/BusBase.hpp>
 #include <Model/PhasorDynamics/Component.hpp>
 
+// Forward declaration of BusData structure
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    template <typename RealT, typename IdxT>
+    struct BusFaultData;
+  }
+} // namespace GridKit
+
 namespace GridKit
 {
   namespace PhasorDynamics
@@ -28,10 +38,12 @@ namespace GridKit
 
       using bus_type  = BusBase<ScalarT, IdxT>;
       using real_type = typename Component<ScalarT, IdxT>::real_type;
+      using DataT     = BusFaultData<real_type, IdxT>;
 
     public:
       BusFault(bus_type* bus);
       BusFault(bus_type* bus, real_type R, real_type X, int status);
+      BusFault(bus_type* bus, DataT& data);
       ~BusFault() = default;
 
       int allocate() override;
@@ -90,7 +102,7 @@ namespace GridKit
       real_type R_;
       real_type X_;
       int       status_;
-      const int busID_;
+      const IdxT busID_;
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/BusFault/BusFaultData.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultData.hpp
@@ -1,0 +1,33 @@
+/**
+ * @file BusFaultData.hpp
+ * @author Slaven Peles (peless@ornl.gov)
+ * @brief Modeling data for short-to-ground fault
+ *
+ */
+#pragma once
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    /**
+     * @brief Contains modeling data for a short-to-ground fault
+     *
+     * @tparam RealT Real parameter data type
+     * @tparam IdxT  Integer parameter data type
+     *
+     * Integer parameters are of the same type as matrix and vector indices.
+     *
+     * @todo Decide on naming scheme for model parameters.
+     */
+    template <typename RealT, typename IdxT>
+    struct BusFaultData
+    {
+      RealT R{0.0}; ///< short to ground resistance
+      RealT X{0.0}; ///< short to ground reactance
+      int status{0}; ///< if the fault happened
+
+      IdxT bus_id{0}; ///< Unique ID of bus where fault occurs.
+    };
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/BusFault/BusFaultData.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultData.hpp
@@ -23,9 +23,9 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     struct BusFaultData
     {
-      RealT R{0.0}; ///< short to ground resistance
-      RealT X{0.0}; ///< short to ground reactance
-      int status{0}; ///< if the fault happened
+      RealT R{0.0};    ///< short to ground resistance
+      RealT X{0.0};    ///< short to ground reactance
+      int   status{0}; ///< if the fault happened
 
       IdxT bus_id{0}; ///< Unique ID of bus where fault occurs.
     };

--- a/src/Model/PhasorDynamics/BusFault/BusFaultData.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultData.hpp
@@ -23,9 +23,9 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     struct BusFaultData
     {
-      RealT R{0.0};    ///< short to ground resistance
-      RealT X{0.0};    ///< short to ground reactance
-      int   status{0}; ///< if the fault happened
+      RealT R{0.0};        ///< short to ground resistance
+      RealT X{0.0};        ///< short to ground reactance
+      bool  status{false}; ///< if the fault happened
 
       IdxT bus_id{0}; ///< Unique ID of bus where fault occurs.
     };

--- a/src/Model/PhasorDynamics/BusFault/README.md
+++ b/src/Model/PhasorDynamics/BusFault/README.md
@@ -4,11 +4,11 @@ Represents an impedance fault at a bus. This device can exist in two states, on 
 
 ## Model Parameters
 
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------| ------
-$R$  | [p.u.] | Fault resistance  | 
-$X$  | [p.u.] | Fault reactance  | 
-$U$ | [unitless] | Binary status $$\in \{0, 1\}$$ | Set by user to put fault on or off.
+Symbol   | Units      | Description                     | Note
+---------|------------|---------------------------------|-------
+$R$      | [p.u.]     | Fault resistance                | 
+$X$      | [p.u.]     | Fault reactance                 | 
+$U$      | [unitless] | Binary status $$\in \{0, 1\}$$  | Set by user to put fault on or off.
 
 ### Model Derived Parameters
 ``` math
@@ -28,10 +28,10 @@ None.
 
 #### Algebraic
 
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------| ------
-$I_r$  | [p.u.] | Terminal current, real component  | Read by bus
-$I_i$  | [p.u.] | Terminal current, imaginary component  |  Read by bus
+Symbol      | Units   | Description                           | Note
+------------|---------|---------------------------------------| ------
+$I_r$       | [p.u.]  | Terminal current, real component      | Read by bus
+$I_i$       | [p.u.]  | Terminal current, imaginary component |  Read by bus
 
 
 ### External Variables
@@ -40,10 +40,10 @@ $I_i$  | [p.u.] | Terminal current, imaginary component  |  Read by bus
 None.
 
 #### Algebraic
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------| ------
-$V_r$  | [p.u.] | Terminal voltage, real component | owned by bus object
-$V_i$  | [p.u.] | Terminal voltage, imaginary component | owned by bus object
+Symbol      | Units   | Description                           | Note
+------------|---------|---------------------------------------| ------
+$V_r$       | [p.u.]  | Terminal voltage, real component      | owned by bus object
+$V_i$       | [p.u.]  | Terminal voltage, imaginary component | owned by bus object
 
 
 ## Model Equations

--- a/src/Model/PhasorDynamics/Load/Load.cpp
+++ b/src/Model/PhasorDynamics/Load/Load.cpp
@@ -39,6 +39,15 @@ namespace GridKit
     }
 
     template <class ScalarT, typename IdxT>
+    Load<ScalarT, IdxT>::Load(bus_type* bus,
+                              model_data_type& data)
+      : bus_(bus),
+        R_(data.R),
+        X_(data.X)
+    {
+    }
+
+    template <class ScalarT, typename IdxT>
     Load<ScalarT, IdxT>::Load(bus_type* bus, IdxT component_id)
       : bus_(bus)
     {

--- a/src/Model/PhasorDynamics/Load/Load.cpp
+++ b/src/Model/PhasorDynamics/Load/Load.cpp
@@ -39,7 +39,7 @@ namespace GridKit
     }
 
     template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::Load(bus_type* bus,
+    Load<ScalarT, IdxT>::Load(bus_type*        bus,
                               model_data_type& data)
       : bus_(bus),
         R_(data.R),

--- a/src/Model/PhasorDynamics/Load/Load.hpp
+++ b/src/Model/PhasorDynamics/Load/Load.hpp
@@ -46,6 +46,7 @@ namespace GridKit
       Load(bus_type* bus);
       Load(bus_type* bus, real_type R, real_type X);
       Load(bus_type* bus, IdxT component_id);
+      Load(bus_type* bus, model_data_type& data);
       virtual ~Load();
 
       virtual int allocate() override;

--- a/src/Model/PhasorDynamics/Load/LoadData.hpp
+++ b/src/Model/PhasorDynamics/Load/LoadData.hpp
@@ -26,7 +26,7 @@ namespace GridKit
       RealT R{0.0}; ///< load resistance
       RealT X{0.0}; ///< load reactance
 
-      IdxT bus_id{0}; ///< Unique ID of bus 1
+      IdxT bus_id{0}; ///< Unique ID of bus to which the load is connnected.
     };
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
+#include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
 
 #define _USE_MATH_DEFINES
 
@@ -31,7 +32,7 @@ namespace GridKit
      * - Number of optimization parameters = 0
      */
     template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, int unit_id)
+    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, IdxT unit_id)
       : bus_(bus),
         busID_(0),
         unit_id_(unit_id),
@@ -65,15 +66,10 @@ namespace GridKit
     /*!
      * @brief Constructor for a pi-model branch
      *
-     * Arguments passed to ModelEvaluatorImpl:
-     * - Number of equations = 0
-     * - Number of independent variables = 0
-     * - Number of quadratures = 0
-     * - Number of optimization parameters = 0
      */
     template <class ScalarT, typename IdxT>
     Genrou<ScalarT, IdxT>::Genrou(bus_type* bus,
-                                  int       unit_id,
+                                  IdxT      unit_id,
                                   ScalarT   p0,
                                   ScalarT   q0,
                                   real_type H,
@@ -113,6 +109,38 @@ namespace GridKit
         Xl_(Xl),
         S10_(S10),
         S12_(S12)
+    {
+      size_ = 21;
+      setDerivedParams();
+    }
+
+    /*!
+     * @brief Constructor for the GENROU generator with saturation.
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, model_data_type& data)
+      : bus_(bus),
+        busID_(0),
+        unit_id_(data.unit_id),
+        p0_(data.p0),
+        q0_(data.q0),
+        H_(data.H),
+        D_(data.D),
+        Ra_(data.Ra),
+        Tdop_(data.Tdop),
+        Tdopp_(data.Tdopp),
+        Tqopp_(data.Tqopp),
+        Tqop_(data.Tqop),
+        Xd_(data.Xd),
+        Xdp_(data.Xdp),
+        Xdpp_(data.Xdpp),
+        Xq_(data.Xq),
+        Xqp_(data.Xqp),
+        Xqpp_(data.Xqpp),
+        Xl_(data.Xl),
+        S10_(data.S10),
+        S12_(data.S12)
     {
       size_ = 21;
       setDerivedParams();

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -17,6 +17,9 @@ namespace GridKit
   {
     template <class ScalarT, typename IdxT>
     class BusBase;
+
+    template <typename RealT, typename IdxT>
+    struct GenrouData;
   }
 } // namespace GridKit
 
@@ -43,13 +46,15 @@ namespace GridKit
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::ypB_;
 
-      using bus_type  = BusBase<ScalarT, IdxT>;
       using real_type = typename Component<ScalarT, IdxT>::real_type;
+      using bus_type  = BusBase<ScalarT, IdxT>;
+      using model_data_type = GenrouData<real_type, IdxT>;
 
     public:
-      Genrou(bus_type* bus, int unit_id);
+      Genrou(bus_type* bus, IdxT unit_id);
+      Genrou(bus_type* bus, model_data_type& data);
       Genrou(bus_type* bus,
-             int       unit_id,
+             IdxT      unit_id,
              ScalarT   p0,
              ScalarT   q0,
              real_type H,
@@ -113,7 +118,7 @@ namespace GridKit
       /* Identification */
       bus_type* bus_;
       const int busID_;
-      int       unit_id_;
+      IdxT      unit_id_;
 
       /* Initial terminal conditions */
       ScalarT p0_;

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -20,7 +20,7 @@ namespace GridKit
 
     template <typename RealT, typename IdxT>
     struct GenrouData;
-  }
+  } // namespace PhasorDynamics
 } // namespace GridKit
 
 namespace GridKit
@@ -46,8 +46,8 @@ namespace GridKit
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::ypB_;
 
-      using real_type = typename Component<ScalarT, IdxT>::real_type;
-      using bus_type  = BusBase<ScalarT, IdxT>;
+      using real_type       = typename Component<ScalarT, IdxT>::real_type;
+      using bus_type        = BusBase<ScalarT, IdxT>;
       using model_data_type = GenrouData<real_type, IdxT>;
 
     public:

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
@@ -23,7 +23,7 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     struct GenrouData
     {
-      IdxT  unit_id{0}; ///< Unique unit ID
+      IdxT unit_id{0}; ///< Unique unit ID
 
       RealT p0{0.0};    ///< Initial active power
       RealT q0{0.0};    ///< Initial reactive power

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
@@ -1,0 +1,50 @@
+/**
+ * @file GenrouData.hpp
+ * @author Slaven Peles (peless@ornl.gov)
+ * @brief Modeling data for branches (transmission lines)
+ *
+ */
+#pragma once
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    /**
+     * @brief Contains modeling data for a Genrou generator model.
+     *
+     * @tparam RealT Real parameter data type
+     * @tparam IdxT  Integer parameter data type
+     *
+     * Integer parameters are of the same type as matrix and vector indices.
+     *
+     * @todo Decide on naming scheme for model parameters.
+     */
+    template <typename RealT, typename IdxT>
+    struct GenrouData
+    {
+      IdxT  unit_id{0}; ///< Unique unit ID
+
+      RealT p0{0.0};    ///< Initial active power
+      RealT q0{0.0};    ///< Initial reactive power
+      RealT H{0.0};     ///< Rotor inertia
+      RealT D{0.0};     ///< Damping coefficient
+      RealT Ra{0.0};    ///< Winding resistance
+      RealT Tdop{0.0};  ///< Open circuit direct axis transient time
+      RealT Tdopp{0.0}; ///< Open circuit direct axis sub-transient time
+      RealT Tqop{0.0};  ///< Open circuit quadrature axis transient
+      RealT Tqopp{0.0}; ///< Open circuit quadrature axis sub-transient time
+      RealT Xd{0.0};    ///< Direct axis synchronous reactance
+      RealT Xdp{0.0};   ///< Direct axis transient reactance
+      RealT Xdpp{0.0};  ///< Direct axis sub-transient reactance
+      RealT Xq{0.0};    ///< Quadrature axis synchronous reactance
+      RealT Xqp{0.0};   ///< Quadrature axis transient reactance
+      RealT Xqpp{0.0};  ///< Quadrature axis sub-transient reactance
+      RealT Xl{0.0};    ///< Stator leakage reactance
+      RealT S10{0.0};   ///< Saturation factor at 1.0 pu flux
+      RealT S12{0.0};   ///< Saturation factor at 1.2 pu flux
+
+      IdxT bus_id{0}; ///< Unique ID of the connecting bus
+    };
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
@@ -18,25 +18,25 @@ Notes:
 
 ## Model Parameters
 
-Symbol      | Units   | Description                     | Typical Value | Note
-------------|---------|---------------------------------|---------------| ------
-$\omega_0$  | [rad/s] | synchronous frequency           | $2\pi \cdot 60$
-$H$         | [s]     | rotor inertia                   | 3
-$D$         | [p.u.]  | damping coefficient             | 0
-$R_a$       | [p.u.]  | winding resistance              | 0
-$X_{\ell}$   | [p.u.] | Stator leakage reactance | 0.15 | 
-$X_{d}$   | [p.u.] | Direct axis synchronous reactance | 2.1 | 
-$X'_{d}$   | [p.u.] | Direct axis transient reactance | 0.2 | 
-$X''_{d}$   | [p.u.] | Direct axis sub-transient reactance | 0.18 | 
-$X_{q}$   | [p.u.] | Quadrature axis synchronous reactance | 0.5 | 
-$X'_{q}$   | [p.u.] | Quadrature axis transient reactance | 0.5 | 
-$X''_{q}$   | [p.u.] | Quadrature axis sub-transient reactance | 0.18 | 
-$T'_{d0}$   | [s] | Open circuit direct axis transient time const. | 7 | 
-$T''_{d0}$   | [s] | Open circuit direct axis sub-transient time const. | 0.04 | 
-$T'_{q0}$   | [s] | Open circuit quadrature axis transient time const. | 0.75 | 
-$T''_{q0}$   | [s] | Open circuit quadrature axis sub-transient time const. | 0.05 | 
-$S_{10}$   | [p.u.] | Saturation factor at 1.0 pu flux | 0 | 
-$S_{12}$   | [p.u.] | Saturation factor at 1.2 pu flux | 0 | 
+Symbol     | Units   | Description                     | Typical Value | Note
+-----------|---------|---------------------------------|---------------| ------
+$\omega_0$ | [rad/s] | synchronous frequency           | $2\pi \cdot 60$
+$H$        | [s]     | rotor inertia                   | 3
+$D$        | [p.u.]  | damping coefficient             | 0
+$R_a$      | [p.u.]  | winding resistance              | 0
+$X_{\ell}$ | [p.u.]  | Stator leakage reactance        | 0.15 | 
+$X_{d}$    | [p.u.]  | Direct axis synchronous reactance | 2.1 | 
+$X'_{d}$   | [p.u.]  | Direct axis transient reactance | 0.2 | 
+$X''_{d}$  | [p.u.]  | Direct axis sub-transient reactance | 0.18 | 
+$X_{q}$    | [p.u.]  | Quadrature axis synchronous reactance | 0.5 | 
+$X'_{q}$   | [p.u.]  | Quadrature axis transient reactance | 0.5 | 
+$X''_{q}$  | [p.u.]  | Quadrature axis sub-transient reactance | 0.18 | 
+$T'_{d0}$  | [s]     | Open circuit direct axis transient time const. | 7 | 
+$T''_{d0}$ | [s]     | Open circuit direct axis sub-transient time const. | 0.04 | 
+$T'_{q0}$  | [s]     | Open circuit quadrature axis transient time const. | 0.75 | 
+$T''_{q0}$ | [s]     | Open circuit quadrature axis sub-transient time const. | 0.05 | 
+$S_{10}$   | [p.u.]  | Saturation factor at 1.0 pu flux | 0 | 
+$S_{12}$   | [p.u.]  | Saturation factor at 1.2 pu flux | 0 | 
 
 ### Model Derived Parameters
 ``` math
@@ -59,29 +59,29 @@ $S_{12}$   | [p.u.] | Saturation factor at 1.2 pu flux | 0 |
 
 #### Differential
 
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------| ------
-$\delta$  | [rad] | Machine internal rotor angle |
+Symbol    | Units  | Description                       | Note
+----------|--------|-----------------------------------|-------
+$\delta$  | [rad]  | Machine internal rotor angle      |
 $\omega$  | [p.u.] | Machine speed | Optionally read by governor or stabilizer component
-$\psi'_d$ | [p.u.] | Direct axis subtransient flux | 
+$\psi'_d$ | [p.u.] | Direct axis subtransient flux     | 
 $\psi'_q$ | [p.u.] | Quadrature axis subtransient flux | 
-$E'_d$ | [p.u.] | Direct axis transient flux | 
-$E'_q$ | [p.u.] | Quadrature axis subtransient flux | 
+$E'_d$    | [p.u.] | Direct axis transient flux        | 
+$E'_q$    | [p.u.] | Quadrature axis subtransient flux | 
 
 #### Algebraic
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------| ------
-$V_d$  | [p.u.] | Machine internal voltage, d-axis | 
-$V_q$  | [p.u.] | Machine internal voltage, q-axis | 
-$I_d$  | [p.u.] | Terminal current, d-axis  | 
-$I_q$  | [p.u.] | Terminal current, q-axis   | 
-$I_r$  | [p.u.] | Terminal current, real component on network reference frame  | Read by bus and optionally by controllers
-$I_i$  | [p.u.] | Terminal current, imaginary component on network reference frame  |  Read by bus and optionally by controllers
-$\psi''_q$  | [p.u.] | Total q-axis subtransient flux
-$\psi''_d$  | [p.u.] | Total d-axis subtransient flux
-$\psi''$    | [p.u.] |   Machine total subtransient flux
-$T_{e}$   | [p.u.] |  Electrical torque
-$k_{sat}$   | [p.u.] |   Saturation coefficient 
+Symbol      | Units  | Description                       | Note
+------------|--------|---------------------------------  | ------
+$V_d$       | [p.u.] | Machine internal voltage, d-axis  | 
+$V_q$       | [p.u.] | Machine internal voltage, q-axis  | 
+$I_d$       | [p.u.] | Terminal current, d-axis          | 
+$I_q$       | [p.u.] | Terminal current, q-axis          | 
+$I_r$       | [p.u.] | Terminal current, real component on network reference frame      | Read by bus and optionally by controllers
+$I_i$       | [p.u.] | Terminal current, imaginary component on network reference frame | Read by bus and optionally by controllers
+$\psi''_q$  | [p.u.] | Total q-axis subtransient flux    |
+$\psi''_d$  | [p.u.] | Total d-axis subtransient flux    |
+$\psi''$    | [p.u.] | Machine total subtransient flux   |
+$T_{e}$     | [p.u.] | Electrical torque                 |
+$k_{sat}$   | [p.u.] | Saturation coefficient            |
 
 ### External Variables
 
@@ -89,12 +89,12 @@ $k_{sat}$   | [p.u.] |   Saturation coefficient
 None.
 
 #### Algebraic
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------| ------
-$V_r$  | [p.u.] | Terminal voltage, real component on network reference frame | owned by bus object
-$V_i$  | [p.u.] | Terminal voltage, imaginary component on network reference frame | owned by bus object
-$P_{m}$   | [p.u.] | Mechanical power from the prime mover | Owned by governor, constant if no governor is connected to the machine
-$E_{fd}$    | [p.u.] | Field winding voltage from the excitation system  | Owned by exciter, constant if no exciter is connected to the machine
+Symbol   | Units  | Description                     | Note
+---------|--------|---------------------------------| ------
+$V_r$    | [p.u.] | Terminal voltage, real component on network reference frame      | owned by bus object
+$V_i$    | [p.u.] | Terminal voltage, imaginary component on network reference frame | owned by bus object
+$P_{m}$  | [p.u.] | Mechanical power from the prime mover            | Owned by governor, constant if no governor is connected to the machine
+$E_{fd}$ | [p.u.] | Field winding voltage from the excitation system | Owned by exciter, constant if no exciter is connected to the machine
 
 ## Model Equations
 
@@ -131,10 +131,10 @@ Note that for implementation purposes, some of these equations may be simplified
   0 &= -V_{q}  +\psi''_{d}\omega\\
   0 &= -T_{elec} +(\psi''_{d} - I_dX_d'')I_q-(\psi''_{q} - I_qX_d'')I_d \\
   0 &= -k_{sat} + S_B (\psi''-S_A)^2 \\
- 0 &= -I_d + I_r \sin(\delta) - I_i \cos(\delta) \\
- 0 &= -I_q + I_r \cos(\delta) + I_i \sin(\delta) \\
- 0 &= -I_r + G (V_d \sin(\delta) + V_q \cos(\delta) - V_r) - B (V_d \cos(\delta) + V_q \sin(\delta) - V_i) \\
- 0 &= -I_i + B (V_d \sin(\delta) + V_q \cos(\delta) - V_r) + G (V_d \cos(\delta) + V_q \sin(\delta) - V_i)
+  0 &= -I_d + I_r \sin(\delta) - I_i \cos(\delta) \\
+  0 &= -I_q + I_r \cos(\delta) + I_i \sin(\delta) \\
+  0 &= -I_r + G (V_d \sin(\delta) + V_q \cos(\delta) - V_r) - B (V_d \cos(\delta) + V_q \sin(\delta) - V_i) \\
+  0 &= -I_i + B (V_d \sin(\delta) + V_q \cos(\delta) - V_r) + G (V_d \cos(\delta) + V_q \sin(\delta) - V_i)
 \end{aligned}
 ```
 

--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -5,7 +5,7 @@
  * @brief Tests for classical generator model.
  *
  */
-#define _USE_MATH_DEFINES  /* need this since directly including GenClassical.cpp for MSVC compiler */
+#define _USE_MATH_DEFINES /* need this since directly including GenClassical.cpp for MSVC compiler */
 #include <iomanip>
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
## Description
 
Create data structures for each component model type that stores all modeling data. 
 
@alexander-novo @reid-g @nkoukpaizan @shakedregev 
 
 ## Proposed changes
 
The data structures contain connectivity information and model parameters for each component model type and as such can be understood as meta models. For example, system matrix sparsity pattern and allocations can be done with information stored in these data structures without instantiating component or system models.

The idea is that these data structures are populated by the GridKit input. GridKit then operates on that data to allocate workspaces and instantiate and parametrize component models.

In this PR:
- Data structures for buses, branches, loads, and Genrou models are added.
- Each component model type has a constructor that uses data structure instead of parameter list.
- Phasor dynamics examples are updated to use data structures and simplified component constructors.

 ## Checklist
 
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
This is first stage in implementing meta models in GridKit. The objective of this PR is to have a matching data structure for each component model type.
 
 
