### PR TITLE
Fix for Definitions.hpp inclusion

### DIFF
--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <limits>
 
+#include <Definitions.hpp>
 #include <AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>

--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -10,8 +10,8 @@
 #include <iostream>
 #include <limits>
 
-#include <Definitions.hpp>
 #include <AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+#include <Definitions.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp>

--- a/tests/UnitTests/PhasorDynamics/LoadTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/LoadTests.hpp
@@ -3,8 +3,8 @@
 #include <iomanip>
 #include <iostream>
 
-#include <Definitions.hpp>
 #include <AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+#include <Definitions.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <Model/PhasorDynamics/Load/Load.hpp>

--- a/tests/UnitTests/PhasorDynamics/LoadTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/LoadTests.hpp
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <iostream>
 
+#include <Definitions.hpp>
 #include <AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>


### PR DESCRIPTION
## Description

This fixes a simple bug that resulted in the `Load` and `GenClassical` Jacobian unit tests to be skipped. `GRIDKIT_ENABLE_ENZYME` was defined in a global scope before the introduction of `Definitions.hpp` in #186.
 
 ## Proposed changes
 
Include `Definitions.hpp` in `GenClassicalTests` and `LoadTests` to get the GRIDKIT_ENABLE_ENZYME definition.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
