### PR TITLE
Governor (GovernorTgov1) Documentation

### DIFF
--- a/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
+++ b/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
@@ -1,0 +1,112 @@
+# **Steam Turbine-Governor Model (TGOV1)**
+
+## Block Diagram
+
+Standard model of the stream turbine
+
+<div align="center">
+   <img align="center" src="../../../../../docs/Figures/TGOV1.JPG">
+   
+   
+  Figure 1: Governor TGOV1 model. Figure courtesy of [PowerWorld](https://www.powerworld.com/WebHelp/)
+</div>
+
+## Model Parameters
+
+Symbol      | Units  | Description                       | Typical Value | Note
+------------|--------|-----------------------------------|---------------| ------
+$R$         | [p.u.] | Droop Constant                    | 0.05 |
+$T_1$       | [sec]  | Valve Time Delay                  | 0.5  |
+$T_2$       | [sec]  | Turbine Numerator Time Constant   | 2.5  |
+$T_3$       | [sec]  | Turbine Delay                     | 7.5  |
+$P_{vmax}$  | [p.u.] | Stator leakage reactance          | 1    | 
+$P_{vmin}$  | [p.u.] | Max Valve Position                | 0    | 
+$D_t$       | [p.u.] | Turbine Damping Coefficient       | 0    | 
+
+## Model Variables 
+
+### Internal Variables
+
+#### Differential
+
+Symbol    | Units  | Description                       | Note
+----------|--------|-----------------------------------|-------
+$P_{tx}$  | [p.u.] | Turbine Power (State 1 in Fig. 1) |
+$P_{v}$   | [p.u.] | Valve Position (State 2 in Fig. 1)| 
+
+#### Algebraic
+Symbol          | Units  | Description                       | Note
+----------------|--------|-----------------------------------|-------
+$P_{m}$      | [p.u.] | Mechnical Power to Generator      | Read by a Machine Model
+
+### External Variables
+
+#### Differential
+Symbol          | Units  | Description                       | Note
+----------------|--------|-----------------------------------|-------
+$\Delta\omega$  | [p.u.] | Speed Deviation                   | Read from a Machine Model
+
+#### Algebraic
+Symbol          | Units  | Description                       | Note
+----------------|--------|-----------------------------------|-------
+$P_{ref}$       | [p.u.] | Reference Power                   | Either a constant parameter or external variable
+
+## Model Equations
+
+### Differential Equations
+The TGOV1 differential equations, as derived from the model diagram. By defining an auxillary valve function $f=-P_{v} + (P_{ref}-\Delta\omega)/R$ one can write the piecewise definition of $\dot P_v$ compactly.
+```math
+\begin{aligned}
+   \dot{P}_{tx}   &= P_v - \dfrac{1}{T_3}(P_{tx}+T_2P_v) \\
+   \dot{P}_{v}    &= \dfrac{1}{T_1}
+   \begin{cases}
+      -P_{v} + \dfrac{1}{R}(P_{ref}-\Delta\omega)
+         &  \text{if } (P_{vmin} < P_v < P_{vmax}) & \lor \\
+         &  \quad (P_v \leq P_{vmin} \land f>0)    & \lor \\
+         &  \quad(P_v \geq P_{vmax} \land f<0)            \\
+      0  
+         &  \text{else}
+   \end{cases}
+\end{aligned}
+```
+
+### Algebraic Equations
+The algebraic equation dictating the mechnical power output.
+```math
+\begin{aligned}
+   P_{m} &= \dfrac{1}{T_3}(P_{tx}+T_2P_v) - D_t \Delta\omega \\
+\end{aligned}
+```
+
+#### Smooth Piecewise Approximation
+The domain of the state variable is enforced
+through the piece-wise definition above. This may need to be expressed as a
+smooth approximation (smooth indicator $\phi$) expressed generically as follows.
+```math
+\begin{aligned}
+   f(P_v)      &= \dfrac{1}{T_1}
+      \left[
+         -P_{v} + \dfrac{1}{R}(P_{ref}-\Delta\omega)
+      \right] \\
+   \dot{P}_{v} &= 
+            \phi(P_v, f(P_v)) \cdot f(P_v)
+\end{aligned}
+```
+
+## Initialization
+At steady state we assume that $P_v$ is at or within its limits. This implies the initial conditions are a function of $P_{m}$ which is equal to the electric torque.
+```math
+\begin{aligned}
+   P_{tx}  &= (T_3-T_2) P_{m}\\
+   P_{v}   &= P_{m}\\
+   \dot{P}_{tx} &=0\\
+   \dot{P}_{v}  &=0\\
+\end{aligned}
+```
+
+And if the reference power is a constant parameter, we can determine the value by solving the steady state equations.
+```math
+\begin{aligned}
+   P_{ref}  &= R P_{m}\\
+\end{aligned}
+```

--- a/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
+++ b/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
@@ -88,7 +88,16 @@ smooth approximation (smooth indicator $\phi$) expressed generically as follows.
          -P_{v} + \dfrac{1}{R}(P_{ref}-\Delta\omega)
       \right] \\
    \dot{P}_{v} &= 
