### PR TITLE
Correctly print all matrices in scalemicrogridarbitrary

### DIFF
--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
@@ -1,5 +1,3 @@
-
-
 #include <cmath>
 #include <filesystem>
 #include <fstream>
@@ -63,6 +61,9 @@ int printMicrogridSystems(index_type N_size)
   using namespace GridKit;
 
   bool use_jac = true;
+
+  real_type t_init = 0.0;
+  real_type t_final = 1.0;
 
   real_type rel_tol = SCALE_MICROGRID_REL_TOL;
   real_type abs_tol = SCALE_MICROGRID_ABS_TOL;
@@ -296,13 +297,22 @@ int printMicrogridSystems(index_type N_size)
   std::string size_suffix = std::to_string(N_size);
 
   // print the residual in matrix market format
-  sys_model.printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + size_suffix + ".mtx",
-                                      "ScaleMicrogrid Residual N" + size_suffix);
+  /*sys_model.printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + size_suffix + "_iter" + std::to_string(mat_num) + ".mtx",
+                                      "ScaleMicrogrid Residual N" + size_suffix + " Iteration " + std::to_string(mat_num));*/
 
   sys_model.updateTime(0.0, 1.0e-8);
   sys_model.evaluateJacobian();
-  sys_model.printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + size_suffix + ".mtx",
-                                      "ScaleMicrogrid Jacobian N" + size_suffix);
+  /*sys_model.printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + size_suffix + "_iter" + std::to_string(mat_num) + ".mtx",
+                                      "ScaleMicrogrid Jacobian N" + size_suffix + " Iteration " + std::to_string(mat_num));*/
+
+  // Create numerical integrator and configure it for the generator model
+  AnalysisManager::Sundials::Ida<real_type, index_type> idas(&sys_model);
+
+  // setup simulation
+  idas.configureSimulation();
+  idas.getDefaultInitialCondition();
+  idas.initializeSimulation(t_init);
+  idas.runSimulation(t_final);
 
   return 0;
 }

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
@@ -62,7 +62,7 @@ int printMicrogridSystems(index_type N_size)
 
   bool use_jac = true;
 
-  real_type t_init = 0.0;
+  real_type t_init  = 0.0;
   real_type t_final = 1.0;
 
   real_type rel_tol = SCALE_MICROGRID_REL_TOL;

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogridArbitrary.cpp
@@ -296,14 +296,8 @@ int printMicrogridSystems(index_type N_size)
   // Output file names based on grid size
   std::string size_suffix = std::to_string(N_size);
 
-  // print the residual in matrix market format
-  /*sys_model.printResidualMatrixMarket("ScaleMicrogrid_Residual_N" + size_suffix + "_iter" + std::to_string(mat_num) + ".mtx",
-                                      "ScaleMicrogrid Residual N" + size_suffix + " Iteration " + std::to_string(mat_num));*/
-
   sys_model.updateTime(0.0, 1.0e-8);
   sys_model.evaluateJacobian();
-  /*sys_model.printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + size_suffix + "_iter" + std::to_string(mat_num) + ".mtx",
-                                      "ScaleMicrogrid Jacobian N" + size_suffix + " Iteration " + std::to_string(mat_num));*/
 
   // Create numerical integrator and configure it for the generator model
   AnalysisManager::Sundials::Ida<real_type, index_type> idas(&sys_model);

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -310,7 +310,6 @@ namespace GridKit
         jac_.axpy(1.0, rgr, cgr, vgr);
       }
 
-      // TODO: finish adding the writing out part stuff
       // jac_.printMatrixMarket("ScaleMicrogrid_Jacobian_N2_number" + std::to_string(jac_call_count_) + ".mtx", "Jacobian N2 number " + std::to_string(jac_call_count_));
       jac_call_count_++;
 

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -11,8 +11,6 @@
 #include <Model/PowerElectronics/CircuitGraph.hpp>
 #include <ScalarTraits.hpp>
 
