### PR TITLE
Install executables in examples tree and print more meaningful error …

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,20 @@
 set(GRIDKIT_EXAMPLES_INSTALL_ROOT "share/gridkit/examples")
 
 #
+# gridkit_example_current_install_path(<output-variable>)
+# 
+# Get the full installation destination for the current example directory.
+# 
+# Result is stored in <output-variable>
+#
+macro(gridkit_example_current_install_path _out)
+    cmake_path(RELATIVE_PATH CMAKE_CURRENT_SOURCE_DIR
+        BASE_DIRECTORY ${CMAKE_SOURCE_DIR}/examples
+        OUTPUT_VARIABLE _rel_path)
+    set(${_out} ${GRIDKIT_EXAMPLES_INSTALL_ROOT}/${_rel_path})
+endmacro()
+
+#
 # gridkit_example_add_file(<filename>)
 #
 # This macro will add a file (e.g., JSON) that is needed for an example to the
@@ -23,10 +37,7 @@ macro(gridkit_example_add_file _filename)
     endif()
     set(_binary_filepath ${CMAKE_CURRENT_BINARY_DIR}/${__fname})
     configure_file(${_source_filepath} ${_binary_filepath} COPYONLY)
-    cmake_path(RELATIVE_PATH CMAKE_CURRENT_SOURCE_DIR
-        BASE_DIRECTORY ${CMAKE_SOURCE_DIR}/examples
-        OUTPUT_VARIABLE _rel_path)
-    set(_ex_install_path ${GRIDKIT_EXAMPLES_INSTALL_ROOT}/${_rel_path})
+    gridkit_example_current_install_path(_ex_install_path)
     install(FILES ${_filename} DESTINATION ${_ex_install_path})
 endmacro()
 

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/CMakeLists.txt
@@ -1,21 +1,25 @@
+gridkit_example_current_install_path(_install_path)
+
 add_executable(TwoBusBasic TwoBusBasic.cpp)
 target_link_libraries(TwoBusBasic
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::solvers_dyn)
-install(TARGETS TwoBusBasic RUNTIME DESTINATION bin)
+install(TARGETS TwoBusBasic RUNTIME DESTINATION ${_install_path})
 
 add_executable(TwoBusBasicJson TwoBusBasicJson.cpp)
