### PR TITLE
Refactored TinyTwoBus examples to use separate JSON files

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,6 +3,33 @@
 #    - Slaven Peles <peless@ornl.gov>
 #]]
 
+set(GRIDKIT_EXAMPLES_INSTALL_ROOT "share/gridkit/examples")
+
+#
+# gridkit_example_add_file(<filename>)
+#
+# This macro will add a file (e.g., JSON) that is needed for an example to the
+# build tree and the install tree following the same directory structure as the
+# source tree under `examples`.
+# 
+# <filename> must exist in the CMAKE_CURRENT_SOURCE_DIR where this macro is
+# called.
+#
+macro(gridkit_example_add_file _filename)
+    get_filename_component(__fname ${_filename} NAME)
+    set(_source_filepath ${CMAKE_CURRENT_SOURCE_DIR}/${__fname})
+    if(NOT EXISTS ${_source_filepath})
+        message(FATAL_ERROR "File does not exist: ${_source_filepath}")
+    endif()
+    set(_binary_filepath ${CMAKE_CURRENT_BINARY_DIR}/${__fname})
+    configure_file(${_source_filepath} ${_binary_filepath} COPYONLY)
+    cmake_path(RELATIVE_PATH CMAKE_CURRENT_SOURCE_DIR
+        BASE_DIRECTORY ${CMAKE_SOURCE_DIR}/examples
+        OUTPUT_VARIABLE _rel_path)
+    set(_ex_install_path ${GRIDKIT_EXAMPLES_INSTALL_ROOT}/${_rel_path})
+    install(FILES ${_filename} DESTINATION ${_ex_install_path})
+endmacro()
+
 add_subdirectory(LinearAlgebra)
 
 add_subdirectory(PowerFlow)

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(TwoBusBasic TwoBusBasic.cpp)
-target_link_libraries(TwoBusBasic 
+target_link_libraries(TwoBusBasic
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::solvers_dyn)
 install(TARGETS TwoBusBasic RUNTIME DESTINATION bin)
@@ -8,9 +8,14 @@ add_executable(TwoBusBasicJson TwoBusBasicJson.cpp)
 target_link_libraries(TwoBusBasicJson 
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::solvers_dyn)
-target_include_directories(TwoBusBasicJson PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
-target_include_directories(TwoBusBasicJson PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
+target_include_directories(TwoBusBasicJson
+    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
+target_include_directories(TwoBusBasicJson
+    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
 install(TARGETS TwoBusBasicJson RUNTIME DESTINATION bin)
+gridkit_example_add_file(TwoBusBasic.json)
 
-add_test(NAME TwoBusBasicTest COMMAND $<TARGET_FILE:TwoBusBasic>)
-add_test(NAME TwoBusBasicJsonTest COMMAND $<TARGET_FILE:TwoBusBasicJson>)
+add_test(NAME TwoBusBasicTest COMMAND TwoBusBasic)
+add_test(NAME TwoBusBasicJsonTest
+    COMMAND TwoBusBasicJson TwoBusBasic.json
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.json
@@ -1,0 +1,74 @@
+{
+    "header": {
+        "format_version": 0,
+        "format_revision": 1,
+        "case_name": "Basic 2-bus test case",
+        "case_description": "A two-bus test case for demonstrating the dynamics format",
+        "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
+        "freq_base": 60.0,
+        "va_base": 100e6
+    },
+    "buses": [
+        { 
+            "number": 0,
+            "class": "bus",
+            "name": "Bus 1",
+            "init": {
+                "Vr":0.9949877346411762,
+                "Vi":0.09999703952427966
+            },
+            "v_base": 115e3,
+            "mon": ["Vr", "Vi"]
+        },
+        { 
+            "number": 1,
+            "class": "infinite_bus",
+            "name": "Bus 2",
+            "init": {
+                "Vr":1.0,
+                "Vi":0.0
+            },
+            "v_base": 115e3
+        }
+    ],
+    "devices": [
+        { 
+            "class": "Branch",
+            "ports": {"bus1":0, "bus2":1},
+            "id": "BR1",
+            "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0}
+        },
+        {
+            "class": "Genrou",
+            "ports": {"bus":0},
+            "id": "DV1",
+            "params": {
+                "p0":1.0,
+                "q0":0.05013,
+                "H":3.0,
+                "D":0.0,
+                "Ra":0.0,
+                "Tdop":7.0,
+                "Tdopp":0.04,
+                "Tqopp":0.05,
+                "Tqop":0.75,
+                "Xd":2.1,
+                "Xdp":0.2,
+                "Xdpp":0.18,
+                "Xq":0.5,
+                "Xqp":0.5,
+                "Xqpp":0.18,
+                "Xl":0.15,
+                "S10":0.0,
+                "S12":0.0
+            },
+            "mon": ["delta", "omega"]
+        },
+        { 
+            "class": "bus_fault",
+            "ports": {"bus":0},
+            "id": "0",
+            "params": {"state0": false, "R":0.0, "X":1e-3}
+        }
+    ]
+}

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
@@ -9,6 +9,7 @@
  *
  */
 #include <ctime>
+#include <filesystem>
 #include <iostream>
 
 #include "TwoBusBasic.hpp"
@@ -20,7 +21,7 @@
 #include <Utilities/Testing.hpp>
 #include <nlohmann/json.hpp>
 
-int main()
+int main(int argc, const char* argv[])
 {
   using namespace GridKit::PhasorDynamics;
   using namespace AnalysisManager::Sundials;
@@ -29,74 +30,27 @@ int main()
   using real_type   = double;
   using index_type  = size_t;
 
+  if (argc < 2)
+  {
+    throw std::runtime_error(
+        "\n\nUsage:\n"
+        "\tTwoBusBasicJson <json-input-file>\n");
+  }
+
   std::cout << "Example: TwoBusBasicJson\n";
 
   //
   // Input file
   //
 
-  const char input_file[] =
-      R"({
-            "header": {
-                "format_version": 0,
-                "format_revision": 1,
-                "case_name": "Basic 2-bus test case",
-                "case_description": "A two-bus test case for demonstrating the dynamics format",
-                "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
-                "freq_base": 60.0,
-                "va_base": 100e6
-            },
-            "buses": [
-                { 
-                  "number": 0,
-                  "class": "bus",
-                  "name": "Bus 1",
-                  "init": {
-                            "Vr":0.9949877346411762,
-                            "Vi":0.09999703952427966
-                          },
-                  "v_base": 115e3,
-                  "mon": ["Vr", "Vi"]
-                },
-                { 
-                  "number": 1,
-                  "class": "infinite_bus",
-                  "name": "Bus 2",
-                  "init": {
-                            "Vr":1.0,
-                            "Vi":0.0
-                          },
-                  "v_base": 115e3
-                }
-            ],
-            "devices": [
-                { 
-                  "class": "Branch",
-                  "ports": {"bus1":0, "bus2":1},
-                  "id": "BR1",
-                  "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0}
-                },
-                {
-                  "class": "Genrou",
-                  "ports": {"bus":0},
-                  "id": "DV1",
-                  "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.5, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0},
-                  "mon": ["delta", "omega"]
-                },
-                { 
-                  "class": "bus_fault",
-                  "ports": {"bus":0},
-                  "id": "0",
-                  "params": {"state0": false, "R":0.0, "X":1e-3}
-                }
-            ]
-        })";
+  auto input_file = std::filesystem::path(argv[1]);
+  std::cout << "Input file: " << input_file << '\n';
 
   //
   // Create model data
   //
 
-  SystemModelData<scalar_type, index_type> data = json::parse(input_file);
+  SystemModelData<scalar_type, index_type> data(json::parse(std::ifstream(input_file)));
 
   //
   // Instantiate system model

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
@@ -1,18 +1,23 @@
 add_executable(TwoBusIeeet1 TwoBusIeeet1.cpp)
-target_link_libraries(TwoBusIeeet1 
+target_link_libraries(TwoBusIeeet1
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::phasor_dynamics_signal
 	GRIDKIT::solvers_dyn)
 install(TARGETS TwoBusIeeet1 RUNTIME DESTINATION bin)
 
 add_executable(TwoBusIeeet1Json TwoBusIeeet1Json.cpp)
-target_link_libraries(TwoBusIeeet1Json 
+target_link_libraries(TwoBusIeeet1Json
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::phasor_dynamics_signal
 	GRIDKIT::solvers_dyn)
-target_include_directories(TwoBusIeeet1Json PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
-target_include_directories(TwoBusIeeet1Json PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
+target_include_directories(TwoBusIeeet1Json
+    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
+target_include_directories(TwoBusIeeet1Json
+    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
 install(TARGETS TwoBusIeeet1Json RUNTIME DESTINATION bin)
+gridkit_example_add_file(TwoBusIeeet1.json)
 
-add_test(NAME GenrouTest1_Ieeet1 COMMAND $<TARGET_FILE:TwoBusIeeet1>)
-add_test(NAME GenrouTest1_Ieeet1_Json COMMAND $<TARGET_FILE:TwoBusIeeet1Json>)
+add_test(NAME GenrouTest1_Ieeet1 COMMAND TwoBusIeeet1)
+add_test(NAME GenrouTest1_Ieeet1_Json
+    COMMAND TwoBusIeeet1Json TwoBusIeeet1.json
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.json
@@ -1,0 +1,114 @@
+{
+    "header": {
+        "format_version": 0,
+        "format_revision": 1,
+        "case_name": "2-bus test case with governor and exciter",
+        "case_description": "A two-bus test case for demonstrating the dynamics format",
+        "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
+        "freq_base": 60.0,
+        "va_base": 100e6
+    },
+    "buses": [
+        { 
+            "number": 0,
+            "class": "bus",
+            "name": "Bus 1",
+            "init": {
+                "Vr":0.9949877346411762,
+                "Vi":0.09999703952427966
+            },
+            "v_base": 115e3,
+            "mon": ["Vr", "Vi"]
+        },
+        { 
+            "number": 1,
+            "class": "infinite_bus",
+            "name": "Bus 2",
+            "init": {
+                "Vr":1.0,
+                "Vi":0.0
+            },
+            "v_base": 115e3
+        }
+    ],
+    "signals": [
+        { "signal_id": 0, "name": "Machine Speed Deviation"},
+        { "signal_id": 1, "name": "Mechanical Power"},
+        { "signal_id": 2, "name": "Excitation Field"}
+    ],
+    "devices": [
+        { 
+            "class": "Branch",
+            "ports": {"bus1":0, "bus2":1},
+            "id": "BR1",
+            "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0}
+        },
+        {
+            "class": "Genrou",
+            "ports": {"bus":0, "speed": 0, "pmech":1, "efd": 2},
+            "id": "DV1",
+            "params": {
+                "p0":1.0,
+                "q0":0.05013,
+                "H":3.0,
+                "D":0.0,
+                "Ra":0.0,
+                "Tdop":7.0,
+                "Tdopp":0.04,
+                "Tqopp":0.05,
+                "Tqop":0.75,
+                "Xd":2.1,
+                "Xdp":0.2,
+                "Xdpp":0.18,
+                "Xq":0.5,
+                "Xqp":0.5,
+                "Xqpp":0.18,
+                "Xl":0.15,
+                "S10":0.0,
+                "S12":0.0
+            },
+            "mon": ["delta", "omega"]
+        },
+        {
+            "class": "Tgov1",
+            "ports": {"bus":0, "speed": 0, "pmech":1},
+            "id": "DV2",
+            "params": {
+                "R":0.05,
+                "T1":0.5,
+                "T2":2.5,
+                "T3":7.5,
+                "Pvmin":0.0,
+                "Pvmax":1.0,
+                "Dt":0.0
+            }
+        },
+        {
+            "class": "Ieeet1",
+            "ports": {"bus":0, "speed": 0, "efd":2},
+            "id": "DV3",
+            "params": {
+                "Tr":0.001,
+                "Ka":50.0,
+                "Ta":0.04,
+                "Ke":-0.06,
+                "Te":0.6,
+                "Kf":0.09,
+                "Tf":1.46,
+                "Vrmin":-1.0,
+                "Vrmax":1.0,
+                "E1":2.8,
+                "E2":3.373,
+                "Se1":0.04,
+                "Se2":0.33,
+                "Ispdlim":0.0
+            }
+        },
+        { 
+            "class": "bus_fault",
+            "ports": {"bus":0},
+            "id": "0",
+            "params": {"state0": false, "R":0.0, "X":1e-3}
+        }
+    ]
+}

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
@@ -6,6 +6,7 @@
  *
  */
 #include <ctime>
+#include <filesystem>
 #include <iostream>
 
 #include "TwoBusIeeet1.hpp"
@@ -17,7 +18,7 @@
 #include <Utilities/Testing.hpp>
 #include <nlohmann/json.hpp>
 
-int main()
+int main(int argc, const char* argv[])
 {
   using namespace GridKit::PhasorDynamics;
   using namespace AnalysisManager::Sundials;
@@ -28,91 +29,27 @@ int main()
   using real_type   = double;
   using index_type  = size_t;
 
+  if (argc < 2)
+  {
+    throw std::runtime_error(
+        "\n\nUsage:\n"
+        "\tTwoBusBasicJson <json-input-file>\n");
+  }
+
   std::cout << "Example: TwoBusTgov1 + IEEET1 Exciter\n";
 
   //
   // Input file
   //
 
-  const char input_file[] =
-      R"({
-            "header": {
-                "format_version": 0,
-                "format_revision": 1,
-                "case_name": "2-bus test case with governor and exciter",
-                "case_description": "A two-bus test case for demonstrating the dynamics format",
-                "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
-                "freq_base": 60.0,
-                "va_base": 100e6
-            },
-            "buses": [
-                { 
-                  "number": 0,
-                  "class": "bus",
-                  "name": "Bus 1",
-                  "init": {
-                            "Vr":0.9949877346411762,
-                            "Vi":0.09999703952427966
-                          },
-                  "v_base": 115e3,
-                  "mon": ["Vr", "Vi"]
-                },
-                { 
-                  "number": 1,
-                  "class": "infinite_bus",
-                  "name": "Bus 2",
-                  "init": {
-                            "Vr":1.0,
-                            "Vi":0.0
-                          },
-                  "v_base": 115e3
-                }
-            ],
-            "signals": [
-                { "signal_id": 0, "name": "Machine Speed Deviation"},
-                { "signal_id": 1, "name": "Mechanical Power"},
-                { "signal_id": 2, "name": "Excitation Field"}
-            ],
-            "devices": [
-                { 
-                  "class": "Branch",
-                  "ports": {"bus1":0, "bus2":1},
-                  "id": "BR1",
-                  "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0}
-                },
-                {
-                  "class": "Genrou",
-                  "ports": {"bus":0, "speed": 0, "pmech":1, "efd": 2},
-                  "id": "DV1",
-                  "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.5, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0},
-                  "mon": ["delta", "omega"]
-                },
-                {
-                  "class": "Tgov1",
-                  "ports": {"bus":0, "speed": 0, "pmech":1},
-                  "id": "DV2",
-                  "params": {"R":0.05, "T1":0.5, "T2":2.5, "T3":7.5, "Pvmin":0.0, "Pvmax":1.0, "Dt":0.0}
-                },
-                {
-                  "class": "Ieeet1",
-                  "ports": {"bus":0, "speed": 0, "efd":2},
-                  "id": "DV3",
-                  "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1.0, "Vrmax":1.0, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlim":0.0}
-                },
-                { 
-                  "class": "bus_fault",
-                  "ports": {"bus":0},
-                  "id": "0",
-                  "params": {"state0": false, "R":0.0, "X":1e-3}
-                }
-            ]
-        })";
+  auto input_file = std::filesystem::path(argv[1]);
+  std::cout << "Input file: " << input_file << '\n';
 
   //
   // Create model data
   //
 
-  SystemModelData<scalar_type, index_type> data = json::parse(input_file);
+  SystemModelData<scalar_type, index_type> data = json::parse(std::ifstream(input_file));
 
   //
   // Instantiate and configure the system model

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
@@ -10,9 +10,14 @@ target_link_libraries(TwoBusTgov1Json
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::phasor_dynamics_signal
 	GRIDKIT::solvers_dyn)
-target_include_directories(TwoBusTgov1Json PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
-target_include_directories(TwoBusTgov1Json PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
+target_include_directories(TwoBusTgov1Json
+    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
+target_include_directories(TwoBusTgov1Json
+    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
 install(TARGETS TwoBusTgov1Json RUNTIME DESTINATION bin)
+gridkit_example_add_file(TwoBusTgov1.json)
 
-add_test(NAME GenrouTest1_tgov1 COMMAND $<TARGET_FILE:TwoBusTgov1>)
-add_test(NAME GenrouTest1_tgov1_json COMMAND $<TARGET_FILE:TwoBusTgov1Json>)
+add_test(NAME GenrouTest1_tgov1 COMMAND TwoBusTgov1)
+add_test(NAME GenrouTest1_tgov1_json
+    COMMAND TwoBusTgov1Json TwoBusTgov1.json
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.json
@@ -1,0 +1,84 @@
+{
+    "header": {
+        "format_version": 0,
+        "format_revision": 1,
+        "case_name": "Two-bus test case with governor",
+        "case_description": "A two-bus test case for demonstrating the dynamics format",
+        "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
+        "freq_base": 60.0,
+        "va_base": 100e6
+    },
+    "buses": [
+        { 
+            "number": 0,
+            "class": "bus",
+            "name": "Bus 1",
+            "init": {
+                "Vr":0.9949877346411762,
+                "Vi":0.09999703952427966
+            },
+            "v_base": 115e3,
+            "mon": ["Vr", "Vi"]
+        },
+        { 
+            "number": 1,
+            "class": "infinite_bus",
+            "name": "Bus 2",
+            "init": {
+                "Vr":1.0,
+                "Vi":0.0
+            },
+            "v_base": 115e3
+        }
+    ],
+    "signals": [
+        { "signal_id": 0, "name": "Machine Speed Deviation"},
+        { "signal_id": 1, "name": "Mechanical Power"}
+    ],
+    "devices": [
+        { 
+            "class": "Branch",
+            "ports": {"bus1":0, "bus2":1},
+            "id": "BR1",
+            "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0}
+        },
+        {
+            "class": "Genrou",
+            "ports": {"bus":0, "speed": 0, "pmech":1},
+            "id": "DV1",
+            "params": {
+                "p0":1.0,
+                "q0":0.05013,
+                "H":3.0,
+                "D":0.0,
+                "Ra":0.0,
+                "Tdop":7.0,
+                "Tdopp":0.04,
+                "Tqopp":0.05,
+                "Tqop":0.75,
+                "Xd":2.1,
+                "Xdp":0.2,
+                "Xdpp":0.18,
+                "Xq":0.5,
+                "Xqp":0.5,
+                "Xqpp":0.18,
+                "Xl":0.15,
+                "S10":0.0,
+                "S12":0.0
+            },
+            "mon": ["delta", "omega"]
+        },
+        {
+            "class": "Tgov1",
+            "ports": {"bus":0, "speed": 0, "pmech":1},
+            "id": "DV2",
+            "params": {"R":0.05, "T1":0.5, "T2":2.5, "T3":7.5, "Pvmin":0.0, "Pvmax":1.0, "Dt":0.0}
+        },
+        { 
+            "class": "bus_fault",
+            "ports": {"bus":0},
+            "id": "0",
+            "params": {"state0": false, "R":0.0, "X":1e-3}
+        }
+    ]
+}

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
@@ -11,6 +11,7 @@
  *
  */
 #include <ctime>
+#include <filesystem>
 #include <iostream>
 
 #include "TwoBusTgov1.hpp"
@@ -22,7 +23,7 @@
 #include <Utilities/Testing.hpp>
 #include <nlohmann/json.hpp>
 
-int main()
+int main(int argc, const char* argv[])
 {
   using namespace GridKit::PhasorDynamics;
   using namespace AnalysisManager::Sundials;
@@ -32,84 +33,27 @@ int main()
   using real_type   = double;
   using index_type  = size_t;
 
+  if (argc < 2)
+  {
+    throw std::runtime_error(
+        "\n\nUsage:\n"
+        "\tTwoBusBasicJson <json-input-file>\n");
+  }
+
   std::cout << "Example: TwoBusTgov1Json \n";
 
   //
   // Input file
   //
 
-  const char input_file[] =
-      R"({
-            "header": {
-                "format_version": 0,
-                "format_revision": 1,
-                "case_name": "Two-bus test case with governor",
-                "case_description": "A two-bus test case for demonstrating the dynamics format",
-                "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
-                "freq_base": 60.0,
-                "va_base": 100e6
-            },
-            "buses": [
-                { 
-                  "number": 0,
-                  "class": "bus",
-                  "name": "Bus 1",
-                  "init": {
-                            "Vr":0.9949877346411762,
-                            "Vi":0.09999703952427966
-                          },
-                  "v_base": 115e3,
-                  "mon": ["Vr", "Vi"]
-                },
-                { 
-                  "number": 1,
-                  "class": "infinite_bus",
-                  "name": "Bus 2",
-                  "init": {
-                            "Vr":1.0,
-                            "Vi":0.0
-                          },
-                  "v_base": 115e3
-                }
-            ],
-            "signals": [
-                { "signal_id": 0, "name": "Machine Speed Deviation"},
-                { "signal_id": 1, "name": "Mechanical Power"}
-            ],
-            "devices": [
-                { 
-                  "class": "Branch",
-                  "ports": {"bus1":0, "bus2":1},
-                  "id": "BR1",
-                  "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0}
-                },
-                {
-                  "class": "Genrou",
-                  "ports": {"bus":0, "speed": 0, "pmech":1},
-                  "id": "DV1",
-                  "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.5, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0},
-                  "mon": ["delta", "omega"]
-                },
-                {
-                  "class": "Tgov1",
-                  "ports": {"bus":0, "speed": 0, "pmech":1},
-                  "id": "DV2",
-                  "params": {"R":0.05, "T1":0.5, "T2":2.5, "T3":7.5, "Pvmin":0.0, "Pvmax":1.0, "Dt":0.0}
-                },
-                { 
-                  "class": "bus_fault",
-                  "ports": {"bus":0},
-                  "id": "0",
-                  "params": {"state0": false, "R":0.0, "X":1e-3}
-                }
-            ]
-        })";
+  auto input_file = std::filesystem::path(argv[1]);
+  std::cout << "Input file: " << input_file << '\n';
 
   //
   // Create model data
   //
 
-  SystemModelData<scalar_type, index_type> data = json::parse(input_file);
+  SystemModelData<scalar_type, index_type> data = json::parse(std::ifstream(input_file));
 
   //
   // Instantiate and allocate the system model


### PR DESCRIPTION
## Description
 
`TinyTwoBus*Json.cpp` examples are refactored to read from a file given on the command line (rather than define the JSON in a raw string literal). These json files are added to the build tree--and in the install prefix (under `share`) using the same directory structure as the `examples` in the source tree.
 
Closes #235 
 
 ## Proposed changes
 
This change (in addition to what is described above) establishes a convention that can easily be generally applied to any other examples that can use JSON files.
 
 ## Checklist
  
- [x] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
