### PR TITLE
Remove adjoint sensitivity methods from phasor dynamics components

### DIFF
--- a/src/Model/PhasorDynamics/Branch/Branch.cpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.cpp
@@ -22,11 +22,9 @@ namespace GridKit
     /*!
      * @brief Constructor for a pi-model branch
      *
-     * Arguments passed to ModelEvaluatorImpl:
+     * Model size:
      * - Number of equations = 0
-     * - Number of independent variables = 0
-     * - Number of quadratures = 0
-     * - Number of optimization parameters = 0
+     * - Number of internal variables = 0
      */
     template <class ScalarT, typename IdxT>
     Branch<ScalarT, IdxT>::Branch(bus_type* bus1, bus_type* bus2)
@@ -159,62 +157,6 @@ namespace GridKit
     {
       std::cout << "Evaluate Jacobian for Branch..." << std::endl;
       std::cout << "Jacobian evaluation not implemented!" << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateIntegrand()
-    {
-      // std::cout << "Evaluate Integrand for Branch..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint initialization not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::initializeAdjoint()
-    {
-      // std::cout << "Initialize adjoint for Branch..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint residual evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateAdjointResidual()
-    {
-      // std::cout << "Evaluate adjoint residual for Branch..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateAdjointIntegrand()
-    {
-      // std::cout << "Evaluate adjoint Integrand for Branch..." << std::endl;
       return 0;
     }
 

--- a/src/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.hpp
@@ -61,12 +61,6 @@ namespace GridKit
       virtual int tagDifferentiable() override;
       virtual int evaluateResidual() override;
       virtual int evaluateJacobian() override;
-      virtual int evaluateIntegrand() override;
-
-      virtual int initializeAdjoint() override;
-      virtual int evaluateAdjointResidual() override;
-      // virtual int evaluateAdjointJacobian() override;
-      virtual int evaluateAdjointIntegrand() override;
 
       virtual void updateTime(real_type /* t */, real_type /* a */) override
       {

--- a/src/Model/PhasorDynamics/Bus/Bus.cpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.cpp
@@ -26,9 +26,6 @@ namespace GridKit
     Bus<ScalarT, IdxT>::Bus()
       : Vr0_(0.0), Vi0_(0.0)
     {
-      // std::cout << "Create Bus..." << std::endl;
-      // std::cout << "Number of equations is " << size_ << std::endl;
-
       size_ = 2;
     }
 
@@ -47,9 +44,6 @@ namespace GridKit
     Bus<ScalarT, IdxT>::Bus(ScalarT Vr, ScalarT Vi)
       : Vr0_(Vr), Vi0_(Vi)
     {
-      // std::cout << "Create Bus..." << std::endl;
-      // std::cout << "Number of equations is " << size_ << std::endl;
-
       size_ = 2;
     }
 
@@ -92,10 +86,6 @@ namespace GridKit
       y_.resize(size);
       yp_.resize(size);
       tag_.resize(size);
-
-      fB_.resize(size);
-      yB_.resize(size);
-      ypB_.resize(size);
 
       return 0;
     }
@@ -151,63 +141,6 @@ namespace GridKit
      */
     template <class ScalarT, typename IdxT>
     int Bus<ScalarT, IdxT>::evaluateJacobian()
-    {
-      return 0;
-    }
-
-    /*!
-     * @brief initialize method sets bus variables to stored initial values.
-     */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::initializeAdjoint()
-    {
-      // std::cout << "Initialize Bus..." << std::endl;
-      yB_[0]  = 0.0;
-      yB_[1]  = 0.0;
-      ypB_[0] = 0.0;
-      ypB_[1] = 0.0;
-
-      return 0;
-    }
-
-    /**
-     * @brief Bus only initializes adjoint residual elements to zero.
-     *
-     * @tparam ScalarT - data type for the integrand
-     * @tparam IdxT    - data type for matrix/vector indices
-     * @return int - error code
-     */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::evaluateAdjointResidual()
-    {
-      fB_[0] = 0.0;
-      fB_[1] = 0.0;
-
-      return 0;
-    }
-
-    /**
-     * @brief Quadrature evaluation not implemented
-     *
-     * @tparam ScalarT - data type for the integrand
-     * @tparam IdxT    - data type for matrix/vector indices
-     * @return int - error code
-     */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::evaluateIntegrand()
-    {
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint quadrature evaluation not implemented
-     *
-     * @tparam ScalarT - data type for the integrand
-     * @tparam IdxT    - data type for matrix/vector indices
-     * @return int - error code
-     */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::evaluateAdjointIntegrand()
     {
       return 0;
     }

--- a/src/Model/PhasorDynamics/Bus/Bus.hpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.hpp
@@ -21,10 +21,7 @@ namespace GridKit
       using BusBase<ScalarT, IdxT>::size_;
       using BusBase<ScalarT, IdxT>::y_;
       using BusBase<ScalarT, IdxT>::yp_;
-      using BusBase<ScalarT, IdxT>::yB_;
-      using BusBase<ScalarT, IdxT>::ypB_;
       using BusBase<ScalarT, IdxT>::f_;
-      using BusBase<ScalarT, IdxT>::fB_;
       using BusBase<ScalarT, IdxT>::tag_;
 
     public:
@@ -41,11 +38,7 @@ namespace GridKit
       virtual int tagDifferentiable() override;
       virtual int initialize() override;
       virtual int evaluateResidual() override;
-      virtual int evaluateIntegrand() override;
       virtual int evaluateJacobian() override;
-      virtual int initializeAdjoint() override;
-      virtual int evaluateAdjointIntegrand() override;
-      virtual int evaluateAdjointResidual() override;
 
       virtual BusTypeT BusType() const override
       {

--- a/src/Model/PhasorDynamics/Bus/BusInfinite.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusInfinite.cpp
@@ -19,15 +19,10 @@ namespace GridKit
      * Arguments to be passed to BusBase:
      * - Number of equations = 0 (size_)
      * - Number of variables = 0 (size_)
-     * - Number of quadratures = 0
-     * - Number of optimization parameters = 0
      */
     template <class ScalarT, typename IdxT>
     BusInfinite<ScalarT, IdxT>::BusInfinite()
     {
-      // std::cout << "Create BusInfinite..." << std::endl;
-      // std::cout << "Number of equations is " << size_ << std::endl;
-
       size_ = 0;
     }
 
@@ -39,16 +34,11 @@ namespace GridKit
      * Arguments to be passed to BusBase:
      * - Number of equations = 0 (size_)
      * - Number of variables = 0 (size_)
-     * - Number of quadratures = 0
-     * - Number of optimization parameters = 0
      */
     template <class ScalarT, typename IdxT>
     BusInfinite<ScalarT, IdxT>::BusInfinite(ScalarT Vr, ScalarT Vi)
       : Vr_(Vr), Vi_(Vi)
     {
-      // std::cout << "Create BusInfinite..." << std::endl;
-      // std::cout << "Number of equations is " << size_ << std::endl;
-
       size_ = 0;
     }
 
@@ -58,8 +48,6 @@ namespace GridKit
      * Arguments to be set in BusBase:
      * - Number of equations = 0 (size_)
      * - Number of variables = 0 (size_)
-     * - Number of quadratures = 0
-     * - Number of optimization parameters = 0
 
      * @tparam ScalarT - type of scalar variables
      * @tparam IdxT    - type for vector/matrix indices
@@ -77,7 +65,6 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     BusInfinite<ScalarT, IdxT>::~BusInfinite()
     {
-      // std::cout << "Destroy PQ bus ..." << std::endl;
     }
 
     /*!
@@ -86,8 +73,6 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int BusInfinite<ScalarT, IdxT>::allocate()
     {
-      // std::cout << "Nothing to allocate for infinite bus ..." << std::endl;
-
       return 0;
     }
 
@@ -103,8 +88,6 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int BusInfinite<ScalarT, IdxT>::initialize()
     {
-      // std::cout << "Initialize BusInfinite..." << std::endl;
-
       return 0;
     }
 
@@ -123,7 +106,6 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int BusInfinite<ScalarT, IdxT>::evaluateResidual()
     {
-      // std::cout << "Evaluating residual of a PQ bus ...\n";
       Ir_ = 0.0;
       Ii_ = 0.0;
       return 0;
@@ -138,56 +120,6 @@ namespace GridKit
      */
     template <class ScalarT, typename IdxT>
     int BusInfinite<ScalarT, IdxT>::evaluateJacobian()
-    {
-      return 0;
-    }
-
-    /*!
-     * @brief initialize method sets bus variables to stored initial values.
-     */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::initializeAdjoint()
-    {
-      // std::cout << "Initialize BusInfinite..." << std::endl;
-
-      return 0;
-    }
-
-    /**
-     * @brief BusInfinite only initializes adjoint residual elements to zero.
-     *
-     * @tparam ScalarT - data type for the integrand
-     * @tparam IdxT    - data type for matrix/vector indices
-     * @return int - error code
-     */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::evaluateAdjointResidual()
-    {
-      return 0;
-    }
-
-    /**
-     * @brief Quadrature evaluation not implemented
-     *
-     * @tparam ScalarT - data type for the integrand
-     * @tparam IdxT    - data type for matrix/vector indices
-     * @return int - error code
-     */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::evaluateIntegrand()
-    {
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint quadrature evaluation not implemented
-     *
-     * @tparam ScalarT - data type for the integrand
-     * @tparam IdxT    - data type for matrix/vector indices
-     * @return int - error code
-     */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::evaluateAdjointIntegrand()
     {
       return 0;
     }

--- a/src/Model/PhasorDynamics/Bus/BusInfinite.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusInfinite.hpp
@@ -19,11 +19,7 @@ namespace GridKit
       using BusBase<ScalarT, IdxT>::size_;
       using BusBase<ScalarT, IdxT>::y_;
       using BusBase<ScalarT, IdxT>::yp_;
-      using BusBase<ScalarT, IdxT>::yB_;
-      using BusBase<ScalarT, IdxT>::ypB_;
       using BusBase<ScalarT, IdxT>::f_;
-      using BusBase<ScalarT, IdxT>::fB_;
-      using BusBase<ScalarT, IdxT>::tag_;
 
     public:
       using real_type = typename BusBase<ScalarT, IdxT>::real_type;
@@ -39,11 +35,7 @@ namespace GridKit
       virtual int tagDifferentiable() override;
       virtual int initialize() override;
       virtual int evaluateResidual() override;
-      virtual int evaluateIntegrand() override;
       virtual int evaluateJacobian() override;
-      virtual int initializeAdjoint() override;
-      virtual int evaluateAdjointIntegrand() override;
-      virtual int evaluateAdjointResidual() override;
 
       virtual BusTypeT BusType() const override
       {

--- a/src/Model/PhasorDynamics/BusBase.hpp
+++ b/src/Model/PhasorDynamics/BusBase.hpp
@@ -31,15 +31,6 @@ namespace GridKit
       {
       }
 
-      BusBase(IdxT size, IdxT size_quad, IdxT size_param)
-        : size_(size),
-          y_(size_),
-          yp_(size_),
-          f_(size_),
-          J_(GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>())
-      {
-      }
-
       virtual ~BusBase()
       {
       }

--- a/src/Model/PhasorDynamics/BusBase.hpp
+++ b/src/Model/PhasorDynamics/BusBase.hpp
@@ -22,9 +22,7 @@ namespace GridKit
       using BusTypeT  = typename BusData<real_type, IdxT>::BusType;
 
       BusBase()
-        : size_(0),
-          size_quad_(0),
-          size_param_(0)
+        : size_(0)
       {
       }
 
@@ -35,8 +33,6 @@ namespace GridKit
 
       BusBase(IdxT size, IdxT size_quad, IdxT size_param)
         : size_(size),
-          size_quad_(size_quad),
-          size_param_(size_param),
           y_(size_),
           yp_(size_),
           f_(size_),
@@ -139,14 +135,11 @@ namespace GridKit
 
       IdxT size_{0};
       IdxT nnz_{0};
-      IdxT size_quad_{0};
-      IdxT size_param_{0};
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;
       std::vector<bool>    tag_;
       std::vector<ScalarT> f_;
-      std::vector<ScalarT> g_;
 
       GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> J_;
 
@@ -162,6 +155,7 @@ namespace GridKit
       // Adjoint sensitivity members
       //
 
+      std::vector<ScalarT> g_{};
       std::vector<ScalarT> yB_{};
       std::vector<ScalarT> ypB_{};
       std::vector<ScalarT> fB_{};
@@ -179,13 +173,13 @@ namespace GridKit
       virtual IdxT sizeQuadrature() override
       {
         throw "ERROR: Method not implemented!\n";
-        return size_quad_;
+        return 0;
       }
 
       virtual IdxT sizeParams() override
       {
         throw "ERROR: Method not implemented!\n";
-        return size_param_;
+        return 0;
       }
 
       std::vector<ScalarT>& yB() override
@@ -246,6 +240,30 @@ namespace GridKit
       {
         throw "ERROR: Method not implemented!\n";
         return param_lo_;
+      }
+
+      int evaluateIntegrand() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 1;
+      }
+
+      int initializeAdjoint() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 1;
+      }
+
+      int evaluateAdjointResidual() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 1;
+      }
+
+      int evaluateAdjointIntegrand() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 1;
       }
 
       std::vector<ScalarT>& getResidual() override

--- a/src/Model/PhasorDynamics/BusBase.hpp
+++ b/src/Model/PhasorDynamics/BusBase.hpp
@@ -307,7 +307,6 @@ namespace GridKit
       {
         return bus_id_;
       }
-
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/BusBase.hpp
+++ b/src/Model/PhasorDynamics/BusBase.hpp
@@ -40,15 +40,7 @@ namespace GridKit
           y_(size_),
           yp_(size_),
           f_(size_),
-          g_(size_quad_),
-          yB_(size_),
-          ypB_(size_),
-          fB_(size_),
-          gB_(size_param_),
-          J_(GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>()),
-          param_(size_param_),
-          param_up_(size_param_),
-          param_lo_(size_param_)
+          J_(GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>())
       {
       }
 
@@ -75,16 +67,6 @@ namespace GridKit
       virtual bool hasJacobian() override
       {
         return false;
-      }
-
-      virtual IdxT sizeQuadrature() override
-      {
-        return size_quad_;
-      }
-
-      virtual IdxT sizeParams() override
-      {
-        return size_param_;
       }
 
       virtual void updateTime(real_type /* t */, real_type /* a */) override
@@ -142,66 +124,6 @@ namespace GridKit
         return tag_;
       }
 
-      std::vector<ScalarT>& yB() override
-      {
-        return yB_;
-      }
-
-      const std::vector<ScalarT>& yB() const override
-      {
-        return yB_;
-      }
-
-      std::vector<ScalarT>& ypB() override
-      {
-        return ypB_;
-      }
-
-      const std::vector<ScalarT>& ypB() const override
-      {
-        return ypB_;
-      }
-
-      std::vector<ScalarT>& param() override
-      {
-        return param_;
-      }
-
-      const std::vector<ScalarT>& param() const override
-      {
-        return param_;
-      }
-
-      std::vector<ScalarT>& param_up() override
-      {
-        return param_up_;
-      }
-
-      const std::vector<ScalarT>& param_up() const override
-      {
-        return param_up_;
-      }
-
-      std::vector<ScalarT>& param_lo() override
-      {
-        return param_lo_;
-      }
-
-      const std::vector<ScalarT>& param_lo() const override
-      {
-        return param_lo_;
-      }
-
-      std::vector<ScalarT>& getResidual() override
-      {
-        return f_;
-      }
-
-      const std::vector<ScalarT>& getResidual() const override
-      {
-        return f_;
-      }
-
       GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& getJacobian() override
       {
         return J_;
@@ -210,41 +132,6 @@ namespace GridKit
       const GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& getJacobian() const override
       {
         return J_;
-      }
-
-      std::vector<ScalarT>& getIntegrand() override
-      {
-        return g_;
-      }
-
-      const std::vector<ScalarT>& getIntegrand() const override
-      {
-        return g_;
-      }
-
-      std::vector<ScalarT>& getAdjointResidual() override
-      {
-        return fB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointResidual() const override
-      {
-        return fB_;
-      }
-
-      std::vector<ScalarT>& getAdjointIntegrand() override
-      {
-        return gB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointIntegrand() const override
-      {
-        return gB_;
-      }
-
-      virtual const IdxT busID() const
-      {
-        return bus_id_;
       }
 
     protected:
@@ -261,16 +148,7 @@ namespace GridKit
       std::vector<ScalarT> f_;
       std::vector<ScalarT> g_;
 
-      std::vector<ScalarT> yB_;
-      std::vector<ScalarT> ypB_;
-      std::vector<ScalarT> fB_;
-      std::vector<ScalarT> gB_;
-
       GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> J_;
-
-      std::vector<ScalarT> param_;
-      std::vector<ScalarT> param_up_;
-      std::vector<ScalarT> param_lo_;
 
       real_type time_;
       real_type alpha_;
@@ -279,6 +157,148 @@ namespace GridKit
       real_type atol_;
 
       IdxT max_steps_;
+
+      //
+      // Adjoint sensitivity members
+      //
+
+      std::vector<ScalarT> yB_{};
+      std::vector<ScalarT> ypB_{};
+      std::vector<ScalarT> fB_{};
+      std::vector<ScalarT> gB_{};
+
+      std::vector<ScalarT> param_{};
+      std::vector<ScalarT> param_up_{};
+      std::vector<ScalarT> param_lo_{};
+
+      //
+      // Public adjoint sensitivity methods (not yet implemented in components)
+      //
+
+    public:
+      virtual IdxT sizeQuadrature() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return size_quad_;
+      }
+
+      virtual IdxT sizeParams() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return size_param_;
+      }
+
+      std::vector<ScalarT>& yB() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return yB_;
+      }
+
+      const std::vector<ScalarT>& yB() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return yB_;
+      }
+
+      std::vector<ScalarT>& ypB() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return ypB_;
+      }
+
+      const std::vector<ScalarT>& ypB() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return ypB_;
+      }
+
+      std::vector<ScalarT>& param() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_;
+      }
+
+      const std::vector<ScalarT>& param() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_;
+      }
+
+      std::vector<ScalarT>& param_up() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_up_;
+      }
+
+      const std::vector<ScalarT>& param_up() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_up_;
+      }
+
+      std::vector<ScalarT>& param_lo() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_lo_;
+      }
+
+      const std::vector<ScalarT>& param_lo() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_lo_;
+      }
+
+      std::vector<ScalarT>& getResidual() override
+      {
+        return f_;
+      }
+
+      const std::vector<ScalarT>& getResidual() const override
+      {
+        return f_;
+      }
+
+      std::vector<ScalarT>& getIntegrand() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return g_;
+      }
+
+      const std::vector<ScalarT>& getIntegrand() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return g_;
+      }
+
+      std::vector<ScalarT>& getAdjointResidual() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return fB_;
+      }
+
+      const std::vector<ScalarT>& getAdjointResidual() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return fB_;
+      }
+
+      std::vector<ScalarT>& getAdjointIntegrand() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return gB_;
+      }
+
+      const std::vector<ScalarT>& getAdjointIntegrand() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return gB_;
+      }
+
+      virtual const IdxT busID() const
+      {
+        return bus_id_;
+      }
+
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/BusFault/BusFault.cpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.cpp
@@ -22,11 +22,9 @@ namespace GridKit
     /*!
      * @brief Constructor for a pi-model branch
      *
-     * Arguments passed to ModelEvaluatorImpl:
+     * Model sizes:
      * - Number of equations = 0
      * - Number of independent variables = 0
-     * - Number of quadratures = 0
-     * - Number of optimization parameters = 0
      */
     template <class ScalarT, typename IdxT>
     BusFault<ScalarT, IdxT>::BusFault(bus_type* bus)
