### PR TITLE
Separate Impl and template instantiation for Branch and Exciter

### DIFF
--- a/src/Model/PhasorDynamics/Branch/BranchDependencyTracking.cpp
+++ b/src/Model/PhasorDynamics/Branch/BranchDependencyTracking.cpp
@@ -1,5 +1,5 @@
 /**
- * @file Branch.cpp
+ * @file BranchDependencyTracking.cpp
  * @author Slaven Peles (peless@ornl.gov)
  *
  */
@@ -11,8 +11,8 @@ namespace GridKit
   namespace PhasorDynamics
   {
     // Available template instantiations
-    template class Branch<double, long int>;
-    template class Branch<double, size_t>;
+    template class Branch<DependencyTracking::Variable, long int>;
+    template class Branch<DependencyTracking::Variable, size_t>;
 
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -7,11 +7,10 @@
  *
  */
 
-#include "Branch.hpp"
-
 #include <cmath>
 #include <iostream>
 
+#include "Branch.hpp"
 #include <Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 

--- a/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -1,0 +1,188 @@
+/**
+ * @file BranchImpl.hpp
+ * @author Slaven Peles (peless@ornl.gov)
+ * @brief Definition of a phasor dynamics branch model.
+ *
+ * The model uses Cartesian coordinates.
+ *
+ */
+
+#include "Branch.hpp"
+
+#include <cmath>
+#include <iostream>
+
+#include <Model/PhasorDynamics/Branch/BranchData.hpp>
+#include <Model/PhasorDynamics/Bus/Bus.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    /**
+     * @brief Constructor for a pi-model branch
+     *
+     * Model size:
+     * - Number of equations = 0
+     * - Number of internal variables = 0
+     */
+    template <class ScalarT, typename IdxT>
+    Branch<ScalarT, IdxT>::Branch(bus_type* bus1, bus_type* bus2)
+      : bus1_(bus1),
+        bus2_(bus2),
+        R_(0.0),
+        X_(0.01),
+        G_(0.0),
+        B_(0.0),
+        bus1_id_(0),
+        bus2_id_(0)
+    {
+      size_ = 0;
+    }
+
+    /**
+     * @brief Construct a new Branch
+     *
+     * @tparam ScalarT - scalar type
+     * @tparam IdxT    - matrix/vector index type
+     * @param bus1 - pointer to bus-1
+     * @param bus2 - pointer to bus-2
+     * @param R - line series resistance
+     * @param X - line series reactance
+     * @param G - line shunt conductance
+     * @param B - line shunt charging
+     */
+    template <class ScalarT, typename IdxT>
+    Branch<ScalarT, IdxT>::Branch(bus_type* bus1,
+                                  bus_type* bus2,
+                                  real_type R,
+                                  real_type X,
+                                  real_type G,
+                                  real_type B)
+      : bus1_(bus1),
+        bus2_(bus2),
+        R_(R),
+        X_(X),
+        G_(G),
+        B_(B),
+        bus1_id_(0),
+        bus2_id_(0)
+    {
+    }
+
+    template <class ScalarT, typename IdxT>
+    Branch<ScalarT, IdxT>::Branch(bus_type* bus1, bus_type* bus2, const model_data_type& data)
+      : bus1_(bus1),
+        bus2_(bus2)
+    {
+      if (data.parameters.contains(model_data_type::Parameters::R))
+      {
+        R_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::R));
+      }
+
+      if (data.parameters.contains(model_data_type::Parameters::X))
+      {
+        X_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::X));
+      }
+
+      if (data.parameters.contains(model_data_type::Parameters::G))
+      {
+        G_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::G));
+      }
+
+      if (data.parameters.contains(model_data_type::Parameters::B))
+      {
+        B_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::B));
+      }
+
+      if (data.ports.contains(model_data_type::Ports::bus1))
+      {
+        bus1_id_ = data.ports.at(model_data_type::Ports::bus1);
+      }
+
+      if (data.ports.contains(model_data_type::Ports::bus2))
+      {
+        bus2_id_ = data.ports.at(model_data_type::Ports::bus2);
+      }
+
+      size_ = 0;
+    }
+
+    /**
+     * @brief Destroy the Branch
+     *
+     * @tparam ScalarT
+     * @tparam IdxT
+     */
+    template <class ScalarT, typename IdxT>
+    Branch<ScalarT, IdxT>::~Branch()
+    {
+      // std::cout << "Destroy Branch..." << std::endl;
+    }
+
+    /*!
+     * @brief allocate method computes sparsity pattern of the Jacobian.
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::allocate()
+    {
+      // std::cout << "Allocate Branch..." << std::endl;
+      return 0;
+    }
+
+    /**
+     * Initialization of the branch model
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::initialize()
+    {
+      return 0;
+    }
+
+    /**
+     * \brief Identify differential variables.
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::tagDifferentiable()
+    {
+      return 0;
+    }
+
+    /**
+     * \brief Residual contribution of the branch is pushed to the
+     * two terminal buses.
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::evaluateResidual()
+    {
+      // std::cout << "Evaluating branch residual ...\n";
+      real_type b = -X_ / (R_ * R_ + X_ * X_);
+      real_type g = R_ / (R_ * R_ + X_ * X_);
+
+      Ir1() += -(g + 0.5 * G_) * Vr1() + (b + 0.5 * B_) * Vi1() + g * Vr2() - b * Vi2();
+      Ii1() += -(b + 0.5 * B_) * Vr1() - (g + 0.5 * G_) * Vi1() + b * Vr2() + g * Vi2();
+      Ir2() += g * Vr1() - b * Vi1() - (g + 0.5 * G_) * Vr2() + (b + 0.5 * B_) * Vi2();
+      Ii2() += b * Vr1() + g * Vi1() - (b + 0.5 * B_) * Vr2() - (g + 0.5 * G_) * Vi2();
+
+      return 0;
+    }
+
+    /**
+     * @brief Jacobian evaluation not implemented yet
+     *
+     * @tparam ScalarT - scalar data type
+     * @tparam IdxT    - matrix index data type
+     * @return int - error code, 0 = success
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::evaluateJacobian()
+    {
+      std::cout << "Evaluate Jacobian for Branch..." << std::endl;
+      std::cout << "Jacobian evaluation not implemented!" << std::endl;
+      return 0;
+    }
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/Branch/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Branch/CMakeLists.txt
@@ -11,5 +11,11 @@ gridkit_add_library(phasor_dynamics_branch
   OUTPUT_NAME
     gridkit_phasor_dynamics_branch)
 
+gridkit_add_library(phasor_dynamics_branch_dependency_tracking
+  SOURCES
+  BranchDependencyTracking.cpp
+  OUTPUT_NAME
+    gridkit_phasor_dynamics_branch_dependency_tracking)
+
 # Link to interface target for all components
 target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_branch)

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
@@ -12,5 +12,13 @@ gridkit_add_library(phasor_dynamics_exciter_ieeet1
   OUTPUT_NAME
     gridkit_phasor_dynamics_exciter_ieeet1)
 
+gridkit_add_library(phasor_dynamics_exciter_ieeet1_dependency_tracking
+  SOURCES
+    Ieeet1DependencyTracking.cpp
+  LINK_LIBRARIES
+    GRIDKIT::phasor_dynamics_signal_dependency_tracking
+  OUTPUT_NAME
+    gridkit_phasor_dynamics_exciter_ieeet1_dependency_tracking)
+
 # Link to interface target for all components
 target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_exciter_ieeet1)

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.cpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.cpp
@@ -15,7 +15,7 @@ namespace GridKit
   {
     namespace Exciter
     {
-      
+
       // Available template instantiations
       template class Ieeet1<double, long int>;
       template class Ieeet1<double, size_t>;

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -97,8 +97,8 @@ namespace GridKit
 
         // Model Derived parameters
         // TODO -> Need to be solved for in instantiation!
-        ScalarT SA_{0};
-        ScalarT SB_{0};
+        real_type SA_{0};
+        real_type SB_{0};
 
         // External Variables that don't have models yet.
         // They are constants until then.
@@ -111,7 +111,7 @@ namespace GridKit
         // Scale of Sigmoid function
         // (temporary local implementation)
         // This value gave higher precision.
-        const ScalarT mu_ = 400000.0;
+        const real_type mu_{400000.0};
 
         // Activation function (sigmoid approximation)
         ScalarT sigmoid(ScalarT x);

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
@@ -1,5 +1,5 @@
 /**
- * @file Ieeet1.cpp
+ * @file Ieeet1DependencyTracking.cpp
  * @author Luke Lowery (lukel@tamu.edu)
  * @author Adam Birchfield (abirchfield@tamu.edu)
  *
@@ -17,8 +17,8 @@ namespace GridKit
     {
       
       // Available template instantiations
-      template class Ieeet1<double, long int>;
-      template class Ieeet1<double, size_t>;
+      template class Ieeet1<DependencyTracking::Variable, long int>;
+      template class Ieeet1<DependencyTracking::Variable, size_t>;
 
     } // namespace Exciter
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
@@ -15,7 +15,7 @@ namespace GridKit
   {
     namespace Exciter
     {
-      
+
       // Available template instantiations
       template class Ieeet1<DependencyTracking::Variable, long int>;
       template class Ieeet1<DependencyTracking::Variable, size_t>;

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -7,11 +7,10 @@
  *
  */
 
