### PR TITLE
Manage component IDs internal to GridKit

### DIFF
--- a/src/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.hpp
@@ -38,6 +38,7 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     class Branch : public Component<ScalarT, IdxT>
     {
+      using Component<ScalarT, IdxT>::gridkit_component_id_;
       using Component<ScalarT, IdxT>::size_;
       using Component<ScalarT, IdxT>::nnz_;
       using Component<ScalarT, IdxT>::time_;
@@ -57,6 +58,7 @@ namespace GridKit
       Branch(bus_type* bus1, bus_type* bus2, const model_data_type& data);
       virtual ~Branch();
 
+      virtual int setGridKitComponentID(IdxT) override;
       virtual int allocate() override;
       virtual int initialize() override;
       virtual int tagDifferentiable() override;

--- a/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -119,6 +119,16 @@ namespace GridKit
       // std::cout << "Destroy Branch..." << std::endl;
     }
 
+    /**
+     * @brief Set the component ID
+     */
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    {
+      gridkit_component_id_ = component_id;
+      return 0;
+    }
+
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */

--- a/src/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -22,6 +22,7 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     class BusFault : public Component<ScalarT, IdxT>
     {
+      using Component<ScalarT, IdxT>::gridkit_component_id_;
       using Component<ScalarT, IdxT>::alpha_;
       using Component<ScalarT, IdxT>::f_;
       using Component<ScalarT, IdxT>::nnz_;
@@ -41,6 +42,7 @@ namespace GridKit
       BusFault(bus_type* bus, const DataT& data);
       ~BusFault() = default;
 
+      int setGridKitComponentID(IdxT) override;
       int allocate() override;
       int initialize() override;
       int tagDifferentiable() override;
@@ -93,7 +95,7 @@ namespace GridKit
       real_type R_{0.0};
       real_type X_{0.0};
       bool      status_{false};
-      IdxT      busID_{0};
+      IdxT      bus_id_{0};
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
@@ -20,9 +20,9 @@ namespace GridKit
      */
     template <class ScalarT, typename IdxT>
     BusFault<ScalarT, IdxT>::BusFault(bus_type* bus)
-      : bus_(bus), R_(0), X_(0.01), status_(0), busID_(0)
+      : bus_(bus), R_(0), X_(0.01), status_(0), bus_id_(0)
     {
-      (void) busID_;
+      (void) bus_id_;
       size_ = 0;
     }
 
@@ -40,7 +40,7 @@ namespace GridKit
      */
     template <class ScalarT, typename IdxT>
     BusFault<ScalarT, IdxT>::BusFault(bus_type* bus, real_type R, real_type X, int status)
-      : bus_(bus), R_(R), X_(X), status_(status), busID_(0)
+      : bus_(bus), R_(R), X_(X), status_(status), bus_id_(0)
     {
       size_ = 0;
     }
@@ -74,10 +74,20 @@ namespace GridKit
 
       if (data.ports.contains(DataT::Ports::bus))
       {
-        busID_ = data.ports.at(DataT::Ports::bus);
+        bus_id_ = data.ports.at(DataT::Ports::bus);
       }
 
       size_ = 0;
+    }
+
+    /**
+     * @brief Set the component ID
+     */
+    template <class ScalarT, typename IdxT>
+    int BusFault<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    {
+      gridkit_component_id_ = component_id;
+      return 0;
     }
 
     /*!
@@ -119,8 +129,8 @@ namespace GridKit
     {
       if (status_)
       {
-        double B = -X_ / (X_ * X_ + R_ * R_);
-        double G = R_ / (X_ * X_ + R_ * R_);
+        real_type B = -X_ / (X_ * X_ + R_ * R_);
+        real_type G = R_ / (X_ * X_ + R_ * R_);
 
         Ir() += -Vr() * G + Vi() * B;
         Ii() += -Vr() * B - Vi() * G;

--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -107,9 +107,17 @@ namespace GridKit
         return J_;
       }
 
+      virtual int setGridKitComponentID(IdxT) = 0;
+
+      IdxT getGridKitComponentID() const
+      {
+        return gridkit_component_id_;
+      }
+
     protected:
-      IdxT size_;
-      IdxT nnz_;
+      IdxT gridkit_component_id_{0};
+      IdxT size_{0};
+      IdxT nnz_{0};
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;
@@ -277,11 +285,6 @@ namespace GridKit
       {
         throw "ERROR: Method not implemented!\n";
         return gB_;
-      }
-
-      IdxT getComponentID() const
-      {
-        return component_id_;
       }
     };
 

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -65,6 +65,7 @@ namespace GridKit
       template <class ScalarT, typename IdxT>
       class Ieeet1 : public Component<ScalarT, IdxT>
       {
+        using Component<ScalarT, IdxT>::gridkit_component_id_;
         using Component<ScalarT, IdxT>::alpha_;
         using Component<ScalarT, IdxT>::f_;
         using Component<ScalarT, IdxT>::nnz_;
@@ -89,6 +90,7 @@ namespace GridKit
                const model_data_type& data);
         ~Ieeet1() = default;
 
+        int setGridKitComponentID(IdxT) override;
         int allocate() override;
         int initialize() override;
         int tagDifferentiable() override;

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -86,12 +86,23 @@ namespace GridKit
       }
 
       /**
+       * @brief Set the component ID
+       */
+      template <class ScalarT, typename IdxT>
+      int Ieeet1<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      {
+        gridkit_component_id_ = component_id;
+        return 0;
+      }
+
+      /**
        * @brief Allocate memory for model
        *
        */
       template <class ScalarT, typename IdxT>
       int Ieeet1<ScalarT, IdxT>::allocate()
       {
+        // Resize component model data
         auto size = static_cast<size_t>(size_); // avoid compiler warnings
         f_.resize(size);
         y_.resize(size);
@@ -131,7 +142,7 @@ namespace GridKit
         // other variables.
         if (signals_.template isAssigned<Ieeet1InternalVariables::EFD>())
         {
-          efd0 = y_[7]; //<- generator needs to be initialized first
+          efd0 = y_[7]; ///<- generator needs to be initialized first
         }
 
         // Terminal Voltage

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -142,7 +142,7 @@ namespace GridKit
         // other variables.
         if (signals_.template isAssigned<Ieeet1InternalVariables::EFD>())
         {
-          efd0 = y_[7]; ///<- generator needs to be initialized first
+          efd0 = y_[7]; //<- generator needs to be initialized first
         }
 
         // Terminal Voltage

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -58,6 +58,7 @@ namespace GridKit
       template <class ScalarT, typename IdxT>
       class Tgov1 : public Component<ScalarT, IdxT>
       {
+        using Component<ScalarT, IdxT>::gridkit_component_id_;
         using Component<ScalarT, IdxT>::alpha_;
         using Component<ScalarT, IdxT>::f_;
         using Component<ScalarT, IdxT>::nnz_;
@@ -78,6 +79,7 @@ namespace GridKit
         Tgov1(const model_data_type&);
         ~Tgov1() = default;
 
+        int setGridKitComponentID(IdxT) override;
         int allocate() override;
         int initialize() override;
         int tagDifferentiable() override;

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -22,6 +22,7 @@ namespace GridKit
       template <class ScalarT, typename IdxT>
       int Tgov1<ScalarT, IdxT>::evaluateJacobian()
       {
+        std::cout << "Evaluate Jacobian for Tgov1..." << std::endl;
         std::cout << "Jacobian evaluation is experimental!" << std::endl;
         GridKit::Enzyme::Sparse::ModelJacobian<Tgov1<ScalarT, IdxT>, ScalarT, IdxT>(this, f_.size(), y_.size(), y_.data(), yp_.data(), J_);
 

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -115,6 +115,16 @@ namespace GridKit
         }
       }
 
+      /**
+       * @brief Set the component ID
+       */
+      template <class ScalarT, typename IdxT>
+      int Tgov1<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      {
+        gridkit_component_id_ = component_id;
+        return 0;
+      }
+
       /*!
        * @brief Allocate memory for model
        */
@@ -150,7 +160,7 @@ namespace GridKit
         // Initial mechanical = initial electric torque
         if (signals_.template isAssigned<Tgov1InternalVariables::PM>())
         {
-          p0 = y_[2]; //<- generator needs to be initialized first
+          p0 = y_[2]; ///<- generator needs to be initialized first
         }
 
         // Input Variables (Parameter for now)

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -160,7 +160,7 @@ namespace GridKit
         // Initial mechanical = initial electric torque
         if (signals_.template isAssigned<Tgov1InternalVariables::PM>())
         {
-          p0 = y_[2]; ///<- generator needs to be initialized first
+          p0 = y_[2]; //<- generator needs to be initialized first
         }
 
         // Input Variables (Parameter for now)

--- a/src/Model/PhasorDynamics/Load/Load.hpp
+++ b/src/Model/PhasorDynamics/Load/Load.hpp
@@ -95,7 +95,7 @@ namespace GridKit
       }
 
     public:
