### PR TITLE
Update cmake to indicate which libraries are optional, and not fail when they cannot be configured

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,6 @@ option(GRIDKIT_ENABLE_IPOPT "Enable Ipopt support" OFF)
 # SUNDIALS support is enabled by default
 option(GRIDKIT_ENABLE_SUNDIALS "Enable SUNDIALS support" OFF)
 
-# Enable KLU
-option(GRIDKIT_ENABLE_SUNDIALS_SPARSE "Enable SUNDIALS sparse linear solvers" OFF)
-
 # Enzyme support is disabled by default
 option(GRIDKIT_ENABLE_ENZYME "Enable automatic differentiation with Enzyme" OFF)
 
@@ -99,10 +96,6 @@ if(GRIDKIT_ENABLE_SUNDIALS)
                      ${SUNDIALS_DIR}/lib/cmake/sundials)
   message(STATUS "SUNDIALS configuration found: ${SUNDIALS_CONFIG}")
 endif()
-if(TARGET SUNDIALS::KLU)
-  set(GRIDKIT_ENABLE_SUNDIALS_SPARSE ON CACHE BOOL "Sparse solver enabled in SUNDIALS." FORCE)
-  message(STATUS "KLU support enabled in SUNDIALS.")
-endif()
 
 if(GRIDKIT_ENABLE_ENZYME)
   include(FindEnzyme)
@@ -118,6 +111,7 @@ install(
   )
 
 # Macro that adds libraries
+include(GridkitAddExecutable)
 include(GridkitAddLibrary)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cmake/GridkitAddExecutable.cmake
+++ b/cmake/GridkitAddExecutable.cmake
@@ -1,0 +1,45 @@
+# add_executable macro loosely based on add_library
+
+macro(gridkit_add_executable target)
+
+  set(options TEST)
+  set(multiValueArgs SOURCES LINK_LIBRARIES COMPILE_OPTIONS)
+
+  # parse arguments
+  cmake_parse_arguments(gridkit_add_executable
+    "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # Before going any further and configuring this library - make sure we can actually link its requirements
+  foreach(_add_lib ${gridkit_add_executable_LINK_LIBRARIES})
+    if(NOT (${_add_lib} MATCHES "PUBLIC" OR ${_add_lib} MATCHES "PRIVATE" OR ${_add_lib} MATCHES "INTERFACE"))
+      if(NOT TARGET ${_add_lib})
+        get_property(_skipped_libs GLOBAL PROPERTY GRIDKIT_SKIPPED_OPTIONAL_LIBS)
+
+        if(${_add_lib} IN_LIST _skipped_libs)
+          message(STATUS "Disabling GridKit executable ${target} due to disabled optional library: ${_add_lib}")
+          return()
+        else()
+          message(SEND_ERROR "Failed to configure GridKit executable due to missing library: ${_add_lib}")
+        endif()
+      endif()
+    endif()
+  endforeach()
+
+  # -- Create executable --
+
+  add_executable(${target} ${gridkit_add_executable_SOURCES})
+
+  if(gridkit_add_executable_COMPILE_OPTIONS)
+    target_compile_options(${target} PUBLIC ${gridkit_add_executable_COMPILE_OPTIONS})
+  endif()
+  
+  if(gridkit_add_executable_LINK_LIBRARIES)
+    target_link_libraries(${target} ${gridkit_add_executable_LINK_LIBRARIES})
+  endif()
+
+  if(gridkit_add_executable_TEST)
+    add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>)
+  endif()
+
+  install(TARGETS ${target} RUNTIME DESTINATION bin)
+endmacro()