-target_link_libraries(TwoBusBasicJson 
+target_link_libraries(TwoBusBasicJson
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::solvers_dyn)
 target_include_directories(TwoBusBasicJson
     PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
 target_include_directories(TwoBusBasicJson
     PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
-install(TARGETS TwoBusBasicJson RUNTIME DESTINATION bin)
+install(TARGETS TwoBusBasicJson RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusBasic.json)
 
-add_test(NAME TwoBusBasicTest COMMAND TwoBusBasic)
-add_test(NAME TwoBusBasicJsonTest
-    COMMAND TwoBusBasicJson TwoBusBasic.json
+add_test(NAME TwoBusBasic COMMAND TwoBusBasic)
+add_test(NAME TwoBusBasicJson
+    COMMAND TwoBusBasicJson ${CMAKE_CURRENT_BINARY_DIR}/TwoBusBasic.json)
+add_test(NAME TwoBusBasicJson_no_arg
+    COMMAND TwoBusBasicJson
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
@@ -30,20 +30,40 @@ int main(int argc, const char* argv[])
   using real_type   = double;
   using index_type  = size_t;
 
-  if (argc < 2)
-  {
-    throw std::runtime_error(
-        "\n\nUsage:\n"
-        "\tTwoBusBasicJson <json-input-file>\n");
-  }
-
-  std::cout << "Example: TwoBusBasicJson\n";
-
   //
   // Input file
   //
 
-  auto input_file = std::filesystem::path(argv[1]);
+  std::filesystem::path input_file;
+  if (argc < 2)
+  {
+    if (std::filesystem::exists("TwoBusBasic.json"))
+    {
+      input_file = std::filesystem::current_path() / "TwoBusBasic.json";
+    }
+    else
+    {
+      std::cout << "\n"
+                   "ERROR: No input file found or provided.\n"
+                   "\n"
+                   "Usage:\n"
+                   "       TwoBusBasicJson <json-input-file>\n"
+                   "\n"
+                   "Please provide a JSON input file as a positional command-line \n"
+                   "argument.\n"
+                   "\n"
+                   "By default this example will look for \"TwoBusBasic.json\" in the \n"
+                   "current working directory and use that if found.\n"
+                   "\n";
+      exit(1);
+    }
+  }
+  else
+  {
+    input_file = argv[1];
+  }
+
+  std::cout << "Example: TwoBusBasicJson\n";
   std::cout << "Input file: " << input_file << '\n';
 
   //

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
@@ -1,9 +1,11 @@
+gridkit_example_current_install_path(_install_path)
+
 add_executable(TwoBusIeeet1 TwoBusIeeet1.cpp)
 target_link_libraries(TwoBusIeeet1
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::phasor_dynamics_signal
 	GRIDKIT::solvers_dyn)
-install(TARGETS TwoBusIeeet1 RUNTIME DESTINATION bin)
+install(TARGETS TwoBusIeeet1 RUNTIME DESTINATION ${_install_path})
 
 add_executable(TwoBusIeeet1Json TwoBusIeeet1Json.cpp)
 target_link_libraries(TwoBusIeeet1Json
@@ -14,10 +16,12 @@ target_include_directories(TwoBusIeeet1Json
     PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
 target_include_directories(TwoBusIeeet1Json
     PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
-install(TARGETS TwoBusIeeet1Json RUNTIME DESTINATION bin)
+install(TARGETS TwoBusIeeet1Json RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusIeeet1.json)
 
 add_test(NAME GenrouTest1_Ieeet1 COMMAND TwoBusIeeet1)
 add_test(NAME GenrouTest1_Ieeet1_Json
-    COMMAND TwoBusIeeet1Json TwoBusIeeet1.json
+    COMMAND TwoBusIeeet1Json ${CMAKE_CURRENT_BINARY_DIR}/TwoBusIeeet1.json)
+add_test(NAME GenrouTest1_Ieeet1_Json_no_arg
+    COMMAND TwoBusIeeet1Json
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
@@ -29,20 +29,40 @@ int main(int argc, const char* argv[])
   using real_type   = double;
   using index_type  = size_t;
 
-  if (argc < 2)
-  {
-    throw std::runtime_error(
-        "\n\nUsage:\n"
-        "\tTwoBusBasicJson <json-input-file>\n");
-  }
-
-  std::cout << "Example: TwoBusTgov1 + IEEET1 Exciter\n";
-
   //
   // Input file
   //
 
-  auto input_file = std::filesystem::path(argv[1]);
+  std::filesystem::path input_file;
+  if (argc < 2)
+  {
+    if (std::filesystem::exists("TwoBusIeeet1.json"))
+    {
+      input_file = std::filesystem::current_path() / "TwoBusIeeet1.json";
+    }
+    else
+    {
+      std::cout << "\n"
+                   "ERROR: No input file found or provided.\n"
+                   "\n"
+                   "Usage:\n"
+                   "       TwoBusIeeet1Json <json-input-file>\n"
+                   "\n"
+                   "Please provide a JSON input file as a positional command-line \n"
+                   "argument.\n"
+                   "\n"
+                   "By default this example will look for \"TwoBusIeeet1.json\" in the \n"
+                   "current working directory and use that if found.\n"
+                   "\n";
+      exit(1);
+    }
+  }
+  else
+  {
+    input_file = argv[1];
+  }
+
+  std::cout << "Example: TwoBusIeeet1Json\n";
   std::cout << "Input file: " << input_file << '\n';
 
   //

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
@@ -1,12 +1,14 @@
+gridkit_example_current_install_path(_install_path)
+
 add_executable(TwoBusTgov1 TwoBusTgov1.cpp)
-target_link_libraries(TwoBusTgov1 
+target_link_libraries(TwoBusTgov1
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::phasor_dynamics_signal
 	GRIDKIT::solvers_dyn)
-install(TARGETS TwoBusTgov1 RUNTIME DESTINATION bin)
+install(TARGETS TwoBusTgov1 RUNTIME DESTINATION ${_install_path})
 
 add_executable(TwoBusTgov1Json TwoBusTgov1Json.cpp)
-target_link_libraries(TwoBusTgov1Json 
+target_link_libraries(TwoBusTgov1Json
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::phasor_dynamics_signal
 	GRIDKIT::solvers_dyn)
@@ -14,10 +16,12 @@ target_include_directories(TwoBusTgov1Json
     PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
 target_include_directories(TwoBusTgov1Json
     PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
-install(TARGETS TwoBusTgov1Json RUNTIME DESTINATION bin)
+install(TARGETS TwoBusTgov1Json RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusTgov1.json)
 
 add_test(NAME GenrouTest1_tgov1 COMMAND TwoBusTgov1)
 add_test(NAME GenrouTest1_tgov1_json
-    COMMAND TwoBusTgov1Json TwoBusTgov1.json
+    COMMAND TwoBusTgov1Json ${CMAKE_CURRENT_BINARY_DIR}/TwoBusTgov1.json)
+add_test(NAME GenrouTest1_tgov1_json_no_arg
+    COMMAND TwoBusTgov1Json
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
@@ -33,20 +33,40 @@ int main(int argc, const char* argv[])
   using real_type   = double;
   using index_type  = size_t;
 
-  if (argc < 2)
-  {
-    throw std::runtime_error(
-        "\n\nUsage:\n"
-        "\tTwoBusBasicJson <json-input-file>\n");
-  }
-
-  std::cout << "Example: TwoBusTgov1Json \n";
-
   //
   // Input file
   //
 
-  auto input_file = std::filesystem::path(argv[1]);
+  std::filesystem::path input_file;
+  if (argc < 2)
+  {
+    if (std::filesystem::exists("TwoBusTgov1.json"))
+    {
+      input_file = std::filesystem::current_path() / "TwoBusTgov1.json";
+    }
+    else
+    {
+      std::cout << "\n"
+                   "ERROR: No input file found or provided.\n"
+                   "\n"
+                   "Usage:\n"
+                   "       TwoBusTgov1Json <json-input-file>\n"
+                   "\n"
+                   "Please provide a JSON input file as a positional command-line \n"
+                   "argument.\n"
+                   "\n"
+                   "By default this example will look for \"TwoBusTgov1.json\" in the \n"
+                   "current working directory and use that if found.\n"
+                   "\n";
+      exit(1);
+    }
+  }
+  else
+  {
+    input_file = argv[1];
+  }
+
+  std::cout << "Example: TwoBusTgov1Json\n";
   std::cout << "Input file: " << input_file << '\n';
 
   //


### PR DESCRIPTION
## Description
 
- Add direct output and exit without an exception
- Make help message more helpful
- Install target binaries in examples tree in the same place as the JSON files
 
Closes #252 

This is intended to more appropriately implement the changes requested in #235.

 ## Proposed changes
 
- Help message explains you either provide the input file on the command line or run from the example directory
- The `bin` install destination should be reserved for actual project executables. It makes more sense for example executables to live under `share`, and that's where I already had the JSON files being installed. This also follows the convention of the build tree.
 
 ## Checklist
  
- [x] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
  - NOTE: this is a follow-up fix for #250 which has already been noted in the changelog.