@@ -134,62 +132,6 @@ namespace GridKit
     {
       std::cout << "Evaluate Jacobian for BusFault..." << std::endl;
       std::cout << "Jacobian evaluation not implemented!" << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::evaluateIntegrand()
-    {
-      // std::cout << "Evaluate Integrand for BusFault..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint initialization not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::initializeAdjoint()
-    {
-      // std::cout << "Initialize adjoint for BusFault..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint residual evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::evaluateAdjointResidual()
-    {
-      // std::cout << "Evaluate adjoint residual for BusFault..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::evaluateAdjointIntegrand()
-    {
-      // std::cout << "Evaluate adjoint Integrand for BusFault..." << std::endl;
       return 0;
     }
 

--- a/src/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -23,18 +23,12 @@ namespace GridKit
     {
       using Component<ScalarT, IdxT>::alpha_;
       using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::fB_;
-      using Component<ScalarT, IdxT>::g_;
-      using Component<ScalarT, IdxT>::gB_;
       using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::param_;
       using Component<ScalarT, IdxT>::size_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::time_;
       using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yB_;
       using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::ypB_;
 
       using bus_type  = BusBase<ScalarT, IdxT>;
       using real_type = typename Component<ScalarT, IdxT>::real_type;
@@ -51,10 +45,6 @@ namespace GridKit
       int tagDifferentiable() override;
       int evaluateResidual() override;
       int evaluateJacobian() override;
-      int evaluateIntegrand() override;
-      int initializeAdjoint() override;
-      int evaluateAdjointResidual() override;
-      int evaluateAdjointIntegrand() override;
 
       void updateTime(real_type /* t */, real_type /* a */) override
       {

--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -22,28 +22,7 @@ namespace GridKit
       using real_type = typename Model::Evaluator<ScalarT, IdxT>::real_type;
 
       Component()
-        : size_(0),
-          size_quad_(0),
-          size_param_(0)
-      {
-      }
-
-      Component(IdxT size, IdxT size_quad, IdxT size_param)
-        : size_(size),
-          // size_quad_(size_quad),
-          // size_param_(size_param),
-          y_(size_),
-          yp_(size_),
-          f_(size_),
-          // g_(size_quad_),
-          // yB_(size_),
-          // ypB_(size_),
-          // fB_(size_),
-          // gB_(size_param_),
-          J_(GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>())
-          // param_(size_param_),
-          // param_up_(size_param_),
-          // param_lo_(size_param_)
+        : size_(0)
       {
       }
 
@@ -61,16 +40,6 @@ namespace GridKit
       virtual bool hasJacobian() override
       {
         return false;
-      }
-
-      virtual IdxT sizeQuadrature() override
-      {
-        return size_quad_;
-      }
-
-      virtual IdxT sizeParams() override
-      {
-        return size_param_;
       }
 
       // virtual void updateTime(real_type t, real_type a)
@@ -167,9 +136,6 @@ namespace GridKit
       // Adjoint sensitivity members
       //
 
-      IdxT size_quad_;
-      IdxT size_param_;
-
       std::vector<ScalarT> yB_{};
       std::vector<ScalarT> ypB_{};
       std::vector<ScalarT> fB_{};
@@ -184,6 +150,18 @@ namespace GridKit
       //
 
     public:
+      virtual IdxT sizeQuadrature() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 0;
+      }
+
+      virtual IdxT sizeParams() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 0;
+      }
+
       std::vector<ScalarT>& yB() override
       {
         throw "ERROR: Method not implemented!\n";
@@ -304,7 +282,6 @@ namespace GridKit
         return gB_;
       }
 
-      //@todo Fix ID naming
       IdxT getComponentID() const
       {
         return component_id_;

--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <exception>
 #include <vector>
 
 #include <AutomaticDifferentiation/DependencyTracking/Variable.hpp>
@@ -29,20 +30,20 @@ namespace GridKit
 
       Component(IdxT size, IdxT size_quad, IdxT size_param)
         : size_(size),
-          size_quad_(size_quad),
-          size_param_(size_param),
+          // size_quad_(size_quad),
+          // size_param_(size_param),
           y_(size_),
           yp_(size_),
           f_(size_),
-          g_(size_quad_),
-          yB_(size_),
-          ypB_(size_),
-          fB_(size_),
-          gB_(size_param_),
-          J_(GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>()),
-          param_(size_param_),
-          param_up_(size_param_),
-          param_lo_(size_param_)
+          // g_(size_quad_),
+          // yB_(size_),
+          // ypB_(size_),
+          // fB_(size_),
+          // gB_(size_param_),
+          J_(GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>())
+          // param_(size_param_),
+          // param_up_(size_param_),
+          // param_lo_(size_param_)
       {
       }
 
@@ -120,56 +121,6 @@ namespace GridKit
         return tag_;
       }
 
-      std::vector<ScalarT>& yB() override
-      {
-        return yB_;
-      }
-
-      const std::vector<ScalarT>& yB() const override
-      {
-        return yB_;
-      }
-
-      std::vector<ScalarT>& ypB() override
-      {
-        return ypB_;
-      }
-
-      const std::vector<ScalarT>& ypB() const override
-      {
-        return ypB_;
-      }
-
-      std::vector<ScalarT>& param() override
-      {
-        return param_;
-      }
-
-      const std::vector<ScalarT>& param() const override
-      {
-        return param_;
-      }
-
-      std::vector<ScalarT>& param_up() override
-      {
-        return param_up_;
-      }
-
-      const std::vector<ScalarT>& param_up() const override
-      {
-        return param_up_;
-      }
-
-      std::vector<ScalarT>& param_lo() override
-      {
-        return param_lo_;
-      }
-
-      const std::vector<ScalarT>& param_lo() const override
-      {
-        return param_lo_;
-      }
-
       std::vector<ScalarT>& getResidual() override
       {
         return f_;
@@ -190,47 +141,9 @@ namespace GridKit
         return J_;
       }
 
-      std::vector<ScalarT>& getIntegrand() override
-      {
-        return g_;
-      }
-
-      const std::vector<ScalarT>& getIntegrand() const override
-      {
-        return g_;
-      }
-
-      std::vector<ScalarT>& getAdjointResidual() override
-      {
-        return fB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointResidual() const override
-      {
-        return fB_;
-      }
-
-      std::vector<ScalarT>& getAdjointIntegrand() override
-      {
-        return gB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointIntegrand() const override
-      {
-        return gB_;
-      }
-
-      //@todo Fix ID naming
-      IdxT getComponentID() const
-      {
-        return component_id_;
-      }
-
     protected:
       IdxT size_;
       IdxT nnz_;
-      IdxT size_quad_;
-      IdxT size_param_;
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;
@@ -238,16 +151,7 @@ namespace GridKit
       std::vector<ScalarT> f_;
       std::vector<ScalarT> g_;
 
-      std::vector<ScalarT> yB_;
-      std::vector<ScalarT> ypB_;
-      std::vector<ScalarT> fB_;
-      std::vector<ScalarT> gB_;
-
       GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> J_;
-
-      std::vector<ScalarT> param_;
-      std::vector<ScalarT> param_up_;
-      std::vector<ScalarT> param_lo_;
 
       real_type time_;
       real_type alpha_;
@@ -258,6 +162,153 @@ namespace GridKit
       IdxT max_steps_;
 
       IdxT component_id_;
+
+      //
+      // Adjoint sensitivity members
+      //
+
+      IdxT size_quad_;
+      IdxT size_param_;
+
+      std::vector<ScalarT> yB_{};
+      std::vector<ScalarT> ypB_{};
+      std::vector<ScalarT> fB_{};
+      std::vector<ScalarT> gB_{};
+
+      std::vector<ScalarT> param_{};
+      std::vector<ScalarT> param_up_{};
+      std::vector<ScalarT> param_lo_{};
+
+      //
+      // Public adjoint sensitivity methods (not yet implemented in components)
+      //
+
+    public:
+      std::vector<ScalarT>& yB() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return yB_;
+      }
+
+      const std::vector<ScalarT>& yB() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return yB_;
+      }
+
+      std::vector<ScalarT>& ypB() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return ypB_;
+      }
+
+      const std::vector<ScalarT>& ypB() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return ypB_;
+      }
+
+      std::vector<ScalarT>& param() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_;
+      }
+
+      const std::vector<ScalarT>& param() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_;
+      }
+
+      std::vector<ScalarT>& param_up() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_up_;
+      }
+
+      const std::vector<ScalarT>& param_up() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_up_;
+      }
+
+      std::vector<ScalarT>& param_lo() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_lo_;
+      }
+
+      const std::vector<ScalarT>& param_lo() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return param_lo_;
+      }
+
+      int evaluateIntegrand() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 1;
+      }
+
+      int initializeAdjoint() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 1;
+      }
+
+      int evaluateAdjointResidual() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 1;
+      }
+
+      int evaluateAdjointIntegrand() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return 1;
+      }
+
+      std::vector<ScalarT>& getIntegrand() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return g_;
+      }
+
+      const std::vector<ScalarT>& getIntegrand() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return g_;
+      }
+
+      std::vector<ScalarT>& getAdjointResidual() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return fB_;
+      }
+
+      const std::vector<ScalarT>& getAdjointResidual() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return fB_;
+      }
+
+      std::vector<ScalarT>& getAdjointIntegrand() override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return gB_;
+      }
+
+      const std::vector<ScalarT>& getAdjointIntegrand() const override
+      {
+        throw "ERROR: Method not implemented!\n";
+        return gB_;
+      }
+
+      //@todo Fix ID naming
+      IdxT getComponentID() const
+      {
+        return component_id_;
+      }
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.cpp
@@ -73,9 +73,6 @@ namespace GridKit
         y_.resize(size);
         yp_.resize(size);
         tag_.resize(size);