-            \phi(P_v, f(P_v)) \cdot f(P_v)
+            \phi(P_v, f) \cdot f(P_v)
+\end{aligned}
+```
+
+The indicator function $\phi$ can be defined in terms of a scaled activation function ($\sigma$, sigmoid) and the $P_v$ limits $(P_{vmin}, P_{vmax})$.
+```math
+\begin{aligned}
+   \phi_L(P_v,f)&= \sigma(P_{vmin}-P_v)\sigma(-f)            \\
+   \phi_U(P_v,f)&= \sigma(P_v-P_{vmax})\sigma(f)             \\
+   \phi(P_v,f)  &= \left[1-\phi_L\right]\left[1-\phi_U\right]\\
 \end{aligned}
 ```
 

--- a/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
+++ b/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
@@ -7,7 +7,6 @@ Standard model of the stream turbine
 <div align="center">
    <img align="center" src="../../../../../docs/Figures/TGOV1.JPG">
    
-   
   Figure 1: Governor TGOV1 model. Figure courtesy of [PowerWorld](https://www.powerworld.com/WebHelp/)
 </div>
 
@@ -37,7 +36,7 @@ $P_{v}$   | [p.u.] | Valve Position (State 2 in Fig. 1)|
 #### Algebraic
 Symbol          | Units  | Description                       | Note
 ----------------|--------|-----------------------------------|-------
-$P_{m}$      | [p.u.] | Mechnical Power to Generator      | Read by a Machine Model
+$P_{m}$         | [p.u.] | Mechnical Power to Generator      | Read by a Machine Model
 
 ### External Variables
 

--- a/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
+++ b/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
@@ -101,6 +101,13 @@ The indicator function $\phi$ can be defined in terms of a scaled activation fun
 \end{aligned}
 ```
 
