### PR TITLE
Remove third party libraries from doxygen documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -920,7 +920,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */third-party/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
## Description
 
Currently third party libraries which are included in-tree as submodules, such as `nlohmann/json` and `magic-enum`, are being documented by doxygen. The JSON library is an especially large library (much much more documentation than Gridkit), so Doxygen spends more time generating documentation for it than for Gridkit.
 
 ## Proposed changes
 
This PR removes all items in the `third-party/` folder from considerations when generating doxygen documentation
 
 ## Checklist
 
N/A
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [ ] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