-        fB_.resize(size);
-        yB_.resize(size);
-        ypB_.resize(size);
         return 0;
       }
 
@@ -207,62 +204,6 @@ namespace GridKit
       int Tgov1<ScalarT, IdxT>::evaluateJacobian()
       {
         std::cout << "Jacobian evaluation not implemented!" << std::endl;
-        return 0;
-      }
-
-      /**
-       * @brief Integrand (objective) evaluation not implemented yet
-       *
-       * @tparam ScalarT - scalar data type
-       * @tparam IdxT    - matrix index data type
-       * @return int - error code, 0 = success
-       */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::evaluateIntegrand()
-      {
-        std::cout << "Evaluate Integrand for Tgov1..." << std::endl;
-        return 0;
-      }
-
-      /**
-       * @brief Adjoint initialization not implemented yet
-       *
-       * @tparam ScalarT - scalar data type
-       * @tparam IdxT    - matrix index data type
-       * @return int - error code, 0 = success
-       */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::initializeAdjoint()
-      {
-        std::cout << "Initialize adjoint for Tgov1..." << std::endl;
-        return 0;
-      }
-
-      /**
-       * @brief Adjoint residual evaluation not implemented yet
-       *
-       * @tparam ScalarT - scalar data type
-       * @tparam IdxT    - matrix index data type
-       * @return int     - error code, 0 = success
-       */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::evaluateAdjointResidual()
-      {
-        std::cout << "Evaluate adjoint residual for Tgov1..." << std::endl;
-        return 0;
-      }
-
-      /**
-       * @brief Adjoint integrand (objective) evaluation not implemented yet
-       *
-       * @tparam ScalarT - scalar data type
-       * @tparam IdxT    - matrix index data type
-       * @return int - error code, 0 = success
-       */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::evaluateAdjointIntegrand()
-      {
-        std::cout << "Evaluate adjoint Integrand for Tgov1..." << std::endl;
         return 0;
       }
 

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -40,19 +40,12 @@ namespace GridKit
       {
         using Component<ScalarT, IdxT>::alpha_;
         using Component<ScalarT, IdxT>::f_;
-        using Component<ScalarT, IdxT>::fB_;
-        using Component<ScalarT, IdxT>::g_;
-        using Component<ScalarT, IdxT>::gB_;
         using Component<ScalarT, IdxT>::nnz_;
-        using Component<ScalarT, IdxT>::param_;
         using Component<ScalarT, IdxT>::size_;
-        using Component<ScalarT, IdxT>::size_param_;
         using Component<ScalarT, IdxT>::tag_;
         using Component<ScalarT, IdxT>::time_;
         using Component<ScalarT, IdxT>::y_;
-        using Component<ScalarT, IdxT>::yB_;
         using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::ypB_;
 
         using machine_type    = Genrou<ScalarT, IdxT>;
         using real_type       = typename Component<ScalarT, IdxT>::real_type;
@@ -70,10 +63,6 @@ namespace GridKit
 
         // Still to be implemented
         int evaluateJacobian() override;
-        int evaluateIntegrand() override;
-        int initializeAdjoint() override;
-        int evaluateAdjointResidual() override;
-        int evaluateAdjointIntegrand() override;
 
         void updateTime(real_type /* t */, real_type /* a */) override
         {

--- a/src/Model/PhasorDynamics/Load/Load.hpp
+++ b/src/Model/PhasorDynamics/Load/Load.hpp
@@ -55,12 +55,6 @@ namespace GridKit
       virtual int tagDifferentiable() override;
       virtual int evaluateResidual() override;
       virtual int evaluateJacobian() override;
-      virtual int evaluateIntegrand() override;
-
-      virtual int initializeAdjoint() override;
-      virtual int evaluateAdjointResidual() override;
-      // virtual int evaluateAdjointJacobian() override;
-      virtual int evaluateAdjointIntegrand() override;
 
       virtual void updateTime(real_type /* t */, real_type /* a */) override
       {

--- a/src/Model/PhasorDynamics/Load/LoadImpl.hpp
+++ b/src/Model/PhasorDynamics/Load/LoadImpl.hpp
@@ -13,11 +13,9 @@ namespace GridKit
     /*!
      * @brief Constructor for a pi-model load
      *
-     * Arguments passed to ModelEvaluatorImpl:
+     * System sizes:
      * - Number of equations = 0
      * - Number of independent variables = 0
-     * - Number of quadratures = 0
-     * - Number of optimization parameters = 0
      */
 
     template <class ScalarT, typename IdxT>
@@ -120,62 +118,6 @@ namespace GridKit
       Ir() += f[0];
       Ii() += f[1];
 
-      return 0;
-    }
-
-    /**
-     * @brief Integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::evaluateIntegrand()
-    {
-      // std::cout << "Evaluate Integrand for Load..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint initialization not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::initializeAdjoint()
-    {
-      // std::cout << "Initialize adjoint for Load..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint residual evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::evaluateAdjointResidual()
-    {
-      // std::cout << "Evaluate adjoint residual for Load..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::evaluateAdjointIntegrand()
-    {
-      // std::cout << "Evaluate adjoint Integrand for Load..." << std::endl;
       return 0;
     }
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
@@ -172,9 +172,6 @@ namespace GridKit
       y_.resize(static_cast<size_t>(size_));
       yp_.resize(static_cast<size_t>(size_));
       tag_.resize(static_cast<size_t>(size_));
-      fB_.resize(static_cast<size_t>(size_));
-      yB_.resize(static_cast<size_t>(size_));
-      ypB_.resize(static_cast<size_t>(size_));
       return 0;
     }
 
@@ -357,62 +354,6 @@ namespace GridKit
     {
       std::cout << "Evaluate Jacobian for Genrou..." << std::endl;
       std::cout << "Jacobian evaluation not implemented!" << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::evaluateIntegrand()
-    {
-      // std::cout << "Evaluate Integrand for Genrou..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint initialization not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::initializeAdjoint()
-    {
-      // std::cout << "Initialize adjoint for Genrou..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint residual evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::evaluateAdjointResidual()
-    {
-      // std::cout << "Evaluate adjoint residual for Genrou..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::evaluateAdjointIntegrand()
-    {
-      // std::cout << "Evaluate adjoint Integrand for Genrou..." << std::endl;
       return 0;
     }
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -36,18 +36,12 @@ namespace GridKit
     {
       using Component<ScalarT, IdxT>::alpha_;
       using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::fB_;
-      using Component<ScalarT, IdxT>::g_;
-      using Component<ScalarT, IdxT>::gB_;
       using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::param_;
       using Component<ScalarT, IdxT>::size_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::time_;
       using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yB_;
       using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::ypB_;
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;
       using gov_type        = GovernorBase<ScalarT, IdxT>;
@@ -86,10 +80,6 @@ namespace GridKit
 
       // Still to be implemented
       int evaluateJacobian() override;
-      int evaluateIntegrand() override;
-      int initializeAdjoint() override;
-      int evaluateAdjointResidual() override;
-      int evaluateAdjointIntegrand() override;
 
       void updateTime(real_type /* t */, real_type /* a */) override
       {

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
@@ -80,9 +80,6 @@ namespace GridKit
       y_.resize(size);
       yp_.resize(size);
       tag_.resize(size);
-      fB_.resize(size);
-      yB_.resize(size);
-      ypB_.resize(size);
       return 0;
     }
 
@@ -181,62 +178,6 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int GenClassical<ScalarT, IdxT>::evaluateJacobian()
     {
-      return 0;
-    }
-
-    /**
-     * @brief Integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::evaluateIntegrand()
-    {
-      // std::cout << "Evaluate Integrand for GenClassical..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint initialization not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::initializeAdjoint()
-    {
-      // std::cout << "Initialize adjoint for GenClassical..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint residual evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::evaluateAdjointResidual()
-    {
-      // std::cout << "Evaluate adjoint residual for GenClassical..." << std::endl;
-      return 0;
-    }
-
-    /**
-     * @brief Adjoint integrand (objective) evaluation not implemented yet
-     *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
-     */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::evaluateAdjointIntegrand()
-    {
-      // std::cout << "Evaluate adjoint Integrand for GenClassical..." << std::endl;
       return 0;
     }
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -28,18 +28,12 @@ namespace GridKit
     {
       using Component<ScalarT, IdxT>::alpha_;
       using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::fB_;
-      using Component<ScalarT, IdxT>::g_;
-      using Component<ScalarT, IdxT>::gB_;
       using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::param_;
       using Component<ScalarT, IdxT>::size_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::time_;
       using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yB_;
       using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::ypB_;
 
       using bus_type  = BusBase<ScalarT, IdxT>;
       using real_type = typename Component<ScalarT, IdxT>::real_type;
@@ -63,10 +57,6 @@ namespace GridKit
 
       // Still to be implemented
       int evaluateJacobian() override;
-      int evaluateIntegrand() override;
-      int initializeAdjoint() override;
-      int evaluateAdjointResidual() override;
-      int evaluateAdjointIntegrand() override;
 
       void updateTime(real_type /* t */, real_type /* a */) override
       {

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -146,9 +146,7 @@ namespace GridKit
        * and computes system size (number of unknowns). Once the size is
        * computed, system global objects are allocated.
        *
-       * @post size_quad_ == 0 or 1
        * @post size_ >= 1
-       * @post size_param_ >= 0
        *
        */
       int allocate()
@@ -173,7 +171,6 @@ namespace GridKit
         y_.resize(size_);
         yp_.resize(size_);
         f_.resize(size_);
-        // fB_.resize(size_);
         tag_.resize(size_);
 
         return 0;
@@ -286,11 +283,11 @@ namespace GridKit
        * then copy values to the global residual vector.
        *
        * @warning Residuals must be computed for buses, before component
-       * residuals are computed. Buses own residuals for active and
-       * power P and Q, but the contributions to these residuals come
+       * residuals are computed. Buses own residuals for currents
+       * Ir and Ii, but the contributions to these residuals come
        * from components. Buses assign their residual values, while components
-       * add to those values by in-place adition. This is why bus residuals
-       * need to be computed first.
+       * add to those values by in-place adition. This is why (for now) bus
+       * residuals need to be computed first.
        *
        * @todo Here, components write to local values, which are then copied
        * to global system vectors. Make components write to the system

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -153,20 +153,20 @@ namespace GridKit
        */
       int allocate()
       {
-        size_       = 0;
+        size_ = 0;
 
         // Allocate all buses
         for (const auto& bus : buses_)
         {
           bus->allocate();
-          size_       += bus->size();
+          size_ += bus->size();
         }
 
         // Allocate all components
         for (const auto& component : components_)
         {
           component->allocate();
-          size_       += component->size();
+          size_ += component->size();
         }
 
         // Allocate global vectors
@@ -359,7 +359,6 @@ namespace GridKit
       {
         return 0;
       }
-
 
       void updateTime(real_type t, real_type a)
       {

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -39,25 +39,15 @@ namespace GridKit
       using real_type      = typename Model::Evaluator<ScalarT, IdxT>::real_type;
 
       using PhasorDynamics::Component<ScalarT, IdxT>::size_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::size_quad_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::size_param_;
       using PhasorDynamics::Component<ScalarT, IdxT>::nnz_;
       using PhasorDynamics::Component<ScalarT, IdxT>::time_;
       using PhasorDynamics::Component<ScalarT, IdxT>::alpha_;
       using PhasorDynamics::Component<ScalarT, IdxT>::y_;
       using PhasorDynamics::Component<ScalarT, IdxT>::yp_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::yB_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::ypB_;
       using PhasorDynamics::Component<ScalarT, IdxT>::tag_;
       using PhasorDynamics::Component<ScalarT, IdxT>::f_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::fB_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::g_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::gB_;
       using PhasorDynamics::Component<ScalarT, IdxT>::rel_tol_;
       using PhasorDynamics::Component<ScalarT, IdxT>::abs_tol_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::param_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::param_up_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::param_lo_;
 
     public:
       /**
@@ -164,16 +154,12 @@ namespace GridKit
       int allocate()
       {
         size_       = 0;
-        size_quad_  = 0;
-        size_param_ = 0;
 
         // Allocate all buses
         for (const auto& bus : buses_)
         {
           bus->allocate();
           size_       += bus->size();
-          size_quad_  += bus->sizeQuadrature();
-          size_param_ += bus->sizeParams();
         }
 
         // Allocate all components
@@ -181,27 +167,14 @@ namespace GridKit
         {
           component->allocate();
           size_       += component->size();
-          size_quad_  += component->sizeQuadrature();
-          size_param_ += component->sizeParams();
         }
 
         // Allocate global vectors
         y_.resize(size_);
         yp_.resize(size_);
-        yB_.resize(size_);
-        ypB_.resize(size_);
         f_.resize(size_);
-        fB_.resize(size_);
+        // fB_.resize(size_);
         tag_.resize(size_);
-
-        g_.resize(size_quad_);
-        gB_.resize(size_quad_ * size_param_);
-
-        param_.resize(size_param_);
-        param_lo_.resize(size_param_);
-        param_up_.resize(size_param_);
-
-        assert(size_quad_ == 1 or size_quad_ == 0);
 
         return 0;
       }
@@ -236,7 +209,6 @@ namespace GridKit
       {
         // Set initial values for global solution vectors
         IdxT varOffset = 0;
-        IdxT optOffset = 0;
 
         for (const auto& bus : buses_)
         {
@@ -251,14 +223,6 @@ namespace GridKit
             yp_[varOffset + j] = bus->yp()[j];
           }
           varOffset += bus->size();
-
-          for (IdxT j = 0; j < bus->sizeParams(); ++j)
-          {
-            param_[optOffset + j]    = bus->param()[j];
-            param_lo_[optOffset + j] = bus->param_lo()[j];
-            param_up_[optOffset + j] = bus->param_up()[j];
-          }
-          optOffset += bus->sizeParams();
         }
 
         // Initialize components
@@ -275,14 +239,6 @@ namespace GridKit
             yp_[varOffset + j] = component->yp()[j];
           }
           varOffset += component->size();
-
-          for (IdxT j = 0; j < component->sizeParams(); ++j)
-          {
-            param_[optOffset + j]    = component->param()[j];
-            param_lo_[optOffset + j] = component->param_lo()[j];
-            param_up_[optOffset + j] = component->param_up()[j];
-          }
-          optOffset += component->sizeParams();
         }
 
         return 0;
@@ -344,7 +300,6 @@ namespace GridKit
       {
         // Update variables
         IdxT varOffset = 0;
-        IdxT optOffset = 0;
         for (const auto& bus : buses_)
         {
           for (IdxT j = 0; j < bus->size(); ++j)
@@ -353,12 +308,6 @@ namespace GridKit
             bus->yp()[j] = yp_[varOffset + j];
           }
           varOffset += bus->size();
-
-          for (IdxT j = 0; j < bus->sizeParams(); ++j)
-          {
-            bus->param()[j] = param_[optOffset + j];
-          }
-          optOffset += bus->sizeParams();
 
           bus->evaluateResidual();
         }
@@ -371,12 +320,6 @@ namespace GridKit
             component->yp()[j] = yp_[varOffset + j];
           }
           varOffset += component->size();
-
-          for (IdxT j = 0; j < component->sizeParams(); ++j)
-          {
-            component->param()[j] = param_[optOffset + j];
-          }
-          optOffset += component->sizeParams();
 
           component->evaluateResidual();
         }
@@ -417,297 +360,6 @@ namespace GridKit
         return 0;
       }
 
-      /**
-       * @brief Evaluate integrands for the system quadratures.
-       */
-      int evaluateIntegrand()
-      {
-        // Update variables
-        IdxT varOffset = 0;
-        IdxT optOffset = 0;
-        for (const auto& bus : buses_)
-        {
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            bus->y()[j]  = y_[varOffset + j];
-            bus->yp()[j] = yp_[varOffset + j];
-          }
-          varOffset += bus->size();
-
-          for (IdxT j = 0; j < bus->sizeParams(); ++j)
-          {
-            bus->param()[j] = param_[optOffset + j];
-          }
-          optOffset += bus->sizeParams();
-
-          bus->evaluateIntegrand();
-        }
-
-        for (const auto& component : components_)
-        {
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            component->y()[j]  = y_[varOffset + j];
-            component->yp()[j] = yp_[varOffset + j];
-          }
-          varOffset += component->size();
-
-          for (IdxT j = 0; j < component->sizeParams(); ++j)
-          {
-            component->param()[j] = param_[optOffset + j];
-          }
-          optOffset += component->sizeParams();
-
-          component->evaluateIntegrand();
-        }
-
-        // Update integrand vector
-        IdxT intOffset = 0;
-        for (const auto& bus : buses_)
-        {
-          for (IdxT j = 0; j < bus->sizeQuadrature(); ++j)
-          {
-            g_[intOffset + j] = bus->getIntegrand()[j];
-          }
-          intOffset += bus->sizeQuadrature();
-        }
-
-        for (const auto& component : components_)
-        {
-          for (IdxT j = 0; j < component->sizeQuadrature(); ++j)
-          {
-            g_[intOffset + j] = component->getIntegrand()[j];
-          }
-          intOffset += component->sizeQuadrature();
-        }
-
-        return 0;
-      }
-
-      /**
-       * @brief Initialize system adjoint.
-       *
-       * Updates variables and optimization parameters, then initializes
-       * adjoints locally and copies them to the system adjoint vector.
-       */
-      int initializeAdjoint()
-      {
-        IdxT offset    = 0;
-        IdxT optOffset = 0;
-
-        // Update bus variables and optimization parameters
-        for (const auto& bus : buses_)
-        {
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            bus->y()[j]  = y_[offset + j];
-            bus->yp()[j] = yp_[offset + j];
-          }
-          offset += bus->size();
-
-          for (IdxT j = 0; j < bus->sizeParams(); ++j)
-          {
-            bus->param()[j] = param_[optOffset + j];
-          }
-          optOffset += bus->sizeParams();
-        }
-
-        // Update component variables and optimization parameters
-        for (const auto& component : components_)
-        {
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            component->y()[j]  = y_[offset + j];
-            component->yp()[j] = yp_[offset + j];
-          }
-          offset += component->size();
-
-          for (IdxT j = 0; j < component->sizeParams(); ++j)
-          {
-            component->param()[j] = param_[optOffset + j];
-          }
-          optOffset += component->sizeParams();
-        }
-
-        // Reset counter
-        offset = 0;
-
-        // Initialize bus adjoints
-        for (const auto& bus : buses_)
-        {
-          bus->initializeAdjoint();
-
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            yB_[offset + j]  = bus->yB()[j];
-            ypB_[offset + j] = bus->ypB()[j];
-          }
-          offset += bus->size();
-        }
-
-        // Initialize component adjoints
-        for (const auto& component : components_)
-        {
-          component->initializeAdjoint();
-
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            yB_[offset + j]  = component->yB()[j];
-            ypB_[offset + j] = component->ypB()[j];
-          }
-          offset += component->size();
-        }
-
-        return 0;
-      }
-
-      /**
-       * @brief Compute adjoint residual for the system model.
-       *
-       * @warning Components write to bus residuals. Do not copy bus residuals
-       * to system vectors before components computed their residuals.
-       *
-       */
-      int evaluateAdjointResidual()
-      {
-        IdxT varOffset = 0;
-        IdxT optOffset = 0;
-
-        // Update variables in component models
-        for (const auto& bus : buses_)
-        {
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            bus->y()[j]   = y_[varOffset + j];
-            bus->yp()[j]  = yp_[varOffset + j];
-            bus->yB()[j]  = yB_[varOffset + j];
-            bus->ypB()[j] = ypB_[varOffset + j];
-          }
-          varOffset += bus->size();
-
-          for (IdxT j = 0; j < bus->sizeParams(); ++j)
-          {
-            bus->param()[j] = param_[optOffset + j];
-          }
-          optOffset += bus->sizeParams();
-        }
-
-        for (const auto& component : components_)
-        {
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            component->y()[j]   = y_[varOffset + j];
-            component->yp()[j]  = yp_[varOffset + j];
-            component->yB()[j]  = yB_[varOffset + j];
-            component->ypB()[j] = ypB_[varOffset + j];
-          }
-          varOffset += component->size();
-
-          for (IdxT j = 0; j < component->sizeParams(); ++j)
-          {
-            component->param()[j] = param_[optOffset + j];
-          }
-          optOffset += component->sizeParams();
-        }
-
-        for (const auto& bus : buses_)
-        {
-          bus->evaluateAdjointResidual();
-        }
-
-        for (const auto& component : components_)
-        {
-          component->evaluateAdjointResidual();
-        }
-
-        // Update residual vector
-        IdxT resOffset = 0;
-        for (const auto& bus : buses_)
-        {
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            fB_[resOffset + j] = bus->getAdjointResidual()[j];
-          }
-          resOffset += bus->size();
-        }
-
-        for (const auto& component : components_)
-        {
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            fB_[resOffset + j] = component->getAdjointResidual()[j];
-          }
-          resOffset += component->size();
-        }
-
-        return 0;
-      }
-
-      // int evaluateAdjointJacobian(){return 0;}
-
-      /**
-       * @brief Evaluate adjoint integrand for the system model.
-       *
-       * @pre Assumes there are no integrands in bus models.
-       * @pre Assumes integrand is implemented in only _one_ component.
-       *
-       */
-      int evaluateAdjointIntegrand()
-      {
-        // First, update variables
-        IdxT varOffset = 0;
-        IdxT optOffset = 0;
-        for (const auto& bus : buses_)
-        {
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            bus->y()[j]   = y_[varOffset + j];
-            bus->yp()[j]  = yp_[varOffset + j];
-            bus->yB()[j]  = yB_[varOffset + j];
-            bus->ypB()[j] = ypB_[varOffset + j];
-          }
-          varOffset += bus->size();
-
-          for (IdxT j = 0; j < bus->sizeParams(); ++j)
-          {
-            bus->param()[j] = param_[optOffset + j];
-          }
-          optOffset += bus->sizeParams();
-        }
-
-        for (const auto& component : components_)
-        {
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            component->y()[j]   = y_[varOffset + j];
-            component->yp()[j]  = yp_[varOffset + j];
-            component->yB()[j]  = yB_[varOffset + j];
-            component->ypB()[j] = ypB_[varOffset + j];
-          }
-          varOffset += component->size();
-
-          for (IdxT j = 0; j < component->sizeParams(); ++j)
-          {
-            component->param()[j] = param_[optOffset + j];
-          }
-          optOffset += component->sizeParams();
-        }
-
-        // Evaluate integrand and update global vector
-        for (const auto& component : components_)
-        {
-          if (component->sizeQuadrature() == 1)
-          {
-            component->evaluateAdjointIntegrand();
-            for (IdxT j = 0; j < size_param_; ++j)
-            {
-              gB_[j] = component->getAdjointIntegrand()[j];
-            }
-            break;
-          }
-        }
-        return 0;
-      }
 
       void updateTime(real_type t, real_type a)
       {


### PR DESCRIPTION
## Description
 
This PR removes all adjoint sensitivity methods from phasor dynamics component models. Placeholders were left only in `Component` and `BusBase` classes. 
 
 ## Proposed changes
 
Adjoint sensitivity analysis methods have not been implemented and what was in the code were just placeholders. Since there is no plan in the near future to implement these methods, we remove the placeholders for now.

In short, this removes dead code from phasor dynamics models.
 
 ## Checklist
 
 
- [ ] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- N/A The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