-#include "Ieeet1.hpp"
-
 #include <cmath>
 #include <iostream>
 
+#include "Ieeet1.hpp"
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp>
 #include <Model/PhasorDynamics/SignalNode/SignalNode.hpp>

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -1,0 +1,358 @@
+/**
+ * @file Ieeet1Impl.cpp
+ * @author Luke Lowery (lukel@tamu.edu)
+ * @author Adam Birchfield (abirchfield@tamu.edu)
+ *
+ * @brief Definition of a IEEET1 Exciter.
+ *
+ */
+
+#include "Ieeet1.hpp"
+
+#include <cmath>
+#include <iostream>
+
+#include <Model/PhasorDynamics/Bus/Bus.hpp>
+#include <Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp>
+#include <Model/PhasorDynamics/SignalNode/SignalNode.hpp>
+
+#define _USE_MATH_DEFINES
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    namespace Exciter
+    {
+
+      /**
+       * @brief  Constructor for IEEET1 Exciter
+       *
+       * @param data  Data object to store parameters
+       * @param bus   Signal used for terminal reference vmag
+       * @param speed Signal used for machine relative speed
+       * @param efd   Signal used for E field
+       * @tparam ScalarT Scalar data type
+       * @tparam IdxT Index data type
+       */
+      template <class ScalarT, typename IdxT>
+      Ieeet1<ScalarT, IdxT>::Ieeet1(signal_type*           efd_signal,
+                                    signal_type*           speed_signal,
+                                    bus_type*              bus,
+                                    const model_data_type& data)
+        : efd_signal_(efd_signal),
+          speed_signal_(speed_signal),
+          bus_(bus)
+      {
+
+        // Parse data struct into model
+        this->initModelParams(data);
+
+        // 9 Internal Variables
+        size_ = 9;
+      }
+
+      /**
+       * @brief Allocate memory for model
+       *
+       */
+      template <class ScalarT, typename IdxT>
+      int Ieeet1<ScalarT, IdxT>::allocate()
+      {
+        auto size = static_cast<size_t>(size_); // avoid compiler warnings
+        f_.resize(size);
+        y_.resize(size);
+        yp_.resize(size);
+        tag_.resize(size);
+
+        // Set output signal after allocation
+        // The signal is accessible to the generator
+        if (efd_signal_)
+        {
+          efd_signal_->set(&y_[7]);
+        }
+        return 0;
+      }
+
+      /**
+       * @brief Initialization of the Exciter
+       *
+       * Sets/configures all of the initial values of the exciter
+       * by assuming no saturation and steady-state.
+       *
+       */
+      template <class ScalarT, typename IdxT>
+      int Ieeet1<ScalarT, IdxT>::initialize()
+      {
+
+        // External Variables
+        ScalarT efd0{0};
+        if (efd_signal_)
+        {
+          efd0 = y_[7]; //<- TODO generator sets efd initial value
+        }
+
+        // Terminal Voltage
+        ScalarT vreal = bus_->Vr();
+        ScalarT vimag = bus_->Vi();
+        Ec_           = std::sqrt(vreal * vreal + vimag * vimag);
+
+        // Derived from External initial values
+        ScalarT vr  = Ke_ * efd0;
+        ScalarT vfx = Kf_ / Tf_ * efd0;
+        ScalarT vtr = Ke_ / Ka_ * efd0;
+
+        // Vref (setpoint = terminal + error)
+        vref_ = Ec_ + vtr;
+
+        // IVP for Internal Variables
+        y_[0] = Ec_;  // y0 - vts  - Sensed term volt
+        y_[1] = vr;   // y1 - vr   - Voltage reg
+        y_[2] = efd0; // y2 - efdp - Efd pre mult
+        y_[3] = vfx;  // y3 - vfx  - Exciter feedback
+        y_[4] = vtr;  // y4 - vtr  - Term Volt Err
+        y_[5] = 0;    // y5 - vf   - Feedback volt
+        y_[6] = 0;    // y6 - ve   - Excit. Cntrl Volt
+        y_[7] = efd0; // y7 - efd  - Efd
+        y_[8] = 0;    // y8 - ksat - Saturation
+
+        // Steady State Conditions
+        yp_[0] = 0.0;
+        yp_[1] = 0.0;
+        yp_[2] = 0.0;
+        yp_[3] = 0.0;
+        yp_[4] = 0.0;
+        yp_[5] = 0.0;
+        yp_[6] = 0.0;
+        yp_[7] = 0.0;
+        yp_[8] = 0.0;
+
+        return 0;
+      }
+
+      /**
+       * @brief  Identify differential variables.
+       *
+       * @tparam ScalarT Scalar data type
+       * @tparam IdxT Index data type
+       * @return int 0
+       */
+      template <class ScalarT, typename IdxT>
+      int Ieeet1<ScalarT, IdxT>::tagDifferentiable()
+      {
+
+        tag_[0] = true;  // y0 - vts  - Sensed term volt
+        tag_[1] = true;  // y1 - vr   - Voltage reg
+        tag_[2] = true;  // y2 - efdp - Efd pre mult
+        tag_[3] = true;  // y3 - vfx  - Exciter feedback
+        tag_[4] = false; // y4 - vtr  - Term Volt Err
+        tag_[5] = false; // y5 - vf   - Feedback volt
+        tag_[6] = false; // y6 - ve   - Excit. Cntrl Volt
+        tag_[7] = false; // y7 - efd  - Efd
+        tag_[8] = false; // y8 - ksat - Saturation
+
+        return 0;
+      }
+
+      /**
+       * @brief  Scaled sigmoid activation function
+       *
+       * @param[in] x State variable
+       * @tparam ScalarT Scalar data type
+       * @tparam IdxT Index data type
+       * @return Sigmoid approximation evaluated at x
+       *
+       * @warning This needs to be abstracted to be used
+       *          across phasor dynamics. Identical pattern is
+       *          being used in TGOV1 model.
+       *
+       *   Algebraic approximation of transcendental sigmoid.
+       */
+      template <class ScalarT, typename IdxT>
+      ScalarT Ieeet1<ScalarT, IdxT>::sigmoid(ScalarT x)
+      {
+        return ((0.5 * mu_ * x) / (1.0 + std::abs(mu_ * x))) + 0.5;
+      }
+
+      /**
+       * @brief Net Indicator function for regulator limits
+       *
+       * @param[in] x State variable
+       * @param[in] f Conditional derivative of state variable
+       * @tparam ScalarT Scalar data type
+       * @tparam IdxT Index data type
+       * @return Scalar value indicating limit activation.
+       *
+       * @warning This needs to be abstracted to be used
+       *          across phasor dynamics. Identical pattern is
+       *          being used in TGOV1 model.
+       */
+      template <class ScalarT, typename IdxT>
+      ScalarT Ieeet1<ScalarT, IdxT>::indicator(ScalarT x, ScalarT f)
+      {
+
+        ScalarT ind_low  = (this->sigmoid(Vrmin_ - x)) * (this->sigmoid(-f));
+        ScalarT ind_high = (this->sigmoid(x - Vrmax_)) * (this->sigmoid(f));
+        return (1 - ind_low) * (1 - ind_high);
+      }
+
+      /**
+       * @brief Residuals of system equations
+       *
+       */
+      template <class ScalarT, typename IdxT>
+      int Ieeet1<ScalarT, IdxT>::evaluateResidual()
+      {
+
+        // Input Variables
+        ScalarT omega{0};
+        if (speed_signal_)
+        {
+          // Meta PR Note
+          // This seems to be very slow,
+          // but I see how read/write ownership may require this
+          //
+          // I believe implementing the equivalent to signal->read()
+          // at the system level would address this, by routing
+          // external signals into a generic inputs_ vector
+          // at the same time as the internal state values y_
+          // are recieved from IDA.
+          omega = speed_signal_->read();
+        }
+
+        // Read E comp (terminal voltage, unless compensation impedance)
+        ScalarT vreal = bus_->Vr();
+        ScalarT vimag = bus_->Vi();
+        Ec_           = std::sqrt(vreal * vreal + vimag * vimag);
+
+        // Read Internal Variables
+        ScalarT vts  = y_[0]; // y0 - Sensed term volt
+        ScalarT vr   = y_[1]; // y1 - Voltage reg
+        ScalarT efdp = y_[2]; // y2 - Efd pre mult
+        ScalarT vfx  = y_[3]; // y3 - Exciter feedback
+        ScalarT vtr  = y_[4]; // y4 - Term Volt Err
+        ScalarT vf   = y_[5]; // y5 - Feedback volt
+        ScalarT ve   = y_[6]; // y6 - Excit. Cntrl Volt
+        ScalarT efd  = y_[7]; // y7 - Efd
+        ScalarT ksat = y_[8]; // y8 - Saturation
+
+        // Read Internal Derivatives
+        ScalarT vts_dot  = yp_[0];
+        ScalarT vr_dot   = yp_[1];
+        ScalarT efdp_dot = yp_[2];
+        ScalarT vfx_dot  = yp_[3];
+
+        // The 'pre-limit' derivative of Pv
+        ScalarT f      = -vr + Ka_ * vtr;
+        ScalarT vr_ind = this->indicator(vr, f);
+
+        // Internal Differential Equations
+        f_[0] = -vts_dot + (Ec_ - vts) / Tr_;
+        f_[1] = -vr_dot + vr_ind * f / Ta_;
+        f_[2] = -efdp_dot + (vr - ve - Ke_ * efdp) / Te_;
+        f_[3] = -vfx_dot + vf / Tf_;
+
+        // Internal Algebraic Equations
+        f_[4] = -vtr + vref_ + vUEL_ + vOEL_ + vS_ - vf - vts;
+        f_[5] = -vf + (efdp * Kf_) / Tf_ - vfx;
+        f_[6] = -ve + ksat * efdp;
+        f_[7] = -efd + efdp + omega * efdp * Ispdlim_;
+
+        // TODO smooth approaximation for Enzyme
+        // NOTE seems about double PW saturation.
+        f_[8] = -ksat;
+        if (efdp > SA_)
+          f_[8] += SB_ * (efdp - SA_) * (efdp - SA_); //
+
+        return 0;
+      }
+
+      /**
+       * @brief Jacobian evaluation not implemented yet
+       *
+       * @tparam ScalarT - Scalar data type
+       * @tparam IdxT    - Index data type
+       * @return int - error code, 0 = success
+       */
+      template <class ScalarT, typename IdxT>
+      int Ieeet1<ScalarT, IdxT>::evaluateJacobian()
+      {
+        std::cout << "Jacobian evaluation not implemented!" << std::endl;
+        return 0;
+      }
+
+      /**
+       * @brief Initialization Exciter Parameters from data structure
+       */
+      template <class ScalarT, typename IdxT>
+      void Ieeet1<ScalarT, IdxT>::initModelParams(const model_data_type& data)
+      {
+
+        if (data.parameters.contains(model_data_type::Parameters::Tr))
+        {
+          Tr_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Tr));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Ka))
+        {
+          Ka_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Ka));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Ta))
+        {
+          Ta_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Ta));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Ke))
+        {
+          Ke_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Ke));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Te))
+        {
+          Te_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Te));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Kf))
+        {
+          Kf_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Kf));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Tf))
+        {
+          Tf_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Tf));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Vrmin))
+        {
+          Vrmin_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Vrmin));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Vrmax))
+        {
+          Vrmax_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Vrmax));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::E1))
+        {
+          E1_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::E1));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::E2))
+        {
+          E2_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::E2));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Se1))
+        {
+          Se1_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Se1));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Se2))
+        {
+          Se2_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Se2));
+        }
+        if (data.parameters.contains(model_data_type::Parameters::Ispdlim))
+        {
+          Ispdlim_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::Ispdlim));
+        }
+
+        // Derived Parameters
+        real_type SR = std::sqrt(Se2_ / Se1_);
+
+        // Solution 1 (Aligned with PW)
+        SA_ = (SR * E1_ - E2_) / (SR - 1);
+        SB_ = Se1_ / (E1_ - SA_) / (E1_ - SA_);
+      }
+
+    } // namespace Exciter
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/tests/UnitTests/PhasorDynamics/CMakeLists.txt
+++ b/tests/UnitTests/PhasorDynamics/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(test_phasor_bus GRIDKIT::phasor_dynamics_bus)
 
 add_executable(test_phasor_branch runBranchTests.cpp)
 target_link_libraries(test_phasor_branch GRIDKIT::phasor_dynamics_branch
+                                         GRIDKIT::phasor_dynamics_branch_dependency_tracking
                                          GRIDKIT::phasor_dynamics_bus)
 
 add_executable(test_phasor_load runLoadTests.cpp)
@@ -18,11 +19,14 @@ target_link_libraries(test_phasor_load GRIDKIT::phasor_dynamics_load
 
 add_executable(test_phasor_genrou runGenrouTests.cpp)
 target_link_libraries(test_phasor_genrou GRIDKIT::phasor_dynamics_genrou
+                                         GRIDKIT::phasor_dynamics_genrou_dependency_tracking
                                          GRIDKIT::phasor_dynamics_bus)
 
 add_executable(test_phasor_governortgov1 runGovernorTgov1Tests.cpp)
 target_link_libraries(test_phasor_governortgov1 GRIDKIT::phasor_dynamics_genrou
+                                                GRIDKIT::phasor_dynamics_genrou_dependency_tracking
                                                 GRIDKIT::phasor_dynamics_governortgov1
+                                                GRIDKIT::phasor_dynamics_governortgov1_dependency_tracking
                                                 GRIDKIT::phasor_dynamics_signal
                                                 GRIDKIT::phasor_dynamics_bus)
 
@@ -34,11 +38,12 @@ target_link_libraries(test_phasor_gen_classical GRIDKIT::phasor_dynamics_gen_cla
 
 add_executable(test_phasor_system runSystemTests.cpp)
 target_link_libraries(test_phasor_system GRIDKIT::phasor_dynamics_components
+                                         GRIDKIT::phasor_dynamics_branch_dependency_tracking
                                          GRIDKIT::phasor_dynamics_load_dependency_tracking
                                          GRIDKIT::phasor_dynamics_genrou_dependency_tracking
+                                         GRIDKIT::phasor_dynamics_governortgov1_dependency_tracking
                                          GRIDKIT::phasor_dynamics_gen_classical_dependency_tracking
                                          GRIDKIT::phasor_dynamics_signal_dependency_tracking
-                                         GRIDKIT::phasor_dynamics_governortgov1_dependency_tracking
                                          GRIDKIT::phasor_dynamics_bus_fault_dependency_tracking)
 
 add_test(NAME PhasorDynamicsBusTest COMMAND $<TARGET_FILE:test_phasor_bus>)


### PR DESCRIPTION
## Description
 
This separates the model implementation from template instantiation for a few models. This will be useful when adding the instantiation with Enzyme and testing the Jacobians.
 
CC @lukelowry @abirchfield It would be good to use this implementation approach (separate *Impl.hpp and *cpp) when adding new models. 
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 N/A
