### PR TITLE
Fix sparse Jacobian allocation

### DIFF
--- a/src/Solver/Dynamic/Ida.cpp
+++ b/src/Solver/Dynamic/Ida.cpp
@@ -117,7 +117,7 @@ namespace AnalysisManager
       if (model_->hasJacobian())
       {
         sunindextype nnz = static_cast<sunindextype>((model_->getJacobian()).nnz());
-        JacobianMat_ = SUNSparseMatrix(static_cast<sunindextype>(model_->size()),
+        JacobianMat_     = SUNSparseMatrix(static_cast<sunindextype>(model_->size()),
                                        static_cast<sunindextype>(model_->size()),
                                        nnz,
                                        CSR_MAT,

--- a/src/Solver/Dynamic/Ida.cpp
+++ b/src/Solver/Dynamic/Ida.cpp
@@ -116,9 +116,11 @@ namespace AnalysisManager
       int retval = 0;
       if (model_->hasJacobian())
       {
+        sunindextype n   = static_cast<sunindextype>(model_->size());
         sunindextype nnz = static_cast<sunindextype>((model_->getJacobian()).nnz());
-        JacobianMat_     = SUNSparseMatrix(static_cast<sunindextype>(model_->size()),
-                                       static_cast<sunindextype>(model_->size()),
+
+        JacobianMat_ = SUNSparseMatrix(n,
+                                       n,
                                        nnz,
                                        CSR_MAT,
                                        context_);

--- a/src/Solver/Dynamic/Ida.cpp
+++ b/src/Solver/Dynamic/Ida.cpp
@@ -116,9 +116,10 @@ namespace AnalysisManager
       int retval = 0;
       if (model_->hasJacobian())
       {
+        sunindextype nnz = static_cast<sunindextype>((model_->getJacobian()).nnz());
         JacobianMat_ = SUNSparseMatrix(static_cast<sunindextype>(model_->size()),
                                        static_cast<sunindextype>(model_->size()),
-                                       static_cast<sunindextype>(model_->size() * model_->size()),
+                                       nnz,
                                        CSR_MAT,
                                        context_);
         checkAllocation((void*) JacobianMat_, "SUNSparseMatrix");
@@ -589,7 +590,7 @@ namespace AnalysisManager
       copyVec(yp, model->yp());
 
       model->evaluateJacobian();
-      GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> Jac = model->getJacobian();
+      GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& Jac = model->getJacobian();
 
       // Get reference to the jacobian entries
       std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<ScalarT>&> tpm = Jac.getEntries();


### PR DESCRIPTION
## Description
 
In `Ida` class, sparse Jacobian is allocated to NxN elements (N being the size of the matrix) instead of number of nonzeros in the matrix. This leads to unnecessary memory complexity and sluggish performance for large systems. 
 
 
 ## Proposed changes
 
Allocate sparse Jacobian in `Ida` to NNZ.
 
 ## Checklist
 

- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- N/A There are unit tests for the new code.
- N/A The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
 
