### PR TITLE
System-level Jacobian assembly

### DIFF
--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -1,3 +1,9 @@
+/**
+ * @file SparseWrapper.hpp
+ * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
+ *
+ */
+
 #pragma once
 
 #include <vector>

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -266,18 +266,18 @@ namespace GridKit
           std::vector<ScalarT>         elementary_v(n_var);
           if (n_res > 0 && n_var > 0)
           {
-            for (size_t res_i = 0; res_i < n_res; ++res_i)
+            for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
 
               // Elementary vector for Jacobian-vector product
-              for (size_t var_i = 0; var_i < n_var; ++var_i)
+              for (size_t res_i = 0; res_i < n_res; ++res_i)
               {
-                elementary_v[var_i] = 0.0;
+                elementary_v[res_i] = 0.0;
               }
-              elementary_v[res_i] = 1.0;
+              elementary_v[var_i] = 1.0;
 
               // Autodiff
               __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
@@ -331,18 +331,18 @@ namespace GridKit
           std::vector<ScalarT>         elementary_v(n_var);
           if (n_res > 0 && n_var > 0)
           {
-            for (size_t res_i = 0; res_i < n_res; ++res_i)
+            for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
 
               // Elementary vector for Jacobian-vector product
-              for (size_t var_i = 0; var_i < n_var; ++var_i)
+              for (size_t res_i = 0; res_i < n_res; ++res_i)
               {
-                elementary_v[var_i] = 0.0;
+                elementary_v[res_i] = 0.0;
               }
-              elementary_v[res_i] = 1.0;
+              elementary_v[var_i] = 1.0;
 
               // Autodiff
               __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
@@ -396,18 +396,18 @@ namespace GridKit
           std::vector<ScalarT>         elementary_v(n_var);
           if (n_res > 0 && n_var > 0)
           {
-            for (size_t res_i = 0; res_i < n_res; ++res_i)
+            for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
 
               // Elementary vector for Jacobian-vector product
-              for (size_t var_i = 0; var_i < n_var; ++var_i)
+              for (size_t res_i = 0; res_i < n_res; ++res_i)
               {
-                elementary_v[var_i] = 0.0;
+                elementary_v[res_i] = 0.0;
               }
-              elementary_v[res_i] = 1.0;
+              elementary_v[var_i] = 1.0;
 
               // Autodiff
               __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -54,9 +54,9 @@ namespace GridKit
       };
 
       /**
-        * @brief Residual wrapper partial template specialization for BusResidual
-        *
-        */
+       * @brief Residual wrapper partial template specialization for BusResidual
+       *
+       */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual, ScalarT>
       {
@@ -67,9 +67,9 @@ namespace GridKit
       };
 
       /**
-        * @brief Residual wrapper partial template specialization for BusResidual11
-        *
-        */
+       * @brief Residual wrapper partial template specialization for BusResidual11
+       *
+       */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual11, ScalarT>
       {
@@ -80,9 +80,9 @@ namespace GridKit
       };
 
       /**
-        * @brief Residual wrapper partial template specialization for BusResidual12
-        *
-        */
+       * @brief Residual wrapper partial template specialization for BusResidual12
+       *
+       */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual12, ScalarT>
       {
@@ -93,9 +93,9 @@ namespace GridKit
       };
 
       /**
-        * @brief Residual wrapper partial template specialization for BusResidual21
-        *
-        */
+       * @brief Residual wrapper partial template specialization for BusResidual21
+       *
+       */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual21, ScalarT>
       {
@@ -106,9 +106,9 @@ namespace GridKit
       };
 
       /**
-        * @brief Residual wrapper partial template specialization for BusResidual22
-        *
-        */
+       * @brief Residual wrapper partial template specialization for BusResidual22
+       *
+       */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual22, ScalarT>
       {
@@ -244,7 +244,7 @@ namespace GridKit
        * @param[in,out] jac - Jacobian
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
-      struct InternalJacobian 
+      struct InternalJacobian
       {
         static void eval(ModelT*                                            model,
                          size_t                                             n_res,
@@ -306,10 +306,10 @@ namespace GridKit
 
       /**
        * @brief Enzyme automatic differentiation Jacobian evaluator: Bus Jacobian
-       * 
+       *
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
-      struct BusJacobian 
+      struct BusJacobian
       {
         static void eval(ModelT*                                            model,
                          size_t                                             n_res,
@@ -371,7 +371,7 @@ namespace GridKit
 
       /**
        * @brief Enzyme automatic differentiation Jacobian evaluator: Branch Jacobian
-       * 
+       *
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
       struct BranchJacobian

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -24,10 +24,10 @@ namespace GridKit
       {
         InternalResidual,
         BusResidual,
-        BusResidual11, ///< Special case for branches that are connected to two buses
-        BusResidual12, ///< Special case for branches that are connected to two buses
-        BusResidual21, ///< Special case for branches that are connected to two buses
-        BusResidual22  ///< Special case for branches that are connected to two buses
+        BusResidual11, //< Special case for branches that are connected to two buses
+        BusResidual12, //< Special case for branches that are connected to two buses
+        BusResidual21, //< Special case for branches that are connected to two buses
+        BusResidual22  //< Special case for branches that are connected to two buses
       };
 
       /**
@@ -36,58 +36,85 @@ namespace GridKit
        * @tparam ModelT - model type
        * @tparam MemberFunctions - member function parameter key
        * @tparam ScalarT - scalar data type
+       *
+       * @param[in] model - Pointer to the model to be differentiated
+       * @param[in] y - Internal variables
+       * @param[in] yp - Internal variable derivatives
+       * @param[in] w - Coupling (bus) variables
+       * @param[out] f - Internal residual
+       * @param[out] h - Coupling (bus) residual
        */
       template <typename ModelT, MemberFunctions function, typename ScalarT>
       struct Wrapper
       {
-        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* f)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* f)
         {
-          obj->evaluateInternalResidual(y, yp, w, f);
+          model->evaluateInternalResidual(y, yp, w, f);
         }
       };
 
+      /**
+        * @brief Residual wrapper partial template specialization for BusResidual
+        *
+        */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual, ScalarT>
       {
-        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
         {
-          obj->evaluateBusResidual(y, yp, w, h);
+          model->evaluateBusResidual(y, yp, w, h);
         }
       };
 
+      /**
+        * @brief Residual wrapper partial template specialization for BusResidual11
+        *
+        */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual11, ScalarT>
       {
-        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
         {
-          obj->evaluateBusResidual11(y, yp, w, h);
+          model->evaluateBusResidual11(y, yp, w, h);
         }
       };
 
+      /**
+        * @brief Residual wrapper partial template specialization for BusResidual12
+        *
+        */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual12, ScalarT>
       {
-        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
         {
-          obj->evaluateBusResidual12(y, yp, w, h);
+          model->evaluateBusResidual12(y, yp, w, h);
         }
       };
 
+      /**
+        * @brief Residual wrapper partial template specialization for BusResidual21
+        *
+        */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual21, ScalarT>
       {
-        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
         {
-          obj->evaluateBusResidual21(y, yp, w, h);
+          model->evaluateBusResidual21(y, yp, w, h);
         }
       };
 
+      /**
+        * @brief Residual wrapper partial template specialization for BusResidual22
+        *
+        */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual22, ScalarT>
       {
-        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
         {
-          obj->evaluateBusResidual22(y, yp, w, h);
+          model->evaluateBusResidual22(y, yp, w, h);
         }
       };
 
@@ -205,17 +232,27 @@ namespace GridKit
        * @tparam MemberFunctions - member function parameter key
        * @tparam ScalarT - scalar data type
        * @tparam IdxT - matrix index data type
+       *
+       * @param[in] model - Pointer to the model to be differentiated
+       * @param[in] n_res - Number of residual functions
+       * @param[in] n_var - Number of independent variables
+       * @param[in] res_indices - Map from local residual indices to global indices
+       * @param[in] var_indices - Map from local variable indices to global indices
+       * @param[in] y - Internal variables
+       * @param[in] yp - Internal variable derivatives
+       * @param[in] w - Coupling (bus) variables
+       * @param[in,out] jac - Jacobian
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
-      void ModelJacobian(ModelT*                                            model,
-                         size_t                                             n_res,
-                         size_t                                             n_var,
-                         const std::map<IdxT, IdxT>&                        res_indices,
-                         const std::map<IdxT, IdxT>&                        var_indices,
-                         ScalarT*                                           y,
-                         ScalarT*                                           yp,
-                         ScalarT*                                           w,
-                         GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
+      void InternalJacobian(ModelT*                                            model,
+                            size_t                                             n_res,
+                            size_t                                             n_var,
+                            const std::map<IdxT, IdxT>&                        res_indices,
+                            const std::map<IdxT, IdxT>&                        var_indices,
+                            ScalarT*                                           y,
+                            ScalarT*                                           yp,
+                            ScalarT*                                           w,
+                            GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
       {
         std::vector<Triple<ScalarT>> triplets;
         std::vector<ScalarT>         elementary_v(n_var);

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -299,7 +299,7 @@ namespace GridKit
               ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
               valtemp.push_back(tup.val);
             }
-            jac.setValues(rtemp, ctemp, valtemp);
+            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
           }
         }
       };
@@ -364,7 +364,7 @@ namespace GridKit
               ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
               valtemp.push_back(tup.val);
             }
-            jac.axpy(1.0, rtemp, ctemp, valtemp); ///< Todo: Update once sparse storage format changes
+            jac.axpy(1.0, rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
           }
         }
       };
@@ -429,7 +429,7 @@ namespace GridKit
               ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
               valtemp.push_back(tup.val);
             }