-      __attribute__((always_inline)) int evaluateResidualLocally(ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateResidualLocally(ScalarT*, ScalarT*, ScalarT*);
 
     private:
       bus_type* bus_{nullptr};

--- a/src/Model/PhasorDynamics/Load/Load.hpp
+++ b/src/Model/PhasorDynamics/Load/Load.hpp
@@ -27,6 +27,7 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     class Load : public Component<ScalarT, IdxT>
     {
+      using Component<ScalarT, IdxT>::gridkit_component_id_;
       using Component<ScalarT, IdxT>::size_;
       using Component<ScalarT, IdxT>::nnz_;
       using Component<ScalarT, IdxT>::time_;
@@ -36,7 +37,6 @@ namespace GridKit
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::f_;
       using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::component_id_;
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;
       using bus_type        = BusBase<ScalarT, IdxT>;
@@ -45,10 +45,10 @@ namespace GridKit
     public:
       Load(bus_type* bus);
       Load(bus_type* bus, real_type R, real_type X);
-      Load(bus_type* bus, IdxT component_id);
       Load(bus_type* bus, const model_data_type& data);
       virtual ~Load();
 
+      virtual int setGridKitComponentID(IdxT) override;
       virtual int allocate() override;
       virtual int initialize() override;
       virtual int tagDifferentiable() override;
@@ -72,6 +72,8 @@ namespace GridKit
       }
 
     private:
+      void setDerivedParams();
+
       ScalarT& Vr()
       {
         return bus_->Vr();
@@ -99,6 +101,10 @@ namespace GridKit
       bus_type* bus_{nullptr};
       real_type R_{0.1};
       real_type X_{0.01};
+
+      /* Derivied parameters */
+      real_type b_;
+      real_type g_;
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/Load/LoadImpl.hpp
+++ b/src/Model/PhasorDynamics/Load/LoadImpl.hpp
@@ -33,6 +33,7 @@ namespace GridKit
         R_(R),
         X_(X)
     {
+      setDerivedParams();
     }
 
     template <class ScalarT, typename IdxT>
@@ -49,20 +50,24 @@ namespace GridKit
       {
         X_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::X));
       }
