### PR TITLE
Add test to verify reading and configuring signal ports by JSON parser.

### DIFF
--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
@@ -81,8 +81,8 @@ int main()
   // Set generator data
   data.genrou.resize(1);
 
-  data.genrou[0].ports[GenrouPorts::signal_in]       = 1;
-  data.genrou[0].ports[GenrouPorts::signal_out]      = 0;
+  data.genrou[0].ports[GenrouPorts::pmech]           = 1;
+  data.genrou[0].ports[GenrouPorts::speed]           = 0;
   data.genrou[0].parameters[GenrouParameters::p0]    = 1.;
   data.genrou[0].parameters[GenrouParameters::q0]    = 0.05013;
   data.genrou[0].parameters[GenrouParameters::H]     = 3.;
@@ -105,8 +105,8 @@ int main()
   // Set governor data (Default PW values)
   data.gov.resize(1);
 
-  data.gov[0].ports[Tgov1Ports::signal_in]       = 0;
-  data.gov[0].ports[Tgov1Ports::signal_out]      = 1;
+  data.gov[0].ports[Tgov1Ports::speed]           = 0;
+  data.gov[0].ports[Tgov1Ports::pmech]           = 1;
   data.gov[0].parameters[Tgov1Parameters::R]     = 0.05;
   data.gov[0].parameters[Tgov1Parameters::Pvmin] = 0.0;
   data.gov[0].parameters[Tgov1Parameters::Pvmax] = 1.0;

--- a/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
@@ -64,6 +64,7 @@ namespace GridKit
         }
         else
         {
+          std::cout << raw_port.key() << "\n";
           throw std::runtime_error("Invalid port mapping");
         }
       }

--- a/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
@@ -45,7 +45,7 @@ namespace GridKit
             c.parameters[key.value()] = raw_parameter.value().template get<IdxT>();
           }
           else
-          {            
+          {
             throw std::runtime_error("Invalid initial parameter");
           }
         }

--- a/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
@@ -45,12 +45,13 @@ namespace GridKit
             c.parameters[key.value()] = raw_parameter.value().template get<IdxT>();
           }
           else
-          {
+          {            
             throw std::runtime_error("Invalid initial parameter");
           }
         }
         else
         {
+          // std::cout << "Key " << raw_parameter.key() << " has no value!\n";
           throw std::runtime_error("Invalid initial parameter");
         }
       }
@@ -64,7 +65,7 @@ namespace GridKit
         }
         else
         {
-          std::cout << raw_port.key() << "\n";
+          // std::cout << raw_port.key() << "\n";
           throw std::runtime_error("Invalid port mapping");
         }
       }

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.cpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.cpp
@@ -15,7 +15,6 @@ namespace GridKit
   {
     namespace Exciter
     {
-
       // Available template instantiations
       template class Ieeet1<double, long int>;
       template class Ieeet1<double, size_t>;

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
@@ -38,8 +38,8 @@ namespace GridKit
       enum class Ieeet1Ports
       {
         bus,          ///< Unique ID of the terminal bus
-        speed_signal, ///< Unique ID of the generator speed signal
-        efd_signal,   ///< Unique ID of the output efd signal
+        speed, ///< Unique ID of the generator speed signal
+        efd,   ///< Unique ID of the output efd signal
       };
 
       /// Variables able to be monitored for a IEEET1 Exciter model

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
@@ -37,7 +37,7 @@ namespace GridKit
       /// Ports for a IEEET1 Exciter model
       enum class Ieeet1Ports
       {
-        bus,          ///< Unique ID of the terminal bus
+        bus,   ///< Unique ID of the terminal bus
         speed, ///< Unique ID of the generator speed signal
         efd,   ///< Unique ID of the output efd signal
       };

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
@@ -15,7 +15,6 @@ namespace GridKit
   {
     namespace Exciter
     {
-
       // Available template instantiations
       template class Ieeet1<DependencyTracking::Variable, long int>;
       template class Ieeet1<DependencyTracking::Variable, size_t>;

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
@@ -36,6 +36,7 @@ namespace GridKit
        */
       enum class Tgov1Ports
       {
+        bus,
         speed,
         pmech,
       };

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
@@ -45,6 +45,7 @@ namespace GridKit
        */
       enum class Tgov1MonitorableVariables
       {
+        NONE,
       };
 
       /**

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
@@ -36,8 +36,8 @@ namespace GridKit
        */
       enum class Tgov1Ports
       {
-        signal_in,
-        signal_out,
+        speed,
+        pmech,
       };
 
       /**

--- a/src/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/src/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -129,8 +129,8 @@ are specified:
   `Genrou`      | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`
   `GenClassical`| the classical machine model                          | `bus`, `pmech`\*, `speed`\*, `efd`\*  | `p0`, `q0`, `H`, `D`, `Ra`, `Xdp` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
   `Tgov1 `      | the TGOV1 governor model                             | `pmech`, `speed`                 | `R`, `T1`, `T2`, `T3`, `Pvmax`, `Pvmin`, `Dt` | `none`
-  `Ieeet1`      | the IEEET1 exciter model                             | `bus`, `speed`, `efd`            | `Tr`, `Ka`, `Ta`, `Ke`, `Te`, `Kf`, `Tf`, `Vrmin`, `Vrmax`, `E1`, `E2`, `Se1`, `Se2`, `Ispdlm` | `efd`, `ksat`
-  `BusFault`   | simple impedance-based fault at a bus                | `bus`, `status`\*                | `state0`, `R`, `X` | `state`, `ir`, `ii`
+  `Ieeet1`      | the IEEET1 exciter model                             | `bus`, `speed`, `efd`            | `Tr`, `Ka`, `Ta`, `Ke`, `Te`, `Kf`, `Tf`, `Vrmin`, `Vrmax`, `E1`, `E2`, `Se1`, `Se2`, `Ispdlim` | `efd`, `ksat`
+  `BusFault`    | simple impedance-based fault at a bus                | `bus`, `status`\*                | `state0`, `R`, `X` | `state`, `ir`, `ii`
 
 Ports marked with \* are optional and, if missing, will be assumed to be
 connected to a constant value. This list is subject to change.
@@ -162,7 +162,7 @@ connected to a constant value. This list is subject to change.
        { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
        { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
        { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0, "Pvmin":1, "Dt":0}},
-       { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "DV3", "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1, "Vrmax":1, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlm":0}},
+       { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "DV3", "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1, "Vrmax":1, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlim":0}},
        { "class": "BusFault", "ports": {"bus":1}, "id": "EVT1", "params": {"state0": false, "R":0.0, "X":1e-3} }
    ]
 }

--- a/src/Model/PhasorDynamics/Load/LoadData.hpp
+++ b/src/Model/PhasorDynamics/Load/LoadData.hpp
@@ -29,6 +29,7 @@ namespace GridKit
     enum class LoadMonitorableVariables
     {
       // TODO: presumably some variables would make sense to monitor here
+      NONE
     };
 
     /**

--- a/src/Model/PhasorDynamics/SignalNode/SignalNodeDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/SignalNode/SignalNodeDataJSONParser.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdexcept>
+
+#include <Model/PhasorDynamics/SignalNode/SignalNodeData.hpp>
+#include <nlohmann/json.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    using json = nlohmann::json;
+
+    /// JSON parser function implementation for the `BusData` type
+    ///
+    /// See the `README.md` in `src/Model/PhasorDynamics` for more information
+    template <typename RealT, typename IdxT>
+    void from_json(const json& j, SignalNodeData<RealT, IdxT>& sd)
+    {
+      j.at("name").get_to(sd.name);
+      j.at("signal_id").get_to(sd.signal_id);
+    }
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
@@ -38,9 +38,10 @@ namespace GridKit
     /// Ports for a Genrou generator model
     enum class GenrouPorts
     {
-      bus,        ///< Unique ID of the connecting bus
-      pmech,  ///< Unique ID of the bus providing the exciter signal
+      bus,   ///< Unique ID of the connecting bus
+      pmech, ///< Unique ID of the bus providing the exciter signal
       speed, ///< Unique ID of the bus providing the governor signal
+      efd,   ///< Unique ID of the bus providing exciter field signal
     };
 
     /// Variables able to be monitored for a Genrou generator model

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
@@ -39,8 +39,8 @@ namespace GridKit
     enum class GenrouPorts
     {
       bus,        ///< Unique ID of the connecting bus
-      signal_in,  ///< Unique ID of the bus providing the exciter signal
-      signal_out, ///< Unique ID of the bus providing the governor signal
+      pmech,  ///< Unique ID of the bus providing the exciter signal
+      speed, ///< Unique ID of the bus providing the governor signal
     };
 
     /// Variables able to be monitored for a Genrou generator model

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -142,16 +142,16 @@ namespace GridKit
           /// @todo Genrou (and likely other components) would need to name multiple
           /// signal inlets and outlets. For now we have only speed out and mechanical
           /// power in.
-          if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::signal_out))
+          if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::speed))
           {
-            IdxT signal_out = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::signal_out);
-            gen->getSignals().template assignSignalNode<GenrouInternalVariables::OMEGA>(getSignal(signal_out));
+            IdxT speed = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::speed);
+            gen->getSignals().template assignSignalNode<GenrouInternalVariables::OMEGA>(getSignal(speed));
           }
 
-          if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::signal_in))
+          if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::pmech))
           {
-            IdxT signal_in = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::signal_in);
-            gen->getSignals().template attachSignalNode<GenrouExternalVariables::PM>(getSignal(signal_in));
+            IdxT pmech = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::pmech);
+            gen->getSignals().template attachSignalNode<GenrouExternalVariables::PM>(getSignal(pmech));
           }
 
           addComponent(gen);
@@ -174,16 +174,16 @@ namespace GridKit
         {
           auto* gov = new Tgov1<ScalarT, IdxT>(govdata);
 
-          if (govdata.ports.contains(Tgov1Data<ScalarT, IdxT>::Ports::signal_in))
+          if (govdata.ports.contains(Tgov1Data<ScalarT, IdxT>::Ports::speed))
           {
-            IdxT signal_in = govdata.ports.at(Tgov1Data<ScalarT, IdxT>::Ports::signal_in);
-            gov->getSignals().template attachSignalNode<Tgov1ExternalVariables::DELTAOMEGA>(getSignal(signal_in));
+            IdxT speed = govdata.ports.at(Tgov1Data<ScalarT, IdxT>::Ports::speed);
+            gov->getSignals().template attachSignalNode<Tgov1ExternalVariables::DELTAOMEGA>(getSignal(speed));
           }
 
-          if (govdata.ports.contains(Tgov1Data<ScalarT, IdxT>::Ports::signal_out))
+          if (govdata.ports.contains(Tgov1Data<ScalarT, IdxT>::Ports::pmech))
           {
-            IdxT signal_out = govdata.ports.at(Tgov1Data<ScalarT, IdxT>::Ports::signal_out);
-            gov->getSignals().template assignSignalNode<Tgov1InternalVariables::PM>(getSignal(signal_out));
+            IdxT pmech = govdata.ports.at(Tgov1Data<ScalarT, IdxT>::Ports::pmech);
+            gov->getSignals().template assignSignalNode<Tgov1InternalVariables::PM>(getSignal(pmech));
           }
 
           addComponent(gov);

--- a/src/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
@@ -4,6 +4,7 @@
 
 #include <Model/PhasorDynamics/Bus/BusDataJSONParser.hpp>
 #include <Model/PhasorDynamics/ComponentDataJSONParser.hpp>
+#include <Model/PhasorDynamics/SignalNode/SignalNodeDataJSONParser.hpp>
 #include <Model/PhasorDynamics/SystemModelData.hpp>
 #include <nlohmann/json.hpp>
 
@@ -48,6 +49,12 @@ namespace GridKit
 
       /// Gets all electrical buses
       j.at("buses").get_to(sm.bus);
+
+      /// Gets all signal nodes (allows for systems without signals)
+      if (j.contains("signals"))
+      {
+        j.at("signals").get_to(sm.signal);
+      }
 
       /// Gets all components
       /// @todo So far handling only branches, Genrous, and bus faults

--- a/src/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
@@ -63,17 +63,35 @@ namespace GridKit
       for (auto& raw_component : j.at("devices"))
       {
         auto kind = raw_component.at("class");
-        if (kind == "branch")
+        if (kind == "Branch")
         {
           typename SystemModelData<RealT, IdxT>::BranchDataT branch;
           raw_component.get_to(branch);
           sm.branch.push_back(branch);
         }
-        else if (kind == "GENROU")
+        else if (kind == "Genrou")
         {
           typename SystemModelData<RealT, IdxT>::GenrouDataT genrou;
           raw_component.get_to(genrou);
           sm.genrou.push_back(genrou);
+        }
+        else if (kind == "Load")
+        {
+          typename SystemModelData<RealT, IdxT>::LoadDataT load;
+          raw_component.get_to(load);
+          sm.load.push_back(load);
+        }
+        else if (kind == "Tgov1")
+        {
+          typename SystemModelData<RealT, IdxT>::Tgov1DataT gov;
+          raw_component.get_to(gov);
+          sm.gov.push_back(gov);
+        }
+        else if (kind == "Ieeet1")
+        {
+          typename SystemModelData<RealT, IdxT>::Ieeet1DataT exciter;
+          raw_component.get_to(exciter);
+          sm.exciter.push_back(exciter);
         }
         else if (kind == "bus_fault")
         {

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -159,6 +159,7 @@ namespace GridKit
                    { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
                    { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
                    { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0.0, "Pvmin":1.0, "Dt":0.0}},
+                   { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "DV3", "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1.0, "Vrmax":1.0, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlim":0.0}},
                    { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
                ]
             })";
@@ -181,6 +182,7 @@ namespace GridKit
         success *= result.genrou.size() == 1;
         success *= result.gov.size() == 1;
         success *= result.load.size() == 0;
+        success *= result.exciter.size() == 1;
 
         success *= result.bus[0].bus_id == 1;
         success *= result.bus[0].bus_type == BusType::DEFAULT;
@@ -251,6 +253,25 @@ namespace GridKit
         success *= result.gov[0].ports[Governor::Tgov1Ports::speed] == 1;
         success *= result.gov[0].ports[Governor::Tgov1Ports::pmech] == 2;
         success *= result.gov[0].disambiguation_string == "DV2";
+        
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Tr]) == 0.001;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Ka]) == 50.0;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Ta]) == 0.04;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Ke]) == -0.06;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Te]) == 0.6;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Kf]) == 0.09;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Tf]) == 1.46;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Vrmin]) == -1.0;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Vrmax]) == 1.0;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::E1]) == 2.8;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::E2]) == 3.373;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Se1]) == 0.04;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Se2]) == 0.33;
+        success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Ispdlim]) == 0.0;
+        success *= result.exciter[0].ports[Exciter::Ieeet1Ports::bus] == 1;
+        success *= result.exciter[0].ports[Exciter::Ieeet1Ports::speed] == 1;
+        success *= result.exciter[0].ports[Exciter::Ieeet1Ports::efd] == 3;
+        success *= result.exciter[0].disambiguation_string == "DV3";
 
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::R]) == 0.0;
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::X]) == 1e-3;

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -253,7 +253,7 @@ namespace GridKit
         success *= result.gov[0].ports[Governor::Tgov1Ports::speed] == 1;
         success *= result.gov[0].ports[Governor::Tgov1Ports::pmech] == 2;
         success *= result.gov[0].disambiguation_string == "DV2";
-        
+
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Tr]) == 0.001;
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Ka]) == 50.0;
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Ta]) == 0.04;

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -45,8 +45,8 @@ namespace GridKit
                    { "number": 2, "class": "infinite_bus", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "v_base": 115e3 }
                ],
                "devices": [
-                   { "class": "branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
-                   { "class": "GENROU", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
+                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
+                   { "class": "Genrou", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
                           "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
                    { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
                ]
@@ -156,8 +156,8 @@ namespace GridKit
                    { "signal_id": 3, "name": "Excitation Field"}
                ],
                "devices": [
-                   { "class": "branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
-                   { "class": "GENROU", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
+                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
+                   { "class": "Genrou", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
                           "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
                    { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
                ]

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -127,6 +127,124 @@ namespace GridKit
 
         return success.report(__func__);
       }
+
+
+      TestOutcome signalParse()
+      {
+        using namespace GridKit::PhasorDynamics;
+        using BusData = BusData<RealT, IdxT>;
+        using BusType = BusData::BusType;
+
+        const char data[] =
+            R"({
+               "header": {
+                   "format_version": 0,
+                   "format_revision": 1,
+                   "case_name": "Two-bus test case 1",
+                   "case_description": "A two-bus test case for demonstrating the dynamics format",
+                   "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
+                   "freq_base": 60.0,
+                   "va_base": 100e6
+               },
+               "buses": [
+                   { "number": 1, "class": "bus", "name": "Bus 1", "init": {"Vr":0.994988, "Vi":0.099997}, "v_base": 115e3, "mon": ["Vr", "Vi"] },
+                   { "number": 2, "class": "infinite_bus", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "v_base": 115e3 }
+               ],
+               "signals": [
+                   { "signal_id": 1, "name": "Machine Speed Deviation"},
+                   { "signal_id": 2, "name": "Mechanical Power"},
+                   { "signal_id": 3, "name": "Excitation Field"}
+               ],
+               "devices": [
+                   { "class": "branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
+                   { "class": "GENROU", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
+                          "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
+                   { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
+               ]
+            })";
+
+        TestStatus                   success = true;
+        SystemModelData<RealT, IdxT> result  = json::parse(data);
+
+        success *= result.format_version == 0;
+        success *= result.format_revision == 1;
+        success *= result.case_name == "Two-bus test case 1";
+        success *= result.case_date_time == std::nullopt;
+        success *= result.case_description == "A two-bus test case for demonstrating the dynamics format";
+        success *= result.case_comments == "This case is set up to monitor the voltage at both buses and the machine angle and speed";
+        success *= result.freq_base == 60.0;
+        success *= result.va_base == 100.0e6;
+
+        success *= result.bus.size() == 2;
+        success *= result.branch.size() == 1;
+        success *= result.bus_fault.size() == 1;
+        success *= result.genrou.size() == 1;
+        success *= result.load.size() == 0;
+
+        success *= result.bus[0].bus_id == 1;
+        success *= result.bus[0].bus_type == BusType::DEFAULT;
+        success *= result.bus[0].name == "Bus 1";
+        success *= result.bus[0].Vr0 == 0.994988;
+        success *= result.bus[0].Vi0 == 0.099997;
+        success *= result.bus[0].v_base == 115e3;
+        success *= result.bus[0].monitored_variables[static_cast<size_t>(BusData::MonitorableVariables::VR)];
+        success *= result.bus[0].monitored_variables[static_cast<size_t>(BusData::MonitorableVariables::VI)];
+        success *= result.bus[1].bus_id == 2;
+        success *= result.bus[1].bus_type == BusType::SLACK;
+        success *= result.bus[1].name == "Bus 2";
+        success *= result.bus[1].Vr0 == 1.0;
+        success *= result.bus[1].Vi0 == 0.0;
+        success *= result.bus[1].v_base == 115e3;
+        success *= result.bus[1].monitored_variables.none();
+
+        success *= result.signal[0].signal_id == 1;
+        success *= result.signal[0].name == "Machine Speed Deviation";
+        success *= result.signal[1].signal_id == 2;
+        success *= result.signal[1].name == "Mechanical Power";
+        success *= result.signal[2].signal_id == 3;
+        success *= result.signal[2].name == "Excitation Field";
+
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::R]) == 0.0;
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::X]) == 0.1;
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::G]) == 0.0;
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::B]) == 0.0;
+        success *= result.branch[0].ports[BranchPorts::bus1] == 1;
+        success *= result.branch[0].ports[BranchPorts::bus2] == 2;
+        success *= result.branch[0].disambiguation_string == "1";
+        success *= result.branch[0].monitored_variables.empty();
+
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::p0]) == 1.0;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::q0]) == 0.05013;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::H]) == 3.0;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::D]) == 0.0;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Ra]) == 0.0;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Tdop]) == 7.0;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Tdopp]) == 0.04;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Tqop]) == 0.75;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Tqopp]) == 0.05;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xd]) == 2.1;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xdp]) == 0.2;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xdpp]) == 0.18;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xq]) == 0.5;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xqp]) == 0.0;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xqpp]) == 0.18;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xl]) == 0.15;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S10]) == 0.0;
+        success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S12]) == 0.0;
+        success *= result.genrou[0].ports[GenrouPorts::bus] == 1;
+        success *= result.genrou[0].disambiguation_string == "1";
+        success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::delta);
+        success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::omega);
+
+        success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::R]) == 0.0;
+        success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::X]) == 1e-3;
+        success *= !std::get<bool>(result.bus_fault[0].parameters[BusFaultParameters::state0]);
+        success *= result.bus_fault[0].ports[BusFaultPorts::bus] == 1;
+        success *= result.bus_fault[0].disambiguation_string == "1";
+        success *= result.bus_fault[0].monitored_variables.empty();
+
+        return success.report(__func__);
+      }
     };
   } // namespace Testing
 } // namespace GridKit

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -156,9 +156,9 @@ namespace GridKit
                    { "signal_id": 3, "name": "Excitation Field"}
                ],
                "devices": [
-                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
-                   { "class": "Genrou", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
-                          "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
+                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
+                   { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
+                   { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0, "Pvmin":1, "Dt":0}},
                    { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
                ]
             })";

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -3,6 +3,7 @@
 #include <Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <Model/PhasorDynamics/Bus/BusData.hpp>
 #include <Model/PhasorDynamics/BusFault/BusFaultData.hpp>
+#include <Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
 #include <Model/PhasorDynamics/SystemModelData.hpp>
 #include <Model/PhasorDynamics/SystemModelDataJSONParser.hpp>
@@ -157,7 +158,7 @@ namespace GridKit
                "devices": [
                    { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
                    { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
-                   { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0, "Pvmin":1, "Dt":0}},
+                   { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0.0, "Pvmin":1.0, "Dt":0.0}},
                    { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
                ]
             })";
@@ -178,6 +179,7 @@ namespace GridKit
         success *= result.branch.size() == 1;
         success *= result.bus_fault.size() == 1;
         success *= result.genrou.size() == 1;
+        success *= result.gov.size() == 1;
         success *= result.load.size() == 0;
 
         success *= result.bus[0].bus_id == 1;
@@ -231,9 +233,24 @@ namespace GridKit
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S10]) == 0.0;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S12]) == 0.0;
         success *= result.genrou[0].ports[GenrouPorts::bus] == 1;
+        success *= result.genrou[0].ports[GenrouPorts::speed] == 1;
+        success *= result.genrou[0].ports[GenrouPorts::pmech] == 2;
+        success *= result.genrou[0].ports[GenrouPorts::efd] == 3;
         success *= result.genrou[0].disambiguation_string == "DV1";
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::delta);
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::omega);
+
+        success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::R]) == 0.05;
+        success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::T1]) == 0.5;
+        success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::T2]) == 2.5;
+        success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::T3]) == 7.5;
+        success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Pvmax]) == 0;
+        success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Pvmin]) == 1;
+        success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Dt]) == 0;
+        success *= result.gov[0].ports[Governor::Tgov1Ports::bus] == 1;
+        success *= result.gov[0].ports[Governor::Tgov1Ports::speed] == 1;
+        success *= result.gov[0].ports[Governor::Tgov1Ports::pmech] == 2;
+        success *= result.gov[0].disambiguation_string == "DV2";
 
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::R]) == 0.0;
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::X]) == 1e-3;

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -128,7 +128,6 @@ namespace GridKit
         return success.report(__func__);
       }
 
-
       TestOutcome signalParse()
       {
         using namespace GridKit::PhasorDynamics;
@@ -210,7 +209,7 @@ namespace GridKit
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::B]) == 0.0;
         success *= result.branch[0].ports[BranchPorts::bus1] == 1;
         success *= result.branch[0].ports[BranchPorts::bus2] == 2;
-        success *= result.branch[0].disambiguation_string == "1";
+        success *= result.branch[0].disambiguation_string == "BR1";
         success *= result.branch[0].monitored_variables.empty();
 
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::p0]) == 1.0;
@@ -232,7 +231,7 @@ namespace GridKit
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S10]) == 0.0;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S12]) == 0.0;
         success *= result.genrou[0].ports[GenrouPorts::bus] == 1;
-        success *= result.genrou[0].disambiguation_string == "1";
+        success *= result.genrou[0].disambiguation_string == "DV1";
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::delta);
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::omega);
 

--- a/tests/UnitTests/Utilities/runCaseFormatTests.cpp
+++ b/tests/UnitTests/Utilities/runCaseFormatTests.cpp
@@ -6,6 +6,7 @@ int main()
   GridKit::Testing::CaseFormatTests<double, size_t> test;
 
   result += test.simpleParse();
+  result += test.signalParse();
 
   return result.summary();
 }


### PR DESCRIPTION
## Description
 
Implement tests for JSON parser that verifies signal ports are correctly processed. 
 
 ## Proposed changes
 
This is a step towards completing a prototype for instantiating the entire system automatically from a JSON input file. In this PR we verify that JSON parser correctly reads and sets data for all supported components.

The second part of this would be to update `SystemModel` class to use parsed data to instantiate system model. This will be handled in a separate PR.
 
 ## Checklist
 

- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
Notably, there is an issue in parser that will infer type of component model parameters based on how they are entered in the input file (with or without decimal point). See #227. 
