### PR TITLE
Fix gridkit_bus_indices_ and gridkit_signal_indices_ maps.

### DIFF
--- a/src/Model/PhasorDynamics/SystemModel.hpp
+++ b/src/Model/PhasorDynamics/SystemModel.hpp
@@ -568,8 +568,8 @@ namespace GridKit
        */
       void addBus(bus_type* bus)
       {
-        IdxT gridkit_bus_id                  = static_cast<IdxT>(buses_.size());
-        gridkit_bus_indices_[gridkit_bus_id] = bus->busID();
+        IdxT gridkit_bus_id                = static_cast<IdxT>(buses_.size());
+        gridkit_bus_indices_[bus->busID()] = gridkit_bus_id;
         buses_.push_back(bus);
       }
 
@@ -581,8 +581,8 @@ namespace GridKit
        */
       void addSignal(signal_type* signal)
       {
-        IdxT gridkit_signal_id                     = static_cast<IdxT>(signals_.size());
-        gridkit_signal_indices_[gridkit_signal_id] = signal->signalId();
+        IdxT gridkit_signal_id                      = static_cast<IdxT>(signals_.size());
+        gridkit_signal_indices_[signal->signalId()] = gridkit_signal_id;
         signals_.push_back(signal);
       }
 


### PR DESCRIPTION
## Description
 
There was a bug in the key value pairs of gridkit index maps leading to a segfault when attempting to access values out of range.

Closes #257 
 
 ## Proposed changes
 
Swap the key and value for `gridkit_bus_indices_` and `gridkit_signal_indices_`.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [N/A] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] This is a minor bug fix and not reflected in the CHANGELOG.
 