-            jac.setValues(rtemp, ctemp, valtemp);
+            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
           }
         }
       };

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -17,16 +17,79 @@ namespace GridKit
     namespace Sparse
     {
       /**
+       * @brief Model member function parameter keys
+       *
+       */
+      enum class MemberFunctions
+      {
+        InternalResidual,
+        BusResidual,
+        BusResidual11, ///< Special case for branches that are connected to two buses
+        BusResidual12, ///< Special case for branches that are connected to two buses
+        BusResidual21, ///< Special case for branches that are connected to two buses
+        BusResidual22  ///< Special case for branches that are connected to two buses
+      };
+
+      /**
        * @brief Residual wrapper around residual methods inside model classes
        *
        * @tparam ModelT - model type
+       * @tparam MemberFunctions - member function parameter key
        * @tparam ScalarT - scalar data type
        */
-      template <typename ModelT, typename ScalarT>
-      void residual_wrapper(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* f)
+      template <typename ModelT, MemberFunctions function, typename ScalarT>
+      struct Wrapper
       {
-        obj->evaluateResidualLocally(y, yp, f);
-      }
+        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* f)
+        {
+          obj->evaluateInternalResidual(y, yp, w, f);
+        }
+      };
+
+      template <typename ModelT, typename ScalarT>
+      struct Wrapper<ModelT, MemberFunctions::BusResidual, ScalarT>
+      {
+        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        {
+          obj->evaluateBusResidual(y, yp, w, h);
+        }
+      };
+
+      template <typename ModelT, typename ScalarT>
+      struct Wrapper<ModelT, MemberFunctions::BusResidual11, ScalarT>
+      {
+        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        {
+          obj->evaluateBusResidual11(y, yp, w, h);
+        }
+      };
+
+      template <typename ModelT, typename ScalarT>
+      struct Wrapper<ModelT, MemberFunctions::BusResidual12, ScalarT>
+      {
+        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        {
+          obj->evaluateBusResidual12(y, yp, w, h);
+        }
+      };
+
+      template <typename ModelT, typename ScalarT>
+      struct Wrapper<ModelT, MemberFunctions::BusResidual21, ScalarT>
+      {
+        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        {
+          obj->evaluateBusResidual21(y, yp, w, h);
+        }
+      };
+
+      template <typename ModelT, typename ScalarT>
+      struct Wrapper<ModelT, MemberFunctions::BusResidual22, ScalarT>
+      {
+        static void eval(ModelT* obj, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        {
+          obj->evaluateBusResidual22(y, yp, w, h);
+        }
+      };
 
       /**
        * @brief Enzyme fwddiff template
@@ -41,10 +104,9 @@ namespace GridKit
        * @brief Enzyme todense template
        *
        * @tparam T - return type
-       * @tparam ModelT - model type
        */
-      template <typename T, typename... ModelT>
-      extern T __enzyme_todense(ModelT...) noexcept;
+      template <typename T>
+      extern T __enzyme_todense(void*...) noexcept;
 
       /**
        * @brief Enzyme sparse storage in triplet format
@@ -140,52 +202,198 @@ namespace GridKit
        * @brief Function that computes the Jacobian via automatic differentiation
        *
        * @tparam ModelT - model type
+       * @tparam MemberFunctions - member function parameter key
        * @tparam ScalarT - scalar data type
-       * @tparam IdxT    - matrix index data type
+       * @tparam IdxT - matrix index data type
        */
-      template <typename ModelT, class ScalarT, typename IdxT>
-      void ModelJacobian(ModelT* model, size_t n_res, size_t n_state, ScalarT* y, ScalarT* yp, GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
+      template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
+      void ModelJacobian(ModelT*                                            model,
+                         size_t                                             n_res,
+                         size_t                                             n_var,
+                         const std::map<IdxT, IdxT>&                        res_indices,
+                         const std::map<IdxT, IdxT>&                        var_indices,
+                         ScalarT*                                           y,
+                         ScalarT*                                           yp,
+                         ScalarT*                                           w,
+                         GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
       {
         std::vector<Triple<ScalarT>> triplets;
-        std::vector<ScalarT>         elementary_v(n_state);
-        for (size_t res_i = 0; res_i < n_res; ++res_i)
+        std::vector<ScalarT>         elementary_v(n_var);
+        if (n_res > 0 && n_var > 0)
         {
-          // Sparse storage
-          ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
-          ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
-
-          // Elementary vector for Jacobian-vector product
-          for (size_t state_i = 0; state_i < n_state; ++state_i)
+          for (size_t res_i = 0; res_i < n_res; ++res_i)
           {
-            elementary_v[state_i] = 0.0;
+            // Sparse storage
+            ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
+            ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
+
+            // Elementary vector for Jacobian-vector product
+            for (size_t var_i = 0; var_i < n_var; ++var_i)
+            {
+              elementary_v[var_i] = 0.0;
+            }
+            elementary_v[res_i] = 1.0;
+
+            // Autodiff
+            __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
+                                   enzyme_const,
+                                   model,
+                                   enzyme_dup,
+                                   y,
+                                   output,
+                                   enzyme_const,
+                                   yp,
+                                   enzyme_const,
+                                   w,
+                                   enzyme_dupnoneed,
+                                   elementary_v.data(),
+                                   d_output);
           }
-          elementary_v[res_i] = 1.0;
 
-          // Autodiff
-          __enzyme_fwddiff<void>((void*) residual_wrapper<ModelT, ScalarT>,
-                                 enzyme_const,
-                                 model,
-                                 enzyme_dup,
-                                 y,
-                                 output,
-                                 enzyme_const,
-                                 yp,
-                                 enzyme_dupnoneed,
-                                 elementary_v.data(),
-                                 d_output);
+          // Store result
+          std::vector<IdxT>    ctemp{};
+          std::vector<IdxT>    rtemp{};
+          std::vector<ScalarT> valtemp{};
+          for (auto& tup : triplets)
+          {
+            rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
+            ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
+            valtemp.push_back(tup.val);
+          }
+          jac.setValues(rtemp, ctemp, valtemp);
         }
+      }
 
-        // Store result
-        std::vector<IdxT>    ctemp{};
-        std::vector<IdxT>    rtemp{};
-        std::vector<ScalarT> valtemp{};
-        for (auto& tup : triplets)
+      /**
+       * @brief Function that computes the Jacobian via automatic differentiation
+       *
+       * @tparam ModelT - model type
+       * @tparam MemberFunctions - member function parameter key
+       * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
+       */
+      template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
+      void BusJacobian(ModelT*                                            model,
+                       size_t                                             n_res,
+                       size_t                                             n_var,
+                       const std::map<IdxT, IdxT>&                        res_indices,
+                       const std::map<IdxT, IdxT>&                        var_indices,
+                       ScalarT*                                           y,
+                       ScalarT*                                           yp,
+                       ScalarT*                                           w,
+                       GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
+      {
+        std::vector<Triple<ScalarT>> triplets;
+        std::vector<ScalarT>         elementary_v(n_var);
+        if (n_res > 0 && n_var > 0)
         {
-          rtemp.push_back(static_cast<IdxT>(tup.row));
-          ctemp.push_back(static_cast<IdxT>(tup.col));
-          valtemp.push_back(tup.val);
+          for (size_t res_i = 0; res_i < n_res; ++res_i)
+          {
+            // Sparse storage
+            ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
+            ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
+
+            // Elementary vector for Jacobian-vector product
+            for (size_t var_i = 0; var_i < n_var; ++var_i)
+            {
+              elementary_v[var_i] = 0.0;
+            }
+            elementary_v[res_i] = 1.0;
+
+            // Autodiff
+            __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
+                                   enzyme_const,
+                                   model,
+                                   enzyme_const,
+                                   y,
+                                   enzyme_const,
+                                   yp,
+                                   enzyme_dup,
+                                   w,
+                                   output,
+                                   enzyme_dupnoneed,
+                                   elementary_v.data(),
+                                   d_output);
+          }
+
+          // Store result
+          std::vector<IdxT>    ctemp{};
+          std::vector<IdxT>    rtemp{};
+          std::vector<ScalarT> valtemp{};
+          for (auto& tup : triplets)
+          {
+            rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
+            ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
+            valtemp.push_back(tup.val);
+          }
+          jac.axpy(1.0, rtemp, ctemp, valtemp); ///< Todo: Update once sparse storage format changes
         }
-        jac.setValues(rtemp, ctemp, valtemp);
+      }
+
+      /**
+       * @brief Function that computes the Jacobian via automatic differentiation
+       *
+       * @tparam ModelT - model type
+       * @tparam MemberFunctions - member function parameter key
+       * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
+       */
+      template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
+      void BranchJacobian(ModelT*                                            model,
+                          size_t                                             n_res,
+                          size_t                                             n_var,
+                          const std::map<IdxT, IdxT>&                        res_indices,
+                          const std::map<IdxT, IdxT>&                        var_indices,
+                          ScalarT*                                           y,
+                          ScalarT*                                           yp,
+                          ScalarT*                                           w,
+                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
+      {
+        std::vector<Triple<ScalarT>> triplets;
+        std::vector<ScalarT>         elementary_v(n_var);
+        if (n_res > 0 && n_var > 0)
+        {
+          for (size_t res_i = 0; res_i < n_res; ++res_i)
+          {
+            // Sparse storage
+            ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
+            ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
+
+            // Elementary vector for Jacobian-vector product
+            for (size_t var_i = 0; var_i < n_var; ++var_i)
+            {
+              elementary_v[var_i] = 0.0;
+            }
+            elementary_v[res_i] = 1.0;
+
+            // Autodiff
+            __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
+                                   enzyme_const,
+                                   model,
+                                   enzyme_const,
+                                   y,
+                                   enzyme_const,
+                                   yp,
+                                   enzyme_dup,
+                                   w,
+                                   output,
+                                   enzyme_dupnoneed,
+                                   elementary_v.data(),
+                                   d_output);
+          }
+
+          // Store result
+          std::vector<IdxT>    ctemp{};
+          std::vector<IdxT>    rtemp{};
+          std::vector<ScalarT> valtemp{};
+          for (auto& tup : triplets)
+          {
+            rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
+            ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
+            valtemp.push_back(tup.val);
+          }
+          jac.setValues(rtemp, ctemp, valtemp);
+        }
       }
     } // namespace Sparse
   } // namespace Enzyme

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -293,9 +293,9 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
+            std::vector<IdxT>    ctemp(triplets.size());
+            std::vector<IdxT>    rtemp(triplets.size());
+            std::vector<ScalarT> valtemp(triplets.size());
             for (auto& tup : triplets)
             {
               rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -293,9 +293,9 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp(triplets.size());
-            std::vector<IdxT>    rtemp(triplets.size());
-            std::vector<ScalarT> valtemp(triplets.size());
+            std::vector<IdxT>    ctemp{};
+            std::vector<IdxT>    rtemp{};
+            std::vector<ScalarT> valtemp{};
             for (auto& tup : triplets)
             {
               rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
@@ -355,9 +355,9 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp(triplets.size());
-            std::vector<IdxT>    rtemp(triplets.size());
-            std::vector<ScalarT> valtemp(triplets.size());
+            std::vector<IdxT>    ctemp{};
+            std::vector<IdxT>    rtemp{};
+            std::vector<ScalarT> valtemp{};
             for (auto& tup : triplets)
             {
               rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
@@ -417,9 +417,9 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp(triplets.size());
-            std::vector<IdxT>    rtemp(triplets.size());
-            std::vector<ScalarT> valtemp(triplets.size());
+            std::vector<IdxT>    ctemp{};
+            std::vector<IdxT>    rtemp{};
+            std::vector<ScalarT> valtemp{};
             for (auto& tup : triplets)
             {
               rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -226,7 +226,7 @@ namespace GridKit
       }
 
       /**
-       * @brief Function that computes the Jacobian via automatic differentiation
+       * @brief Enzyme automatic differentiation Jacobian evaluator: Internal Jacobian
        *
        * @tparam ModelT - model type
        * @tparam MemberFunctions - member function parameter key
@@ -244,194 +244,195 @@ namespace GridKit
        * @param[in,out] jac - Jacobian
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
-      void InternalJacobian(ModelT*                                            model,
-                            size_t                                             n_res,
-                            size_t                                             n_var,
-                            const std::map<IdxT, IdxT>&                        res_indices,
-                            const std::map<IdxT, IdxT>&                        var_indices,
-                            ScalarT*                                           y,
-                            ScalarT*                                           yp,
-                            ScalarT*                                           w,
-                            GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
+      struct InternalJacobian 
       {
-        std::vector<Triple<ScalarT>> triplets;
-        std::vector<ScalarT>         elementary_v(n_var);
-        if (n_res > 0 && n_var > 0)
+        static void eval(ModelT*                                            model,
+                         size_t                                             n_res,
+                         size_t                                             n_var,
+                         const std::map<IdxT, IdxT>&                        res_indices,
+                         const std::map<IdxT, IdxT>&                        var_indices,
+                         ScalarT*                                           y,
+                         ScalarT*                                           yp,
+                         ScalarT*                                           w,
+                         GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
-          for (size_t res_i = 0; res_i < n_res; ++res_i)
+          std::vector<Triple<ScalarT>> triplets;
+          std::vector<ScalarT>         elementary_v(n_var);
+          if (n_res > 0 && n_var > 0)
           {
-            // Sparse storage
-            ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
-            ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
-
-            // Elementary vector for Jacobian-vector product
-            for (size_t var_i = 0; var_i < n_var; ++var_i)
+            for (size_t res_i = 0; res_i < n_res; ++res_i)
             {
-              elementary_v[var_i] = 0.0;
+              // Sparse storage
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
+
+              // Elementary vector for Jacobian-vector product
+              for (size_t var_i = 0; var_i < n_var; ++var_i)
+              {
+                elementary_v[var_i] = 0.0;
+              }
+              elementary_v[res_i] = 1.0;
+
+              // Autodiff
+              __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
+                                     enzyme_const,
+                                     model,
+                                     enzyme_dup,
+                                     y,
+                                     output,
+                                     enzyme_const,
+                                     yp,
+                                     enzyme_const,
+                                     w,
+                                     enzyme_dupnoneed,
+                                     elementary_v.data(),
+                                     d_output);
             }
-            elementary_v[res_i] = 1.0;
 
-            // Autodiff
-            __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
-                                   enzyme_const,
-                                   model,
-                                   enzyme_dup,
-                                   y,
-                                   output,
-                                   enzyme_const,
-                                   yp,
-                                   enzyme_const,
-                                   w,
-                                   enzyme_dupnoneed,
-                                   elementary_v.data(),
-                                   d_output);
+            // Store result
+            std::vector<IdxT>    ctemp{};
+            std::vector<IdxT>    rtemp{};
+            std::vector<ScalarT> valtemp{};
+            for (auto& tup : triplets)
+            {
+              rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
+              ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
+              valtemp.push_back(tup.val);
+            }
+            jac.setValues(rtemp, ctemp, valtemp);
           }
-
-          // Store result
-          std::vector<IdxT>    ctemp{};
-          std::vector<IdxT>    rtemp{};
-          std::vector<ScalarT> valtemp{};
-          for (auto& tup : triplets)
-          {
-            rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
-            ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
-            valtemp.push_back(tup.val);
-          }
-          jac.setValues(rtemp, ctemp, valtemp);
         }
-      }
+      };
 
       /**
-       * @brief Function that computes the Jacobian via automatic differentiation
-       *
-       * @tparam ModelT - model type
-       * @tparam MemberFunctions - member function parameter key
-       * @tparam ScalarT - scalar data type
-       * @tparam IdxT - matrix index data type
+       * @brief Enzyme automatic differentiation Jacobian evaluator: Bus Jacobian
+       * 
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
-      void BusJacobian(ModelT*                                            model,
-                       size_t                                             n_res,
-                       size_t                                             n_var,
-                       const std::map<IdxT, IdxT>&                        res_indices,
-                       const std::map<IdxT, IdxT>&                        var_indices,
-                       ScalarT*                                           y,
-                       ScalarT*                                           yp,
-                       ScalarT*                                           w,
-                       GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
+      struct BusJacobian 
       {
-        std::vector<Triple<ScalarT>> triplets;
-        std::vector<ScalarT>         elementary_v(n_var);
-        if (n_res > 0 && n_var > 0)
+        static void eval(ModelT*                                            model,
+                         size_t                                             n_res,
+                         size_t                                             n_var,
+                         const std::map<IdxT, IdxT>&                        res_indices,
+                         const std::map<IdxT, IdxT>&                        var_indices,
+                         ScalarT*                                           y,
+                         ScalarT*                                           yp,
+                         ScalarT*                                           w,
+                         GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
-          for (size_t res_i = 0; res_i < n_res; ++res_i)
+          std::vector<Triple<ScalarT>> triplets;
+          std::vector<ScalarT>         elementary_v(n_var);
+          if (n_res > 0 && n_var > 0)
           {
-            // Sparse storage
-            ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
-            ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
-
-            // Elementary vector for Jacobian-vector product
-            for (size_t var_i = 0; var_i < n_var; ++var_i)
+            for (size_t res_i = 0; res_i < n_res; ++res_i)
             {
-              elementary_v[var_i] = 0.0;
+              // Sparse storage
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
+
+              // Elementary vector for Jacobian-vector product
+              for (size_t var_i = 0; var_i < n_var; ++var_i)
+              {
+                elementary_v[var_i] = 0.0;
+              }
+              elementary_v[res_i] = 1.0;
+
+              // Autodiff
+              __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
+                                     enzyme_const,
+                                     model,
+                                     enzyme_const,
+                                     y,
+                                     enzyme_const,
+                                     yp,
+                                     enzyme_dup,
+                                     w,
+                                     output,
+                                     enzyme_dupnoneed,
+                                     elementary_v.data(),
+                                     d_output);
             }
-            elementary_v[res_i] = 1.0;
 
-            // Autodiff
-            __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
-                                   enzyme_const,
-                                   model,
-                                   enzyme_const,
-                                   y,
-                                   enzyme_const,
-                                   yp,
-                                   enzyme_dup,
-                                   w,
-                                   output,
-                                   enzyme_dupnoneed,
-                                   elementary_v.data(),
-                                   d_output);
+            // Store result
+            std::vector<IdxT>    ctemp{};
+            std::vector<IdxT>    rtemp{};
+            std::vector<ScalarT> valtemp{};
+            for (auto& tup : triplets)
+            {
+              rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
+              ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
+              valtemp.push_back(tup.val);
+            }
+            jac.axpy(1.0, rtemp, ctemp, valtemp); ///< Todo: Update once sparse storage format changes
           }
-
-          // Store result
-          std::vector<IdxT>    ctemp{};
-          std::vector<IdxT>    rtemp{};
-          std::vector<ScalarT> valtemp{};
-          for (auto& tup : triplets)
-          {
-            rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
-            ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
-            valtemp.push_back(tup.val);
-          }
-          jac.axpy(1.0, rtemp, ctemp, valtemp); ///< Todo: Update once sparse storage format changes
         }
-      }
+      };
 
       /**
-       * @brief Function that computes the Jacobian via automatic differentiation
-       *
-       * @tparam ModelT - model type
-       * @tparam MemberFunctions - member function parameter key
-       * @tparam ScalarT - scalar data type
-       * @tparam IdxT - matrix index data type
+       * @brief Enzyme automatic differentiation Jacobian evaluator: Branch Jacobian
+       * 
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
-      void BranchJacobian(ModelT*                                            model,
-                          size_t                                             n_res,
-                          size_t                                             n_var,
-                          const std::map<IdxT, IdxT>&                        res_indices,
-                          const std::map<IdxT, IdxT>&                        var_indices,
-                          ScalarT*                                           y,
-                          ScalarT*                                           yp,
-                          ScalarT*                                           w,
-                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
+      struct BranchJacobian
       {
-        std::vector<Triple<ScalarT>> triplets;
-        std::vector<ScalarT>         elementary_v(n_var);
-        if (n_res > 0 && n_var > 0)
+        static void eval(ModelT*                                            model,
+                         size_t                                             n_res,
+                         size_t                                             n_var,
+                         const std::map<IdxT, IdxT>&                        res_indices,
+                         const std::map<IdxT, IdxT>&                        var_indices,
+                         ScalarT*                                           y,
+                         ScalarT*                                           yp,
+                         ScalarT*                                           w,
+                         GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
-          for (size_t res_i = 0; res_i < n_res; ++res_i)
+          std::vector<Triple<ScalarT>> triplets;
+          std::vector<ScalarT>         elementary_v(n_var);
+          if (n_res > 0 && n_var > 0)
           {
-            // Sparse storage
-            ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
-            ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
-
-            // Elementary vector for Jacobian-vector product
-            for (size_t var_i = 0; var_i < n_var; ++var_i)
+            for (size_t res_i = 0; res_i < n_res; ++res_i)
             {
-              elementary_v[var_i] = 0.0;
+              // Sparse storage
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, res_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, res_i, &triplets);
+
+              // Elementary vector for Jacobian-vector product
+              for (size_t var_i = 0; var_i < n_var; ++var_i)
+              {
+                elementary_v[var_i] = 0.0;
+              }
+              elementary_v[res_i] = 1.0;
+
+              // Autodiff
+              __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
+                                     enzyme_const,
+                                     model,
+                                     enzyme_const,
+                                     y,
+                                     enzyme_const,
+                                     yp,
+                                     enzyme_dup,
+                                     w,
+                                     output,
+                                     enzyme_dupnoneed,
+                                     elementary_v.data(),
+                                     d_output);
             }
-            elementary_v[res_i] = 1.0;
 
-            // Autodiff
-            __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
-                                   enzyme_const,
-                                   model,
-                                   enzyme_const,
-                                   y,
-                                   enzyme_const,
-                                   yp,
-                                   enzyme_dup,
-                                   w,
-                                   output,
-                                   enzyme_dupnoneed,
-                                   elementary_v.data(),
-                                   d_output);
+            // Store result
+            std::vector<IdxT>    ctemp{};
+            std::vector<IdxT>    rtemp{};
+            std::vector<ScalarT> valtemp{};
+            for (auto& tup : triplets)
+            {
+              rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
+              ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
+              valtemp.push_back(tup.val);
+            }
+            jac.setValues(rtemp, ctemp, valtemp);
           }
-
-          // Store result
-          std::vector<IdxT>    ctemp{};
-          std::vector<IdxT>    rtemp{};
-          std::vector<ScalarT> valtemp{};
-          for (auto& tup : triplets)
-          {
-            rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
-            ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
-            valtemp.push_back(tup.val);
-          }
-          jac.setValues(rtemp, ctemp, valtemp);
         }
-      }
+      };
     } // namespace Sparse
   } // namespace Enzyme
 } // namespace GridKit

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -417,9 +417,9 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
+            std::vector<IdxT>    ctemp(triplets.size());
+            std::vector<IdxT>    rtemp(triplets.size());
+            std::vector<ScalarT> valtemp(triplets.size());
             for (auto& tup : triplets)
             {
               rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -335,10 +335,7 @@ namespace GridKit
               ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
 
               // Elementary vector for Jacobian-vector product
-              for (size_t res_i = 0; res_i < n_res; ++res_i)
-              {
-                elementary_v[res_i] = 0.0;
-              }
+              std::ranges::fill(elementary_v, 0.0);
               elementary_v[var_i] = 1.0;
 
               // Autodiff

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -397,10 +397,7 @@ namespace GridKit
               ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
 
               // Elementary vector for Jacobian-vector product
-              for (size_t res_i = 0; res_i < n_res; ++res_i)
-              {
-                elementary_v[res_i] = 0.0;
-              }
+              std::ranges::fill(elementary_v, 0.0);
               elementary_v[var_i] = 1.0;
 
               // Autodiff

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -262,10 +262,10 @@ namespace GridKit
                          ScalarT*                                           w,
                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
-          std::vector<Triple<ScalarT>> triplets;
-          std::vector<ScalarT>         elementary_v(n_var);
           if (n_res > 0 && n_var > 0)
           {
+            std::vector<Triple<ScalarT>> triplets;
+            std::vector<ScalarT>         elementary_v(n_res);
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage
@@ -327,10 +327,10 @@ namespace GridKit
                          ScalarT*                                           w,
                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
-          std::vector<Triple<ScalarT>> triplets;
-          std::vector<ScalarT>         elementary_v(n_var);
           if (n_res > 0 && n_var > 0)
           {
+            std::vector<Triple<ScalarT>> triplets;
+            std::vector<ScalarT>         elementary_v(n_res);
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage
@@ -392,10 +392,10 @@ namespace GridKit
                          ScalarT*                                           w,
                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
-          std::vector<Triple<ScalarT>> triplets;
-          std::vector<ScalarT>         elementary_v(n_var);
           if (n_res > 0 && n_var > 0)
           {
+            std::vector<Triple<ScalarT>> triplets;
+            std::vector<ScalarT>         elementary_v(n_res);
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -355,9 +355,9 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
+            std::vector<IdxT>    ctemp(triplets.size());
+            std::vector<IdxT>    rtemp(triplets.size());
+            std::vector<ScalarT> valtemp(triplets.size());
             for (auto& tup : triplets)
             {
               rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -273,10 +273,7 @@ namespace GridKit
               ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
 
               // Elementary vector for Jacobian-vector product
-              for (size_t res_i = 0; res_i < n_res; ++res_i)
-              {
-                elementary_v[res_i] = 0.0;
-              }
+              std::ranges::fill(elementary_v, 0.0);
               elementary_v[var_i] = 1.0;
 
               // Autodiff

--- a/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/src/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -54,8 +54,10 @@ namespace GridKit
       std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<ScalarT>> setDataToCSR();
       std::vector<IdxT>                                                      getCSRRowData();
 
+      // Set values from vector storage. Will sort before storing
+      void setValues(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v);
+
       // BLAS. Will sort before running
-      void    setValues(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v);
       void    axpy(ScalarT alpha, COO_Matrix<ScalarT, IdxT>& a);
       void    axpy(ScalarT alpha, std::vector<IdxT> r, std::vector<IdxT> c, std::vector<ScalarT> v);
       void    scal(ScalarT alpha);
@@ -66,8 +68,8 @@ namespace GridKit
       void permutation(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm);
       void permutationSizeMap(std::vector<IdxT> row_perm, std::vector<IdxT> col_perm, IdxT m, IdxT n);
 
+      // Special matrices (zero and identity)
       void zeroMatrix();
-
       void identityMatrix(IdxT n);
 
       // Resort values_

--- a/src/Model/PhasorDynamics/Branch/Branch.cpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.cpp
@@ -10,6 +10,22 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    /**
+     * @brief Jacobian evaluation not implemented
+     *
+     * @tparam ScalarT - scalar data type
+     * @tparam IdxT    - matrix index data type
+     * @return int - error code, 0 = success
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::evaluateJacobian()
+    {
+      std::cout << "Evaluate Jacobian for Branch..." << std::endl;
+      std::cout << "Jacobian evaluation is not implemented!" << std::endl;
+
+      return 0;
+    }
+
     // Available template instantiations
     template class Branch<double, long int>;
     template class Branch<double, size_t>;

--- a/src/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.hpp
@@ -47,6 +47,9 @@ namespace GridKit
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::f_;
+      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::h_;
+      using Component<ScalarT, IdxT>::J_;
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;
       using bus_type        = BusBase<ScalarT, IdxT>;
@@ -73,25 +76,31 @@ namespace GridKit
       void setR(real_type R)
       {
         R_ = R;
+        setDerivedParams();
       }
 
       void setX(real_type X)
       {
         // std::cout << "Setting X ...\n";
         X_ = X;
+        setDerivedParams();
       }
 
       void setG(real_type G)
       {
         G_ = G;
+        setDerivedParams();
       }
 
       void setB(real_type B)
       {
         B_ = B;
+        setDerivedParams();
       }
 
     private:
+      void setDerivedParams();
+
       ScalarT& Vr1()
       {
         return bus1_->Vr();
@@ -132,6 +141,12 @@ namespace GridKit
         return bus2_->Ii();
       }
 
+    public:
+      __attribute__((always_inline)) inline int evaluateBusResidual11(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateBusResidual12(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateBusResidual21(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateBusResidual22(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+
     private:
       bus_type* bus1_;
       bus_type* bus2_;
@@ -141,6 +156,10 @@ namespace GridKit
       real_type B_{0.0};
       IdxT      bus1_id_{0};
       IdxT      bus2_id_{0};
+
+      /* Derivied parameters */
+      real_type b_;
+      real_type g_;
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/Branch/BranchDependencyTracking.cpp
+++ b/src/Model/PhasorDynamics/Branch/BranchDependencyTracking.cpp
@@ -10,6 +10,22 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    /**
+     * @brief Jacobian evaluation not implemented
+     *
+     * @tparam ScalarT - scalar data type
+     * @tparam IdxT    - matrix index data type
+     * @return int - error code, 0 = success
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::evaluateJacobian()
+    {
+      std::cout << "Evaluate Jacobian for Branch..." << std::endl;
+      std::cout << "Jacobian evaluation is not implemented!" << std::endl;
+
+      return 0;
+    }
+
     // Available template instantiations
     template class Branch<DependencyTracking::Variable, long int>;
     template class Branch<DependencyTracking::Variable, size_t>;

--- a/src/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
@@ -1,0 +1,99 @@
+/**
+ * @file BranchEnzyme.cpp
+ * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
+ *
+ */
+
+#include "BranchImpl.hpp"
+#include <AutomaticDifferentiation/Enzyme/SparseWrapper.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    /**
+     * @brief Jacobian evaluation experimental
+     *
+     * @tparam ScalarT - scalar data type
+     * @tparam IdxT    - matrix index data type
+     * @return int - error code, 0 = success
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::evaluateJacobian()
+    {
+      std::cout << "Evaluate Jacobian for Branch..." << std::endl;
+      std::cout << "Jacobian evaluation is experimental!" << std::endl;
+
+      // Bus 1 diagonal Jacobian block owned by the bus
+      GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
+                                           GridKit::Enzyme::Sparse::MemberFunctions::BusResidual11,
+                                           ScalarT,
+                                           IdxT>(
+          this,
+          static_cast<size_t>(bus1_->size()),
+          static_cast<size_t>((bus1_->y()).size()),
+          bus1_->getResidualIndices(),
+          bus1_->getVariableIndices(),
+          y_.data(),
+          yp_.data(),
+          (bus1_->y()).data(),
+          bus1_->getJacobian());
+
+      // Bus 2 diagonal Jacobian block owned by the bus
+      GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
+                                           GridKit::Enzyme::Sparse::MemberFunctions::BusResidual22,
+                                           ScalarT,
+                                           IdxT>(
+          this,
+          static_cast<size_t>(bus2_->size()),
+          static_cast<size_t>((bus2_->y()).size()),
+          bus2_->getResidualIndices(),
+          bus2_->getVariableIndices(),
+          y_.data(),
+          yp_.data(),
+          (bus2_->y()).data(),
+          bus2_->getJacobian());
+
+      // Off-diagonal Jacobian block (Bus2 variables) owned by the branch
+      GridKit::Enzyme::Sparse::BranchJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
+                                              GridKit::Enzyme::Sparse::MemberFunctions::BusResidual12,
+                                              ScalarT,
+                                              IdxT>(
+          this,
+          static_cast<size_t>(bus1_->size()),
+          static_cast<size_t>((bus2_->y()).size()),
+          bus1_->getResidualIndices(),
+          bus2_->getVariableIndices(),
+          y_.data(),
+          yp_.data(),
+          (bus2_->y()).data(),
+          J_);
+
+      J_.printMatrix("Branch after BusJacobian12 call");
+
+      // Off-diagonal Jacobian block (Bus1 variables) owned by the branch
+      GridKit::Enzyme::Sparse::BranchJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
+                                              GridKit::Enzyme::Sparse::MemberFunctions::BusResidual21,
+                                              ScalarT,
+                                              IdxT>(
+          this,
+          static_cast<size_t>(bus2_->size()),
+          static_cast<size_t>((bus1_->y()).size()),
+          bus2_->getResidualIndices(),
+          bus1_->getVariableIndices(),
+          y_.data(),
+          yp_.data(),
+          (bus1_->y()).data(),
+          J_);
+
+      J_.printMatrix("Branch after BusJacobian21 call");
+
+      return 0;
+    }
+
+    // Available template instantiations
+    template class Branch<double, long int>;
+    template class Branch<double, size_t>;
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
@@ -28,46 +28,43 @@ namespace GridKit
       GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
                                            GridKit::Enzyme::Sparse::MemberFunctions::BusResidual11,
                                            ScalarT,
-                                           IdxT>::eval(
-          this,
-          static_cast<size_t>(bus1_->size()),
-          static_cast<size_t>((bus1_->y()).size()),
-          bus1_->getResidualIndices(),
-          bus1_->getVariableIndices(),
-          y_.data(),
-          yp_.data(),
-          (bus1_->y()).data(),
-          bus1_->getJacobian());
+                                           IdxT>::eval(this,
+                                                       static_cast<size_t>(bus1_->size()),
+                                                       static_cast<size_t>((bus1_->y()).size()),
+                                                       bus1_->getResidualIndices(),
+                                                       bus1_->getVariableIndices(),
+                                                       y_.data(),
+                                                       yp_.data(),
+                                                       (bus1_->y()).data(),
+                                                       bus1_->getJacobian());
 
       // Bus 2 diagonal Jacobian block owned by the bus
       GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
                                            GridKit::Enzyme::Sparse::MemberFunctions::BusResidual22,
                                            ScalarT,
-                                           IdxT>::eval(
-          this,
-          static_cast<size_t>(bus2_->size()),
-          static_cast<size_t>((bus2_->y()).size()),
-          bus2_->getResidualIndices(),
-          bus2_->getVariableIndices(),
-          y_.data(),
-          yp_.data(),
-          (bus2_->y()).data(),
-          bus2_->getJacobian());
+                                           IdxT>::eval(this,
+                                                       static_cast<size_t>(bus2_->size()),
+                                                       static_cast<size_t>((bus2_->y()).size()),
+                                                       bus2_->getResidualIndices(),
+                                                       bus2_->getVariableIndices(),
+                                                       y_.data(),
+                                                       yp_.data(),
+                                                       (bus2_->y()).data(),
+                                                       bus2_->getJacobian());
 
       // Off-diagonal Jacobian block (Bus2 variables) owned by the branch
       GridKit::Enzyme::Sparse::BranchJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
                                               GridKit::Enzyme::Sparse::MemberFunctions::BusResidual12,
                                               ScalarT,
-                                              IdxT>::eval(
-          this,
-          static_cast<size_t>(bus1_->size()),
-          static_cast<size_t>((bus2_->y()).size()),
-          bus1_->getResidualIndices(),
-          bus2_->getVariableIndices(),
-          y_.data(),
-          yp_.data(),
-          (bus2_->y()).data(),
-          J_);
+                                              IdxT>::eval(this,
+                                                          static_cast<size_t>(bus1_->size()),
+                                                          static_cast<size_t>((bus2_->y()).size()),
+                                                          bus1_->getResidualIndices(),
+                                                          bus2_->getVariableIndices(),
+                                                          y_.data(),
+                                                          yp_.data(),
+                                                          (bus2_->y()).data(),
+                                                          J_);
 
       J_.printMatrix("Branch after BusJacobian12 call");
 
@@ -75,16 +72,15 @@ namespace GridKit
       GridKit::Enzyme::Sparse::BranchJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
                                               GridKit::Enzyme::Sparse::MemberFunctions::BusResidual21,
                                               ScalarT,
-                                              IdxT>::eval(
-          this,
-          static_cast<size_t>(bus2_->size()),
-          static_cast<size_t>((bus1_->y()).size()),
-          bus2_->getResidualIndices(),
-          bus1_->getVariableIndices(),
-          y_.data(),
-          yp_.data(),
-          (bus1_->y()).data(),
-          J_);
+                                              IdxT>::eval(this,
+                                                          static_cast<size_t>(bus2_->size()),
+                                                          static_cast<size_t>((bus1_->y()).size()),
+                                                          bus2_->getResidualIndices(),
+                                                          bus1_->getVariableIndices(),
+                                                          y_.data(),
+                                                          yp_.data(),
+                                                          (bus1_->y()).data(),
+                                                          J_);
 
       J_.printMatrix("Branch after BusJacobian21 call");
 

--- a/src/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
@@ -28,7 +28,7 @@ namespace GridKit
       GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
                                            GridKit::Enzyme::Sparse::MemberFunctions::BusResidual11,
                                            ScalarT,
-                                           IdxT>(
+                                           IdxT>::eval(
           this,
           static_cast<size_t>(bus1_->size()),
           static_cast<size_t>((bus1_->y()).size()),
@@ -43,7 +43,7 @@ namespace GridKit
       GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
                                            GridKit::Enzyme::Sparse::MemberFunctions::BusResidual22,
                                            ScalarT,
-                                           IdxT>(
+                                           IdxT>::eval(
           this,
           static_cast<size_t>(bus2_->size()),
           static_cast<size_t>((bus2_->y()).size()),
@@ -58,7 +58,7 @@ namespace GridKit
       GridKit::Enzyme::Sparse::BranchJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
                                               GridKit::Enzyme::Sparse::MemberFunctions::BusResidual12,
                                               ScalarT,
-                                              IdxT>(
+                                              IdxT>::eval(
           this,
           static_cast<size_t>(bus1_->size()),
           static_cast<size_t>((bus2_->y()).size()),
@@ -75,7 +75,7 @@ namespace GridKit
       GridKit::Enzyme::Sparse::BranchJacobian<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
                                               GridKit::Enzyme::Sparse::MemberFunctions::BusResidual21,
                                               ScalarT,
-                                              IdxT>(
+                                              IdxT>::eval(
           this,
           static_cast<size_t>(bus2_->size()),
           static_cast<size_t>((bus1_->y()).size()),

--- a/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -170,7 +170,7 @@ namespace GridKit
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual11(
+    __attribute__((always_inline)) inline int Branch<ScalarT, IdxT>::evaluateBusResidual11(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  w,

--- a/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -191,7 +191,7 @@ namespace GridKit
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual12(
+    __attribute__((always_inline)) inline int Branch<ScalarT, IdxT>::evaluateBusResidual12(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  w,

--- a/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -37,6 +37,7 @@ namespace GridKit
         bus2_id_(0)
     {
       size_ = 0;
+      setDerivedParams();
     }
 
     /**
@@ -67,6 +68,7 @@ namespace GridKit
         bus1_id_(0),
         bus2_id_(0)
     {
+      setDerivedParams();
     }
 
     template <class ScalarT, typename IdxT>
@@ -105,6 +107,7 @@ namespace GridKit
       }
 
       size_ = 0;
+      setDerivedParams();
     }
 
     /**
@@ -136,6 +139,10 @@ namespace GridKit
     int Branch<ScalarT, IdxT>::allocate()
     {
       // std::cout << "Allocate Branch..." << std::endl;
+
+      w_.resize(2);
+      h_.resize(2);
+
       return 0;
     }
 
@@ -159,38 +166,126 @@ namespace GridKit
     }
 
     /**
-     * \brief Residual contribution of the branch is pushed to the
-     * two terminal buses.
+     * @brief Bus 1 residual contribution from bus 1 variables
      *
      */
     template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateResidual()
+    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual11(
+        [[maybe_unused]] ScalarT* y,
+        [[maybe_unused]] ScalarT* yp,
+        ScalarT*                  w,
+        ScalarT*                  h)
     {
-      // std::cout << "Evaluating branch residual ...\n";
-      real_type b = -X_ / (R_ * R_ + X_ * X_);
-      real_type g = R_ / (R_ * R_ + X_ * X_);
-
-      Ir1() += -(g + 0.5 * G_) * Vr1() + (b + 0.5 * B_) * Vi1() + g * Vr2() - b * Vi2();
-      Ii1() += -(b + 0.5 * B_) * Vr1() - (g + 0.5 * G_) * Vi1() + b * Vr2() + g * Vi2();
-      Ir2() += g * Vr1() - b * Vi1() - (g + 0.5 * G_) * Vr2() + (b + 0.5 * B_) * Vi2();
-      Ii2() += b * Vr1() + g * Vi1() - (b + 0.5 * B_) * Vr2() - (g + 0.5 * G_) * Vi2();
+      ScalarT Vr1 = w[0];
+      ScalarT Vi1 = w[1];
+      ScalarT Ir1 = -(g_ + 0.5 * G_) * Vr1 + (b_ + 0.5 * B_) * Vi1;
+      ScalarT Ii1 = -(b_ + 0.5 * B_) * Vr1 - (g_ + 0.5 * G_) * Vi1;
+      h[0]        = Ir1;
+      h[1]        = Ii1;
 
       return 0;
     }
 
     /**
-     * @brief Jacobian evaluation not implemented yet
+     * @brief Bus 1 residual contribution from bus 2 variables
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
      */
     template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateJacobian()
+    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual12(
+        [[maybe_unused]] ScalarT* y,
+        [[maybe_unused]] ScalarT* yp,
+        ScalarT*                  w,
+        ScalarT*                  h)
     {
-      std::cout << "Evaluate Jacobian for Branch..." << std::endl;
-      std::cout << "Jacobian evaluation not implemented!" << std::endl;
+      ScalarT Vr2 = w[0];
+      ScalarT Vi2 = w[1];
+      ScalarT Ir1 = g_ * Vr2 - b_ * Vi2;
+      ScalarT Ii1 = b_ * Vr2 + g_ * Vi2;
+      h[0]        = Ir1;
+      h[1]        = Ii1;
+
       return 0;
+    }
+
+    /**
+     * @brief Bus 2 residual contribution from bus 1 variables
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual21(
+        [[maybe_unused]] ScalarT* y,
+        [[maybe_unused]] ScalarT* yp,
+        ScalarT*                  w,
+        ScalarT*                  h)
+    {
+      ScalarT Vr1 = w[0];
+      ScalarT Vi1 = w[1];
+      ScalarT Ir2 = g_ * Vr1 - b_ * Vi1;
+      ScalarT Ii2 = b_ * Vr1 + g_ * Vi1;
+      h[0]        = Ir2;
+      h[1]        = Ii2;
+
+      return 0;
+    }
+
+    /**
+     * @brief Bus 2 residual contribution from bus 2 variables
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual22(
+        [[maybe_unused]] ScalarT* y,
+        [[maybe_unused]] ScalarT* yp,
+        ScalarT*                  w,
+        ScalarT*                  h)
+    {
+      ScalarT Vr2 = w[0];
+      ScalarT Vi2 = w[1];
+      ScalarT Ir2 = -(g_ + 0.5 * G_) * Vr2 + (b_ + 0.5 * B_) * Vi2;
+      ScalarT Ii2 = -(b_ + 0.5 * B_) * Vr2 - (g_ + 0.5 * G_) * Vi2;
+      h[0]        = Ir2;
+      h[1]        = Ii2;
+
+      return 0;
+    }
+
+    /**
+     * @brief Residual contribution of the branch is computed and pushed to the terminal buses.
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::evaluateResidual()
+    {
+      w_[0] = Vr1();
+      w_[1] = Vi1();
+      evaluateBusResidual11(y_.data(), yp_.data(), w_.data(), h_.data());
+      Ir1() += h_[0];
+      Ii1() += h_[1];
+      evaluateBusResidual21(y_.data(), yp_.data(), w_.data(), h_.data());
+      Ir2() += h_[0];
+      Ii2() += h_[1];
+
+      w_[0] = Vr2();
+      w_[1] = Vi2();
+      evaluateBusResidual12(y_.data(), yp_.data(), w_.data(), h_.data());
+      Ir1() += h_[0];
+      Ii1() += h_[1];
+      evaluateBusResidual22(y_.data(), yp_.data(), w_.data(), h_.data());
+      Ir2() += h_[0];
+      Ii2() += h_[1];
+
+      return 0;
+    }
+
+    /**
+     * @brief Derived parameters
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    void Branch<ScalarT, IdxT>::setDerivedParams()
+    {
+      b_ = -X_ / (R_ * R_ + X_ * X_);
+      g_ = R_ / (R_ * R_ + X_ * X_);
     }
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/Branch/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Branch/CMakeLists.txt
@@ -5,15 +5,27 @@
 #    - Slaven Peles <peless@ornl.gov>
 # ]]
 
-gridkit_add_library(phasor_dynamics_branch
-  SOURCES
-    Branch.cpp
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_branch)
+if(GRIDKIT_ENABLE_ENZYME)
+  gridkit_add_library(phasor_dynamics_branch
+    SOURCES
+      BranchEnzyme.cpp
+    LINK_LIBRARIES
+      ClangEnzymeFlags
+    COMPILE_OPTIONS
+      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno
+    OUTPUT_NAME
+      gridkit_phasor_dynamics_branch)
+else()
+  gridkit_add_library(phasor_dynamics_branch
+    SOURCES
+      Branch.cpp
+    OUTPUT_NAME
+      gridkit_phasor_dynamics_branch)
+endif()
 
 gridkit_add_library(phasor_dynamics_branch_dependency_tracking
   SOURCES
-  BranchDependencyTracking.cpp
+    BranchDependencyTracking.cpp
   OUTPUT_NAME
     gridkit_phasor_dynamics_branch_dependency_tracking)
 

--- a/src/Model/PhasorDynamics/Bus/Bus.cpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.cpp
@@ -8,9 +8,9 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
+     * @tparam ScalarT - data type for Jacobian elements
+     * @tparam IdxT    - data type for matrix indices
+     * @return int - error code
      */
     template <class ScalarT, typename IdxT>
     int Bus<ScalarT, IdxT>::evaluateJacobian()

--- a/src/Model/PhasorDynamics/Bus/Bus.hpp
+++ b/src/Model/PhasorDynamics/Bus/Bus.hpp
@@ -18,11 +18,15 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     class Bus : public BusBase<ScalarT, IdxT>
     {
+      using BusBase<ScalarT, IdxT>::bus_id_;
       using BusBase<ScalarT, IdxT>::size_;
       using BusBase<ScalarT, IdxT>::y_;
       using BusBase<ScalarT, IdxT>::yp_;
       using BusBase<ScalarT, IdxT>::f_;
+      using BusBase<ScalarT, IdxT>::J_;
       using BusBase<ScalarT, IdxT>::tag_;
+      using BusBase<ScalarT, IdxT>::variable_indices_;
+      using BusBase<ScalarT, IdxT>::residual_indices_;
 
     public:
       using real_type = typename BusBase<ScalarT, IdxT>::real_type;
@@ -34,6 +38,7 @@ namespace GridKit
       Bus(const DataT& data);
       virtual ~Bus();
 
+      virtual int setBusID(IdxT) override;
       virtual int allocate() override;
       virtual int tagDifferentiable() override;
       virtual int initialize() override;

--- a/src/Model/PhasorDynamics/Bus/BusDependencyTracking.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusDependencyTracking.cpp
@@ -8,9 +8,9 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
+     * @tparam ScalarT - data type for Jacobian elements
+     * @tparam IdxT    - data type for matrix indices
+     * @return int - error code
      */
     template <class ScalarT, typename IdxT>
     int Bus<ScalarT, IdxT>::evaluateJacobian()

--- a/src/Model/PhasorDynamics/Bus/BusDependencyTracking.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusDependencyTracking.cpp
@@ -22,8 +22,8 @@ namespace GridKit
     }
 
     // Available template instantiations
-    template class Bus<double, long int>;
-    template class Bus<double, size_t>;
+    template class Bus<DependencyTracking::Variable, long int>;
+    template class Bus<DependencyTracking::Variable, size_t>;
 
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/BusEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusEnzyme.cpp
@@ -1,0 +1,38 @@
+
+#include "BusImpl.hpp"
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    /**
+     * @brief Jacobian evaluation experimental. This sets values to, for other
+     * components to add their contributions.
+     *
+     * @warning This implementation assumes bus Jacobians are always evaluated
+     * _before_ component model Jacobians.
+     *
+     * @tparam ScalarT - data type for Jacobian elements
+     * @tparam IdxT    - data type for matrix indices
+     * @return int - error code
+     */
+    template <class ScalarT, typename IdxT>
+    int Bus<ScalarT, IdxT>::evaluateJacobian()
+    {
+      std::cout << "Evaluate Jacobian for Bus..." << std::endl;
+      std::cout << "Jacobian evaluation is experimental!" << std::endl;
+
+      std::vector<IdxT>    rtemp   = {residual_indices_.at(0), residual_indices_.at(0), residual_indices_.at(1), residual_indices_.at(1)};
+      std::vector<IdxT>    ctemp   = {variable_indices_.at(0), variable_indices_.at(1), variable_indices_.at(0), variable_indices_.at(1)};
+      std::vector<ScalarT> valtemp = {0.0, 0.0, 0.0, 0.0};
+      J_.setValues(rtemp, ctemp, valtemp); ///< Todo: Update once sparse storage format changes
+      J_.printMatrix("Bus Jacobian initialization... should be 2x2 with zero values.");
+      return 0;
+    }
+
+    // Available template instantiations
+    template class Bus<double, long int>;
+    template class Bus<double, size_t>;
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/BusEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusEnzyme.cpp
@@ -1,3 +1,8 @@
+/**
+ * @file BusEnzyme.cpp
+ * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
+ *
+ */
 
 #include "BusImpl.hpp"
 
@@ -25,7 +30,7 @@ namespace GridKit
       std::vector<IdxT>    rtemp   = {residual_indices_.at(0), residual_indices_.at(0), residual_indices_.at(1), residual_indices_.at(1)};
       std::vector<IdxT>    ctemp   = {variable_indices_.at(0), variable_indices_.at(1), variable_indices_.at(0), variable_indices_.at(1)};
       std::vector<ScalarT> valtemp = {0.0, 0.0, 0.0, 0.0};
-      J_.setValues(rtemp, ctemp, valtemp); ///< Todo: Update once sparse storage format changes
+      J_.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
       J_.printMatrix("Bus Jacobian initialization... should be 2x2 with zero values.");
       return 0;
     }

--- a/src/Model/PhasorDynamics/Bus/BusEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusEnzyme.cpp
@@ -6,7 +6,7 @@ namespace GridKit
   namespace PhasorDynamics
   {
     /**
-     * @brief Jacobian evaluation experimental. This sets values to, for other
+     * @brief Jacobian evaluation experimental. This sets values to 0, for other
      * components to add their contributions.
      *
      * @warning This implementation assumes bus Jacobians are always evaluated

--- a/src/Model/PhasorDynamics/Bus/BusImpl.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusImpl.hpp
@@ -1,0 +1,151 @@
+
+#include <cmath>
+#include <iostream>
+
+#include "Bus.hpp"
+#include <Model/PhasorDynamics/Bus/BusData.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+
+    /*!
+     * @brief Constructor for a phasor dynamics bus.
+     *
+     * The model is using current balance in Cartesian coordinates.
+     *
+     * @todo Arguments that should be passed to ModelEvaluatorImpl constructor:
+     * - Number of equations = 2 (size_)
+     * - Number of variables = 2 (size_)
+     * - Number of quadratures = 0
+     * - Number of optimization parameters = 0
+     */
+    template <class ScalarT, typename IdxT>
+    Bus<ScalarT, IdxT>::Bus()
+      : Vr0_(0.0), Vi0_(0.0)
+    {
+      size_ = 2;
+    }
+
+    /*!
+     * @brief Bus constructor.
+     *
+     * This constructor sets initial values for active and reactive voltage.
+     *
+     * @todo Arguments that should be passed to ModelEvaluatorImpl constructor:
+     * - Number of equations = 2 (size_)
+     * - Number of variables = 2 (size_)
+     * - Number of quadratures = 0
+     * - Number of optimization parameters = 0
+     */
+    template <class ScalarT, typename IdxT>
+    Bus<ScalarT, IdxT>::Bus(ScalarT Vr, ScalarT Vi)
+      : Vr0_(Vr), Vi0_(Vi)
+    {
+      size_ = 2;
+    }
+
+    /**
+     * @brief Construct a new Bus
+     *
+     * @tparam ScalarT - type of scalar variables
+     * @tparam IdxT    - type for vector/matrix indices
+     * @param[in] data - structure with bus data
+     */
+    template <class ScalarT, typename IdxT>
+    Bus<ScalarT, IdxT>::Bus(const DataT& data)
+      : BusBase<ScalarT, IdxT>(data.bus_id),
+        Vr0_(data.Vr0),
+        Vi0_(data.Vi0)
+    {
+      // std::cout << "Create Bus..." << std::endl;
+      // std::cout << "Number of equations is " << size_ << std::endl;
+
+      size_ = 2;
+    }
+
+    template <class ScalarT, typename IdxT>
+    Bus<ScalarT, IdxT>::~Bus()
+    {
+      // std::cout << "Destroy PQ bus ..." << std::endl;
+    }
+
+    /*!
+     * @brief allocate method resizes local solution and residual vectors.
+     */
+    template <class ScalarT, typename IdxT>
+    int Bus<ScalarT, IdxT>::allocate()
+    {
+      // Temporary while we use std::vector in the code
+      size_t size = static_cast<size_t>(size_);
+
+      // Resize component model data
+      f_.resize(size);
+      y_.resize(size);
+      yp_.resize(size);
+      tag_.resize(size);
+
+      // Default variable and residual index mapping to local index
+      for (IdxT j = 0; j < size_; ++j)
+      {
+        this->setVariableIndex(j, j);
+        this->setResidualIndex(j, j);
+      }
+
+      return 0;
+    }
+
+    /**
+     * @brief Set the component ID
+     */
+    template <class ScalarT, typename IdxT>
+    int Bus<ScalarT, IdxT>::setBusID(IdxT bus_id)
+    {
+      bus_id_ = bus_id;
+      return 0;
+    }
+
+    /*!
+     * @brief Bus variables are algebraic.
+     */
+    template <class ScalarT, typename IdxT>
+    int Bus<ScalarT, IdxT>::tagDifferentiable()
+    {
+      tag_[0] = false;
+      tag_[1] = false;
+      return 0;
+    }
+
+    /*!
+     * @brief initialize method sets bus variables to stored initial values.
+     */
+    template <class ScalarT, typename IdxT>
+    int Bus<ScalarT, IdxT>::initialize()
+    {
+      // std::cout << "Initialize Bus..." << std::endl;
+      y_[0]  = Vr0_;
+      y_[1]  = Vi0_;
+      yp_[0] = 0.0;
+      yp_[1] = 0.0;
+
+      return 0;
+    }
+
+    /*!
+     * @brief PQ bus does not compute residuals, so here we just reset residual values.
+     *
+     * @warning This implementation assumes bus residuals are always evaluated
+     * _before_ component model residuals.
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    int Bus<ScalarT, IdxT>::evaluateResidual()
+    {
+      // std::cout << "Evaluating residual of a PQ bus ...\n";
+      f_[0] = 0.0;
+      f_[1] = 0.0;
+      return 0;
+    }
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/BusInfinite.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusInfinite.hpp
@@ -16,10 +16,12 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     class BusInfinite : public BusBase<ScalarT, IdxT>
     {
+      using BusBase<ScalarT, IdxT>::bus_id_;
       using BusBase<ScalarT, IdxT>::size_;
       using BusBase<ScalarT, IdxT>::y_;
       using BusBase<ScalarT, IdxT>::yp_;
       using BusBase<ScalarT, IdxT>::f_;
+      using BusBase<ScalarT, IdxT>::J_;
 
     public:
       using real_type = typename BusBase<ScalarT, IdxT>::real_type;
@@ -31,6 +33,7 @@ namespace GridKit
       BusInfinite(const DataT& data);
       virtual ~BusInfinite();
 
+      virtual int setBusID(IdxT) override;
       virtual int allocate() override;
       virtual int tagDifferentiable() override;
       virtual int initialize() override;

--- a/src/Model/PhasorDynamics/Bus/BusInfiniteDependencyTracking.cpp
+++ b/src/Model/PhasorDynamics/Bus/BusInfiniteDependencyTracking.cpp
@@ -6,8 +6,8 @@ namespace GridKit
   namespace PhasorDynamics
   {
     // Available template instantiations
-    template class BusInfinite<double, long int>;
-    template class BusInfinite<double, size_t>;
+    template class BusInfinite<DependencyTracking::Variable, long int>;
+    template class BusInfinite<DependencyTracking::Variable, size_t>;
 
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/BusInfiniteImpl.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusInfiniteImpl.hpp
@@ -1,0 +1,140 @@
+
+#include <cmath>
+#include <iostream>
+
+#include "BusInfinite.hpp"
+#include <Model/PhasorDynamics/Bus/BusData.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+
+    /*!
+     * @brief Constructor for an infinite (slack) bus.
+     *
+     * The model is using current balance in Cartesian coordinates.
+     *
+     * Arguments to be passed to BusBase:
+     * - Number of equations = 0 (size_)
+     * - Number of variables = 0 (size_)
+     */
+    template <class ScalarT, typename IdxT>
+    BusInfinite<ScalarT, IdxT>::BusInfinite()
+    {
+      size_ = 0;
+    }
+
+    /*!
+     * @brief BusInfinite constructor.
+     *
+     * This constructor sets initial values for active and reactive voltage.
+     *
+     * Arguments to be passed to BusBase:
+     * - Number of equations = 0 (size_)
+     * - Number of variables = 0 (size_)
+     */
+    template <class ScalarT, typename IdxT>
+    BusInfinite<ScalarT, IdxT>::BusInfinite(ScalarT Vr, ScalarT Vi)
+      : Vr_(Vr), Vi_(Vi)
+    {
+      size_ = 0;
+    }
+
+    /**
+     * @brief Construct a new BusInfinite
+     *
+     * Arguments to be set in BusBase:
+     * - Number of equations = 0 (size_)
+     * - Number of variables = 0 (size_)
+
+     * @tparam ScalarT - type of scalar variables
+     * @tparam IdxT    - type for vector/matrix indices
+     * @param[in] data - structure with bus data
+     */
+    template <class ScalarT, typename IdxT>
+    BusInfinite<ScalarT, IdxT>::BusInfinite(const DataT& data)
+      : BusBase<ScalarT, IdxT>(data.bus_id),
+        Vr_(data.Vr0),
+        Vi_(data.Vi0)
+    {
+      size_ = 0;
+    }
+
+    template <class ScalarT, typename IdxT>
+    BusInfinite<ScalarT, IdxT>::~BusInfinite()
+    {
+    }
+
+    /**
+     * @brief Set the bus ID
+     */
+    template <class ScalarT, typename IdxT>
+    int BusInfinite<ScalarT, IdxT>::setBusID(IdxT bus_id)
+    {
+      bus_id_ = bus_id;
+      return 0;
+    }
+
+    /*!
+     * @brief allocate method resizes local solution and residual vectors.
+     */
+    template <class ScalarT, typename IdxT>
+    int BusInfinite<ScalarT, IdxT>::allocate()
+    {
+      return 0;
+    }
+
+    /**
+     * @brief Tag differentiable variables
+     */
+    template <class ScalarT, typename IdxT>
+    int BusInfinite<ScalarT, IdxT>::tagDifferentiable()
+    {
+      return 0;
+    }
+
+    /*!
+     * @brief initialize method sets bus variables to stored initial values.
+     */
+    template <class ScalarT, typename IdxT>
+    int BusInfinite<ScalarT, IdxT>::initialize()
+    {
+      return 0;
+    }
+
+    /*!
+     * @brief Reset slack currents to zero.
+     *
+     * Infinite bus does not compute residuals, so here we just reset
+     * current values to zero. Components connected to the infinite bus
+     * will add their currents to Ir_ and Ii_. The resultant will be slack
+     * current that the infinite bus has to pick up.
+     *
+     * @warning This implementation assumes bus residuals are always evaluated
+     * _before_ component model residuals.
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    int BusInfinite<ScalarT, IdxT>::evaluateResidual()
+    {
+      Ir_ = 0.0;
+      Ii_ = 0.0;
+      return 0;
+    }
+
+    /**
+     * @brief There is no Jacobian for slack variables
+     *
+     * @tparam ScalarT - data type for Jacobian elements
+     * @tparam IdxT    - data type for matrix indices
+     * @return int - error code
+     */
+    template <class ScalarT, typename IdxT>
+    int BusInfinite<ScalarT, IdxT>::evaluateJacobian()
+    {
+      return 0;
+    }
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/Bus/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Bus/CMakeLists.txt
@@ -4,12 +4,29 @@
 #    - Slaven Peles <peless@ornl.gov>
 #]]
 
-gridkit_add_library(phasor_dynamics_bus
+if(GRIDKIT_ENABLE_ENZYME)
+  gridkit_add_library(phasor_dynamics_bus
+    SOURCES
+      BusEnzyme.cpp
+      BusInfinite.cpp
+    OUTPUT_NAME
+      gridkit_phasor_dynamics_bus)
+else()
+  gridkit_add_library(phasor_dynamics_bus
+    SOURCES
+      Bus.cpp
+      BusInfinite.cpp
+    OUTPUT_NAME
+      gridkit_phasor_dynamics_bus)
+endif()
+
+gridkit_add_library(phasor_dynamics_bus_dependency_tracking
   SOURCES
-    Bus.cpp
-    BusInfinite.cpp
+    BusDependencyTracking.cpp
+    BusInfiniteDependencyTracking.cpp
   OUTPUT_NAME
-    gridkit_phasor_dynamics_bus)
+    gridkit_phasor_dynamics_bus_dependency_tracking)
 
 # Link to interface target for all components
 target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_bus)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_bus_dependency_tracking)

--- a/src/Model/PhasorDynamics/BusBase.hpp
+++ b/src/Model/PhasorDynamics/BusBase.hpp
@@ -165,10 +165,10 @@ namespace GridKit
 
       IdxT                 size_{0};
       IdxT                 nnz_{0};
-      std::map<IdxT, IdxT> variable_indices_; ///< Map between local and global (system-level) 
-                                              ///variable indices
-      std::map<IdxT, IdxT> residual_indices_; ///< Map between local and global (system-level) 
-                                              ///residual indices
+      std::map<IdxT, IdxT> variable_indices_; ///< Map between local and global (system-level)
+                                              /// variable indices
+      std::map<IdxT, IdxT> residual_indices_; ///< Map between local and global (system-level)
+                                              /// residual indices
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;

--- a/src/Model/PhasorDynamics/BusBase.hpp
+++ b/src/Model/PhasorDynamics/BusBase.hpp
@@ -121,16 +121,52 @@ namespace GridKit
         return J_;
       }
 
+      virtual int setBusID(IdxT) = 0;
+
       virtual const IdxT busID() const
       {
         return bus_id_;
       }
 
-    protected:
-      const IdxT bus_id_{static_cast<IdxT>(-1)};
+      int setVariableIndex(IdxT local_index, IdxT global_index)
+      {
+        variable_indices_[local_index] = global_index;
+        return 0;
+      }
 
-      IdxT size_{0};
-      IdxT nnz_{0};
+      IdxT getVariableIndex(IdxT local_index) const
+      {
+        return variable_indices_.at(local_index);
+      }
+
+      const std::map<IdxT, IdxT>& getVariableIndices() const
+      {
+        return variable_indices_;
+      }
+
+      int setResidualIndex(IdxT local_index, IdxT global_index)
+      {
+        residual_indices_[local_index] = global_index;
+        return 0;
+      }
+
+      IdxT getResidualIndex(IdxT local_index) const
+      {
+        return residual_indices_.at(local_index);
+      }
+
+      const std::map<IdxT, IdxT>& getResidualIndices() const
+      {
+        return residual_indices_;
+      }
+
+    protected:
+      IdxT bus_id_{static_cast<IdxT>(-1)};
+
+      IdxT                 size_{0};
+      IdxT                 nnz_{0};
+      std::map<IdxT, IdxT> variable_indices_;
+      std::map<IdxT, IdxT> residual_indices_;
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;

--- a/src/Model/PhasorDynamics/BusBase.hpp
+++ b/src/Model/PhasorDynamics/BusBase.hpp
@@ -165,8 +165,10 @@ namespace GridKit
 
       IdxT                 size_{0};
       IdxT                 nnz_{0};
-      std::map<IdxT, IdxT> variable_indices_;
-      std::map<IdxT, IdxT> residual_indices_;
+      std::map<IdxT, IdxT> variable_indices_; ///< Map between local and global (system-level) 
+                                              ///variable indices
+      std::map<IdxT, IdxT> residual_indices_; ///< Map between local and global (system-level) 
+                                              ///residual indices
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;

--- a/src/Model/PhasorDynamics/BusFault/BusFault.cpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.cpp
@@ -12,6 +12,21 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    /**
+     * @brief Jacobian evaluation not implemented yet
+     *
+     * @tparam ScalarT - scalar data type
+     * @tparam IdxT    - matrix index data type
+     * @return int - error code, 0 = success
+     */
+    template <class ScalarT, typename IdxT>
+    int BusFault<ScalarT, IdxT>::evaluateJacobian()
+    {
+      std::cout << "Evaluate Jacobian for BusFault..." << std::endl;
+      std::cout << "Jacobian evaluation not implemented!" << std::endl;
+      return 0;
+    }
+
     // available template instantiations
     template class BusFault<double, long int>;
     template class BusFault<double, size_t>;

--- a/src/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -24,13 +24,14 @@ namespace GridKit
     {
       using Component<ScalarT, IdxT>::gridkit_component_id_;
       using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::f_;
       using Component<ScalarT, IdxT>::nnz_;
       using Component<ScalarT, IdxT>::size_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::time_;
       using Component<ScalarT, IdxT>::y_;
       using Component<ScalarT, IdxT>::yp_;
+      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::h_;
 
       using bus_type  = BusBase<ScalarT, IdxT>;
       using real_type = typename Component<ScalarT, IdxT>::real_type;
@@ -57,11 +58,13 @@ namespace GridKit
       void setR(real_type R)
       {
         R_ = R;
+        setDerivedParams();
       }
 
       void setX(real_type X)
       {
         X_ = X;
+        setDerivedParams();
       }
 
       void setStatus(bool status)
@@ -70,6 +73,8 @@ namespace GridKit
       }
 
     private:
+      void setDerivedParams();
+
       ScalarT& Vr()
       {
         return bus_->Vr();
@@ -90,12 +95,19 @@ namespace GridKit
         return bus_->Ii();
       }
 
+    public:
+      __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+
     private:
       bus_type* bus_;
       real_type R_{0.0};
       real_type X_{0.0};
       bool      status_{false};
       IdxT      bus_id_{0};
+
+      /* Derivied parameters */
+      real_type B_;
+      real_type G_;
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/BusFault/BusFaultDependencyTracking.cpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultDependencyTracking.cpp
@@ -4,6 +4,21 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    /**
+     * @brief Jacobian evaluation not implemented yet
+     *
+     * @tparam ScalarT - scalar data type
+     * @tparam IdxT    - matrix index data type
+     * @return int - error code, 0 = success
+     */
+    template <class ScalarT, typename IdxT>
+    int BusFault<ScalarT, IdxT>::evaluateJacobian()
+    {
+      std::cout << "Evaluate Jacobian for BusFault..." << std::endl;
+      std::cout << "Jacobian evaluation not implemented!" << std::endl;
+      return 0;
+    }
+
     // Additional template instantiations
     template class BusFault<DependencyTracking::Variable, long int>;
     template class BusFault<DependencyTracking::Variable, size_t>;

--- a/src/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
@@ -24,16 +24,15 @@ namespace GridKit
         GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::BusFault<ScalarT, IdxT>,
                                              GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
                                              ScalarT,
-                                             IdxT>::eval(
-            this,
-            static_cast<size_t>(bus_->size()),
-            static_cast<size_t>(bus_->size()),
-            bus_->getResidualIndices(),
-            bus_->getVariableIndices(),
-            y_.data(),
-            yp_.data(),
-            (bus_->y()).data(),
-            bus_->getJacobian());
+                                             IdxT>::eval(this,
+                                                         static_cast<size_t>(bus_->size()),
+                                                         static_cast<size_t>(bus_->size()),
+                                                         bus_->getResidualIndices(),
+                                                         bus_->getVariableIndices(),
+                                                         y_.data(),
+                                                         yp_.data(),
+                                                         (bus_->y()).data(),
+                                                         bus_->getJacobian());
       }
 
       return 0;

--- a/src/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
@@ -1,3 +1,8 @@
+/**
+ * @file BusFaultEnzyme.cpp
+ * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
+ *
+ */
 
 #include "BusFaultImpl.hpp"
 #include <AutomaticDifferentiation/Enzyme/SparseWrapper.hpp>

--- a/src/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
@@ -1,0 +1,46 @@
+
+#include "BusFaultImpl.hpp"
+#include <AutomaticDifferentiation/Enzyme/SparseWrapper.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    /**
+     * @brief Jacobian evaluation experimental
+     *
+     * @tparam ScalarT - scalar data type
+     * @tparam IdxT    - matrix index data type
+     * @return int - error code, 0 = success
+     */
+    template <class ScalarT, typename IdxT>
+    int BusFault<ScalarT, IdxT>::evaluateJacobian()
+    {
+      std::cout << "Evaluate Jacobian for BusFault..." << std::endl;
+      std::cout << "Jacobian evaluation is experimental!" << std::endl;
+
+      if (status_)
+      {
+        GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::BusFault<ScalarT, IdxT>,
+                                             GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
+                                             ScalarT,
+                                             IdxT>(
+            this,
+            static_cast<size_t>(bus_->size()),
+            static_cast<size_t>(bus_->size()),
+            bus_->getResidualIndices(),
+            bus_->getVariableIndices(),
+            y_.data(),
+            yp_.data(),
+            (bus_->y()).data(),
+            bus_->getJacobian());
+      }
+
+      return 0;
+    }
+
+    // Available template instantiations
+    template class BusFault<double, long int>;
+    template class BusFault<double, size_t>;
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
@@ -24,7 +24,7 @@ namespace GridKit
         GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::BusFault<ScalarT, IdxT>,
                                              GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
                                              ScalarT,
-                                             IdxT>(
+                                             IdxT>::eval(
             this,
             static_cast<size_t>(bus_->size()),
             static_cast<size_t>(bus_->size()),

--- a/src/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
@@ -24,6 +24,7 @@ namespace GridKit
     {
       (void) bus_id_;
       size_ = 0;
+      setDerivedParams();
     }
 
     /**
@@ -43,6 +44,7 @@ namespace GridKit
       : bus_(bus), R_(R), X_(X), status_(status), bus_id_(0)
     {
       size_ = 0;
+      setDerivedParams();
     }
 
     /**
@@ -78,6 +80,17 @@ namespace GridKit
       }
 
       size_ = 0;
+      setDerivedParams();
+    }
+
+    /**
+     * @brief Set the component ID
+     */
+    template <class ScalarT, typename IdxT>
+    int BusFault<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    {
+      gridkit_component_id_ = component_id;
+      return 0;
     }
 
     /**
@@ -97,6 +110,10 @@ namespace GridKit
     int BusFault<ScalarT, IdxT>::allocate()
     {
       // std::cout << "Allocate BusFault..." << std::endl;
+
+      w_.resize(2);
+      h_.resize(2);
+
       return 0;
     }
 
@@ -120,6 +137,24 @@ namespace GridKit
     }
 
     /**
+     * @brief Bus residual
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    __attribute__((always_inline)) int BusFault<ScalarT, IdxT>::evaluateBusResidual(
+        [[maybe_unused]] ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* w, ScalarT* h)
+    {
+      ScalarT Vr = w[0];
+      ScalarT Vi = w[1];
+      ScalarT Ir = -Vr * G_ + Vi * B_;
+      ScalarT Ii = -Vr * B_ - Vi * G_;
+      h[0]       = Ir;
+      h[1]       = Ii;
+
+      return 0;
+    }
+
+    /**
      * \brief Residual contribution of the branch is pushed to the
      * two terminal buses.
      *
@@ -129,28 +164,24 @@ namespace GridKit
     {
       if (status_)
       {
-        real_type B = -X_ / (X_ * X_ + R_ * R_);
-        real_type G = R_ / (X_ * X_ + R_ * R_);
-
-        Ir() += -Vr() * G + Vi() * B;
-        Ii() += -Vr() * B - Vi() * G;
+        w_[0] = Vr();
+        w_[1] = Vi();
+        evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
+        Ir() += h_[0];
+        Ii() += h_[1];
       }
       return 0;
     }
 
     /**
-     * @brief Jacobian evaluation not implemented yet
+     * @brief Derived parameters
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
-     * @return int - error code, 0 = success
      */
     template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::evaluateJacobian()
+    void BusFault<ScalarT, IdxT>::setDerivedParams()
     {
-      std::cout << "Evaluate Jacobian for BusFault..." << std::endl;
-      std::cout << "Jacobian evaluation not implemented!" << std::endl;
-      return 0;
+      B_ = -X_ / (X_ * X_ + R_ * R_);
+      G_ = R_ / (X_ * X_ + R_ * R_);
     }
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/src/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
@@ -93,16 +93,6 @@ namespace GridKit
       return 0;
     }
 
-    /**
-     * @brief Set the component ID
-     */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
-    {
-      gridkit_component_id_ = component_id;
-      return 0;
-    }
-
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */

--- a/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
@@ -1,8 +1,21 @@
-gridkit_add_library(phasor_dynamics_bus_fault
-  SOURCES
-    BusFault.cpp
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_bus_fault)
+
+if(GRIDKIT_ENABLE_ENZYME)
+  gridkit_add_library(phasor_dynamics_bus_fault
+    SOURCES
+      BusFaultEnzyme.cpp
+    LINK_LIBRARIES
+      ClangEnzymeFlags
+    COMPILE_OPTIONS
+      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno
+    OUTPUT_NAME
+      gridkit_phasor_dynamics_bus_fault)
+else()
+  gridkit_add_library(phasor_dynamics_bus_fault
+    SOURCES
+      BusFault.cpp
+    OUTPUT_NAME
+      gridkit_phasor_dynamics_bus_fault)
+endif()
 
 gridkit_add_library(phasor_dynamics_bus_fault_dependency_tracking
   SOURCES

--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -114,16 +114,52 @@ namespace GridKit
         return gridkit_component_id_;
       }
 
+      int setVariableIndex(IdxT local_index, IdxT global_index)
+      {
+        variable_indices_[local_index] = global_index;
+        return 0;
+      }
+
+      IdxT getVariableIndex(IdxT local_index) const
+      {
+        return variable_indices_.at(local_index);
+      }
+
+      const std::map<IdxT, IdxT>& getVariableIndices() const
+      {
+        return variable_indices_;
+      }
+
+      int setResidualIndex(IdxT local_index, IdxT global_index)
+      {
+        residual_indices_[local_index] = global_index;
+        return 0;
+      }
+
+      IdxT getResidualIndex(IdxT local_index) const
+      {
+        return residual_indices_.at(local_index);
+      }
+
+      const std::map<IdxT, IdxT>& getResidualIndices() const
+      {
+        return residual_indices_;
+      }
+
     protected:
-      IdxT gridkit_component_id_{0};
-      IdxT size_{0};
-      IdxT nnz_{0};
+      IdxT                 gridkit_component_id_{0};
+      IdxT                 size_{0};
+      IdxT                 nnz_{0};
+      std::map<IdxT, IdxT> variable_indices_;
+      std::map<IdxT, IdxT> residual_indices_;
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;
       std::vector<bool>    tag_;
       std::vector<ScalarT> f_;
       std::vector<ScalarT> g_;
+      std::vector<ScalarT> w_;
+      std::vector<ScalarT> h_;
 
       GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> J_;
 
@@ -134,8 +170,6 @@ namespace GridKit
       real_type abs_tol_;
 
       IdxT max_steps_;
-
-      IdxT component_id_;
 
       //
       // Adjoint sensitivity members

--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -150,8 +150,10 @@ namespace GridKit
       IdxT                 gridkit_component_id_{0};
       IdxT                 size_{0};
       IdxT                 nnz_{0};
-      std::map<IdxT, IdxT> variable_indices_;
-      std::map<IdxT, IdxT> residual_indices_;
+      std::map<IdxT, IdxT> variable_indices_; ///< Map between local and global (system-level) 
+                                              ///variable indices
+      std::map<IdxT, IdxT> residual_indices_; ///< Map between local and global (system-level) 
+                                              ///residual indices
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;

--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -150,10 +150,10 @@ namespace GridKit
       IdxT                 gridkit_component_id_{0};
       IdxT                 size_{0};
       IdxT                 nnz_{0};
-      std::map<IdxT, IdxT> variable_indices_; ///< Map between local and global (system-level) 
-                                              ///variable indices
-      std::map<IdxT, IdxT> residual_indices_; ///< Map between local and global (system-level) 
-                                              ///residual indices
+      std::map<IdxT, IdxT> variable_indices_; ///< Map between local and global (system-level)
+                                              /// variable indices
+      std::map<IdxT, IdxT> residual_indices_; ///< Map between local and global (system-level)
+                                              /// residual indices
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -65,6 +65,16 @@ namespace GridKit
       }
 
       /**
+       * @brief Set the component ID
+       */
+      template <class ScalarT, typename IdxT>
+      int Ieeet1<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      {
+        gridkit_component_id_ = component_id;
+        return 0;
+      }
+
+      /**
        * @brief  Constructor for IEEET1 Exciter
        *
        * @param bus   Signal used for terminal reference vmag
@@ -109,12 +119,19 @@ namespace GridKit
         yp_.resize(size);
         tag_.resize(size);
 
+        // Default variable and residual index mapping to local index
+        for (IdxT j = 0; j < size_; ++j)
+        {
+          this->setVariableIndex(j, j);
+          this->setResidualIndex(j, j);
+        }
+
         // Set output signal after allocation. Check if system composer
         // requested Efd and, if so, connect it to the signal node.
         // The signal is accessible to any object connecting to the signal node
         if (signals_.template isAssigned<Ieeet1InternalVariables::EFD>())
         {
-          signals_.template getSignalNode<Ieeet1InternalVariables::EFD>()->set(&y_[7]);
+          signals_.template getSignalNode<Ieeet1InternalVariables::EFD>()->set(&y_[7], this->getVariableIndex(7));
         }
 
         return 0;
@@ -142,7 +159,7 @@ namespace GridKit
         // other variables.
         if (signals_.template isAssigned<Ieeet1InternalVariables::EFD>())
         {
-          efd0 = y_[7]; //<- generator needs to be initialized first
+          efd0 = y_[7]; ///<- generator needs to be initialized first
         }
 
         // Terminal Voltage

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -65,16 +65,6 @@ namespace GridKit
       }
 
       /**
-       * @brief Set the component ID
-       */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
-      {
-        gridkit_component_id_ = component_id;
-        return 0;
-      }
-
-      /**
        * @brief  Constructor for IEEET1 Exciter
        *
        * @param bus   Signal used for terminal reference vmag

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -67,6 +67,8 @@ namespace GridKit
         using Component<ScalarT, IdxT>::time_;
         using Component<ScalarT, IdxT>::y_;
         using Component<ScalarT, IdxT>::yp_;
+        using Component<ScalarT, IdxT>::w_;
+        using Component<ScalarT, IdxT>::h_;
         using Component<ScalarT, IdxT>::J_;
 
         using real_type       = typename Component<ScalarT, IdxT>::real_type;
@@ -103,7 +105,7 @@ namespace GridKit
         }
 
       public:
-        __attribute__((always_inline)) inline int evaluateResidualLocally(ScalarT*, ScalarT*, ScalarT*);
+        __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
       private:
         // Input parameters

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -28,16 +28,15 @@ namespace GridKit
         GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
                                                   GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
                                                   ScalarT,
-                                                  IdxT>::eval(
-            this,
-            f_.size(),
-            y_.size(),
-            this->getResidualIndices(),
-            this->getVariableIndices(),
-            y_.data(),
-            yp_.data(),
-            w_.data(),
-            J_);
+                                                  IdxT>::eval(this,
+                                                              f_.size(),
+                                                              y_.size(),
+                                                              this->getResidualIndices(),
+                                                              this->getVariableIndices(),
+                                                              y_.data(),
+                                                              yp_.data(),
+                                                              w_.data(),
+                                                              J_);
 
         J_.printMatrix("Tgov1 internal Jacobian");
 

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -24,7 +24,22 @@ namespace GridKit
       {
         std::cout << "Evaluate Jacobian for Tgov1..." << std::endl;
         std::cout << "Jacobian evaluation is experimental!" << std::endl;
-        GridKit::Enzyme::Sparse::ModelJacobian<Tgov1<ScalarT, IdxT>, ScalarT, IdxT>(this, f_.size(), y_.size(), y_.data(), yp_.data(), J_);
+
+        GridKit::Enzyme::Sparse::ModelJacobian<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
+                                               GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
+                                               ScalarT,
+                                               IdxT>(
+            this,
+            f_.size(),
+            y_.size(),
+            this->getResidualIndices(),
+            this->getVariableIndices(),
+            y_.data(),
+            yp_.data(),
+            w_.data(),
+            J_);
+
+        J_.printMatrix("Tgov1 internal Jacobian");
 
         return 0;
       }

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -28,7 +28,7 @@ namespace GridKit
         GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
                                                   GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
                                                   ScalarT,
-                                                  IdxT>(
+                                                  IdxT>::eval(
             this,
             f_.size(),
             y_.size(),

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -25,10 +25,10 @@ namespace GridKit
         std::cout << "Evaluate Jacobian for Tgov1..." << std::endl;
         std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-        GridKit::Enzyme::Sparse::ModelJacobian<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
-                                               GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
-                                               ScalarT,
-                                               IdxT>(
+        GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
+                                                  GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
+                                                  ScalarT,
+                                                  IdxT>(
             this,
             f_.size(),
             y_.size(),

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -1,5 +1,6 @@
 /**
  * @file Tgov1Enzyme.cpp
+ * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
  *
  */
 

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -247,7 +247,7 @@ namespace GridKit
        *
        */
       template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) int Tgov1<ScalarT, IdxT>::evaluateInternalResidual(
+      __attribute__((always_inline)) inline int Tgov1<ScalarT, IdxT>::evaluateInternalResidual(
           ScalarT*                  y,
           ScalarT*                  yp,
           [[maybe_unused]] ScalarT* w,

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -138,11 +138,18 @@ namespace GridKit
         yp_.resize(size);
         tag_.resize(size);
 
+        // Default variable and residual index mapping to local index
+        for (IdxT j = 0; j < size_; ++j)
+        {
+          this->setVariableIndex(j, j);
+          this->setResidualIndex(j, j);
+        }
+
         // Set output signal after allocation
         // The signal is accessible to the generator
         if (signals_.template isAssigned<Tgov1InternalVariables::PM>())
         {
-          signals_.template getSignalNode<Tgov1InternalVariables::PM>()->set(&y_[2]);
+          signals_.template getSignalNode<Tgov1InternalVariables::PM>()->set(&y_[2], this->getVariableIndex(2));
         }
 
         return 0;
@@ -160,7 +167,7 @@ namespace GridKit
         // Initial mechanical = initial electric torque
         if (signals_.template isAssigned<Tgov1InternalVariables::PM>())
         {
-          p0 = y_[2]; //<- generator needs to be initialized first
+          p0 = y_[2]; ///<- generator needs to be initialized first
         }
 
         // Input Variables (Parameter for now)
@@ -236,11 +243,15 @@ namespace GridKit
       }
 
       /**
-       * @brief Residuals of system equations evaluated locally
+       * @brief Internal residuals
        *
        */
       template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) int Tgov1<ScalarT, IdxT>::evaluateResidualLocally(ScalarT* y, ScalarT* yp, ScalarT* f)
+      __attribute__((always_inline)) int Tgov1<ScalarT, IdxT>::evaluateInternalResidual(
+          ScalarT*                  y,
+          ScalarT*                  yp,
+          [[maybe_unused]] ScalarT* w,
+          ScalarT*                  f)
       {
         // Read Internal Variables
         ScalarT ptx   = y[0]; // y0 - Ptx
@@ -278,7 +289,7 @@ namespace GridKit
           omega_ = signals_.template readExternalVariable<Tgov1ExternalVariables::DELTAOMEGA>();
         }
 
-        evaluateResidualLocally(y_.data(), yp_.data(), f_.data());
+        evaluateInternalResidual(y_.data(), yp_.data(), w_.data(), f_.data());
 
         return 0;
       }

--- a/src/Model/PhasorDynamics/Load/Load.hpp
+++ b/src/Model/PhasorDynamics/Load/Load.hpp
@@ -35,13 +35,8 @@ namespace GridKit
       using Component<ScalarT, IdxT>::y_;
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::tag_;
-<<<<<<< HEAD
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::J_;
-=======
       using Component<ScalarT, IdxT>::w_;
       using Component<ScalarT, IdxT>::h_;
->>>>>>> 6424c768 (Functional system level Jacobian for internal variables/residuals and bus variables/residuals.)
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;
       using bus_type        = BusBase<ScalarT, IdxT>;

--- a/src/Model/PhasorDynamics/Load/Load.hpp
+++ b/src/Model/PhasorDynamics/Load/Load.hpp
@@ -35,8 +35,13 @@ namespace GridKit
       using Component<ScalarT, IdxT>::y_;
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::tag_;
+<<<<<<< HEAD
       using Component<ScalarT, IdxT>::f_;
       using Component<ScalarT, IdxT>::J_;
+=======
+      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::h_;
+>>>>>>> 6424c768 (Functional system level Jacobian for internal variables/residuals and bus variables/residuals.)
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;
       using bus_type        = BusBase<ScalarT, IdxT>;
@@ -95,7 +100,7 @@ namespace GridKit
       }
 
     public:
-      __attribute__((always_inline)) inline int evaluateResidualLocally(ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
       bus_type* bus_{nullptr};

--- a/src/Model/PhasorDynamics/Load/LoadEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Load/LoadEnzyme.cpp
@@ -22,7 +22,7 @@ namespace GridKit
       GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Load<ScalarT, IdxT>,
                                            GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
                                            ScalarT,
-                                           IdxT>(
+                                           IdxT>::eval(
           this,
           static_cast<size_t>(bus_->size()),
           static_cast<size_t>(bus_->size()),

--- a/src/Model/PhasorDynamics/Load/LoadEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Load/LoadEnzyme.cpp
@@ -19,15 +19,19 @@ namespace GridKit
       std::cout << "Evaluate Jacobian for Load..." << std::endl;
       std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-      std::vector<ScalarT> y(2);
-      std::vector<ScalarT> yp(2);
-      std::vector<ScalarT> f(2);
-      y[0] = Vr();
-      y[1] = Vi();
-      /// Setting J_ via Enzyme works, though J_ had not been initialized within the model.
-      /// This is because the COO_Matrix class is very permissive.
-      /// Having the currents as model variables and allocating J_ accordingly will be helpful.
-      GridKit::Enzyme::Sparse::ModelJacobian<Load<ScalarT, IdxT>, ScalarT, IdxT>(this, f.size(), y.size(), y.data(), yp.data(), J_);
+      GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Load<ScalarT, IdxT>,
+                                           GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
+                                           ScalarT,
+                                           IdxT>(
+          this,
+          static_cast<size_t>(bus_->size()),
+          static_cast<size_t>(bus_->size()),
+          bus_->getResidualIndices(),
+          bus_->getVariableIndices(),
+          y_.data(),
+          yp_.data(),
+          (bus_->y()).data(),
+          bus_->getJacobian());
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/Load/LoadEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Load/LoadEnzyme.cpp
@@ -1,3 +1,8 @@
+/**
+ * @file LoadEnzyme.cpp
+ * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
+ *
+ */
 
 #include "LoadImpl.hpp"
 #include <AutomaticDifferentiation/Enzyme/SparseWrapper.hpp>

--- a/src/Model/PhasorDynamics/Load/LoadEnzyme.cpp
+++ b/src/Model/PhasorDynamics/Load/LoadEnzyme.cpp
@@ -22,16 +22,15 @@ namespace GridKit
       GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Load<ScalarT, IdxT>,
                                            GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
                                            ScalarT,
-                                           IdxT>::eval(
-          this,
-          static_cast<size_t>(bus_->size()),
-          static_cast<size_t>(bus_->size()),
-          bus_->getResidualIndices(),
-          bus_->getVariableIndices(),
-          y_.data(),
-          yp_.data(),
-          (bus_->y()).data(),
-          bus_->getJacobian());
+                                           IdxT>::eval(this,
+                                                       static_cast<size_t>(bus_->size()),
+                                                       static_cast<size_t>(bus_->size()),
+                                                       bus_->getResidualIndices(),
+                                                       bus_->getVariableIndices(),
+                                                       y_.data(),
+                                                       yp_.data(),
+                                                       (bus_->y()).data(),
+                                                       bus_->getJacobian());
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/Load/LoadImpl.hpp
+++ b/src/Model/PhasorDynamics/Load/LoadImpl.hpp
@@ -33,6 +33,7 @@ namespace GridKit
         R_(R),
         X_(X)
     {
+      size_ = 0;
       setDerivedParams();
     }
 
@@ -51,6 +52,7 @@ namespace GridKit
         X_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::X));
       }
 
+      size_ = 0;
       setDerivedParams();
     }
 
@@ -77,6 +79,10 @@ namespace GridKit
     int Load<ScalarT, IdxT>::allocate()
     {
       // std::cout << "Allocate Load..." << std::endl;
+
+      w_.resize(2);
+      h_.resize(2);
+
       return 0;
     }
 
@@ -100,17 +106,19 @@ namespace GridKit
     }
 
     /**
-     * @brief Residual contribution computed locally
+     * @brief Bus residual
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Load<ScalarT, IdxT>::evaluateResidualLocally(ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* f)
+    __attribute__((always_inline)) int Load<ScalarT, IdxT>::evaluateBusResidual(
+        [[maybe_unused]] ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* w, ScalarT* h)
     {
-      real_type b = -X_ / (R_ * R_ + X_ * X_);
-      real_type g = R_ / (R_ * R_ + X_ * X_);
-
-      f[0] = -g * y[0] + b * y[1];
-      f[1] = -b * y[0] - g * y[1];
+      ScalarT Vr = w[0];
+      ScalarT Vi = w[1];
+      ScalarT Ir = -g_ * Vr + b_ * Vi;
+      ScalarT Ii = -b_ * Vr - g_ * Vi;
+      h[0]       = Ir;
+      h[1]       = Ii;
 
       return 0;
     }
@@ -122,14 +130,11 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int Load<ScalarT, IdxT>::evaluateResidual()
     {
-      std::vector<ScalarT> y(2);
-      std::vector<ScalarT> yp(2);
-      std::vector<ScalarT> f(2);
-      y[0] = Vr();
-      y[1] = Vi();
-      evaluateResidualLocally(y.data(), yp.data(), f.data());
-      Ir() += f[0];
-      Ii() += f[1];
+      w_[0] = Vr();
+      w_[1] = Vi();
+      evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
+      Ir() += h_[0];
+      Ii() += h_[1];
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/SignalNode/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SignalNode/CMakeLists.txt
@@ -18,4 +18,5 @@ gridkit_add_library(phasor_dynamics_signal_dependency_tracking
     gridkit_phasor_dynamics_signal_dependency_tracking)
 
 # Link to interface target for all components
+target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_signal)
 target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_signal_dependency_tracking)

--- a/src/Model/PhasorDynamics/SignalNode/SignalNode.hpp
+++ b/src/Model/PhasorDynamics/SignalNode/SignalNode.hpp
@@ -39,7 +39,7 @@ namespace GridKit
       virtual int evaluateResidual() override;
       virtual int evaluateJacobian() override;
 
-      void    set(ScalarT* signal_in);
+      void    set(ScalarT* signal_in, IdxT global_index);
       ScalarT read() const;
       void    init(ScalarT signal_in);
 
@@ -119,6 +119,17 @@ namespace GridKit
         return J_;
       }
 
+      int setVariableIndex(IdxT global_index)
+      {
+        variable_index_ = global_index;
+        return 0;
+      }
+
+      IdxT getVariableIndex() const
+      {
+        return variable_index_;
+      }
+
     private:
       ScalarT* signal_{nullptr};
       IdxT     signal_id_{0};
@@ -128,6 +139,7 @@ namespace GridKit
 
       IdxT size_{0};
       IdxT nnz_{0};
+      IdxT variable_index_{0};
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;

--- a/src/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
+++ b/src/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
@@ -52,9 +52,10 @@ namespace GridKit
     }
 
     template <class ScalarT, typename IdxT>
-    void SignalNode<ScalarT, IdxT>::set(ScalarT* signal)
+    void SignalNode<ScalarT, IdxT>::set(ScalarT* signal, IdxT variable_index)
     {
-      signal_ = signal;
+      signal_         = signal;
+      variable_index_ = variable_index;
     }
 
     template <class ScalarT, typename IdxT>

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -79,6 +79,8 @@ namespace GridKit
       using Component<ScalarT, IdxT>::time_;
       using Component<ScalarT, IdxT>::y_;
       using Component<ScalarT, IdxT>::yp_;
+      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;
@@ -174,7 +176,8 @@ namespace GridKit
       }
 
     public:
-      __attribute__((always_inline)) inline int evaluateResidualLocally(ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
       /* Identification */
@@ -227,12 +230,6 @@ namespace GridKit
       /* Setpoints for control variables (determined at initialization) */
       ScalarT pmech_set_;
       ScalarT efd_set_;
-
-      /* Local copies of bus variables */
-      ScalarT vr_;
-      ScalarT vi_;
-      ScalarT ir_;
-      ScalarT ii_;
 
       /* Local copies of signal variables */
       ScalarT pmech_;

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -1,3 +1,8 @@
+/**
+ * @file GenrouEnzyme.cpp
+ * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
+ *
+ */
 
 #include "GenrouImpl.hpp"
 #include <AutomaticDifferentiation/Enzyme/SparseWrapper.hpp>

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -22,32 +22,30 @@ namespace GridKit
       GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
                                                 GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
                                                 ScalarT,
-                                                IdxT>::eval(
-          this,
-          f_.size(),
-          y_.size(),
-          this->getResidualIndices(),
-          this->getVariableIndices(),
-          y_.data(),
-          yp_.data(),
-          w_.data(),
-          J_);
+                                                IdxT>::eval(this,
+                                                            f_.size(),
+                                                            y_.size(),
+                                                            this->getResidualIndices(),
+                                                            this->getVariableIndices(),
+                                                            y_.data(),
+                                                            yp_.data(),
+                                                            w_.data(),
+                                                            J_);
 
       J_.printMatrix("Genrou internal Jacobian");
 
       GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
                                            GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
                                            ScalarT,
-                                           IdxT>::eval(
-          this,
-          static_cast<size_t>(bus_->size()),
-          static_cast<size_t>(bus_->size()),
-          bus_->getResidualIndices(),
-          bus_->getVariableIndices(),
-          y_.data(),
-          yp_.data(),
-          (bus_->y()).data(),
-          bus_->getJacobian());
+                                           IdxT>::eval(this,
+                                                       static_cast<size_t>(bus_->size()),
+                                                       static_cast<size_t>(bus_->size()),
+                                                       bus_->getResidualIndices(),
+                                                       bus_->getVariableIndices(),
+                                                       y_.data(),
+                                                       yp_.data(),
+                                                       (bus_->y()).data(),
+                                                       bus_->getJacobian());
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -19,7 +19,35 @@ namespace GridKit
       std::cout << "Evaluate Jacobian for Genrou..." << std::endl;
       std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-      GridKit::Enzyme::Sparse::ModelJacobian<Genrou<ScalarT, IdxT>, ScalarT, IdxT>(this, f_.size(), y_.size(), y_.data(), yp_.data(), J_);
+      GridKit::Enzyme::Sparse::ModelJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
+                                             GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
+                                             ScalarT,
+                                             IdxT>(
+          this,
+          f_.size(),
+          y_.size(),
+          this->getResidualIndices(),
+          this->getVariableIndices(),
+          y_.data(),
+          yp_.data(),
+          w_.data(),
+          J_);
+
+      J_.printMatrix("Genrou internal Jacobian");
+
+      GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
+                                           GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
+                                           ScalarT,
+                                           IdxT>(
+          this,
+          static_cast<size_t>(bus_->size()),
+          static_cast<size_t>(bus_->size()),
+          bus_->getResidualIndices(),
+          bus_->getVariableIndices(),
+          y_.data(),
+          yp_.data(),
+          (bus_->y()).data(),
+          bus_->getJacobian());
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -22,7 +22,7 @@ namespace GridKit
       GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
                                                 GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
                                                 ScalarT,
-                                                IdxT>(
+                                                IdxT>::eval(
           this,
           f_.size(),
           y_.size(),
@@ -38,7 +38,7 @@ namespace GridKit
       GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
                                            GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
                                            ScalarT,
-                                           IdxT>(
+                                           IdxT>::eval(
           this,
           static_cast<size_t>(bus_->size()),
           static_cast<size_t>(bus_->size()),

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -19,10 +19,10 @@ namespace GridKit
       std::cout << "Evaluate Jacobian for Genrou..." << std::endl;
       std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-      GridKit::Enzyme::Sparse::ModelJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
-                                             GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
-                                             ScalarT,
-                                             IdxT>(
+      GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
+                                                GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
+                                                ScalarT,
+                                                IdxT>(
           this,
           f_.size(),
           y_.size(),

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -271,10 +271,21 @@ namespace GridKit
       yp_.resize(static_cast<size_t>(size_));
       tag_.resize(static_cast<size_t>(size_));
 
+      // Resize coupling data
+      w_.resize(2);
+      h_.resize(2);
+
+      // Default variable and residual index mapping to local index
+      for (IdxT j = 0; j < size_; ++j)
+      {
+        this->setVariableIndex(j, j);
+        this->setResidualIndex(j, j);
+      }
+
       // Set output signal after allocation
       if (signals_.template isAssigned<GenrouInternalVariables::OMEGA>())
       {
-        signals_.template getSignalNode<GenrouInternalVariables::OMEGA>()->set(&y_[1]);
+        signals_.template getSignalNode<GenrouInternalVariables::OMEGA>()->set(&y_[1], this->getVariableIndex(1));
       }
 
       return 0;
@@ -377,11 +388,15 @@ namespace GridKit
     }
 
     /**
-     * @brief Residual contribution computed locally
+     * @brief Internal residual
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Genrou<ScalarT, IdxT>::evaluateResidualLocally(ScalarT* y, ScalarT* yp, ScalarT* f)
+    __attribute__((always_inline)) int Genrou<ScalarT, IdxT>::evaluateInternalResidual(
+        ScalarT* y,
+        ScalarT* yp,
+        ScalarT* w,
+        ScalarT* f)
     {
       /* Read variables */
       ScalarT delta  = y[0];
@@ -412,6 +427,10 @@ namespace GridKit
       ScalarT psiqp_dot = yp[4];
       ScalarT Edp_dot   = yp[5];
 
+      // Set coupling variable aliases
+      ScalarT vr = w[0];
+      ScalarT vi = w[1];
+
       /* 6 Genrou differential equations */
       f[0] = delta_dot - omega * (2.0 * M_PI * 60.0);
       f[1] = omega_dot - (1.0 / (2.0 * H_)) * ((pmech_ - D_ * omega) / (1.0 + omega) - telec);
@@ -430,8 +449,8 @@ namespace GridKit
       f[12] = telec - ((psidpp - id * Xdpp_) * iq - (psiqpp - iq * Xdpp_) * id);
       f[13] = id - (ir * std::sin(delta) - ii * std::cos(delta));
       f[14] = iq - (ir * std::cos(delta) + ii * std::sin(delta));
-      f[15] = ir + G_ * vr_ - B_ * vi_ - inr;
-      f[16] = ii + B_ * vr_ + G_ * vi_ - ini;
+      f[15] = ir + G_ * vr - B_ * vi - inr;
+      f[16] = ii + B_ * vr + G_ * vi - ini;
 
       /* 2 Genrou control inputs are set to constant for this example */
       // f[17] = efd_ - efd_set_;
@@ -440,9 +459,27 @@ namespace GridKit
       f[17] = inr - (G_ * (std::sin(delta) * vd + std::cos(delta) * vq) - B_ * (-std::cos(delta) * vd + std::sin(delta) * vq));
       f[18] = ini - (B_ * (std::sin(delta) * vd + std::cos(delta) * vq) + G_ * (-std::cos(delta) * vd + std::sin(delta) * vq));
 
-      /* Bus current injection */
-      ir_ = inr - vr_ * G_ + vi_ * B_;
-      ii_ = ini - vr_ * B_ - vi_ * G_;
+      return 0;
+    }
+
+    /**
+     * @brief Bus residual
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    __attribute__((always_inline)) int Genrou<ScalarT, IdxT>::evaluateBusResidual(
+        [[maybe_unused]] ScalarT* y,
+        [[maybe_unused]] ScalarT* yp,
+        ScalarT*                  w,
+        ScalarT*                  h)
+    {
+      ScalarT inr = y[17];
+      ScalarT ini = y[18];
+      ScalarT vr  = w[0];
+      ScalarT vi  = w[1];
+
+      h[0] = inr - vr * G_ + vi * B_;
+      h[1] = ini - vr * B_ - vi * G_;
 
       return 0;
     }
@@ -475,15 +512,16 @@ namespace GridKit
       }
 
       // Bus voltages
-      vr_ = Vr();
-      vi_ = Vi();
+      w_[0] = Vr();
+      w_[1] = Vi();
 
       // Residual evaluation
-      evaluateResidualLocally(y_.data(), yp_.data(), f_.data());
+      evaluateInternalResidual(y_.data(), yp_.data(), w_.data(), f_.data());
+      evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
 
       // Genrou contribution to bus algebraic equations
-      Ir() += ir_;
-      Ii() += ii_;
+      Ir() += h_[0];
+      Ii() += h_[1];
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -467,7 +467,7 @@ namespace GridKit
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Genrou<ScalarT, IdxT>::evaluateBusResidual(
+    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateBusResidual(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  w,

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -392,7 +392,7 @@ namespace GridKit
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Genrou<ScalarT, IdxT>::evaluateInternalResidual(
+    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateInternalResidual(
         ScalarT* y,
         ScalarT* yp,
         ScalarT* w,

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -1,5 +1,5 @@
 /**
- * @file GenClassical.cpp
+ * @file GenClassical.hpp
  * @author Abdourahman Barry (abdourahman@vt.edu)
  * @author Slaven Peles (peless@ornl.gov)
  *
@@ -40,6 +40,8 @@ namespace GridKit
       using Component<ScalarT, IdxT>::time_;
       using Component<ScalarT, IdxT>::y_;
       using Component<ScalarT, IdxT>::yp_;
+      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
 
       using bus_type  = BusBase<ScalarT, IdxT>;
@@ -106,7 +108,8 @@ namespace GridKit
       }
 
     public:
-      __attribute__((always_inline)) inline int evaluateResidualLocally(ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
       /* Identification */
@@ -131,12 +134,6 @@ namespace GridKit
       /* Setpoints for control variables (determined at initialization) */
       ScalarT pmech_set_;
       ScalarT ep_set_;
-
-      /* Local copies of bus variables */
-      ScalarT vr_;
-      ScalarT vi_;
-      ScalarT ir_;
-      ScalarT ii_;
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -19,7 +19,21 @@ namespace GridKit
       std::cout << "Evaluate Jacobian for GenClassical..." << std::endl;
       std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-      GridKit::Enzyme::Sparse::ModelJacobian<GenClassical<ScalarT, IdxT>, ScalarT, IdxT>(this, f_.size(), y_.size(), y_.data(), yp_.data(), J_);
+      GridKit::Enzyme::Sparse::ModelJacobian<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
+                                             GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
+                                             ScalarT,
+                                             IdxT>(
+          this,
+          f_.size(),
+          y_.size(),
+          this->getResidualIndices(),
+          this->getVariableIndices(),
+          y_.data(),
+          yp_.data(),
+          w_.data(),
+          J_);
+      
+      J_.printMatrix("GenClassical internal Jacobian");
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -22,7 +22,7 @@ namespace GridKit
       GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
                                                 GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
                                                 ScalarT,
-                                                IdxT>(
+                                                IdxT>::eval(
           this,
           f_.size(),
           y_.size(),

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -1,3 +1,8 @@
+/**
+ * @file GenClassicalEnzyme.cpp
+ * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
+ *
+ */
 
 #include "GenClassicalImpl.hpp"
 #include <AutomaticDifferentiation/Enzyme/SparseWrapper.hpp>

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -19,10 +19,10 @@ namespace GridKit
       std::cout << "Evaluate Jacobian for GenClassical..." << std::endl;
       std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-      GridKit::Enzyme::Sparse::ModelJacobian<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
-                                             GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
-                                             ScalarT,
-                                             IdxT>(
+      GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
+                                                GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
+                                                ScalarT,
+                                                IdxT>(
           this,
           f_.size(),
           y_.size(),

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -22,16 +22,15 @@ namespace GridKit
       GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
                                                 GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
                                                 ScalarT,
-                                                IdxT>::eval(
-          this,
-          f_.size(),
-          y_.size(),
-          this->getResidualIndices(),
-          this->getVariableIndices(),
-          y_.data(),
-          yp_.data(),
-          w_.data(),
-          J_);
+                                                IdxT>::eval(this,
+                                                            f_.size(),
+                                                            y_.size(),
+                                                            this->getResidualIndices(),
+                                                            this->getVariableIndices(),
+                                                            y_.data(),
+                                                            yp_.data(),
+                                                            w_.data(),
+                                                            J_);
 
       J_.printMatrix("GenClassical internal Jacobian");
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -32,7 +32,7 @@ namespace GridKit
           yp_.data(),
           w_.data(),
           J_);
-      
+
       J_.printMatrix("GenClassical internal Jacobian");
 
       return 0;

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -132,6 +132,18 @@ namespace GridKit
       y_.resize(size);
       yp_.resize(size);
       tag_.resize(size);
+
+      // Resize coupling data
+      w_.resize(2);
+      h_.resize(2);
+
+      // Default variable and residual index mapping to local index
+      for (IdxT j = 0; j < size_; ++j)
+      {
+        this->setVariableIndex(j, j);
+        this->setResidualIndex(j, j);
+      }
+
       return 0;
     }
 
@@ -183,11 +195,15 @@ namespace GridKit
     }
 
     /**
-     * @brief Residual contribution computed locally
+     * @brief Internal residual
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateResidualLocally(ScalarT* y, ScalarT* yp, ScalarT* f)
+    __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateInternalResidual(
+        ScalarT* y,
+        ScalarT* yp,
+        ScalarT* w,
+        ScalarT* f)
     {
       // Set variable aliases for better readability.
       const ScalarT delta = y[0];
@@ -202,19 +218,38 @@ namespace GridKit
       const ScalarT delta_dot = yp[0];
       const ScalarT omega_dot = yp[1];
 
+      // Set coupling variable aliases
+      const ScalarT vr = w[0];
+      const ScalarT vi = w[1];
+
       // GenClassical differential equations
       f[0] = delta_dot - (omega - 1.0) * (2.0 * M_PI * 60.0);
       f[1] = omega_dot - (1.0 / (2.0 * H_)) * ((pmech - D_ * (omega - 1.0)) / omega - telec);
 
       // GenClassical algebraic equations
-      f[2] = telec - (G_ * ep * ep - ep * ((G_ * vr_ - B_ * vi_) * std::cos(delta) + (B_ * vr_ + G_ * vi_) * std::sin(delta)));
+      f[2] = telec - (G_ * ep * ep - ep * ((G_ * vr - B_ * vi) * std::cos(delta) + (B_ * vr + G_ * vi) * std::sin(delta)));
 
-      f[3] = ir + G_ * vr_ - B_ * vi_ - ep * (G_ * std::cos(delta) - B_ * std::sin(delta));
-      f[4] = ii + B_ * vr_ + G_ * vi_ - ep * (B_ * std::cos(delta) + G_ * std::sin(delta));
+      f[3] = ir + G_ * vr - B_ * vi - ep * (G_ * std::cos(delta) - B_ * std::sin(delta));
+      f[4] = ii + B_ * vr + G_ * vi - ep * (B_ * std::cos(delta) + G_ * std::sin(delta));
 
-      // Bus current injection
-      ir_ = ir;
-      ii_ = ii;
+      return 0;
+    }
+
+    /**
+     * @brief Bus residual
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateBusResidual(
+        ScalarT*                  y,
+        [[maybe_unused]] ScalarT* yp,
+        [[maybe_unused]] ScalarT* w,
+        ScalarT*                  h)
+    {
+      const ScalarT ir = y[3];
+      const ScalarT ii = y[4];
+      h[0]             = ir;
+      h[1]             = ii;
 
       return 0;
     }
@@ -226,14 +261,14 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int GenClassical<ScalarT, IdxT>::evaluateResidual()
     {
-      vr_ = Vr();
-      vi_ = Vi();
+      w_[0] = Vr();
+      w_[1] = Vi();
 
-      evaluateResidualLocally(y_.data(), yp_.data(), f_.data());
+      evaluateInternalResidual(y_.data(), yp_.data(), w_.data(), f_.data());
+      evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
 
-      // GenClassical contribution to bus algebraic equations
-      Ir() += ir_;
-      Ii() += ii_;
+      Ir() += h_[0];
+      Ii() += h_[1];
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -557,11 +557,8 @@ namespace GridKit
       /**
        * @brief Add bus
        *
-<<<<<<< HEAD
        * Add bus at the end of the bus array and map bus ID with GridKit's ID for the bus
        *
-=======
->>>>>>> 6424c768 (Functional system level Jacobian for internal variables/residuals and bus variables/residuals.)
        */
       void addBus(bus_type* bus)
       {
@@ -573,11 +570,8 @@ namespace GridKit
       /**
        * @brief Add signal
        *
-<<<<<<< HEAD
        * Add signal at the end of the signals array and map signal ID with GridKit's ID for the signal
        *
-=======
->>>>>>> 6424c768 (Functional system level Jacobian for internal variables/residuals and bus variables/residuals.)
        */
       void addSignal(signal_type* signal)
       {

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -45,6 +45,7 @@ namespace GridKit
       using PhasorDynamics::Component<ScalarT, IdxT>::yp_;
       using PhasorDynamics::Component<ScalarT, IdxT>::tag_;
       using PhasorDynamics::Component<ScalarT, IdxT>::f_;
+      using PhasorDynamics::Component<ScalarT, IdxT>::J_;
       using PhasorDynamics::Component<ScalarT, IdxT>::rel_tol_;
       using PhasorDynamics::Component<ScalarT, IdxT>::abs_tol_;
 
@@ -292,6 +293,11 @@ namespace GridKit
         for (const auto& bus : buses_)
         {
           bus->allocate();
+          for (IdxT j = 0; j < bus->size(); ++j)
+          {
+            bus->setVariableIndex(j, size_ + j);
+            bus->setResidualIndex(j, size_ + j);
+          }
           size_ += bus->size();
         }
 
@@ -299,6 +305,11 @@ namespace GridKit
         for (const auto& component : components_)
         {
           component->allocate();
+          for (IdxT j = 0; j < component->size(); ++j)
+          {
+            component->setVariableIndex(j, size_ + j);
+            component->setResidualIndex(j, size_ + j);
+          }
           size_ += component->size();
         }
 
@@ -307,6 +318,13 @@ namespace GridKit
         yp_.resize(size_);
         f_.resize(size_);
         tag_.resize(size_);
+
+        // Default variable and residual index mapping to local index
+        for (IdxT j = 0; j < size_; ++j)
+        {
+          this->setVariableIndex(j, j);
+          this->setResidualIndex(j, j);
+        }
 
         return 0;
       }
@@ -342,9 +360,6 @@ namespace GridKit
        */
       int initialize()
       {
-        // Set initial values for global solution vectors
-        IdxT varOffset = 0;
-
         for (const auto& bus : buses_)
         {
           bus->initialize();
@@ -354,10 +369,9 @@ namespace GridKit
         {
           for (IdxT j = 0; j < bus->size(); ++j)
           {
-            y_[varOffset + j]  = bus->y()[j];
-            yp_[varOffset + j] = bus->yp()[j];
+            y_[bus->getVariableIndex(j)]  = bus->y()[j];
+            yp_[bus->getVariableIndex(j)] = bus->yp()[j];
           }
-          varOffset += bus->size();
         }
 
         // Initialize components
@@ -370,10 +384,9 @@ namespace GridKit
         {
           for (IdxT j = 0; j < component->size(); ++j)
           {
-            y_[varOffset + j]  = component->y()[j];
-            yp_[varOffset + j] = component->yp()[j];
+            y_[component->getVariableIndex(j)]  = component->y()[j];
+            yp_[component->getVariableIndex(j)] = component->yp()[j];
           }
-          varOffset += component->size();
         }
 
         return 0;
@@ -389,15 +402,13 @@ namespace GridKit
       int tagDifferentiable()
       {
         // Set initial values for global solution vectors
-        IdxT offset = 0;
         for (const auto& bus : buses_)
         {
           bus->tagDifferentiable();
           for (IdxT j = 0; j < bus->size(); ++j)
           {
-            tag_[offset + j] = bus->tag()[j];
+            tag_[bus->getVariableIndex(j)] = bus->tag()[j];
           }
-          offset += bus->size();
         }
 
         for (const auto& component : components_)
@@ -405,9 +416,8 @@ namespace GridKit
           component->tagDifferentiable();
           for (IdxT j = 0; j < component->size(); ++j)
           {
-            tag_[offset + j] = component->tag()[j];
+            tag_[component->getVariableIndex(j)] = component->tag()[j];
           }
-          offset += component->size();
         }
 
         return 0;
@@ -433,16 +443,14 @@ namespace GridKit
        */
       int evaluateResidual()
       {
-        // Update variables
-        IdxT varOffset = 0;
+        // Update variables and evaluate component residuals
         for (const auto& bus : buses_)
         {
           for (IdxT j = 0; j < bus->size(); ++j)
           {
-            bus->y()[j]  = y_[varOffset + j];
-            bus->yp()[j] = yp_[varOffset + j];
+            bus->y()[j]  = y_[bus->getVariableIndex(j)];
+            bus->yp()[j] = yp_[bus->getVariableIndex(j)];
           }
-          varOffset += bus->size();
 
           bus->evaluateResidual();
         }
@@ -451,32 +459,28 @@ namespace GridKit
         {
           for (IdxT j = 0; j < component->size(); ++j)
           {
-            component->y()[j]  = y_[varOffset + j];
-            component->yp()[j] = yp_[varOffset + j];
+            component->y()[j]  = y_[component->getVariableIndex(j)];
+            component->yp()[j] = yp_[component->getVariableIndex(j)];
           }
-          varOffset += component->size();
 
           component->evaluateResidual();
         }
 
         // Update residual vector
-        IdxT resOffset = 0;
         for (const auto& bus : buses_)
         {
           for (IdxT j = 0; j < bus->size(); ++j)
           {
-            f_[resOffset + j] = bus->getResidual()[j];
+            f_[bus->getResidualIndex(j)] = bus->getResidual()[j];
           }
-          resOffset += bus->size();
         }
 
         for (const auto& component : components_)
         {
           for (IdxT j = 0; j < component->size(); ++j)
           {
-            f_[resOffset + j] = component->getResidual()[j];
+            f_[component->getResidualIndex(j)] = component->getResidual()[j];
           }
-          resOffset += component->size();
         }
 
         return 0;
@@ -485,13 +489,56 @@ namespace GridKit
       /**
        * @brief Evaluate system Jacobian.
        *
-       * @todo Need to implement Jacobian. For now, using finite difference
-       * approximation provided by IDA. This works for dense Jacobian matrix
-       * only.
+       * @note Experimental Jacobian evaluation
+       * @todo Add a proper way to handle off-diagonal (coupling terms)
        *
        */
       int evaluateJacobian()
       {
+        std::vector<IdxT>    ctemp{};
+        std::vector<IdxT>    rtemp{};
+        std::vector<ScalarT> valtemp{};
+
+        // Initialize bus Jacobians
+        for (const auto& bus : buses_)
+        {
+          bus->evaluateJacobian();
+        }
+
+        // Component Jacobian diagonal blocks
+        // Also updates bus Jacobians
+        for (const auto& component : components_)
+        {
+          component->evaluateJacobian();
+          auto component_jacobian = component->getJacobian();
+
+          std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<ScalarT>&> component_jacobian_entries = component_jacobian.getEntries();
+          const auto [rows, columns, values]                                                                   = component_jacobian_entries;
+          for (size_t i = 0; i < rows.size(); ++i)
+          {
+            rtemp.push_back(rows[i]);
+            ctemp.push_back(columns[i]);
+            valtemp.push_back(values[i]);
+          }
+        }
+
+        // Bus Jacobian diagonal blocks
+        for (const auto& bus : buses_)
+        {
+          auto bus_jacobian = bus->getJacobian();
+
+          std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<ScalarT>&> bus_jacobian_entries = bus_jacobian.getEntries();
+          const auto [rows, columns, values]                                                             = bus_jacobian_entries;
+          for (size_t i = 0; i < rows.size(); ++i)
+          {
+            rtemp.push_back(rows[i]);
+            ctemp.push_back(columns[i]);
+            valtemp.push_back(values[i]);
+          }
+        }
+
+        J_.setValues(rtemp, ctemp, valtemp);
+
         return 0;
       }
 
@@ -510,8 +557,11 @@ namespace GridKit
       /**
        * @brief Add bus
        *
+<<<<<<< HEAD
        * Add bus at the end of the bus array and map bus ID with GridKit's ID for the bus
        *
+=======
+>>>>>>> 6424c768 (Functional system level Jacobian for internal variables/residuals and bus variables/residuals.)
        */
       void addBus(bus_type* bus)
       {
@@ -523,8 +573,11 @@ namespace GridKit
       /**
        * @brief Add signal
        *
+<<<<<<< HEAD
        * Add signal at the end of the signals array and map signal ID with GridKit's ID for the signal
        *
+=======
+>>>>>>> 6424c768 (Functional system level Jacobian for internal variables/residuals and bus variables/residuals.)
        */
       void addSignal(signal_type* signal)
       {

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -489,10 +489,10 @@ namespace GridKit
       /**
        * @brief Evaluate system Jacobian.
        *
-       * First, initialize bus Jacobians to 0. 
-       * Then, evaluate component Jacobians (internal block and bus Jacobian contributions). 
-       * Once component Jacobians are evaluated, store the result in the system Jacobian. 
-       * Finally, store bus Jacobians into the system Jacobian after all component have added their 
+       * First, initialize bus Jacobians to 0.
+       * Then, evaluate component Jacobians (internal block and bus Jacobian contributions).
+       * Once component Jacobians are evaluated, store the result in the system Jacobian.
+       * Finally, store bus Jacobians into the system Jacobian after all component have added their
        * contributions.
        *
        * @todo split the initial assembly from updating values. This will the

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -489,8 +489,14 @@ namespace GridKit
       /**
        * @brief Evaluate system Jacobian.
        *
-       * @note Experimental Jacobian evaluation
-       * @todo Add a proper way to handle off-diagonal (coupling terms)
+       * First, initialize bus Jacobians to 0. 
+       * Then, evaluate component Jacobians (internal block and bus Jacobian contributions). 
+       * Once component Jacobians are evaluated, store the result in the system Jacobian. 
+       * Finally, store bus Jacobians into the system Jacobian after all component have added their 
+       * contributions.
+       *
+       * @todo split the initial assembly from updating values. This will the
+       * slow otherwise.
        *
        */
       int evaluateJacobian()
@@ -505,7 +511,7 @@ namespace GridKit
           bus->evaluateJacobian();
         }
 
-        // Component Jacobian diagonal blocks
+        // Jacobian blocks owed by components
         // Also updates bus Jacobians
         for (const auto& component : components_)
         {
@@ -522,7 +528,7 @@ namespace GridKit
           }
         }
 
-        // Bus Jacobian diagonal blocks
+        // Bus Jacobians
         for (const auto& bus : buses_)
         {
           auto bus_jacobian = bus->getJacobian();

--- a/tests/UnitTests/PhasorDynamics/CMakeLists.txt
+++ b/tests/UnitTests/PhasorDynamics/CMakeLists.txt
@@ -10,17 +10,20 @@ target_link_libraries(test_phasor_bus GRIDKIT::phasor_dynamics_bus)
 add_executable(test_phasor_branch runBranchTests.cpp)
 target_link_libraries(test_phasor_branch GRIDKIT::phasor_dynamics_branch
                                          GRIDKIT::phasor_dynamics_branch_dependency_tracking
-                                         GRIDKIT::phasor_dynamics_bus)
+                                         GRIDKIT::phasor_dynamics_bus
+                                         GRIDKIT::phasor_dynamics_bus_dependency_tracking)
 
 add_executable(test_phasor_load runLoadTests.cpp)
 target_link_libraries(test_phasor_load GRIDKIT::phasor_dynamics_load
                                        GRIDKIT::phasor_dynamics_load_dependency_tracking
-                                       GRIDKIT::phasor_dynamics_bus)
+                                       GRIDKIT::phasor_dynamics_bus
+                                       GRIDKIT::phasor_dynamics_bus_dependency_tracking)
 
 add_executable(test_phasor_genrou runGenrouTests.cpp)
 target_link_libraries(test_phasor_genrou GRIDKIT::phasor_dynamics_genrou
                                          GRIDKIT::phasor_dynamics_genrou_dependency_tracking
-                                         GRIDKIT::phasor_dynamics_bus)
+                                         GRIDKIT::phasor_dynamics_bus
+                                         GRIDKIT::phasor_dynamics_bus_dependency_tracking)
 
 add_executable(test_phasor_governortgov1 runGovernorTgov1Tests.cpp)
 target_link_libraries(test_phasor_governortgov1 GRIDKIT::phasor_dynamics_genrou
@@ -28,12 +31,14 @@ target_link_libraries(test_phasor_governortgov1 GRIDKIT::phasor_dynamics_genrou
                                                 GRIDKIT::phasor_dynamics_governortgov1
                                                 GRIDKIT::phasor_dynamics_governortgov1_dependency_tracking
                                                 GRIDKIT::phasor_dynamics_signal
-                                                GRIDKIT::phasor_dynamics_bus)
+                                                GRIDKIT::phasor_dynamics_bus
+                                                GRIDKIT::phasor_dynamics_bus_dependency_tracking)
 
 add_executable(test_phasor_gen_classical runGenClassicalTests.cpp)
 target_link_libraries(test_phasor_gen_classical GRIDKIT::phasor_dynamics_gen_classical
                                                 GRIDKIT::phasor_dynamics_gen_classical_dependency_tracking
-                                                GRIDKIT::phasor_dynamics_bus)
+                                                GRIDKIT::phasor_dynamics_bus
+                                                GRIDKIT::phasor_dynamics_bus_dependency_tracking)
 
 
 add_executable(test_phasor_system runSystemTests.cpp)

--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -266,11 +266,10 @@ namespace GridKit
         gen.allocate();
         gen.initialize();
 
-        (gen.y()[0]).setVariableNumber(0); ///< Independent variables: first
-        (gen.y()[1]).setVariableNumber(1); ///< Independent variables: second
-        (gen.y()[2]).setVariableNumber(2); ///< Independent variables: third
-        (gen.y()[3]).setVariableNumber(3); ///< Independent variables: fourth
-        (gen.y()[4]).setVariableNumber(4); ///< Independent variables: fifth
+        for (size_t i = 0; i < gen.size(); ++i)
+        {
+          gen.y()[i].setVariableNumber(i); ///< Independent variables
+        }
 
         gen.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
                                 ///< the dependencies

--- a/tests/UnitTests/PhasorDynamics/LoadTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/LoadTests.hpp
@@ -59,8 +59,9 @@ namespace GridKit
         const ScalarT Ii{0.0};  ///< Solution imaginary current
 
         PhasorDynamics::BusInfinite<ScalarT, IdxT> bus(Vr, Vi);
-
-        PhasorDynamics::Load<ScalarT, IdxT> load(&bus, R, X);
+        PhasorDynamics::Load<ScalarT, IdxT>        load(&bus, R, X);
+        bus.allocate();
+        load.allocate();
         load.evaluateResidual();
 
         success *= isEqual(bus.Ir(), Ir);
@@ -83,8 +84,9 @@ namespace GridKit
         Vi.setVariableNumber(1); ///< Independent variables: second
 
         PhasorDynamics::BusInfinite<DependencyTracking::Variable, IdxT> bus(Vr, Vi);
-
-        PhasorDynamics::Load<DependencyTracking::Variable, IdxT> load(&bus, R, X);
+        PhasorDynamics::Load<DependencyTracking::Variable, IdxT>        load(&bus, R, X);
+        bus.allocate();
+        load.allocate();
         load.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
                                  ///< the dependencies
 
@@ -113,12 +115,12 @@ namespace GridKit
         ScalarT Vr{10.0}; ///< Bus real voltage
         ScalarT Vi{20.0}; ///< Bus imaginary voltage
 
-        PhasorDynamics::BusInfinite<ScalarT, IdxT> bus(Vr, Vi);
-        PhasorDynamics::Load<ScalarT, IdxT>        load(&bus, R, X);
+        PhasorDynamics::Bus<ScalarT, IdxT>  bus(Vr, Vi);
+        PhasorDynamics::Load<ScalarT, IdxT> load(&bus, R, X);
         bus.allocate();
         load.allocate();
         load.evaluateJacobian();
-        GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> model_jacobian = load.getJacobian();
+        GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> model_jacobian = bus.getJacobian();
         model_jacobian.printMatrix("Model Jacobian");
 
         /// Compare model Jacobian wih dependencies computed analytically

--- a/tests/UnitTests/PhasorDynamics/SystemTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/SystemTests.hpp
@@ -4,12 +4,14 @@
 #include <iostream>
 
 #include <AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+#include <Definitions.hpp>
 #include <Model/PhasorDynamics/Branch/Branch.hpp>
 #include <Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
 #include <Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Model/PhasorDynamics/SystemModelData.hpp>
+#include <Utilities/MapFromCOO.hpp>
 #include <Utilities/TestHelpers.hpp>
 #include <Utilities/Testing.hpp>
 
@@ -104,72 +106,6 @@ namespace GridKit
         return success.report(__func__);
       }
 
-      TestOutcome dependencyTracking()
-      {
-        TestStatus success = true;
-
-        PhasorDynamics::SystemModelData<ScalarT, IdxT> data;
-
-        // Set bus data
-        data.bus.resize(2);
-
-        // Bus 0
-        data.bus[0].bus_id   = 0;
-        data.bus[0].bus_type = PhasorDynamics::BusData<ScalarT, IdxT>::BusType::SLACK;
-        data.bus[0].Vr0      = 10.0;
-        data.bus[0].Vi0      = 20.0;
-
-        // Bus 1
-        data.bus[1].bus_id   = 1;
-        data.bus[1].bus_type = PhasorDynamics::BusData<ScalarT, IdxT>::BusType::DEFAULT;
-        data.bus[1].Vr0      = 30.0;
-        data.bus[1].Vi0      = 40.0;
-
-        // Set branch data
-        data.branch.resize(1);
-
-        // Branch 0-1
-        data.branch[0].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-        data.branch[0].ports[BranchPorts::bus2]        = data.bus[1].bus_id;
-        data.branch[0].parameters[BranchParameters::R] = 2.0;
-        data.branch[0].parameters[BranchParameters::X] = 4.0;
-        data.branch[0].parameters[BranchParameters::G] = 0.2;
-        data.branch[0].parameters[BranchParameters::B] = 1.2;
-
-        // Create an empty system model
-        PhasorDynamics::SystemModel<DependencyTracking::Variable, IdxT> system(data);
-
-        // Allocate and initialize the system
-        system.allocate();
-        system.initialize();
-
-        // Set independent variables
-        success *= (system.size() == 2);
-        for (size_t i = 0; i < system.size(); ++i)
-        {
-          system.y()[i].setVariableNumber(i);
-        }
-
-        // Evaluate and get the system residuals
-        system.evaluateResidual();
-        std::vector<DependencyTracking::Variable> residuals = system.getResidual();
-
-        /// Verify the size and structure of the residual dependencies.
-        /// We expect a 2x2 dense Jacobian for a branch connecting a slack bus and a default bus.
-        /// We are less concerned with the values here, as the goal is to get the sparsity pattern.
-        success *= (residuals.size() == 2);
-        for (size_t i = 0; i < residuals.size(); ++i)
-        {
-          DependencyTracking::Variable                       res           = residuals[i];
-          const DependencyTracking::Variable::DependencyMap& dependencies  = res.getDependencies();
-          success                                                         *= (dependencies.size() == 2);
-          success                                                         *= (dependencies.find(0) != dependencies.end());
-          success                                                         *= (dependencies.find(1) != dependencies.end());
-        }
-
-        return success.report(__func__);
-      }
-
       TestOutcome composer()
       {
         TestStatus success = true;
@@ -214,7 +150,108 @@ namespace GridKit
 
         return success.report(__func__);
       }
-    };
 
+#ifdef GRIDKIT_ENABLE_ENZYME
+      TestOutcome jacobian()
+      {
+        TestStatus success = true;
+
+        PhasorDynamics::SystemModelData<ScalarT, IdxT> data;
+
+        // Set bus data
+        data.bus.resize(2);
+
+        // Bus 0
+        data.bus[0].bus_id   = 0;
+        data.bus[0].bus_type = PhasorDynamics::BusData<ScalarT, IdxT>::BusType::SLACK;
+        data.bus[0].Vr0      = 10.0;
+        data.bus[0].Vi0      = 20.0;
+
+        // Bus 1
+        data.bus[1].bus_id   = 1;
+        data.bus[1].bus_type = PhasorDynamics::BusData<ScalarT, IdxT>::BusType::DEFAULT;
+        data.bus[1].Vr0      = 30.0;
+        data.bus[1].Vi0      = 40.0;
+
+        // Set branch data
+        data.branch.resize(1);
+
+        // Branch 0-1
+        data.branch[0].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
+        data.branch[0].ports[BranchPorts::bus2]        = data.bus[1].bus_id;
+        data.branch[0].parameters[BranchParameters::R] = 2.0;
+        data.branch[0].parameters[BranchParameters::X] = 4.0;
+        data.branch[0].parameters[BranchParameters::G] = 0.2;
+        data.branch[0].parameters[BranchParameters::B] = 1.2;
+
+        // Jacobian via DependencyTracking
+        std::vector<DependencyTracking::Variable> dependency_tracking_residuals = DependencyTrackingJacobian(data);
+
+        // Jacobian via Enzyme
+        std::vector<DependencyTracking::Variable::DependencyMap> enzyme_jacobian = EnzymeJacobian(data);
+
+        /// Compare DependencyTracking dependencies to Enzyme's
+        for (size_t i = 0; i < dependency_tracking_residuals.size(); ++i)
+        {
+          DependencyTracking::Variable                       res           = dependency_tracking_residuals[i];
+          const DependencyTracking::Variable::DependencyMap& dependencies  = res.getDependencies();
+          success                                                         *= (GridKit::Testing::isEqual(dependencies, enzyme_jacobian[i]));
+        }
+
+        return success.report(__func__);
+      }
+
+    private:
+      std::vector<DependencyTracking::Variable> DependencyTrackingJacobian(
+          PhasorDynamics::SystemModelData<ScalarT, IdxT> data)
+      {
+        // Create an empty system model
+        PhasorDynamics::SystemModel<DependencyTracking::Variable, IdxT> system(data);
+
+        // Allocate and initialize the system
+        system.allocate();
+        system.initialize();
+
+        // Set independent variables
+        for (size_t i = 0; i < system.size(); ++i)
+        {
+          system.y()[i].setVariableNumber(i);
+        }
+
+        // Evaluate and get the system residuals
+        system.evaluateResidual();
+        std::vector<DependencyTracking::Variable> residuals = system.getResidual();
+
+        /// Print the dependencies
+        for (size_t i = 0; i < residuals.size(); ++i)
+        {
+          std::cout << i << "th residual: ";
+          (residuals[i]).print(std::cout);
+          std::cout << "\n";
+        }
+
+        return residuals;
+      }
+
+      std::vector<DependencyTracking::Variable::DependencyMap> EnzymeJacobian(
+          PhasorDynamics::SystemModelData<ScalarT, IdxT> data)
+      {
+        // Create an empty system model
+        PhasorDynamics::SystemModel<ScalarT, IdxT> system(data);
+
+        // Allocate and initialize the system
+        system.allocate();
+        system.initialize();
+
+        // Evaluate and get the system Jacobian
+        system.evaluateResidual();
+        system.evaluateJacobian();
+        GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> system_jacobian = system.getJacobian();
+        system_jacobian.printMatrix("System Jacobian");
+
+        return GridKit::Testing::MapFromCOO(system_jacobian);
+      }
+#endif
+    };
   } // namespace Testing
 } // namespace GridKit

--- a/tests/UnitTests/PhasorDynamics/runSystemTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runSystemTests.cpp
@@ -9,8 +9,10 @@ int main()
   GridKit::Testing::SystemTests<double, size_t> test;
 
   result += test.constructor();
-  result += test.dependencyTracking();
   result += test.composer();
+#ifdef GRIDKIT_ENABLE_ENZYME
+  result += test.jacobian();
+#endif
 
   return result.summary();
 }


### PR DESCRIPTION
 ## Description
 This is work in progress to assemble system-level Jacobian from component-level ones. This is functional for internal Jacobians ($\partial{f}/\partial{y}$) and bus Jacobians ($\partial{h}/\partial{w}$). Extending to $\partial{f}/\partial{w}$ and $\partial{h}/\partial{y}$ is straight forward with this implementation. I need to give more thought to the derivatives associated with other external variables (coming from optional signal nodes).

cc @alexander-novo @reid-g @abdourahmanbarry @lukelowry 
 
 ## Proposed changes
 - The current approach is to have `SystemModel` access the component-level Jacobians and assemble them in a block-arrow structure that is known.
 - Added methods to store and pass variable and residual mappings between components and systems.
 - Split residual evaluation into `evaluateInternalResidual` and `evaluateBusResidual`, so the associated derivatives can be computed separately.
 - Introduced `w` and `h` to pass bus variables and residual contributions in components.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
