### PR TITLE
Disable GenrouEnzyme

### DIFF
--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
@@ -1,15 +1,16 @@
 
-if(GRIDKIT_ENABLE_ENZYME)
-  gridkit_add_library(phasor_dynamics_genrou
-    SOURCES
-      GenrouEnzyme.cpp
-    LINK_LIBRARIES
-      PUBLIC GRIDKIT::phasor_dynamics_signal ClangEnzymeFlags
-    COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno -fno-vectorize
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_genrou)
-else()
+# Disabled GenrouEnzyme because of an intermittent build issue
+#if(GRIDKIT_ENABLE_ENZYME)
+#  gridkit_add_library(phasor_dynamics_genrou
+#    SOURCES
+#      GenrouEnzyme.cpp
+#    LINK_LIBRARIES
+#      PUBLIC GRIDKIT::phasor_dynamics_signal ClangEnzymeFlags
+#    COMPILE_OPTIONS
+#      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno -fno-vectorize
+#    OUTPUT_NAME
+#      gridkit_phasor_dynamics_genrou)
+#else()
   gridkit_add_library(phasor_dynamics_genrou
     SOURCES
       Genrou.cpp
@@ -17,7 +18,7 @@ else()
       PUBLIC GRIDKIT::phasor_dynamics_signal
     OUTPUT_NAME
       gridkit_phasor_dynamics_genrou)
-endif()
+#endif()
 
 gridkit_add_library(phasor_dynamics_genrou_dependency_tracking
   SOURCES

--- a/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
@@ -217,7 +217,6 @@ namespace GridKit
         return success.report(__func__);
       }
 
-
 #if 0 // Disabled GenrouEnzyme because of an intermittent build issue
 #ifdef GRIDKIT_ENABLE_ENZYME
       /**

--- a/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
@@ -217,6 +217,8 @@ namespace GridKit
         return success.report(__func__);
       }
 
+
+#if 0 // Disabled GenrouEnzyme because of an intermittent build issue
 #ifdef GRIDKIT_ENABLE_ENZYME
       /**
        * @brief Checks Jacobian evaluation.
@@ -338,6 +340,7 @@ namespace GridKit
 
         return GridKit::Testing::MapFromCOO(model_jacobian);
       }
+#endif
 #endif
     }; // class GenrouTest
 

--- a/tests/UnitTests/PhasorDynamics/runGenrouTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runGenrouTests.cpp
@@ -11,9 +11,10 @@ int main()
   result += test.hard_coded_residual();
   result += test.residual();
 
+#if 0 // Disabled GenrouEnzyme because of an intermittent build issue
 #ifdef GRIDKIT_ENABLE_ENZYME
   result += test.jacobian();
 #endif
-
+#endif
   return result.summary();
 }


### PR DESCRIPTION
## Description
 
The intermittent failure to build GenrouEnzyme (#234) is too disruptive for CI. 
 
 ## Proposed changes
 
Disable the build of GenrouEnzyme and related test.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [N/A] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