--- a/cmake/GridkitAddExecutable.cmake
+++ b/cmake/GridkitAddExecutable.cmake
@@ -9,7 +9,7 @@ macro(gridkit_add_executable target)
   cmake_parse_arguments(gridkit_add_executable
     "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  # Before going any further and configuring this library - make sure we can actually link its requirements
+  # Before going any further and configuring this library, make sure we can actually link its requirements.
   foreach(_add_lib ${gridkit_add_executable_LINK_LIBRARIES})
     if(NOT (${_add_lib} MATCHES "PUBLIC" OR ${_add_lib} MATCHES "PRIVATE" OR ${_add_lib} MATCHES "INTERFACE"))
       if(NOT TARGET ${_add_lib})

--- a/cmake/GridkitAddLibrary.cmake
+++ b/cmake/GridkitAddLibrary.cmake
@@ -16,7 +16,7 @@ macro(gridkit_add_library target)
   cmake_parse_arguments(gridkit_add_library
     "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  # Before going any further and configuring this library - make sure we can actually link its requirements
+  # Before going any further and configuring this library, make sure we can actually link its requirements.
   foreach(_add_lib ${gridkit_add_library_LINK_LIBRARIES})
     if(NOT (${_add_lib} STREQUAL "PUBLIC" OR ${_add_lib} STREQUAL "PRIVATE" OR ${_add_lib} STREQUAL "INTERFACE"))
       if(NOT TARGET ${_add_lib})

--- a/cmake/GridkitAddLibrary.cmake
+++ b/cmake/GridkitAddLibrary.cmake
@@ -8,13 +8,28 @@
 
 macro(gridkit_add_library target)
 
-  set(options STATIC_ONLY SHARED_ONLY)
+  set(options STATIC_ONLY SHARED_ONLY OPTIONAL)
   set(oneValueArgs OUTPUT_NAME)
   set(multiValueArgs SOURCES LINK_LIBRARIES INCLUDE_DIRECTORIES COMPILE_OPTIONS)
 
   # parse arguments
   cmake_parse_arguments(gridkit_add_library
     "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # Before going any further and configuring this library - make sure we can actually link its requirements
+  foreach(_add_lib ${gridkit_add_library_LINK_LIBRARIES})
+    if(NOT (${_add_lib} STREQUAL "PUBLIC" OR ${_add_lib} STREQUAL "PRIVATE" OR ${_add_lib} STREQUAL "INTERFACE"))
+      if(NOT TARGET ${_add_lib})
+        if(gridkit_add_library_OPTIONAL)
+          message(STATUS "Disabling optional GridKit library ${target} due to missing library: ${_add_lib}")
+          set_property(GLOBAL APPEND PROPERTY GRIDKIT_SKIPPED_OPTIONAL_LIBS GRIDKIT::${target})
+          return()
+        else()
+          message(SEND_ERROR "Failed to configure required GridKit library ${target} due to missing library: ${_add_lib}")
+        endif()
+      endif()
+    endif()
+  endforeach()
 
   # library types to create
   set(_libtypes "")

--- a/examples/PowerElectronics/CMakeLists.txt
+++ b/examples/PowerElectronics/CMakeLists.txt
@@ -5,10 +5,6 @@
 
 add_subdirectory(DistributedGeneratorTest)
 
-if(TARGET SUNDIALS::idas)
-  if(GRIDKIT_ENABLE_SUNDIALS_SPARSE)
-    add_subdirectory(RLCircuit)
-    add_subdirectory(Microgrid)
-    add_subdirectory(ScaleMicrogrid)
-  endif()
-endif()
+add_subdirectory(RLCircuit)
+add_subdirectory(Microgrid)
+add_subdirectory(ScaleMicrogrid)

--- a/examples/PowerElectronics/Microgrid/CMakeLists.txt
+++ b/examples/PowerElectronics/Microgrid/CMakeLists.txt
@@ -1,13 +1,11 @@
-
-
-
-
-add_executable(microgrid Microgrid.cpp)
-target_link_libraries(microgrid GRIDKIT::power_elec_disgen
-                                GRIDKIT::power_elec_microline
-                                GRIDKIT::power_elec_microload
-                                GRIDKIT::solvers_dyn
-                                GRIDKIT::power_elec_microbusdq)
-                                
-add_test(NAME Microgrid    COMMAND $<TARGET_FILE:microgrid>)
-install(TARGETS microgrid RUNTIME DESTINATION bin)
+gridkit_add_executable(microgrid
+    TEST
+    SOURCES
+        Microgrid.cpp
+    LINK_LIBRARIES
+        GRIDKIT::power_elec_disgen
+        GRIDKIT::power_elec_microline
+        GRIDKIT::power_elec_microload
+        GRIDKIT::solvers_dyn
+        GRIDKIT::power_elec_microbusdq
+)

--- a/examples/PowerElectronics/RLCircuit/CMakeLists.txt
+++ b/examples/PowerElectronics/RLCircuit/CMakeLists.txt
@@ -1,13 +1,11 @@
-
-
-
-
-add_executable(rlcircuit RLCircuit.cpp)
-target_link_libraries(rlcircuit GRIDKIT::power_elec_capacitor
-                                GRIDKIT::power_elec_inductor
-                                GRIDKIT::power_elec_resistor
-                                GRIDKIT::power_elec_voltagesource
-                                GRIDKIT::solvers_dyn)
-                                
-add_test(NAME RLCircuit    COMMAND $<TARGET_FILE:rlcircuit>)
-install(TARGETS rlcircuit RUNTIME DESTINATION bin)
+gridkit_add_executable(rlcircuit
+    TEST
+    SOURCES
+        RLCircuit.cpp
+    LINK_LIBRARIES
+        GRIDKIT::power_elec_capacitor
+        GRIDKIT::power_elec_inductor
+        GRIDKIT::power_elec_resistor
+        GRIDKIT::power_elec_voltagesource
+        GRIDKIT::solvers_dyn
+    )

--- a/examples/PowerElectronics/ScaleMicrogrid/CMakeLists.txt
+++ b/examples/PowerElectronics/ScaleMicrogrid/CMakeLists.txt
@@ -1,20 +1,22 @@
+gridkit_add_executable(scalemicrogrid
+    TEST
+    SOURCES
+        ScaleMicrogrid.cpp
+    LINK_LIBRARIES
+        GRIDKIT::power_elec_disgen
+        GRIDKIT::power_elec_microline
+        GRIDKIT::power_elec_microload
+        GRIDKIT::solvers_dyn
+        GRIDKIT::power_elec_microbusdq
+)
 
-
-
-
-add_executable(scalemicrogrid ScaleMicrogrid.cpp)
-add_executable(scalemicrogridarbitrary ScaleMicrogridArbitrary.cpp)
-target_link_libraries(scalemicrogrid GRIDKIT::power_elec_disgen
-                                     GRIDKIT::power_elec_microline
-                                     GRIDKIT::power_elec_microload
-                                     GRIDKIT::solvers_dyn
-                                     GRIDKIT::power_elec_microbusdq)
-
-target_link_libraries(scalemicrogridarbitrary GRIDKIT::power_elec_disgen
-                                        GRIDKIT::power_elec_microline
-                                        GRIDKIT::power_elec_microload
-                                        GRIDKIT::solvers_dyn
-                                        GRIDKIT::power_elec_microbusdq)
-								
-add_test(NAME ScaleMicrogrid    COMMAND $<TARGET_FILE:scalemicrogrid>)
-install(TARGETS scalemicrogrid RUNTIME DESTINATION bin)
+gridkit_add_executable(scalemicrogridarbitrary
+    SOURCES
+        ScaleMicrogridArbitrary.cpp
+    LINK_LIBRARIES
+        GRIDKIT::power_elec_disgen
+        GRIDKIT::power_elec_microline
+        GRIDKIT::power_elec_microload
+        GRIDKIT::solvers_dyn
+        GRIDKIT::power_elec_microbusdq
+)

--- a/src/Model/PhasorDynamics/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 add_library(gridkit_phasor_dynamics_components INTERFACE)
 
+add_subdirectory(SignalNode)
+
 add_subdirectory(Branch)
 add_subdirectory(Bus)
 add_subdirectory(BusFault)
@@ -12,7 +14,5 @@ add_subdirectory(Exciter)
 add_subdirectory(Governor)
 add_subdirectory(Load)
 add_subdirectory(SynchronousMachine)
-
-add_subdirectory(SignalNode)
 
 add_library(GRIDKIT::phasor_dynamics_components ALIAS gridkit_phasor_dynamics_components)

--- a/src/Solver/CMakeLists.txt
+++ b/src/Solver/CMakeLists.txt
@@ -8,9 +8,8 @@ if(TARGET SUNDIALS::kinsol)
   add_subdirectory(SteadyState)
 endif()
 
-if(TARGET SUNDIALS::idas)
-  add_subdirectory(Dynamic)
-  if(GRIDKIT_ENABLE_IPOPT)
-    add_subdirectory(Optimization)
-  endif()
+add_subdirectory(Dynamic)
+
+if(GRIDKIT_ENABLE_IPOPT)
+  add_subdirectory(Optimization)
 endif()

--- a/src/Solver/Dynamic/CMakeLists.txt
+++ b/src/Solver/Dynamic/CMakeLists.txt
@@ -6,6 +6,7 @@
 #]]
 
 gridkit_add_library(solvers_dyn
+  OPTIONAL
   SOURCES
     Ida.cpp
   LINK_LIBRARIES

--- a/src/Solver/Dynamic/Ida.cpp
+++ b/src/Solver/Dynamic/Ida.cpp
@@ -6,6 +6,7 @@
 
 #include <idas/idas.h>
 #include <idas/idas_ls.h>
+#include <sunlinsol/sunlinsol_klu.h>
 
 #include "Model/Evaluator.hpp"
 

--- a/src/Solver/Dynamic/Ida.hpp
+++ b/src/Solver/Dynamic/Ida.hpp
@@ -11,14 +11,9 @@
 #include <sunlinsol/sunlinsol_dense.h>  /* access to dense linear solver        */
 #include <sunmatrix/sunmatrix_sparse.h> /* access to sparse SUNMatrix           */
 
-#include <Definitions.hpp>
-
-#ifdef GRIDKIT_ENABLE_SUNDIALS_SPARSE
-#include <sunlinsol/sunlinsol_klu.h> /* access to KLU linear solver          */
-#endif
-
 #include "DynamicSolver.hpp"
 #include "Model/Evaluator.hpp"
+#include <Definitions.hpp>
 
 namespace AnalysisManager
 {


### PR DESCRIPTION
## Description
 
Fixes #212.

There's currently an issue with how optional library components and executables are setup in the cmake. These libraries and executables are guarded by if statements checking if their optional components are installed before including their folders. If a library changes which optional components it needs, then all of the if statements guarding its folder and all derivative executables need to change. This is also fragile, since it requires all optional components to be identified ahead of time (see #212 where it was assumed `sunlinsolklu` wasn't optional).
 
 ## Proposed changes
 
Now, the `gridkit_add_library` macro allows an `OPTIONAL` parameter and will check the existence of all linked libraries. If the linked libraries exist - nothing different happens, but if a library which must be linked doesn't exist and the library is marked as `OPTIONAL`, then that target will simply be ignored.

There is a new `gridkit_add_executable` macro as well which does a similar process - if an executable depends on a disabled optional library, then the executable target will just become ignored.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
Only the `PowerElectronics` examples have been configured using the new `gridkit_add_executable` macro, since these were the ones giving me trouble - due to a cmake file looking for the `KLU` target instead of `sunlinsolklu` (which was actually what was needed).
 
