### PR TITLE
Input Format README Updates

### DIFF
--- a/src/Model/PhasorDynamics/Exciter/IEEET1/README.md
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/README.md
@@ -93,7 +93,7 @@ $k_{sat}$       | [p.u.] | Saturation variable               |
 #### Differential
 Symbol          | Units  | Description                       | Note
 ----------------|--------|-----------------------------------|-------
-$\Delta\omega$  | [p.u.] | Speed Deviation                   | Read from a Machine Model
+$\omega$  | [p.u.] | Speed Deviation                   | Read from a Machine Model
 
 #### Algebraic
 
@@ -219,7 +219,7 @@ The algebraic equations of the exciter.
     V_{f} &= \dfrac{E_{fd}' K_F}{T_F} - V_{fx}\\
     V_{E} &= k_{sat}\cdot E_{fd}' \\
     E_{fd}&= \begin{cases}
-        (1+\Delta \omega)E_{fd}'           &  \text{if } I_{spdlm}=1\\
+        (1+\omega)E_{fd}'           &  \text{if } I_{spdlm}=1\\
          E_{fd}' &  \text{else} \\
    \end{cases}\\
     k_{sat}&= \begin{cases}

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/README.md
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/README.md
@@ -93,7 +93,7 @@ $k_{sat}$       | [p.u.] | Saturation variable               |
 #### Differential
 Symbol          | Units  | Description                       | Note
 ----------------|--------|-----------------------------------|-------
-$\omega$  | [p.u.] | Speed Deviation                   | Read from a Machine Model
+$\omega$  | [p.u.] | Machine Speed Deviation                   | Read from a Machine Model
 
 #### Algebraic
 

--- a/src/Model/PhasorDynamics/Governor/README.md
+++ b/src/Model/PhasorDynamics/Governor/README.md
@@ -8,4 +8,4 @@ A governor models the control system that regulates the output power of a machin
 
 There are a few standard Governor models
 
-- Turbine Governor (See [TGOV1](GovernorTgov1/README.md))
+- Turbine Governor (See [TGOV1](Tgov1/README.md))

--- a/src/Model/PhasorDynamics/Governor/Tgov1/README.md
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/README.md
@@ -43,7 +43,7 @@ $P_{m}$         | [p.u.] | Mechnical Power to Generator      | Read by a Machine
 #### Differential
 Symbol          | Units  | Description                       | Note
 ----------------|--------|-----------------------------------|-------
-$\omega$  | [p.u.] | Speed Deviation                   | Read from a Machine Model
+$\omega$  | [p.u.] | Machine Speed Deviation                   | Read from a Machine Model
 
 #### Algebraic
 Symbol          | Units  | Description                       | Note

--- a/src/Model/PhasorDynamics/Governor/Tgov1/README.md
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/README.md
@@ -43,7 +43,7 @@ $P_{m}$         | [p.u.] | Mechnical Power to Generator      | Read by a Machine
 #### Differential
 Symbol          | Units  | Description                       | Note
 ----------------|--------|-----------------------------------|-------
-$\Delta\omega$  | [p.u.] | Speed Deviation                   | Read from a Machine Model
+$\omega$  | [p.u.] | Speed Deviation                   | Read from a Machine Model
 
 #### Algebraic
 Symbol          | Units  | Description                       | Note
@@ -53,13 +53,13 @@ $P_{ref}$       | [p.u.] | Reference Power                   | Either a constant
 ## Model Equations
 
 ### Differential Equations
-The TGOV1 differential equations, as derived from the model diagram. By defining an auxillary valve function $f=-P_{v} + (P_{ref}-\Delta\omega)/R$ one can write the piecewise definition of $\dot P_v$ compactly.
+The TGOV1 differential equations, as derived from the model diagram. By defining an auxillary valve function $f=-P_{v} + (P_{ref}-\omega)/R$ one can write the piecewise definition of $\dot P_v$ compactly.
 ```math
 \begin{aligned}
    \dot{P}_{tx}   &= P_v - \dfrac{1}{T_3}(P_{tx}+T_2P_v) \\
    \dot{P}_{v}    &= \dfrac{1}{T_1}
    \begin{cases}
-      -P_{v} + \dfrac{1}{R}(P_{ref}-\Delta\omega)
+      -P_{v} + \dfrac{1}{R}(P_{ref}-\omega)
          &  \text{if } (P_{vmin} < P_v < P_{vmax}) & \lor \\
          &  \quad (P_v \leq P_{vmin} \land f>0)    & \lor \\
          &  \quad(P_v \geq P_{vmax} \land f<0)            \\
@@ -73,7 +73,7 @@ The TGOV1 differential equations, as derived from the model diagram. By defining
 The algebraic equation dictating the mechnical power output.
 ```math
 \begin{aligned}
-   P_{m} &= \dfrac{1}{T_3}(P_{tx}+T_2P_v) - D_t \Delta\omega \\
+   P_{m} &= \dfrac{1}{T_3}(P_{tx}+T_2P_v) - D_t \omega \\
 \end{aligned}
 ```
 
@@ -85,7 +85,7 @@ smooth approximation (smooth indicator $\phi$) expressed generically as follows.
 \begin{aligned}
    f(P_v)      &= \dfrac{1}{T_1}
       \left[
-         -P_{v} + \dfrac{1}{R}(P_{ref}-\Delta\omega)
+         -P_{v} + \dfrac{1}{R}(P_{ref}-\omega)
       \right] \\
    \dot{P}_{v} &= 
             \phi(P_v, f) \cdot f(P_v)

--- a/src/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/src/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -82,8 +82,6 @@ specified:
   `bus`              | Positive-sequence, AC phasor domain bus                    | `Vr`, `Vi`               | `Vm`, `Va`
   `infinite_bus`     | Positive-sequence, AC phasor domain bus with fixed voltage | `Vr`, `Vi`               | `Vm`, `Va`
   `emt_bus`          | 3-phase bus with instantaneous voltages                    | `Va`, `Vb`, `Vc`         |
-  `infinite_emt_bus` | 3-phase bus with instantaneous voltages                    | `Va`, `Vb`, `Vc`         |
-  `control`          | A single control signal                                    | `x`                      |
 
 For fields named `Vr` or `Va`, the default value is `1.0`, otherwise it is
 `0.0`. This list is subject to change.
@@ -111,13 +109,13 @@ are specified:
 
   Device class  | Description                                          | Ports                            | Initialization parameters   | Variables available to monitor
   --------------|------------------------------------------------------|----------------------------------|---------------------------- | -------------------------
-  `branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`          | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
-  `static_load` | a basic static ZIP load                              | `bus`                            | `Pz`, `Qz`, `Pi`, `Qi`, `Pp`, `Qp` | `ir`, `ii`, `p`, `q`
+  `Branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`          | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
+  `Load`        | a basic static impedence load model                  | `bus`                            | `R`, `X` | `p`, `q`
   `Genrou`      | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`
   `GenClassical`| the classical machine model                          | `bus`, `pmech`\*, `speed`\*, `efd`\*  | `p0`, `q0`, `H`, `D`, `Ra`, `Xdp` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
   `Tgov1 `      | the TGOV1 governor model                             | `pmech`, `speed`                 | `R`, `T1`, `T2`, `T3`, `Pvmax`, `Pvmin`, `Dt` | `none`
   `Ieeet1`      | the IEEET1 exciter model                             | `bus`, `speed`, `efd`            | `Tr`, `Ka`, `Ta`, `Ke`, `Te`, `Kf`, `Tf`, `Vrmin`, `Vrmax`, `E1`, `E2`, `Se1`, `Se2`, `Ispdlm` | `efd`, `ksat`
-  `bus_fault`   | simple impedance-based fault at a bus                | `bus`, `status`\*                | `state0`, `R`, `X` | `state`, `ir`, `ii`
+  `BusFault`   | simple impedance-based fault at a bus                | `bus`, `status`\*                | `state0`, `R`, `X` | `state`, `ir`, `ii`
 
 Ports marked with \* are optional and, if missing, will be assumed to be
 connected to a constant value. This list is subject to change.
@@ -132,7 +130,6 @@ a signal and has the following fields:
   -------------------|------------------------------------------------------
   `signal_id`        | Unique positive (> 0) integer identifying the signal
   `name`             | Optional string containing the name or description of the signal. This may be empty or non-unique
-  `extension`        | Optional field containing an object with implementation-defined keys
 
 All interactions with signals are handled by `devices`, which reference signals via `signal_id`
 
@@ -155,12 +152,11 @@ All interactions with signals are handled by `devices`, which reference signals 
        { "number": 2, "class": "infinite_bus", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "v_base": 115e3 }
    ],
    "devices": [
-       { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
-       { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
-              "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
-       { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "1", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0, "Pvmin":1, "Dt":0}},
-       { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "1", "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1, "Vrmax":1, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlm":0}, "mon": ["efd"] },
-       { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
+       { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
+       { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
+       { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0, "Pvmin":1, "Dt":0}},
+       { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "DV3", "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1, "Vrmax":1, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlm":0}},
+       { "class": "BusFault", "ports": {"bus":1}, "id": "EVT1", "params": {"state0": false, "R":0.0, "X":1e-3} }
    ],
    "signals": [
        { "signal_id": 1, "name": "Machine Speed Deviation"},

--- a/src/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/src/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -88,6 +88,32 @@ specified:
 For fields named `Vr` or `Va`, the default value is `1.0`, otherwise it is
 `0.0`. This list is subject to change.
 
+### Signals
+
+Contained in the `signals` key is an array of objects, each of which represent
+a signal and has the following fields:
+
+  Name               | Description
+  -------------------|------------------------------------------------------
+  `number`           | Unique positive (> 0) integer identifying the node
+  `class`            | A string indicating the class of node. See the table below for more information
+  `name`             | Optional string containing the name of the node. This may be empty or non-unique
+  `init`             | Optional object mapping string variable names to floating point values, specifying default voltages or signal values. The available initialization variables are dependent upon the node class. Any variables missing will be given default values, which are specified beneath the table below. If this object is missing, all variables will be given default values. See the table below for more information
+  `extension`        | Optional field containing an object with implementation-defined keys
+
+#### Signal classes
+
+As of the current version and revision, the following bus classes are
+specified:
+
+  Signal class          | Description                                                | Initialization variables | Other variables available to monitor
+  -------------------|------------------------------------------------------------|------------------------- | -------------------------
+  `signal_node`              | A single channel value for intra model variables                    | `Vr`, `Vi`               | `Vm`, `Va`
+
+
+For fields named `Vr` or `Va`, the default value is `1.0`, otherwise it is
+`0.0`. This list is subject to change.
+
 ### Devices
 
 Contained in the `devices` section is an array of objects, each of which
@@ -114,7 +140,7 @@ are specified:
   `branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                                 | `R`, `X`, `G`, `B` | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
   `static_load` | a basic static ZIP load                              | `bus`                                          | `Pz`, `Qz`, `Pi`, `Qi`, `Pp`, `Qp` | `ir`, `ii`, `p`, `q`
   `GENROU`      | 6th order machine model                              | `bus`, `signal_in`\*, `signal_out`\*           | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
-  `IEEET1`      | a basic exciter model                                | `bus`, `speed_signal`, `efd_signal`            | `Efd` | `Efd`, `ksat`
+  `IEEET1`      | a basic exciter model                                | `bus`, `speed`, `efd`            | `Efd` | `Efd`, `ksat`
   `bus_fault`   | simple impedance-based fault at a bus                | `bus`, `signal_in`\*                           | `state0`, `R`, `X` | `state`, `ir`, `ii`
 
 Ports marked with \* are optional and, if missing, will be assumed to be

--- a/src/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/src/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -88,32 +88,6 @@ specified:
 For fields named `Vr` or `Va`, the default value is `1.0`, otherwise it is
 `0.0`. This list is subject to change.
 
-### Signals
-
-Contained in the `signals` key is an array of objects, each of which represent
-a signal and has the following fields:
-
-  Name               | Description
-  -------------------|------------------------------------------------------
-  `number`           | Unique positive (> 0) integer identifying the node
-  `class`            | A string indicating the class of node. See the table below for more information
-  `name`             | Optional string containing the name of the node. This may be empty or non-unique
-  `init`             | Optional object mapping string variable names to floating point values, specifying default voltages or signal values. The available initialization variables are dependent upon the node class. Any variables missing will be given default values, which are specified beneath the table below. If this object is missing, all variables will be given default values. See the table below for more information
-  `extension`        | Optional field containing an object with implementation-defined keys
-
-#### Signal classes
-
-As of the current version and revision, the following bus classes are
-specified:
-
-  Signal class          | Description                                                | Initialization variables | Other variables available to monitor
-  -------------------|------------------------------------------------------------|------------------------- | -------------------------
-  `signal_node`              | A single channel value for intra model variables                    | `Vr`, `Vi`               | `Vm`, `Va`
-
-
-For fields named `Vr` or `Va`, the default value is `1.0`, otherwise it is
-`0.0`. This list is subject to change.
-
 ### Devices
 
 Contained in the `devices` section is an array of objects, each of which
@@ -139,12 +113,25 @@ are specified:
   --------------|------------------------------------------------------|------------------------------------------------|---------------------------- | -------------------------
   `branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                                 | `R`, `X`, `G`, `B` | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
   `static_load` | a basic static ZIP load                              | `bus`                                          | `Pz`, `Qz`, `Pi`, `Qi`, `Pp`, `Qp` | `ir`, `ii`, `p`, `q`
-  `GENROU`      | 6th order machine model                              | `bus`, `signal_in`\*, `signal_out`\*           | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
+  `GENROU`      | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*           | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
   `IEEET1`      | a basic exciter model                                | `bus`, `speed`, `efd`            | `Efd` | `Efd`, `ksat`
-  `bus_fault`   | simple impedance-based fault at a bus                | `bus`, `signal_in`\*                           | `state0`, `R`, `X` | `state`, `ir`, `ii`
+  `bus_fault`   | simple impedance-based fault at a bus                | `bus`, `status`\*                           | `state0`, `R`, `X` | `state`, `ir`, `ii`
 
 Ports marked with \* are optional and, if missing, will be assumed to be
 connected to a constant value. This list is subject to change.
+
+
+### Signals
+
+Contained in the `signals` key is an array of objects, each of which represent
+a signal and has the following fields:
+
+  Name               | Description
+  -------------------|------------------------------------------------------
+  `signal_id`        | Unique positive (> 0) integer identifying the node
+  `name`             | Optional string containing the name of the node. This may be empty or non-unique
+  `extension`        | Optional field containing an object with implementation-defined keys
+
 
 ## Example File for a 2-Bus System
 
@@ -168,7 +155,11 @@ connected to a constant value. This list is subject to change.
        { "class": "GENROU", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
               "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
        { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
-   ]
+   ],
+   "signals": [
+       { "signal_id": 1, "name": "Governor Pmech Signal"},
+       { "signal_id": 2, "name": "Exciter Efd Signal"}
+   ],
 }
 ```
 

--- a/src/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/src/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -66,7 +66,7 @@ a bus and has the following fields:
   `class`            | A string indicating the class of node. See the table below for more information
   `name`             | Optional string containing the name of the node. This may be empty or non-unique
   `init`             | Optional object mapping string variable names to floating point values, specifying default voltages or signal values. The available initialization variables are dependent upon the node class. Any variables missing will be given default values, which are specified beneath the table below. If this object is missing, all variables will be given default values. See the table below for more information
-  `v_base`           | Optional floating point value giving the voltage base in volts (V). If omitted, default value of 1 V is assumed (common for signal buses)
+  `v_base`           | Optional floating point value giving the voltage base in volts (V). 
   `mon`              | Optional field, which is an array specifying variables to monitor the value of in an output channel. Available variables include all the initialization variables, along with others as determined by the node class. See the table below for more information
   `freq_base`        | Optional field to override the system frequency base at this bus
   `va_base`          | Optional field to override the system power base at this bus
@@ -86,6 +86,19 @@ specified:
 For fields named `Vr` or `Va`, the default value is `1.0`, otherwise it is
 `0.0`. This list is subject to change.
 
+### Signals
+
+Contained in the `signals` key is an array of objects, each of which represent
+a signal and has the following fields:
+
+  Name               | Description
+  -------------------|------------------------------------------------------
+  `signal_id`        | Unique positive (> 0) integer identifying the signal
+  `name`             | Optional string containing the name or description of the signal. This may be empty or non-unique
+
+All interactions with signals are handled by `devices`, which reference signals via `signal_id`
+
+
 ### Devices
 
 Contained in the `devices` section is an array of objects, each of which
@@ -101,6 +114,8 @@ represent a device and has the following fields:
   `va_base`         | Optional field to override the system power base for this device
   `freq_base`       | Optional field to override the system frequency base for this device
   `extension`       | Optional field containing an object with implementation-defined keys
+
+For more information, see the detailed documentation for each device class containing equations, electrical bus configuration, and signal inlets/outlets specifications.
 
 #### Device classes
 
@@ -121,19 +136,6 @@ Ports marked with \* are optional and, if missing, will be assumed to be
 connected to a constant value. This list is subject to change.
 
 
-### Signals
-
-Contained in the `signals` key is an array of objects, each of which represent
-a signal and has the following fields:
-
-  Name               | Description
-  -------------------|------------------------------------------------------
-  `signal_id`        | Unique positive (> 0) integer identifying the signal
-  `name`             | Optional string containing the name or description of the signal. This may be empty or non-unique
-
-All interactions with signals are handled by `devices`, which reference signals via `signal_id`
-
-
 ## Example File for a 2-Bus System
 
 ```json
@@ -151,18 +153,18 @@ All interactions with signals are handled by `devices`, which reference signals 
        { "number": 1, "class": "bus", "name": "Bus 1", "init": {"Vr":0.994988, "Vi":0.099997}, "v_base": 115e3, "mon": ["Vr", "Vi"] },
        { "number": 2, "class": "infinite_bus", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "v_base": 115e3 }
    ],