-static int jacobianCallCount = 0;
-
 namespace GridKit
 {
   /**
@@ -34,8 +32,8 @@ namespace GridKit
       return;
     }
 
-    // Write Matrix Market header
-    outFile << "%%MatrixMarket vector array real general" << std::endl;
+    // Uncomment to write Matrix Market header
+    // outFile << "%%MatrixMarket vector array real general" << std::endl;
 
     // Write additional header information as comments
     if (!header.empty())
@@ -268,8 +266,8 @@ namespace GridKit
         }
       }
 
-      // Print the residual in matrix market format
-      writeVectorToMatrixMarket(f_, "ScaleMicrogrid_Residual_N2_number" + std::to_string(jacobianCallCount) + ".mtx", "Residual N2 number " + std::to_string(jacobianCallCount));
+      // Uncomment to print the residual in matrix market format
+      // writeVectorToMatrixMarket(f_, "ScaleMicrogrid_Residual_N2_number" + std::to_string(jac_call_count_) + ".mtx", "Residual N2 number " + std::to_string(jac_call_count_));
 
       return 0;
     }
@@ -313,8 +311,8 @@ namespace GridKit
       }
 
       // TODO: finish adding the writing out part stuff
-      jac_.printMatrixMarket("ScaleMicrogrid_Jacobian_N2_number" + std::to_string(jacobianCallCount) + ".mtx", "Jacobian N2 number " + std::to_string(jacobianCallCount));
-      jacobianCallCount++;
+      // jac_.printMatrixMarket("ScaleMicrogrid_Jacobian_N2_number" + std::to_string(jac_call_count_) + ".mtx", "Jacobian N2 number " + std::to_string(jac_call_count_));
+      jac_call_count_++;
 
       return 0;
     }
@@ -407,7 +405,9 @@ namespace GridKit
     static constexpr IdxT neg1_ = static_cast<IdxT>(-1);
 
     std::vector<component_type*> components_;
-    bool                         use_jac_;
+
+    int  jac_call_count_{0};
+    bool use_jac_;
 
   }; // class PowerElectronicsModel
 

--- a/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/src/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -11,6 +11,8 @@
 #include <Model/PowerElectronics/CircuitGraph.hpp>
 #include <ScalarTraits.hpp>
 
+static int jacobianCallCount = 0;
+
 namespace GridKit
 {
   /**
@@ -266,6 +268,9 @@ namespace GridKit
         }
       }
 
+      // Print the residual in matrix market format
+      writeVectorToMatrixMarket(f_, "ScaleMicrogrid_Residual_N2_number" + std::to_string(jacobianCallCount) + ".mtx", "Residual N2 number " + std::to_string(jacobianCallCount));
+
       return 0;
     }
 
@@ -306,6 +311,10 @@ namespace GridKit
         // elementwise jac_(rgr, cgr) += vgr
         jac_.axpy(1.0, rgr, cgr, vgr);
       }
+
+      // TODO: finish adding the writing out part stuff
+      jac_.printMatrixMarket("ScaleMicrogrid_Jacobian_N2_number" + std::to_string(jacobianCallCount) + ".mtx", "Jacobian N2 number " + std::to_string(jacobianCallCount));
+      jacobianCallCount++;
 
       return 0;
     }

--- a/src/Solver/Dynamic/Ida.cpp
+++ b/src/Solver/Dynamic/Ida.cpp
@@ -116,9 +116,12 @@ namespace AnalysisManager
       int retval = 0;
       if (model_->hasJacobian())
       {
-        JacobianMat_ = SUNSparseMatrix(static_cast<sunindextype>(model_->size()),
-                                       static_cast<sunindextype>(model_->size()),
-                                       static_cast<sunindextype>(model_->size() * model_->size()),
+        sunindextype n   = static_cast<sunindextype>(model_->size());
+        sunindextype nnz = static_cast<sunindextype>((model_->getJacobian()).nnz());
+
+        JacobianMat_ = SUNSparseMatrix(n,
+                                       n,
+                                       nnz,
                                        CSR_MAT,
                                        context_);
         checkAllocation((void*) JacobianMat_, "SUNSparseMatrix");
@@ -589,7 +592,7 @@ namespace AnalysisManager
       copyVec(yp, model->yp());
 
       model->evaluateJacobian();
-      GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> Jac = model->getJacobian();
+      GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& Jac = model->getJacobian();
 
       // Get reference to the jacobian entries
       std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<ScalarT>&> tpm = Jac.getEntries();

--- a/src/Solver/Dynamic/Ida.hpp
+++ b/src/Solver/Dynamic/Ida.hpp
@@ -156,7 +156,8 @@ namespace AnalysisManager
 
       real_type t_init_{};
       real_type t_final_{};
-      int       nout_{}; ///< Number of integration outputs
+      int       nout_{};             ///< Number of integration outputs
+      int       num_jacobian_evals_; ///< Number of Jacobian evaluations
 
       N_Vector yy_{};  ///< Solution vector
       N_Vector yp_{};  ///< Solution derivatives vector

--- a/src/Solver/Dynamic/Ida.hpp
+++ b/src/Solver/Dynamic/Ida.hpp
@@ -156,8 +156,7 @@ namespace AnalysisManager
 
       real_type t_init_{};
       real_type t_final_{};
-      int       nout_{};             ///< Number of integration outputs
-      int       num_jacobian_evals_; ///< Number of Jacobian evaluations
+      int       nout_{}; ///< Number of integration outputs
 
       N_Vector yy_{};  ///< Solution vector
       N_Vector yp_{};  ///< Solution derivatives vector


### PR DESCRIPTION
## Description
 
 _The current code only print the first matrix in the series. This allows printing all matrices. It works for $`N=2000`$, but not $`N=4000`$ due to lack of RAM. I rebased to develop, but I need help with the address sanitizer._
 
 ## Proposed changes
 
 The code will correctly output all matrices with the command
```
./examples/ScaleMicrogrid/scalemicrogridarbitrary <N>
```
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [ ] All tests pass.
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [ ] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
