### PR TITLE
Change label to "BusFault" to match the input guidelines

### DIFF
--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.json
@@ -65,7 +65,7 @@
             "mon": ["delta", "omega"]
         },
         { 
-            "class": "bus_fault",
+            "class": "BusFault",
             "ports": {"bus":0},
             "id": "0",
             "params": {"state0": false, "R":0.0, "X":1e-3}

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.json
@@ -105,7 +105,7 @@
             }
         },
         { 
-            "class": "bus_fault",
+            "class": "BusFault",
             "ports": {"bus":0},
             "id": "0",
             "params": {"state0": false, "R":0.0, "X":1e-3}

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.json
@@ -75,7 +75,7 @@
             "params": {"R":0.05, "T1":0.5, "T2":2.5, "T3":7.5, "Pvmin":0.0, "Pvmax":1.0, "Dt":0.0}
         },
         { 
-            "class": "bus_fault",
+            "class": "BusFault",
             "ports": {"bus":0},
             "id": "0",
             "params": {"state0": false, "R":0.0, "X":1e-3}

--- a/src/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
@@ -93,7 +93,7 @@ namespace GridKit
           raw_component.get_to(exciter);
           sm.exciter.push_back(exciter);
         }
-        else if (kind == "bus_fault")
+        else if (kind == "BusFault")
         {
           typename SystemModelData<RealT, IdxT>::BusFaultDataT bus_fault;
           raw_component.get_to(bus_fault);

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -49,7 +49,7 @@ namespace GridKit
                    { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
                    { "class": "Genrou", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
                           "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
-                   { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
+                   { "class": "BusFault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
                ]
             })";
 
@@ -160,7 +160,7 @@ namespace GridKit
                    { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
                    { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0.0, "Pvmin":1.0, "Dt":0.0}},
                    { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "DV3", "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1.0, "Vrmax":1.0, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlim":0.0}},
-                   { "class": "bus_fault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
+                   { "class": "BusFault", "ports": {"bus":1}, "id": "1", "params": {"state0": false, "R":0.0, "X":1e-3} }
                ]
             })";
 


### PR DESCRIPTION
## Description

Input guidelines specify "BusFault" as the [device](https://github.com/ORNL/GridKit/blob/develop/src/Model/PhasorDynamics/INPUT_FORMAT.md#device-classes) class name.

 ## Proposed changes
 
This adds the "BusFault" as an additional option, keeping the existing "bus_fault" label in case that's being used.
 
 ## Checklist
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [ ] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.