+   "signals": [
+       { "signal_id": 1, "name": "Machine Speed Deviation"},
+       { "signal_id": 2, "name": "Mechanical Power"},
+       { "signal_id": 3, "name": "Excitation Field"}
+   ],
    "devices": [
        { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
        { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
        { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0, "Pvmin":1, "Dt":0}},
        { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "DV3", "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1, "Vrmax":1, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlm":0}},
        { "class": "BusFault", "ports": {"bus":1}, "id": "EVT1", "params": {"state0": false, "R":0.0, "X":1e-3} }
-   ],
-   "signals": [
-       { "signal_id": 1, "name": "Machine Speed Deviation"},
-       { "signal_id": 2, "name": "Mechanical Power"},
-       { "signal_id": 3, "name": "Excitation Field"}
-   ],
+   ]
 }
 ```
 

--- a/src/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/src/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -109,13 +109,15 @@ represent a device and has the following fields:
 As of the current version and revision, the following device classes
 are specified:
 
-  Device class  | Description                                          | Ports                                          | Initialization parameters | Variables available to monitor
-  --------------|------------------------------------------------------|------------------------------------------------|---------------------------- | -------------------------
-  `branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                                 | `R`, `X`, `G`, `B` | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
-  `static_load` | a basic static ZIP load                              | `bus`                                          | `Pz`, `Qz`, `Pi`, `Qi`, `Pp`, `Qp` | `ir`, `ii`, `p`, `q`
-  `GENROU`      | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*           | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
-  `IEEET1`      | a basic exciter model                                | `bus`, `speed`, `efd`            | `Efd` | `Efd`, `ksat`
-  `bus_fault`   | simple impedance-based fault at a bus                | `bus`, `status`\*                           | `state0`, `R`, `X` | `state`, `ir`, `ii`
+  Device class  | Description                                          | Ports                            | Initialization parameters   | Variables available to monitor
+  --------------|------------------------------------------------------|----------------------------------|---------------------------- | -------------------------
+  `branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`          | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
+  `static_load` | a basic static ZIP load                              | `bus`                            | `Pz`, `Qz`, `Pi`, `Qi`, `Pp`, `Qp` | `ir`, `ii`, `p`, `q`
+  `Genrou`      | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`
+  `GenClassical`| the classical machine model                          | `bus`, `pmech`\*, `speed`\*, `efd`\*  | `p0`, `q0`, `H`, `D`, `Ra`, `Xdp` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
+  `Tgov1 `      | the TGOV1 governor model                             | `pmech`, `speed`                 | `R`, `T1`, `T2`, `T3`, `Pvmax`, `Pvmin`, `Dt` | `none`
+  `Ieeet1`      | the IEEET1 exciter model                             | `bus`, `speed`, `efd`            | `Tr`, `Ka`, `Ta`, `Ke`, `Te`, `Kf`, `Tf`, `Vrmin`, `Vrmax`, `E1`, `E2`, `Se1`, `Se2`, `Ispdlm` | `efd`, `ksat`
+  `bus_fault`   | simple impedance-based fault at a bus                | `bus`, `status`\*                | `state0`, `R`, `X` | `state`, `ir`, `ii`
 
 Ports marked with \* are optional and, if missing, will be assumed to be
 connected to a constant value. This list is subject to change.
@@ -128,9 +130,11 @@ a signal and has the following fields:
 
   Name               | Description
   -------------------|------------------------------------------------------
-  `signal_id`        | Unique positive (> 0) integer identifying the node
-  `name`             | Optional string containing the name of the node. This may be empty or non-unique
+  `signal_id`        | Unique positive (> 0) integer identifying the signal
+  `name`             | Optional string containing the name or description of the signal. This may be empty or non-unique
   `extension`        | Optional field containing an object with implementation-defined keys
+
+All interactions with signals are handled by `devices`, which reference signals via `signal_id`
 
 
 ## Example File for a 2-Bus System
@@ -151,14 +155,17 @@ a signal and has the following fields:
        { "number": 2, "class": "infinite_bus", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "v_base": 115e3 }
    ],
    "devices": [
-       { "class": "branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
-       { "class": "GENROU", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
+       { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
+       { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
               "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
+       { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "1", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0, "Pvmin":1, "Dt":0}},
+       { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "1", "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1, "Vrmax":1, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlm":0}, "mon": ["efd"] },
        { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
    ],
    "signals": [
-       { "signal_id": 1, "name": "Governor Pmech Signal"},
-       { "signal_id": 2, "name": "Exciter Efd Signal"}
+       { "signal_id": 1, "name": "Machine Speed Deviation"},
+       { "signal_id": 2, "name": "Mechanical Power"},
+       { "signal_id": 3, "name": "Excitation Field"}
    ],
 }
 ```

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
@@ -4,7 +4,7 @@ This synchronous machine model is 6th order and is specifically designed for rou
 See the [General Synchronous Machine Model](../README.md) for general synchronous machine information.
 
 Notes:
-- $X''_{q}=X''_{d}$  (round rotor assumptions)
+- $X_q''=X_d''$  (round rotor assumptions)
 - $X''_{d}$ does not saturate
 - Same relative amount of saturation occurs on both $d$ and $q$ axis
 
@@ -41,8 +41,8 @@ $S_{12}$   | [p.u.]  | Saturation factor at 1.2 pu flux | 0 |
 ### Model Derived Parameters
 ``` math
 \begin{aligned}
-  G   &=\dfrac{R_a}{R_a^2+(X''_q)^2}&
-  B   &= -\dfrac{X''_q}{R_a^2+(X''_q)^2}\\
+  G   &=\dfrac{R_a}{R_a^2+(X_q'')^2}&
+  B   &= -\dfrac{X_q''}{R_a^2+(X_q'')^2}\\
   S_A &= \dfrac{1.2\sqrt{S_{10}/S_{12}} +1}{\sqrt{S_{10}/S_{12}} +1} & 
   S_B &= \dfrac{1.2\sqrt{S_{10}/S_{12}} -1}{\sqrt{S_{10}/S_{12}} -1} \\
   X_{d1} &= X_d-X_d'      & X_{q1} &= X_q-X_q' \\
@@ -102,7 +102,7 @@ $E_{fd}$ | [p.u.] | Field winding voltage from the excitation system | Owned by 
 ``` math
 \begin{aligned}
   \dot\delta      &= \omega\cdot\omega_0 \\
-  \dot\omega      &= \dfrac{1}{2H}\left(\dfrac{P_{mech}-D\omega}{1+\omega}
+  \dot\omega      &= \dfrac{1}{2H}\left(\dfrac{P_{m}-D\omega}{1+\omega}
                    - T_{elec}\right)\\
   \dot{\psi}'_{d} &= \dfrac{1}{T''_{d0}}(E'_{q}-\psi'_{d}-X_{d2}I_{d})\\
   \dot{\psi}'_{q} &= \dfrac{1}{T''_{q0}}(E'_{d}-\psi'_{q}+X_{q2}I_{q})\\
@@ -157,7 +157,7 @@ from the steady-state initial conditions.
   \psi^{''} &= \sqrt{(\psi''_{d})^2+(\psi''_{q})^2} \\
   k_{sat}     &= S_B(\psi^{''}-S_A)^2 \\
   T_{elec}    &= (\psi''_{d} - I_dX_d^{''})I_q-(\psi''_{q} - I_qX_d^{''})I_d \\
-  P_{mech}    &= T_{elec} \\
+  P_{m}    &= T_{elec} \\
   \psi^{'}_d  &=
   \dfrac{\psi^{''}_d-X_{d5}X_{d2}I_d}{X_{d5}+1}\\
   \psi^{'}_q  &=\dfrac{X_{q5}X_{q2}I_q-\psi^{''}_q}{X_{q5}+1}\\

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
@@ -62,7 +62,7 @@ $S_{12}$   | [p.u.]  | Saturation factor at 1.2 pu flux | 0 |
 Symbol    | Units  | Description                       | Note
 ----------|--------|-----------------------------------|-------
 $\delta$  | [rad]  | Machine internal rotor angle      |
-$\omega$  | [p.u.] | Machine speed | Optionally read by governor or stabilizer component
+$\omega$  | [p.u.] | Machine Speed Deviation           | Optionally read by governor or stabilizer component
 $\psi'_d$ | [p.u.] | Direct axis subtransient flux     | 
 $\psi'_q$ | [p.u.] | Quadrature axis subtransient flux | 
 $E'_d$    | [p.u.] | Direct axis transient flux        | 
@@ -101,8 +101,8 @@ $E_{fd}$ | [p.u.] | Field winding voltage from the excitation system | Owned by 
 ### Differential Equations
 ``` math
 \begin{aligned}
-  \dot\delta      &= (\omega-1)\cdot\omega_0 \\
-  \dot\omega      &= \dfrac{1}{2H}\left(\dfrac{P_{mech}-D(\omega-1)}{\omega}
+  \dot\delta      &= \omega\cdot\omega_0 \\
+  \dot\omega      &= \dfrac{1}{2H}\left(\dfrac{P_{mech}-D\omega}{1+\omega}
                    - T_{elec}\right)\\
   \dot{\psi}'_{d} &= \dfrac{1}{T''_{d0}}(E'_{q}-\psi'_{d}-X_{d2}I_{d})\\
   \dot{\psi}'_{q} &= \dfrac{1}{T''_{q0}}(E'_{d}-\psi'_{q}+X_{q2}I_{q})\\
@@ -127,8 +127,8 @@ Note that for implementation purposes, some of these equations may be simplified
   0 &= -\psi''_{q} -E'_{d}X_{q5} - \psi'_{q}X_{q4} \\
   0 &= -\psi''_{d} +E'_{q}X_{d5} + \psi'_{d}X_{d4}\\
   0 &= -\psi'' +\sqrt{(\psi''_{d})^2+(\psi''_{q})^2} \\
-  0 &= -V_{d} -\psi''_{q}\omega\\
-  0 &= -V_{q}  +\psi''_{d}\omega\\
+  0 &= -V_{d} -\psi''_{q}(1+\omega)\\
+  0 &= -V_{q}  +\psi''_{d}(1+\omega)\\
   0 &= -T_{elec} +(\psi''_{d} - I_dX_d'')I_q-(\psi''_{q} - I_qX_d'')I_d \\
   0 &= -k_{sat} + S_B (\psi''-S_A)^2 \\
   0 &= -I_d + I_r \sin(\delta) - I_i \cos(\delta) \\

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
@@ -31,7 +31,7 @@ $X_{dp}$    | [p.u.]  | machine reactance parameter     |
 Symbol      | Units   | Description         | Note
 ------------|---------|---------------------|----------------------
 $\delta$    | [rad]   | machine power angle |
-$\omega$    | [p.u]   | machine speed       | Optionally read by a governor or a stabilizer component
+$\omega$    | [p.u]   | machine speed deviation       | Optionally read by a governor or a stabilizer component
 
 #### Algebraic
 
@@ -74,8 +74,8 @@ $E_p$  | [p.u.]  | field winding voltage         | owned by exciter, constant if
 
 ```math 
 \begin{aligned}
-\dot{\delta} &= (\omega - 1) \cdot \omega_0 \\
-\dot{\omega} &= \frac{1}{2H}\left( \frac{P_{m} - D(\omega - 1)}{\omega}   - T_{e}\right)
+\dot{\delta} &= \omega \cdot \omega_0 \\
+\dot{\omega} &= \frac{1}{2H}\left( \frac{P_{m} - D\omega}{1+\omega}   - T_{e}\right)
 \end{aligned}
 ```
 


### PR DESCRIPTION
## Description

Various changes to the INPUT_FORMAT document so that it aligns with the documentation and implementation of models. The README files and small Syntax corrections were made in various models.
 
 ## Proposed changes
 
The `signal_in` and `signal_out` terminology should not be used because a model can/will have multiple input and outputs. Instead the proposed format uses `pmech` and `speed` and `efd` directly named.

All documentation and implementation now uses $\omega$ for speed deviation.
All documentation now  uses $P_m$ for mechanical power.
 

 ## Further comments
 
Draft. Some implementation variables still need to be updated. 