-    }
 
-    template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::Load(bus_type* bus, IdxT component_id)
-      : bus_(bus)
-    {
-      size_         = 0;
-      component_id_ = component_id;
+      setDerivedParams();
     }
 
     template <class ScalarT, typename IdxT>
     Load<ScalarT, IdxT>::~Load()
     {
       // std::cout << "Destroy Load..." << std::endl;
+    }
+
+    /**
+     * @brief Set the component ID
+     */
+    template <class ScalarT, typename IdxT>
+    int Load<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    {
+      gridkit_component_id_ = component_id;
+      return 0;
     }
 
     /*!
@@ -127,6 +132,17 @@ namespace GridKit
       Ii() += f[1];
 
       return 0;
+    }
+
+    /**
+     * @brief Derived parameters
+     *
+     */
+    template <class ScalarT, typename IdxT>
+    void Load<ScalarT, IdxT>::setDerivedParams()
+    {
+      b_ = -X_ / (R_ * R_ + X_ * X_);
+      g_ = R_ / (R_ * R_ + X_ * X_);
     }
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
@@ -6,7 +6,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     LINK_LIBRARIES
       PUBLIC GRIDKIT::phasor_dynamics_signal ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno
+      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno -fno-vectorize
     OUTPUT_NAME
       gridkit_phasor_dynamics_genrou)
 else()

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -70,6 +70,7 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     class Genrou : public Component<ScalarT, IdxT>
     {
+      using Component<ScalarT, IdxT>::gridkit_component_id_;
       using Component<ScalarT, IdxT>::alpha_;
       using Component<ScalarT, IdxT>::f_;
       using Component<ScalarT, IdxT>::nnz_;
@@ -120,6 +121,7 @@ namespace GridKit
              real_type S12);
       ~Genrou() = default;
 