+The scale of the sigmoid function ($\alpha$ on the order of $10^3$) should be chosen so that for all practical parameters of the TGOV1 model, the sigmoid acts as a step function. This is further approximated by an algebraic form to obtain a practical function during implementation.
+```math
+\begin{aligned}
+   \sigma(x) =\dfrac{1}{1+\exp(-\alpha x)}\approx \dfrac{1}{2}\left(\dfrac{\alpha x}{1+|\alpha x|}\right)
+\end{aligned}
+```
+
 ## Initialization
 At steady state we assume that $P_v$ is at or within its limits. This implies the initial conditions are a function of $P_{m}$ which is equal to the electric torque.
 ```math

--- a/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
+++ b/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md
@@ -19,8 +19,8 @@ $R$         | [p.u.] | Droop Constant                    | 0.05 |
 $T_1$       | [sec]  | Valve Time Delay                  | 0.5  |
 $T_2$       | [sec]  | Turbine Numerator Time Constant   | 2.5  |
 $T_3$       | [sec]  | Turbine Delay                     | 7.5  |
-$P_{vmax}$  | [p.u.] | Stator leakage reactance          | 1    | 
-$P_{vmin}$  | [p.u.] | Max Valve Position                | 0    | 
+$P_{vmax}$  | [p.u.] | Max Valve Position                | 1    | 
+$P_{vmin}$  | [p.u.] | Min Valve Position                | 0    | 
 $D_t$       | [p.u.] | Turbine Damping Coefficient       | 0    | 
 
 ## Model Variables 

--- a/src/Model/PhasorDynamics/Governor/README.md
+++ b/src/Model/PhasorDynamics/Governor/README.md
@@ -9,4 +9,4 @@ A governor models the control system that regulates the output power of a machin
 
 ## Types
 There are a few standard Governor models
-- Turbine Governor (See [TGOV1](TGOV1/README.md))
+- Turbine Governor (See [TGOV1](GovernorTgov1/README.md))

--- a/src/Model/PhasorDynamics/Governor/README.md
+++ b/src/Model/PhasorDynamics/Governor/README.md
@@ -1,57 +1,12 @@
-# **Governor**
+# **Governor Model**
 
-## TGOV1 Model
+> [!NOTE]  
+> No implementation yet.
 
+## Introduction
 
-**Note: Governor model not yet implemented**
+A governor models the control system that regulates the output power of a machine.
 
-Standard model of the stream turbine
-
-<div align="center">
-   <img align="center" src="../../../../docs/Figures/TGOV1.JPG">
-   
-   
-  Figure 1: Governor TGOV1 model. Figure courtesy of [PowerWorld](https://www.powerworld.com/WebHelp/)
-</div>
-
-## Nomenclature
-
-### Inputs 
-- $`P_{REF}`$ - reference power (set point)
-- $`\Delta\omega`$
-### States 
-- $`P`$ - turbine power (state 1 in the Figure)
-- $`V`$ - valve position (state 2 in the Figure)
-### Parameters
-- $`R`$ - permanent droop, pu (0.05)
-- $`T2`$ - steam bowl time constant, sec (0.5)
-- $`V_{max}`$ - maximum valve position limit (1)
-- $`V_{min}`$ -  minimum valve position limit (0)
-- $`T2`$ - numerator time constant of T2, T3 block, sec (2.5)
-- $`T3`$ - reheater time constant, sec (7.5)
-- $`D_{t}`$ - turbine damping coefficient, pu (0)
-- $`T_{rate}`$ - turbine rating, MW (0) 
-
-## Equations
-```math
-\Delta\omega=\dfrac{\omega-\omega_{s}}{\omega_{s}}
-```
-First block
-```math
-\dfrac{dV}{dt} = \begin{cases}
-   \dfrac{1}{T1}(\dfrac{P_{REF}-\Delta\omega}{R}-V) &\text{if } V_{min}<=V<= V_{max}\\
-   0 &\text{if } \dfrac{P_{REF}-\Delta\omega}{R}>0 \text{  and  } V>=V_{max} &\text{ also then } V=V_{max}\\
-   0 &\text{if } \dfrac{P_{REF}-\Delta\omega}{R}<0 \text{  and  } V<=V_{min} &\text{ also then } V=V_{min}\\
-\end{cases}
-```
-Second block
-```math
-\dfrac{dx}{dt}=\dfrac{1}{T3}(V-P)
-```
-```math
-P=x+\dfrac{T2}{T3}V
-```
-Output
-```math
-P_{mech}=P-\Delta\omega D_{t}
-```
+## Types
+There are a few standard Governor models
+- Turbine Governor (See [TGOV1](TGOV1/README.md))


### PR DESCRIPTION
## Description
 
A PR to review the TGOV1 Governor documentation for Phasor Dynamics.

The TGOV1 Model Documentation is located [here](https://github.com/ORNL/GridKit/blob/lukel/phasor_tgov1_docs_dev/src/Model/PhasorDynamics/Governor/GovernorTgov1/README.md).

 ## Proposed changes
 
README for TGOV1 governor model, in alignment with the new formatting of GENROU. The folder name 'GovernorTgov1' for the model has been used to align with the camel-case convention of GridKit.
 
 ## Further comments
 
 The previous PR regarding Governor grew too large in scope and we observed some issues when re-basing.  The implementation of TGOV1 is complete, but we will submit a separate PR to prevent confusion along the way.
 