+      int setGridKitComponentID(IdxT) override;
       int allocate() override;
       int initialize() override;
       int tagDifferentiable() override;

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -249,17 +249,29 @@ namespace GridKit
       }
     }
 
+    /**
+     * @brief Set the component ID
+     */
+    template <class ScalarT, typename IdxT>
+    int Genrou<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    {
+      gridkit_component_id_ = component_id;
+      return 0;
+    }
+
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
     template <class ScalarT, typename IdxT>
     int Genrou<ScalarT, IdxT>::allocate()
     {
+      // Resize component model data
       f_.resize(static_cast<size_t>(size_));
       y_.resize(static_cast<size_t>(size_));
       yp_.resize(static_cast<size_t>(size_));
       tag_.resize(static_cast<size_t>(size_));
 
+      // Set output signal after allocation
       if (signals_.template isAssigned<GenrouInternalVariables::OMEGA>())
       {
         signals_.template getSignalNode<GenrouInternalVariables::OMEGA>()->set(&y_[1]);
@@ -442,7 +454,7 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int Genrou<ScalarT, IdxT>::evaluateResidual()
     {
-      // Mechanmical Power
+      // Mechanical Power
       if (signals_.template isAttached<GenrouExternalVariables::PM>())
       {
         pmech_ = signals_.template readExternalVariable<GenrouExternalVariables::PM>();

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -31,6 +31,7 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     class GenClassical : public Component<ScalarT, IdxT>
     {
+      using Component<ScalarT, IdxT>::gridkit_component_id_;
       using Component<ScalarT, IdxT>::alpha_;
       using Component<ScalarT, IdxT>::f_;
       using Component<ScalarT, IdxT>::nnz_;
@@ -58,6 +59,7 @@ namespace GridKit
       GenClassical(bus_type* bus, const DataT& data);
       ~GenClassical() = default;
 
+      int setGridKitComponentID(IdxT) override;
       int allocate() override;
       int initialize() override;
       int tagDifferentiable() override;
@@ -109,7 +111,7 @@ namespace GridKit
     private:
       /* Identification */
       bus_type* bus_;
-      IdxT      busID_{0};
+      IdxT      bus_id_{0};
       int       unit_id_; //< @todo this should be removed
 
       /* Initial terminal conditions */

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -106,7 +106,7 @@ namespace GridKit
       }
 
     public:
-      __attribute__((always_inline)) int evaluateResidualLocally(ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateResidualLocally(ScalarT*, ScalarT*, ScalarT*);
 
     private:
       /* Identification */

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -24,7 +24,7 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     GenClassical<ScalarT, IdxT>::GenClassical(bus_type* bus, int unit_id)
       : bus_(bus),
-        busID_(0),
+        bus_id_(0),
         unit_id_(unit_id),
         p0_(0.0),
         q0_(0.0),
@@ -50,7 +50,7 @@ namespace GridKit
                                               real_type Ra,
                                               real_type Xdp)
       : bus_(bus),
-        busID_(0),
+        bus_id_(0),
         unit_id_(unit_id),
         p0_(p0),
         q0_(q0),
@@ -103,11 +103,21 @@ namespace GridKit
 
       if (data.ports.contains(DataT::Ports::bus))
       {
-        busID_ = data.ports.at(DataT::Ports::bus);
+        bus_id_ = data.ports.at(DataT::Ports::bus);
       }
 
       size_ = 5;
       setDerivedParams();
+    }
+
+    /**
+     * @brief Set the component ID
+     */
+    template <class ScalarT, typename IdxT>
+    int GenClassical<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    {
+      gridkit_component_id_ = component_id;
+      return 0;
     }
 
     /**
@@ -116,6 +126,7 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int GenClassical<ScalarT, IdxT>::allocate()
     {
+      // Resize component model data
       auto size = static_cast<size_t>(size_);
       f_.resize(size);
       y_.resize(size);
@@ -178,7 +189,7 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateResidualLocally(ScalarT* y, ScalarT* yp, ScalarT* f)
     {
-      // Set variable aliases for better reliability.
+      // Set variable aliases for better readability.
       const ScalarT delta = y[0];
       const ScalarT omega = y[1];
       const ScalarT telec = y[2];
@@ -187,7 +198,7 @@ namespace GridKit
       const ScalarT pmech = pmech_set_; /* Later optionally acquire from governor */
       const ScalarT ep    = ep_set_;    /* Later optionally acquire from exciter */
 
-      // Set derivative aliases for better reliability
+      // Set derivative aliases for better readability
       const ScalarT delta_dot = yp[0];
       const ScalarT omega_dot = yp[1];
 

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -36,6 +36,7 @@ namespace GridKit
       using component_type = PhasorDynamics::Component<ScalarT, IdxT>;
       using real_type      = typename Model::Evaluator<ScalarT, IdxT>::real_type;
 
+      using PhasorDynamics::Component<ScalarT, IdxT>::gridkit_component_id_;
       using PhasorDynamics::Component<ScalarT, IdxT>::size_;
       using PhasorDynamics::Component<ScalarT, IdxT>::nnz_;
       using PhasorDynamics::Component<ScalarT, IdxT>::time_;
@@ -262,6 +263,18 @@ namespace GridKit
       }
 
       /**
+       * @brief Set component ID
+       *
+       * @note Should default to 0. The system model could be used as a
+       * component in a larger system that would need to set this value.
+       */
+      int setGridKitComponentID(IdxT component_id)
+      {
+        gridkit_component_id_ = component_id;
+        return 0;
+      }
+
+      /**
        * @brief Allocate buses, components, and system objects.
        *
        * This method first allocates bus objects, then component objects,
@@ -323,6 +336,9 @@ namespace GridKit
        * exciters, etc.) during the initialization.
        *
        * @todo Implement writting to system vectors in a thread-safe way.
+       *
+       * @note Currently assuming each component stores variables contiguously in memory and
+       * that these are simply concateneted in the global system.
        */
       int initialize()
       {
@@ -479,6 +495,10 @@ namespace GridKit
         return 0;
       }
 
+      /**
+       * @brief Update time
+       *
+       */
       void updateTime(real_type t, real_type a)
       {
         for (const auto& component : components_)
@@ -487,39 +507,84 @@ namespace GridKit
         }
       }
 
+      /**
+       * @brief Add bus
+       *
+       */
       void addBus(bus_type* bus)
       {
+        IdxT gridkit_bus_id                  = static_cast<IdxT>(buses_.size());
+        gridkit_bus_indices_[gridkit_bus_id] = bus->busID();
         buses_.push_back(bus);
       }
 
+      /**
+       * @brief Add signal
+       *
+       */
       void addSignal(signal_type* signal)
       {
+        IdxT gridkit_signal_id                     = static_cast<IdxT>(signals_.size());
+        gridkit_signal_indices_[gridkit_signal_id] = signal->signalId();
         signals_.push_back(signal);
       }
 
+      /**
+       * @brief Add component
+       *
+       */
       void addComponent(component_type* component)
       {
+        IdxT gridkit_component_id = static_cast<IdxT>(components_.size());
+        // No user-facing component_id for now, but we could add a map to the disambiguation_string
+        component->setGridKitComponentID(gridkit_component_id);
         components_.push_back(component);
       }
 
+      /**
+       * @brief Add fault
+       *
+       */
       void addFault(component_type* component)
       {
-        components_.push_back(component);
-        faults_.push_back(component);
+        IdxT gridkit_component_id                = static_cast<IdxT>(components_.size());
+        IdxT gridkit_fault_id                    = static_cast<IdxT>(gridkit_fault_indices_.size());
+        gridkit_fault_indices_[gridkit_fault_id] = gridkit_component_id;
+        addComponent(component);
       }
 
-      bus_type* getBus(IdxT busid)
+      /**
+       * @brief Return pointer to a bus
+       *
+       */
+      bus_type* getBus(IdxT bus_id)
       {
-        // Need to implement mapping of bus IDs to buses in the system model
-        assert((buses_[busid])->busID() == busid);
-        return buses_[busid];
+        // Should fail if user-provided bus_id is incorrect
+        IdxT gridkit_bus_id = gridkit_bus_indices_.at(bus_id);
+        assert((buses_[gridkit_bus_id])->busID() == bus_id);
+        return buses_[gridkit_bus_id];
       }
 
-      signal_type* getSignal(IdxT signalid)
+      /**
+       * @brief Return pointer to a signal
+       *
+       */
+      signal_type* getSignal(IdxT signal_id)
       {
-        // Need to implement mapping of signal IDs to signals in the system model
-        assert((signals_[signalid])->signalId() == signalid);
-        return signals_[signalid];
+        // Should fail if user-provided signal_id is incorrect
+        IdxT gridkit_signal_id = gridkit_signal_indices_.at(signal_id);
+        assert((signals_[gridkit_signal_id])->signalId() == signal_id);
+        return signals_[gridkit_signal_id];
+      }
+
+      /**
+       * @brief Return pointer to a component
+       *
+       */
+      component_type* getComponent(IdxT gridkit_component_id)
+      {
+        // gridkit_component_id_ is set by System model and guarantied to be unique
+        return components_[gridkit_component_id];
       }
 
       /**
@@ -528,19 +593,21 @@ namespace GridKit
        * This function is used to provide easier access to setting and
        * clearing faults from the SystemModel interface.
        *
-       * @warning This is a hack to get access to bus faults in examples.
-       * A more comprehensive solution is needed.
        */
       BusFault<ScalarT, IdxT>* getBusFault(IdxT fault_id)
       {
-        return dynamic_cast<BusFault<ScalarT, IdxT>*>(faults_[fault_id]);
+        IdxT component_id = gridkit_fault_indices_.at(fault_id);
+        return dynamic_cast<BusFault<ScalarT, IdxT>*>(components_[component_id]);
       }
 
     private:
       std::vector<bus_type*>       buses_;
       std::vector<signal_type*>    signals_;
       std::vector<component_type*> components_;
-      std::vector<component_type*> faults_;
+
+      std::map<IdxT, IdxT> gridkit_bus_indices_;    ///< Map between gridkit_bus_id and bus_id
+      std::map<IdxT, IdxT> gridkit_signal_indices_; ///< Map between gridkit_signal_id and signal_id
+      std::map<IdxT, IdxT> gridkit_fault_indices_;  ///< Map between fault_id and component_id
 
       bool owns_components_{false};
 

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -312,7 +312,7 @@ namespace GridKit
       }
 
       /**
-       * @brief Assume that jacobian is not avalible
+       * @brief Assume that jacobian is not available
        *
        * @return true
        * @return false
@@ -510,6 +510,8 @@ namespace GridKit
       /**
        * @brief Add bus
        *
+       * Add bus at the end of the bus array and map bus ID with GridKit's ID for the bus
+       *
        */
       void addBus(bus_type* bus)
       {
@@ -520,6 +522,8 @@ namespace GridKit
 
       /**
        * @brief Add signal
+       *
+       * Add signal at the end of the signals array and map signal ID with GridKit's ID for the signal
        *
        */
       void addSignal(signal_type* signal)
@@ -532,17 +536,24 @@ namespace GridKit
       /**
        * @brief Add component
        *
+       * Add component at the end of the components array and set GridKit's component ID
+       *
+       * @todo: No integer user-facing component_id for now, but we could map GridKit's 
+       * component ID to the disambiguation_string
+       *
        */
       void addComponent(component_type* component)
       {
         IdxT gridkit_component_id = static_cast<IdxT>(components_.size());
-        // No user-facing component_id for now, but we could add a map to the disambiguation_string
         component->setGridKitComponentID(gridkit_component_id);
         components_.push_back(component);
       }
 
       /**
        * @brief Add fault
+       *
+       * The fault is added to the components array, and we keep a map to its
+       * location, so it can easily be accessed.
        *
        */
       void addFault(component_type* component)

--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -538,7 +538,7 @@ namespace GridKit
        *
        * Add component at the end of the components array and set GridKit's component ID
        *
-       * @todo: No integer user-facing component_id for now, but we could map GridKit's 
+       * @todo: No integer user-facing component_id for now, but we could map GridKit's
        * component ID to the disambiguation_string
        *
        */

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -68,6 +68,7 @@ namespace GridKit
         PhasorDynamics::BusInfinite<ScalarT, IdxT> bus2(Vr2, Vi2);
 
         PhasorDynamics::Branch<ScalarT, IdxT> branch(&bus1, &bus2, R, X, G, B);
+        branch.allocate();
         branch.evaluateResidual();
 
         success *= isEqual(bus1.Ir(), Ir1);
@@ -101,6 +102,7 @@ namespace GridKit
         PhasorDynamics::BusInfinite<DependencyTracking::Variable, IdxT> bus2(Vr2, Vi2);
 
         PhasorDynamics::Branch<DependencyTracking::Variable, IdxT> branch(&bus1, &bus2, R, X, G, B);
+        branch.allocate();
         branch.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
                                    ///< the dependencies
 
@@ -148,6 +150,7 @@ namespace GridKit
                                                      zero,
                                                      zero,
                                                      zero);
+        branch.allocate();
 
         // Test setting branch series resistance
         branch.setR(R);

--- a/tests/UnitTests/PhasorDynamics/LoadTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/LoadTests.hpp
@@ -114,7 +114,7 @@ namespace GridKit
         ScalarT Vi{20.0}; ///< Bus imaginary voltage
 
         PhasorDynamics::BusInfinite<ScalarT, IdxT> bus(Vr, Vi);
-        PhasorDynamics::Load<ScalarT, IdxT> load(&bus, R, X);
+        PhasorDynamics::Load<ScalarT, IdxT>        load(&bus, R, X);
         bus.allocate();
         load.allocate();
         load.evaluateJacobian();

--- a/tests/UnitTests/PhasorDynamics/LoadTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/LoadTests.hpp
@@ -114,8 +114,9 @@ namespace GridKit
         ScalarT Vi{20.0}; ///< Bus imaginary voltage
 
         PhasorDynamics::BusInfinite<ScalarT, IdxT> bus(Vr, Vi);
-
         PhasorDynamics::Load<ScalarT, IdxT> load(&bus, R, X);
+        bus.allocate();
+        load.allocate();
         load.evaluateJacobian();
         GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> model_jacobian = load.getJacobian();
         model_jacobian.printMatrix("Model Jacobian");


### PR DESCRIPTION
 ## Description

 We need to differentiate between user-facing component IDs and the indices internal to GridKit. This adds some maps in `SystemModel` to address buses, signals and faults.
 
 ## Proposed changes
 - `gridkit_bus_indices_` maps between `gridkit_bus_id` and user-facing `bus_id`
 - `gridkit_signal_indices_` maps between `gridkit_signal_id` and user-facing `signal_id`
 - `gridkit_fault_indices` maps to `component_id`, so we no longer need to store faults separately.
 - `gridkit_component_id` values are set by `SystemModel` for each instantiated component.
 - Other minor changes pulled from #229 that are unrelated to Jacobian assembly.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments