### PR TITLE
Model Jacobians with respect to external variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added 3, 10, and 37 bus test cases.
 - Updated documentation.
 - Added JSON parsing.
-- Automatic differentiation with enzyme.
+- Automatic differentiation with enzyme (w.r.t. internal, bus and external variables).
 - Added PR and issue templates.
 - Added Genrou class unit test and example.
 - Added Dev container.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added 3, 10, and 37 bus test cases.
 - Updated documentation.
 - Added JSON parsing.
-- Automatic differentiation with enzyme (w.r.t. internal, bus and external variables).
+- Automatic differentiation with enzyme (w.r.t. internal and external variables).
 - Added PR and issue templates.
 - Added Genrou class unit test and example.
 - Added Dev container.

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -38,23 +38,32 @@ namespace GridKit
       };
 
       /**
-       * @brief Residual wrapper around residual methods inside model classes
+       * @brief Template definition for wrapper around residual methods inside model classes
        *
        * @tparam ModelT - model type
        * @tparam MemberFunctions - member function parameter key
        * @tparam ScalarT - scalar data type
        *
-       * @param[in] model - Pointer to the model to be differentiated
-       * @param[in] y - Internal variables
-       * @param[in] yp - Internal variable derivatives
-       * @param[in] wb - Coupling (bus) variables
-       * @param[in] we - External variables
-       * @param[out] f - Internal residual
-       * @param[out] h - Coupling (bus) residual
        */
       template <typename ModelT, MemberFunctions function, typename ScalarT>
       struct Wrapper
       {
+      };
+
+      /**
+       * @brief Residual wrapper partial template specialization for InternalResidual
+       *
+       */        
+      template <typename ModelT, typename ScalarT>
+      struct Wrapper<ModelT, MemberFunctions::InternalResidual, ScalarT>
+      {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[out] f - Internal residual
+         */
         static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* f)
         {
           model->evaluateInternalResidual(y, yp, wb, f);
@@ -68,9 +77,17 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::InternalResidualWithExternal, ScalarT>
       {
-        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* we, ScalarT* h)
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[in] we - Signal variables
+         * @param[out] f - Internal residual
+         */
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* we, ScalarT* f)
         {
-          model->evaluateInternalResidualWithExternal(y, yp, wb, we, h);
+          model->evaluateInternalResidualWithExternal(y, yp, wb, we, f);
         }
       };
 
@@ -81,6 +98,13 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual, ScalarT>
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[out] h - Bus residual
+         */
         static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
           model->evaluateBusResidual(y, yp, wb, h);
@@ -94,6 +118,13 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual11, ScalarT>
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[out] h - Bus residual
+         */
         static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
           model->evaluateBusResidual11(y, yp, wb, h);
@@ -107,6 +138,13 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual12, ScalarT>
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[out] h - Bus residual
+         */
         static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
           model->evaluateBusResidual12(y, yp, wb, h);
@@ -120,6 +158,13 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual21, ScalarT>
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[out] h - Bus residual
+         */
         static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
           model->evaluateBusResidual21(y, yp, wb, h);
@@ -133,6 +178,13 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual22, ScalarT>
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[out] h - Bus residual
+         */
         static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
           model->evaluateBusResidual22(y, yp, wb, h);
@@ -253,21 +305,21 @@ namespace GridKit
        * @tparam MemberFunctions - member function parameter key
        * @tparam ScalarT - scalar data type
        * @tparam IdxT - matrix index data type
-       *
-       * @param[in] model - Pointer to the model to be differentiated
-       * @param[in] n_res - Number of residual functions
-       * @param[in] n_var - Number of independent variables
-       * @param[in] res_indices - Map from local residual indices to global indices
-       * @param[in] var_indices - Map from local variable indices to global indices
-       * @param[in] y - Internal variables
-       * @param[in] yp - Internal variable derivatives
-       * @param[in] wb - Coupling (bus) variables
-       * @param[in] we - External variables
-       * @param[in,out] jac - Jacobian
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
       struct InternalJacobian
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] n_res - Number of residual functions
+         * @param[in] n_var - Number of independent variables
+         * @param[in] res_indices - Map from local residual indices to global indices
+         * @param[in] var_indices - Map from local variable indices to global indices
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[in,out] jac - Jacobian
+         */
         static void eval(ModelT*                                            model,
                          size_t                                             n_res,
                          size_t                                             n_var,
@@ -326,10 +378,26 @@ namespace GridKit
       /**
        * @brief Enzyme automatic differentiation Jacobian evaluator: Internal Jacobian with external variables
        *
+       * @tparam ModelT - model type
+       * @tparam MemberFunctions - member function parameter key
+       * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
       struct InternalJacobianWithExternal
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] n_res - Number of residual functions
+         * @param[in] n_var - Number of independent variables
+         * @param[in] res_indices - Map from local residual indices to global indices
+         * @param[in] var_indices - Map from local variable indices to global indices
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[in] we - Signal variables
+         * @param[in,out] jac - Jacobian
+         */
         static void eval(ModelT*                                            model,
                          size_t                                             n_res,
                          size_t                                             n_var,
@@ -391,10 +459,26 @@ namespace GridKit
       /**
        * @brief Enzyme automatic differentiation Jacobian evaluator: External Jacobian
        *
+       * @tparam ModelT - model type
+       * @tparam MemberFunctions - member function parameter key
+       * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
       struct ExternalJacobian
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] n_res - Number of residual functions
+         * @param[in] n_var - Number of independent variables
+         * @param[in] res_indices - Map from local residual indices to global indices
+         * @param[in] var_indices - Map from local variable indices to global indices
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[in] we - Signal variables
+         * @param[in,out] jac - Jacobian
+         */
         static void eval(ModelT*                                            model,
                          size_t                                             n_res,
                          size_t                                             n_var,
@@ -461,10 +545,25 @@ namespace GridKit
       /**
        * @brief Enzyme automatic differentiation Jacobian evaluator: Bus Jacobian
        *
+       * @tparam ModelT - model type
+       * @tparam MemberFunctions - member function parameter key
+       * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
       struct BusJacobian
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] n_res - Number of residual functions
+         * @param[in] n_var - Number of independent variables
+         * @param[in] res_indices - Map from local residual indices to global indices
+         * @param[in] var_indices - Map from local variable indices to global indices
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[in,out] jac - Jacobian
+         */
         static void eval(ModelT*                                            model,
                          size_t                                             n_res,
                          size_t                                             n_var,
@@ -523,10 +622,25 @@ namespace GridKit
       /**
        * @brief Enzyme automatic differentiation Jacobian evaluator: Branch Jacobian
        *
+       * @tparam ModelT - model type
+       * @tparam MemberFunctions - member function parameter key
+       * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
       struct BranchJacobian
       {
+        /**
+         * @param[in] model - Pointer to the model to be differentiated
+         * @param[in] n_res - Number of residual functions
+         * @param[in] n_var - Number of independent variables
+         * @param[in] res_indices - Map from local residual indices to global indices
+         * @param[in] var_indices - Map from local variable indices to global indices
+         * @param[in] y - Internal variables
+         * @param[in] yp - Internal variable derivatives
+         * @param[in] wb - Bus variables
+         * @param[in,out] jac - Jacobian
+         */
         static void eval(ModelT*                                            model,
                          size_t                                             n_res,
                          size_t                                             n_var,

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -29,7 +29,7 @@ namespace GridKit
       enum class MemberFunctions
       {
         InternalResidual,
-        InternalResidualWithExternal,
+        InternalResidualWithSignal,
         BusResidual,
         BusResidual11, //< Special case for branches that are connected to two buses
         BusResidual12, //< Special case for branches that are connected to two buses
@@ -71,11 +71,11 @@ namespace GridKit
       };
 
       /**
-       * @brief Residual wrapper partial template specialization for InternalResidualWithExternal
+       * @brief Residual wrapper partial template specialization for InternalResidualWithSignal
        *
        */
       template <typename ModelT, typename ScalarT>
-      struct Wrapper<ModelT, MemberFunctions::InternalResidualWithExternal, ScalarT>
+      struct Wrapper<ModelT, MemberFunctions::InternalResidualWithSignal, ScalarT>
       {
         /**
          * @param[in] model - Pointer to the model to be differentiated
@@ -87,7 +87,7 @@ namespace GridKit
          */
         static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* we, ScalarT* f)
         {
-          model->evaluateInternalResidualWithExternal(y, yp, wb, we, f);
+          model->evaluateInternalResidualWithSignal(y, yp, wb, we, f);
         }
       };
 
@@ -376,7 +376,7 @@ namespace GridKit
       };
 
       /**
-       * @brief Enzyme automatic differentiation Jacobian evaluator: Internal Jacobian with external variables
+       * @brief Enzyme automatic differentiation Jacobian evaluator: Internal Jacobian with signal variables
        *
        * @tparam ModelT - model type
        * @tparam MemberFunctions - member function parameter key
@@ -384,7 +384,7 @@ namespace GridKit
        * @tparam IdxT - matrix index data type
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
-      struct InternalJacobianWithExternal
+      struct InternalJacobianWithSignal
       {
         /**
          * @param[in] model - Pointer to the model to be differentiated

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -53,7 +53,7 @@ namespace GridKit
       /**
        * @brief Residual wrapper partial template specialization for InternalResidual
        *
-       */        
+       */
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::InternalResidual, ScalarT>
       {

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -87,7 +87,7 @@ namespace GridKit
          */
         static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* we, ScalarT* f)
         {
-          model->evaluateInternalResidualWithSignal(y, yp, wb, we, f);
+          model->evaluateInternalResidual(y, yp, wb, we, f);
         }
       };
 

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -29,6 +29,7 @@ namespace GridKit
       enum class MemberFunctions
       {
         InternalResidual,
+        InternalResidualWithExternal,
         BusResidual,
         BusResidual11, //< Special case for branches that are connected to two buses
         BusResidual12, //< Special case for branches that are connected to two buses
@@ -46,16 +47,30 @@ namespace GridKit
        * @param[in] model - Pointer to the model to be differentiated
        * @param[in] y - Internal variables
        * @param[in] yp - Internal variable derivatives
-       * @param[in] w - Coupling (bus) variables
+       * @param[in] wb - Coupling (bus) variables
+       * @param[in] we - External variables
        * @param[out] f - Internal residual
        * @param[out] h - Coupling (bus) residual
        */
       template <typename ModelT, MemberFunctions function, typename ScalarT>
       struct Wrapper
       {
-        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* f)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* f)
         {
-          model->evaluateInternalResidual(y, yp, w, f);
+          model->evaluateInternalResidual(y, yp, wb, f);
+        }
+      };
+
+      /**
+       * @brief Residual wrapper partial template specialization for InternalResidualWithExternal
+       *
+       */
+      template <typename ModelT, typename ScalarT>
+      struct Wrapper<ModelT, MemberFunctions::InternalResidualWithExternal, ScalarT>
+      {
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* we, ScalarT* h)
+        {
+          model->evaluateInternalResidualWithExternal(y, yp, wb, we, h);
         }
       };
 
@@ -66,9 +81,9 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual, ScalarT>
       {
-        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
-          model->evaluateBusResidual(y, yp, w, h);
+          model->evaluateBusResidual(y, yp, wb, h);
         }
       };
 
@@ -79,9 +94,9 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual11, ScalarT>
       {
-        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
-          model->evaluateBusResidual11(y, yp, w, h);
+          model->evaluateBusResidual11(y, yp, wb, h);
         }
       };
 
@@ -92,9 +107,9 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual12, ScalarT>
       {
-        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
-          model->evaluateBusResidual12(y, yp, w, h);
+          model->evaluateBusResidual12(y, yp, wb, h);
         }
       };
 
@@ -105,9 +120,9 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual21, ScalarT>
       {
-        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
-          model->evaluateBusResidual21(y, yp, w, h);
+          model->evaluateBusResidual21(y, yp, wb, h);
         }
       };
 
@@ -118,9 +133,9 @@ namespace GridKit
       template <typename ModelT, typename ScalarT>
       struct Wrapper<ModelT, MemberFunctions::BusResidual22, ScalarT>
       {
-        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* w, ScalarT* h)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* h)
         {
-          model->evaluateBusResidual22(y, yp, w, h);
+          model->evaluateBusResidual22(y, yp, wb, h);
         }
       };
 
@@ -246,7 +261,8 @@ namespace GridKit
        * @param[in] var_indices - Map from local variable indices to global indices
        * @param[in] y - Internal variables
        * @param[in] yp - Internal variable derivatives
-       * @param[in] w - Coupling (bus) variables
+       * @param[in] wb - Coupling (bus) variables
+       * @param[in] we - External variables
        * @param[in,out] jac - Jacobian
        */
       template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
@@ -259,7 +275,7 @@ namespace GridKit
                          const std::map<IdxT, IdxT>&                        var_indices,
                          ScalarT*                                           y,
                          ScalarT*                                           yp,
-                         ScalarT*                                           w,
+                         ScalarT*                                           wb,
                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
           if (n_res > 0 && n_var > 0)
@@ -286,7 +302,7 @@ namespace GridKit
                                      enzyme_const,
                                      yp,
                                      enzyme_const,
-                                     w,
+                                     wb,
                                      enzyme_dupnoneed,
                                      elementary_v.data(),
                                      d_output);
@@ -308,6 +324,141 @@ namespace GridKit
       };
 
       /**
+       * @brief Enzyme automatic differentiation Jacobian evaluator: Internal Jacobian with external variables
+       *
+       */
+      template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
+      struct InternalJacobianWithExternal
+      {
+        static void eval(ModelT*                                            model,
+                         size_t                                             n_res,
+                         size_t                                             n_var,
+                         const std::map<IdxT, IdxT>&                        res_indices,
+                         const std::map<IdxT, IdxT>&                        var_indices,
+                         ScalarT*                                           y,
+                         ScalarT*                                           yp,
+                         ScalarT*                                           wb,
+                         ScalarT*                                           we,
+                         GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
+        {
+          if (n_res > 0 && n_var > 0)
+          {
+            std::vector<Triple<ScalarT>> triplets;
+            std::vector<ScalarT>         elementary_v(n_res);
+            for (size_t var_i = 0; var_i < n_var; ++var_i)
+            {
+              // Sparse storage
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+
+              // Elementary vector for Jacobian-vector product
+              std::ranges::fill(elementary_v, 0.0);
+              elementary_v[var_i] = 1.0;
+
+              // Autodiff
+              __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
+                                     enzyme_const,
+                                     model,
+                                     enzyme_dup,
+                                     y,
+                                     output,
+                                     enzyme_const,
+                                     yp,
+                                     enzyme_const,
+                                     wb,
+                                     enzyme_const,
+                                     we,
+                                     enzyme_dupnoneed,
+                                     elementary_v.data(),
+                                     d_output);
+            }
+
+            // Store result
+            std::vector<IdxT>    ctemp{};
+            std::vector<IdxT>    rtemp{};
+            std::vector<ScalarT> valtemp{};
+            for (auto& tup : triplets)
+            {
+              rtemp.push_back(res_indices.at(static_cast<IdxT>(tup.row)));
+              ctemp.push_back(var_indices.at(static_cast<IdxT>(tup.col)));
+              valtemp.push_back(tup.val);
+            }
+            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+          }
+        }
+      };
+
+      /**
+       * @brief Enzyme automatic differentiation Jacobian evaluator: External Jacobian
+       *
+       */
+      template <typename ModelT, MemberFunctions function, class ScalarT, typename IdxT>
+      struct ExternalJacobian
+      {
+        static void eval(ModelT*                                            model,
+                         size_t                                             n_res,
+                         size_t                                             n_var,
+                         const std::map<IdxT, IdxT>&                        res_indices,
+                         const std::map<IdxT, IdxT>&                        var_indices,
+                         ScalarT*                                           y,
+                         ScalarT*                                           yp,
+                         ScalarT*                                           wb,
+                         ScalarT*                                           we,
+                         GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
+        {
+          if (n_res > 0 && n_var > 0)
+          {
+            std::vector<Triple<ScalarT>> triplets;
+            std::vector<ScalarT>         elementary_v(n_res);
+            for (size_t var_i = 0; var_i < n_var; ++var_i)
+            {
+              // Sparse storage
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+
+              // Elementary vector for Jacobian-vector product
+              std::ranges::fill(elementary_v, 0.0);
+              elementary_v[var_i] = 1.0;
+
+              // Autodiff
+              __enzyme_fwddiff<void>((void*) Wrapper<ModelT, function, ScalarT>::eval,
+                                     enzyme_const,
+                                     model,
+                                     enzyme_const,
+                                     y,
+                                     enzyme_const,
+                                     yp,
+                                     enzyme_const,
+                                     wb,
+                                     enzyme_dup,
+                                     we,
+                                     output,
+                                     enzyme_dupnoneed,
+                                     elementary_v.data(),
+                                     d_output);
+            }
+
+            // Store result
+            std::vector<IdxT>    ctemp{};
+            std::vector<IdxT>    rtemp{};
+            std::vector<ScalarT> valtemp{};
+            for (auto& tup : triplets)
+            {
+              IdxT row = res_indices.at(static_cast<IdxT>(tup.row));
+              IdxT col = var_indices.at(static_cast<IdxT>(tup.col));
+              if (col != static_cast<IdxT>(-1))
+              {
+                rtemp.push_back(row);
+                ctemp.push_back(col);
+                valtemp.push_back(tup.val);
+              }
+            }
+            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+          }
+        }
+      };
+
+      /**
        * @brief Enzyme automatic differentiation Jacobian evaluator: Bus Jacobian
        *
        */
@@ -321,7 +472,7 @@ namespace GridKit
                          const std::map<IdxT, IdxT>&                        var_indices,
                          ScalarT*                                           y,
                          ScalarT*                                           yp,
-                         ScalarT*                                           w,
+                         ScalarT*                                           wb,
                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
           if (n_res > 0 && n_var > 0)
@@ -347,7 +498,7 @@ namespace GridKit
                                      enzyme_const,
                                      yp,
                                      enzyme_dup,
-                                     w,
+                                     wb,
                                      output,
                                      enzyme_dupnoneed,
                                      elementary_v.data(),
@@ -383,7 +534,7 @@ namespace GridKit
                          const std::map<IdxT, IdxT>&                        var_indices,
                          ScalarT*                                           y,
                          ScalarT*                                           yp,
-                         ScalarT*                                           w,
+                         ScalarT*                                           wb,
                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
           if (n_res > 0 && n_var > 0)
@@ -409,7 +560,7 @@ namespace GridKit
                                      enzyme_const,
                                      yp,
                                      enzyme_dup,
-                                     w,
+                                     wb,
                                      output,
                                      enzyme_dupnoneed,
                                      elementary_v.data(),

--- a/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
+++ b/src/AutomaticDifferentiation/Enzyme/SparseWrapper.hpp
@@ -82,12 +82,12 @@ namespace GridKit
          * @param[in] y - Internal variables
          * @param[in] yp - Internal variable derivatives
          * @param[in] wb - Bus variables
-         * @param[in] we - Signal variables
+         * @param[in] ws - Signal variables
          * @param[out] f - Internal residual
          */
-        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* we, ScalarT* f)
+        static void eval(ModelT* model, ScalarT* y, ScalarT* yp, ScalarT* wb, ScalarT* ws, ScalarT* f)
         {
-          model->evaluateInternalResidual(y, yp, wb, we, f);
+          model->evaluateInternalResidual(y, yp, wb, ws, f);
         }
       };
 
@@ -395,7 +395,7 @@ namespace GridKit
          * @param[in] y - Internal variables
          * @param[in] yp - Internal variable derivatives
          * @param[in] wb - Bus variables
-         * @param[in] we - Signal variables
+         * @param[in] ws - Signal variables
          * @param[in,out] jac - Jacobian
          */
         static void eval(ModelT*                                            model,
@@ -406,7 +406,7 @@ namespace GridKit
                          ScalarT*                                           y,
                          ScalarT*                                           yp,
                          ScalarT*                                           wb,
-                         ScalarT*                                           we,
+                         ScalarT*                                           ws,
                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
           if (n_res > 0 && n_var > 0)
@@ -435,7 +435,7 @@ namespace GridKit
                                      enzyme_const,
                                      wb,
                                      enzyme_const,
-                                     we,
+                                     ws,
                                      enzyme_dupnoneed,
                                      elementary_v.data(),
                                      d_output);
@@ -476,7 +476,7 @@ namespace GridKit
          * @param[in] y - Internal variables
          * @param[in] yp - Internal variable derivatives
          * @param[in] wb - Bus variables
-         * @param[in] we - Signal variables
+         * @param[in] ws - Signal variables
          * @param[in,out] jac - Jacobian
          */
         static void eval(ModelT*                                            model,
@@ -487,7 +487,7 @@ namespace GridKit
                          ScalarT*                                           y,
                          ScalarT*                                           yp,
                          ScalarT*                                           wb,
-                         ScalarT*                                           we,
+                         ScalarT*                                           ws,
                          GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& jac)
         {
           if (n_res > 0 && n_var > 0)
@@ -515,7 +515,7 @@ namespace GridKit
                                      enzyme_const,
                                      wb,
                                      enzyme_dup,
-                                     we,
+                                     ws,
                                      output,
                                      enzyme_dupnoneed,
                                      elementary_v.data(),

--- a/src/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/src/Model/PhasorDynamics/Branch/Branch.hpp
@@ -47,7 +47,7 @@ namespace GridKit
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
 

--- a/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/src/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -140,7 +140,7 @@ namespace GridKit
     {
       // std::cout << "Allocate Branch..." << std::endl;
 
-      w_.resize(2);
+      wb_.resize(2);
       h_.resize(2);
 
       return 0;
@@ -173,11 +173,11 @@ namespace GridKit
     __attribute__((always_inline)) inline int Branch<ScalarT, IdxT>::evaluateBusResidual11(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
-        ScalarT*                  w,
+        ScalarT*                  wb,
         ScalarT*                  h)
     {
-      ScalarT Vr1 = w[0];
-      ScalarT Vi1 = w[1];
+      ScalarT Vr1 = wb[0];
+      ScalarT Vi1 = wb[1];
       ScalarT Ir1 = -(g_ + 0.5 * G_) * Vr1 + (b_ + 0.5 * B_) * Vi1;
       ScalarT Ii1 = -(b_ + 0.5 * B_) * Vr1 - (g_ + 0.5 * G_) * Vi1;
       h[0]        = Ir1;
@@ -194,11 +194,11 @@ namespace GridKit
     __attribute__((always_inline)) inline int Branch<ScalarT, IdxT>::evaluateBusResidual12(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
-        ScalarT*                  w,
+        ScalarT*                  wb,
         ScalarT*                  h)
     {
-      ScalarT Vr2 = w[0];
-      ScalarT Vi2 = w[1];
+      ScalarT Vr2 = wb[0];
+      ScalarT Vi2 = wb[1];
       ScalarT Ir1 = g_ * Vr2 - b_ * Vi2;
       ScalarT Ii1 = b_ * Vr2 + g_ * Vi2;
       h[0]        = Ir1;
@@ -215,11 +215,11 @@ namespace GridKit
     __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual21(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
-        ScalarT*                  w,
+        ScalarT*                  wb,
         ScalarT*                  h)
     {
-      ScalarT Vr1 = w[0];
-      ScalarT Vi1 = w[1];
+      ScalarT Vr1 = wb[0];
+      ScalarT Vi1 = wb[1];
       ScalarT Ir2 = g_ * Vr1 - b_ * Vi1;
       ScalarT Ii2 = b_ * Vr1 + g_ * Vi1;
       h[0]        = Ir2;
@@ -236,11 +236,11 @@ namespace GridKit
     __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual22(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
-        ScalarT*                  w,
+        ScalarT*                  wb,
         ScalarT*                  h)
     {
-      ScalarT Vr2 = w[0];
-      ScalarT Vi2 = w[1];
+      ScalarT Vr2 = wb[0];
+      ScalarT Vi2 = wb[1];
       ScalarT Ir2 = -(g_ + 0.5 * G_) * Vr2 + (b_ + 0.5 * B_) * Vi2;
       ScalarT Ii2 = -(b_ + 0.5 * B_) * Vr2 - (g_ + 0.5 * G_) * Vi2;
       h[0]        = Ir2;
@@ -256,21 +256,21 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int Branch<ScalarT, IdxT>::evaluateResidual()
     {
-      w_[0] = Vr1();
-      w_[1] = Vi1();
-      evaluateBusResidual11(y_.data(), yp_.data(), w_.data(), h_.data());
+      wb_[0] = Vr1();
+      wb_[1] = Vi1();
+      evaluateBusResidual11(y_.data(), yp_.data(), wb_.data(), h_.data());
       Ir1() += h_[0];
       Ii1() += h_[1];
-      evaluateBusResidual21(y_.data(), yp_.data(), w_.data(), h_.data());
+      evaluateBusResidual21(y_.data(), yp_.data(), wb_.data(), h_.data());
       Ir2() += h_[0];
       Ii2() += h_[1];
 
-      w_[0] = Vr2();
-      w_[1] = Vi2();
-      evaluateBusResidual12(y_.data(), yp_.data(), w_.data(), h_.data());
+      wb_[0] = Vr2();
+      wb_[1] = Vi2();
+      evaluateBusResidual12(y_.data(), yp_.data(), wb_.data(), h_.data());
       Ir1() += h_[0];
       Ii1() += h_[1];
-      evaluateBusResidual22(y_.data(), yp_.data(), w_.data(), h_.data());
+      evaluateBusResidual22(y_.data(), yp_.data(), wb_.data(), h_.data());
       Ir2() += h_[0];
       Ii2() += h_[1];
 

--- a/src/Model/PhasorDynamics/Bus/BusImpl.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusImpl.hpp
@@ -97,7 +97,7 @@ namespace GridKit
     }
 
     /**
-     * @brief Set the component ID
+     * @brief Set the bus ID
      */
     template <class ScalarT, typename IdxT>
     int Bus<ScalarT, IdxT>::setBusID(IdxT bus_id)

--- a/src/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -30,7 +30,7 @@ namespace GridKit
       using Component<ScalarT, IdxT>::time_;
       using Component<ScalarT, IdxT>::y_;
       using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
 
       using bus_type  = BusBase<ScalarT, IdxT>;

--- a/src/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
+++ b/src/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
@@ -101,7 +101,7 @@ namespace GridKit
     {
       // std::cout << "Allocate BusFault..." << std::endl;
 
-      w_.resize(2);
+      wb_.resize(2);
       h_.resize(2);
 
       return 0;
@@ -132,10 +132,10 @@ namespace GridKit
      */
     template <class ScalarT, typename IdxT>
     __attribute__((always_inline)) int BusFault<ScalarT, IdxT>::evaluateBusResidual(
-        [[maybe_unused]] ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* w, ScalarT* h)
+        [[maybe_unused]] ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* wb, ScalarT* h)
     {
-      ScalarT Vr = w[0];
-      ScalarT Vi = w[1];
+      ScalarT Vr = wb[0];
+      ScalarT Vi = wb[1];
       ScalarT Ir = -Vr * G_ + Vi * B_;
       ScalarT Ii = -Vr * B_ - Vi * G_;
       h[0]       = Ir;
@@ -154,9 +154,9 @@ namespace GridKit
     {
       if (status_)
       {
-        w_[0] = Vr();
-        w_[1] = Vi();
-        evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
+        wb_[0] = Vr();
+        wb_[1] = Vi();
+        evaluateBusResidual(y_.data(), yp_.data(), wb_.data(), h_.data());
         Ir() += h_[0];
         Ii() += h_[1];
       }

--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -120,7 +120,7 @@ namespace GridKit
         return 0;
       }
 
-      IdxT getVariableIndex(IdxT local_index) const
+      IdxT& getVariableIndex(IdxT local_index)
       {
         return variable_indices_.at(local_index);
       }
@@ -136,7 +136,7 @@ namespace GridKit
         return 0;
       }
 
-      IdxT getResidualIndex(IdxT local_index) const
+      IdxT& getResidualIndex(IdxT local_index)
       {
         return residual_indices_.at(local_index);
       }
@@ -160,7 +160,7 @@ namespace GridKit
       std::vector<bool>    tag_;
       std::vector<ScalarT> f_;
       std::vector<ScalarT> g_;
-      std::vector<ScalarT> w_;
+      std::vector<ScalarT> wb_;
       std::vector<ScalarT> h_;
 
       GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> J_;

--- a/src/Model/PhasorDynamics/ComponentSignals.hpp
+++ b/src/Model/PhasorDynamics/ComponentSignals.hpp
@@ -127,6 +127,23 @@ namespace GridKit
         return (*external_variable_signals_[static_cast<size_t>(variable)])->read();
       }
 
+      /// Returns the global index of the specified external variable
+      ///
+      /// @tparam variable The external variable to read from
+      /// @pre A signal node has been assigned to the requested external
+      ///      variable
+      template <ExternalVariables variable>
+      auto readExternalVariableIndex() const -> IdxT
+      {
+        static_assert(variable < ExternalVariables::MAXIMUM);
+        if (!external_variable_signals_[static_cast<size_t>(variable)])
+        {
+          throw std::logic_error("A signal node has not been assigned to this external variable");
+        }
+
+        return (*external_variable_signals_[static_cast<size_t>(variable)])->getVariableIndex();
+      }
+
       /// Writes a value to the specified external variable
       ///
       /// @warning This method should be used only in component initialization

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -101,7 +101,7 @@ namespace GridKit
         {
         }
 
-        /// Get the `ComponentSignals` from this `GenClassical`
+        /// Get the `ComponentSignals` from this `Ieeet1`
         auto getSignals()
             -> ComponentSignals<ScalarT,
                                 IdxT,

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -116,12 +116,10 @@ namespace GridKit
           this->setResidualIndex(j, j);
         }
 
-        // Set output signal after allocation. Check if system composer
-        // requested Efd and, if so, connect it to the signal node.
-        // The signal is accessible to any object connecting to the signal node
+        // Set output signals
         if (signals_.template isAssigned<Ieeet1InternalVariables::EFD>())
         {
-          signals_.template getSignalNode<Ieeet1InternalVariables::EFD>()->set(&y_[7], this->getVariableIndex(7));
+          signals_.template getSignalNode<Ieeet1InternalVariables::EFD>()->set(&y_[7], &(this->getVariableIndex(7)));
         }
 
         return 0;

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -67,7 +67,7 @@ namespace GridKit
         using Component<ScalarT, IdxT>::time_;
         using Component<ScalarT, IdxT>::y_;
         using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::w_;
+        using Component<ScalarT, IdxT>::wb_;
         using Component<ScalarT, IdxT>::h_;
         using Component<ScalarT, IdxT>::J_;
 
@@ -105,7 +105,7 @@ namespace GridKit
         }
 
       public:
-        __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+        __attribute__((always_inline)) inline int evaluateInternalResidualWithExternal(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
       private:
         // Input parameters
@@ -136,8 +136,9 @@ namespace GridKit
 
         void initializeParameters(const model_data_type& data);
 
-        /* Local copies of signal variables */
-        ScalarT omega_{0};
+        /* Local copies of external variables */
+        std::vector<ScalarT> we_;
+        std::map<IdxT, IdxT> we_indices_;
       };
 
     } // namespace Governor

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -105,7 +105,7 @@ namespace GridKit
         }
 
       public:
-        __attribute__((always_inline)) inline int evaluateInternalResidualWithSignal(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+        __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
       private:
         // Input parameters

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -137,8 +137,8 @@ namespace GridKit
         void initializeParameters(const model_data_type& data);
 
         /* Local copies of external variables */
-        std::vector<ScalarT> we_;
-        std::map<IdxT, IdxT> we_indices_;
+        std::vector<ScalarT> ws_;
+        std::map<IdxT, IdxT> ws_indices_;
       };
 
     } // namespace Governor

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -105,7 +105,7 @@ namespace GridKit
         }
 
       public:
-        __attribute__((always_inline)) inline int evaluateInternalResidualWithExternal(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+        __attribute__((always_inline)) inline int evaluateInternalResidualWithSignal(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
       private:
         // Input parameters

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -26,20 +26,37 @@ namespace GridKit
         std::cout << "Evaluate Jacobian for Tgov1..." << std::endl;
         std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-        GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
-                                                  GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
+        GridKit::Enzyme::Sparse::InternalJacobianWithExternal<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
+                                                              GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithExternal,
+                                                              ScalarT,
+                                                              IdxT>::eval(this,
+                                                                          f_.size(),
+                                                                          y_.size(),
+                                                                          this->getResidualIndices(),
+                                                                          this->getVariableIndices(),
+                                                                          y_.data(),
+                                                                          yp_.data(),
+                                                                          wb_.data(),
+                                                                          we_.data(),
+                                                                          J_);
+
+        J_.printMatrix("Tgov1 internal Jacobian");
+
+        GridKit::Enzyme::Sparse::ExternalJacobian<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
+                                                  GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithExternal,
                                                   ScalarT,
                                                   IdxT>::eval(this,
                                                               f_.size(),
-                                                              y_.size(),
+                                                              we_.size(),
                                                               this->getResidualIndices(),
-                                                              this->getVariableIndices(),
+                                                              we_indices_,
                                                               y_.data(),
                                                               yp_.data(),
-                                                              w_.data(),
+                                                              wb_.data(),
+                                                              we_.data(),
                                                               J_);
 
-        J_.printMatrix("Tgov1 internal Jacobian");
+        J_.printMatrix("Tgov1 Jacobian after signal evaluation");
 
         return 0;
       }

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -27,18 +27,18 @@ namespace GridKit
         std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
         GridKit::Enzyme::Sparse::InternalJacobianWithSignal<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
-                                                              GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
-                                                              ScalarT,
-                                                              IdxT>::eval(this,
-                                                                          f_.size(),
-                                                                          y_.size(),
-                                                                          this->getResidualIndices(),
-                                                                          this->getVariableIndices(),
-                                                                          y_.data(),
-                                                                          yp_.data(),
-                                                                          wb_.data(),
-                                                                          we_.data(),
-                                                                          J_);
+                                                            GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
+                                                            ScalarT,
+                                                            IdxT>::eval(this,
+                                                                        f_.size(),
+                                                                        y_.size(),
+                                                                        this->getResidualIndices(),
+                                                                        this->getVariableIndices(),
+                                                                        y_.data(),
+                                                                        yp_.data(),
+                                                                        wb_.data(),
+                                                                        we_.data(),
+                                                                        J_);
 
         J_.printMatrix("Tgov1 internal Jacobian");
 

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -37,7 +37,7 @@ namespace GridKit
                                                                         y_.data(),
                                                                         yp_.data(),
                                                                         wb_.data(),
-                                                                        we_.data(),
+                                                                        ws_.data(),
                                                                         J_);
 
         J_.printMatrix("Tgov1 internal Jacobian");
@@ -47,13 +47,13 @@ namespace GridKit
                                                   ScalarT,
                                                   IdxT>::eval(this,
                                                               f_.size(),
-                                                              we_.size(),
+                                                              ws_.size(),
                                                               this->getResidualIndices(),
-                                                              we_indices_,
+                                                              ws_indices_,
                                                               y_.data(),
                                                               yp_.data(),
                                                               wb_.data(),
-                                                              we_.data(),
+                                                              ws_.data(),
                                                               J_);
 
         J_.printMatrix("Tgov1 Jacobian after signal evaluation");

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -26,8 +26,8 @@ namespace GridKit
         std::cout << "Evaluate Jacobian for Tgov1..." << std::endl;
         std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-        GridKit::Enzyme::Sparse::InternalJacobianWithExternal<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
-                                                              GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithExternal,
+        GridKit::Enzyme::Sparse::InternalJacobianWithSignal<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
+                                                              GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
                                                               ScalarT,
                                                               IdxT>::eval(this,
                                                                           f_.size(),
@@ -43,7 +43,7 @@ namespace GridKit
         J_.printMatrix("Tgov1 internal Jacobian");
 
         GridKit::Enzyme::Sparse::ExternalJacobian<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
-                                                  GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithExternal,
+                                                  GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
                                                   ScalarT,
                                                   IdxT>::eval(this,
                                                               f_.size(),

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -138,6 +138,11 @@ namespace GridKit
         yp_.resize(size);
         tag_.resize(size);
 
+        // Resize external variable data
+        we_.resize(1);
+        we_[0]         = 0.0;
+        we_indices_[0] = static_cast<IdxT>(-1);
+
         // Default variable and residual index mapping to local index
         for (IdxT j = 0; j < size_; ++j)
         {
@@ -145,11 +150,10 @@ namespace GridKit
           this->setResidualIndex(j, j);
         }
 
-        // Set output signal after allocation
-        // The signal is accessible to the generator
+        // Set output signals
         if (signals_.template isAssigned<Tgov1InternalVariables::PM>())
         {
-          signals_.template getSignalNode<Tgov1InternalVariables::PM>()->set(&y_[2], this->getVariableIndex(2));
+          signals_.template getSignalNode<Tgov1InternalVariables::PM>()->set(&y_[2], &(this->getVariableIndex(2)));
         }
 
         return 0;
@@ -247,10 +251,11 @@ namespace GridKit
        *
        */
       template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int Tgov1<ScalarT, IdxT>::evaluateInternalResidual(
+      __attribute__((always_inline)) inline int Tgov1<ScalarT, IdxT>::evaluateInternalResidualWithExternal(
           ScalarT*                  y,
           ScalarT*                  yp,
-          [[maybe_unused]] ScalarT* w,
+          [[maybe_unused]] ScalarT* wb,
+          [[maybe_unused]] ScalarT* we,
           ScalarT*                  f)
       {
         // Read Internal Variables
@@ -262,8 +267,11 @@ namespace GridKit
         ScalarT ptx_dot = yp[0];
         ScalarT pv_dot  = yp[1];
 
+        // Set external variable aliases
+        ScalarT omega = we[0];
+
         // The 'pre-limit' derivative of Pv
-        ScalarT func     = (-pv + (pref_ - omega_) / R_) / T1_;
+        ScalarT func     = (-pv + (pref_ - omega) / R_) / T1_;
         ScalarT valv_ind = this->indicator(pv, func);
 
         // Internal Differential Equations
@@ -271,7 +279,7 @@ namespace GridKit
         f[1] = -pv_dot + valv_ind * func;
 
         // Internal Algebraic Equations
-        f[2] = -pmech + (ptx + T2_ * pv) / T3_ - (Dt_ * omega_);
+        f[2] = -pmech + (ptx + T2_ * pv) / T3_ - (Dt_ * omega);
 
         return 0;
       }
@@ -286,10 +294,11 @@ namespace GridKit
         // Input Variables
         if (signals_.template isAttached<Tgov1ExternalVariables::DELTAOMEGA>())
         {
-          omega_ = signals_.template readExternalVariable<Tgov1ExternalVariables::DELTAOMEGA>();
+          we_[0]         = signals_.template readExternalVariable<Tgov1ExternalVariables::DELTAOMEGA>();
+          we_indices_[0] = signals_.template readExternalVariableIndex<Tgov1ExternalVariables::DELTAOMEGA>();
         }
 
-        evaluateInternalResidual(y_.data(), yp_.data(), w_.data(), f_.data());
+        evaluateInternalResidualWithExternal(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
 
         return 0;
       }

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -251,7 +251,7 @@ namespace GridKit
        *
        */
       template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int Tgov1<ScalarT, IdxT>::evaluateInternalResidualWithExternal(
+      __attribute__((always_inline)) inline int Tgov1<ScalarT, IdxT>::evaluateInternalResidualWithSignal(
           ScalarT*                  y,
           ScalarT*                  yp,
           [[maybe_unused]] ScalarT* wb,
@@ -298,7 +298,7 @@ namespace GridKit
           we_indices_[0] = signals_.template readExternalVariableIndex<Tgov1ExternalVariables::DELTAOMEGA>();
         }
 
-        evaluateInternalResidualWithExternal(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
+        evaluateInternalResidualWithSignal(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
 
         return 0;
       }

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -251,7 +251,7 @@ namespace GridKit
        *
        */
       template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int Tgov1<ScalarT, IdxT>::evaluateInternalResidualWithSignal(
+      __attribute__((always_inline)) inline int Tgov1<ScalarT, IdxT>::evaluateInternalResidual(
           ScalarT*                  y,
           ScalarT*                  yp,
           [[maybe_unused]] ScalarT* wb,
@@ -298,7 +298,7 @@ namespace GridKit
           we_indices_[0] = signals_.template readExternalVariableIndex<Tgov1ExternalVariables::DELTAOMEGA>();
         }
 
-        evaluateInternalResidualWithSignal(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
+        evaluateInternalResidual(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
 
         return 0;
       }

--- a/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -139,9 +139,9 @@ namespace GridKit
         tag_.resize(size);
 
         // Resize external variable data
-        we_.resize(1);
-        we_[0]         = 0.0;
-        we_indices_[0] = static_cast<IdxT>(-1);
+        ws_.resize(1);
+        ws_[0]         = 0.0;
+        ws_indices_[0] = static_cast<IdxT>(-1);
 
         // Default variable and residual index mapping to local index
         for (IdxT j = 0; j < size_; ++j)
@@ -255,7 +255,7 @@ namespace GridKit
           ScalarT*                  y,
           ScalarT*                  yp,
           [[maybe_unused]] ScalarT* wb,
-          [[maybe_unused]] ScalarT* we,
+          [[maybe_unused]] ScalarT* ws,
           ScalarT*                  f)
       {
         // Read Internal Variables
@@ -268,7 +268,7 @@ namespace GridKit
         ScalarT pv_dot  = yp[1];
 
         // Set external variable aliases
-        ScalarT omega = we[0];
+        ScalarT omega = ws[0];
 
         // The 'pre-limit' derivative of Pv
         ScalarT func     = (-pv + (pref_ - omega) / R_) / T1_;
@@ -294,11 +294,11 @@ namespace GridKit
         // Input Variables
         if (signals_.template isAttached<Tgov1ExternalVariables::DELTAOMEGA>())
         {
-          we_[0]         = signals_.template readExternalVariable<Tgov1ExternalVariables::DELTAOMEGA>();
-          we_indices_[0] = signals_.template readExternalVariableIndex<Tgov1ExternalVariables::DELTAOMEGA>();
+          ws_[0]         = signals_.template readExternalVariable<Tgov1ExternalVariables::DELTAOMEGA>();
+          ws_indices_[0] = signals_.template readExternalVariableIndex<Tgov1ExternalVariables::DELTAOMEGA>();
         }
 
-        evaluateInternalResidual(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
+        evaluateInternalResidual(y_.data(), yp_.data(), wb_.data(), ws_.data(), f_.data());
 
         return 0;
       }

--- a/src/Model/PhasorDynamics/Load/Load.hpp
+++ b/src/Model/PhasorDynamics/Load/Load.hpp
@@ -35,7 +35,7 @@ namespace GridKit
       using Component<ScalarT, IdxT>::y_;
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;

--- a/src/Model/PhasorDynamics/Load/LoadImpl.hpp
+++ b/src/Model/PhasorDynamics/Load/LoadImpl.hpp
@@ -80,7 +80,7 @@ namespace GridKit
     {
       // std::cout << "Allocate Load..." << std::endl;
 
-      w_.resize(2);
+      wb_.resize(2);
       h_.resize(2);
 
       return 0;
@@ -111,10 +111,10 @@ namespace GridKit
      */
     template <class ScalarT, typename IdxT>
     __attribute__((always_inline)) int Load<ScalarT, IdxT>::evaluateBusResidual(
-        [[maybe_unused]] ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* w, ScalarT* h)
+        [[maybe_unused]] ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* wb, ScalarT* h)
     {
-      ScalarT Vr = w[0];
-      ScalarT Vi = w[1];
+      ScalarT Vr = wb[0];
+      ScalarT Vi = wb[1];
       ScalarT Ir = -g_ * Vr + b_ * Vi;
       ScalarT Ii = -b_ * Vr - g_ * Vi;
       h[0]       = Ir;
@@ -130,9 +130,9 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int Load<ScalarT, IdxT>::evaluateResidual()
     {
-      w_[0] = Vr();
-      w_[1] = Vi();
-      evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
+      wb_[0] = Vr();
+      wb_[1] = Vi();
+      evaluateBusResidual(y_.data(), yp_.data(), wb_.data(), h_.data());
       Ir() += h_[0];
       Ii() += h_[1];
 

--- a/src/Model/PhasorDynamics/SignalNode/SignalNode.hpp
+++ b/src/Model/PhasorDynamics/SignalNode/SignalNode.hpp
@@ -39,7 +39,7 @@ namespace GridKit
       virtual int evaluateResidual() override;
       virtual int evaluateJacobian() override;
 
-      void    set(ScalarT* signal_in, IdxT global_index);
+      void    set(ScalarT* signal_in, IdxT* global_index);
       ScalarT read() const;
       void    init(ScalarT signal_in);
 
@@ -119,15 +119,9 @@ namespace GridKit
         return J_;
       }
 
-      int setVariableIndex(IdxT global_index)
-      {
-        variable_index_ = global_index;
-        return 0;
-      }
-
       IdxT getVariableIndex() const
       {
-        return variable_index_;
+        return *variable_index_;
       }
 
     private:
@@ -137,9 +131,9 @@ namespace GridKit
     protected:
       const IdxT bus_id_{static_cast<IdxT>(-1)};
 
-      IdxT size_{0};
-      IdxT nnz_{0};
-      IdxT variable_index_{0};
+      IdxT  size_{0};
+      IdxT  nnz_{0};
+      IdxT* variable_index_{nullptr};
 
       std::vector<ScalarT> y_;
       std::vector<ScalarT> yp_;

--- a/src/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
+++ b/src/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
@@ -52,7 +52,7 @@ namespace GridKit
     }
 
     template <class ScalarT, typename IdxT>
-    void SignalNode<ScalarT, IdxT>::set(ScalarT* signal, IdxT variable_index)
+    void SignalNode<ScalarT, IdxT>::set(ScalarT* signal, IdxT* variable_index)
     {
       signal_         = signal;
       variable_index_ = variable_index;

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -176,7 +176,7 @@ namespace GridKit
       }
 
     public:
-      __attribute__((always_inline)) inline int evaluateInternalResidualWithExternal(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateInternalResidualWithSignal(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
       __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -79,7 +79,7 @@ namespace GridKit
       using Component<ScalarT, IdxT>::time_;
       using Component<ScalarT, IdxT>::y_;
       using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
 
@@ -176,7 +176,7 @@ namespace GridKit
       }
 
     public:
-      __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateInternalResidualWithExternal(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
       __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
@@ -228,12 +228,12 @@ namespace GridKit
       real_type B_;
 
       /* Setpoints for control variables (determined at initialization) */
-      ScalarT pmech_set_;
-      ScalarT efd_set_;
+      ScalarT pmech_set_{0.0}; // TODO remove default initialization and ensure this gets set
+      ScalarT efd_set_{0.0};   // TODO remove default initialization and ensure this gets set
 
-      /* Local copies of signal variables */
-      ScalarT pmech_;
-      ScalarT efd_;
+      /* Local copies of external variables */
+      std::vector<ScalarT> we_;
+      std::map<IdxT, IdxT> we_indices_;
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -232,8 +232,8 @@ namespace GridKit
       ScalarT efd_set_{0.0};   // TODO remove default initialization and ensure this gets set
 
       /* Local copies of external variables */
-      std::vector<ScalarT> we_;
-      std::map<IdxT, IdxT> we_indices_;
+      std::vector<ScalarT> ws_;
+      std::map<IdxT, IdxT> ws_indices_;
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -176,7 +176,7 @@ namespace GridKit
       }
 
     public:
-      __attribute__((always_inline)) inline int evaluateInternalResidualWithSignal(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
+      __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
       __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -24,20 +24,37 @@ namespace GridKit
       std::cout << "Evaluate Jacobian for Genrou..." << std::endl;
       std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-      GridKit::Enzyme::Sparse::InternalJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
-                                                GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
+      GridKit::Enzyme::Sparse::InternalJacobianWithExternal<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
+                                                            GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithExternal,
+                                                            ScalarT,
+                                                            IdxT>::eval(this,
+                                                                        f_.size(),
+                                                                        y_.size(),
+                                                                        this->getResidualIndices(),
+                                                                        this->getVariableIndices(),
+                                                                        y_.data(),
+                                                                        yp_.data(),
+                                                                        wb_.data(),
+                                                                        we_.data(),
+                                                                        J_);
+
+      J_.printMatrix("Genrou internal Jacobian");
+
+      GridKit::Enzyme::Sparse::ExternalJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
+                                                GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithExternal,
                                                 ScalarT,
                                                 IdxT>::eval(this,
                                                             f_.size(),
-                                                            y_.size(),
+                                                            we_.size(),
                                                             this->getResidualIndices(),
-                                                            this->getVariableIndices(),
+                                                            we_indices_,
                                                             y_.data(),
                                                             yp_.data(),
-                                                            w_.data(),
+                                                            wb_.data(),
+                                                            we_.data(),
                                                             J_);
 
-      J_.printMatrix("Genrou internal Jacobian");
+      J_.printMatrix("Genrou Jacobian after signal evaluation");
 
       GridKit::Enzyme::Sparse::BusJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
                                            GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -24,8 +24,8 @@ namespace GridKit
       std::cout << "Evaluate Jacobian for Genrou..." << std::endl;
       std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
-      GridKit::Enzyme::Sparse::InternalJacobianWithExternal<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
-                                                            GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithExternal,
+      GridKit::Enzyme::Sparse::InternalJacobianWithSignal<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
+                                                            GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
                                                             ScalarT,
                                                             IdxT>::eval(this,
                                                                         f_.size(),
@@ -41,7 +41,7 @@ namespace GridKit
       J_.printMatrix("Genrou internal Jacobian");
 
       GridKit::Enzyme::Sparse::ExternalJacobian<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
-                                                GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithExternal,
+                                                GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
                                                 ScalarT,
                                                 IdxT>::eval(this,
                                                             f_.size(),

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -25,18 +25,18 @@ namespace GridKit
       std::cout << "Jacobian evaluation is experimental!" << std::endl;
 
       GridKit::Enzyme::Sparse::InternalJacobianWithSignal<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
-                                                            GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
-                                                            ScalarT,
-                                                            IdxT>::eval(this,
-                                                                        f_.size(),
-                                                                        y_.size(),
-                                                                        this->getResidualIndices(),
-                                                                        this->getVariableIndices(),
-                                                                        y_.data(),
-                                                                        yp_.data(),
-                                                                        wb_.data(),
-                                                                        we_.data(),
-                                                                        J_);
+                                                          GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
+                                                          ScalarT,
+                                                          IdxT>::eval(this,
+                                                                      f_.size(),
+                                                                      y_.size(),
+                                                                      this->getResidualIndices(),
+                                                                      this->getVariableIndices(),
+                                                                      y_.data(),
+                                                                      yp_.data(),
+                                                                      wb_.data(),
+                                                                      we_.data(),
+                                                                      J_);
 
       J_.printMatrix("Genrou internal Jacobian");
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -35,7 +35,7 @@ namespace GridKit
                                                                       y_.data(),
                                                                       yp_.data(),
                                                                       wb_.data(),
-                                                                      we_.data(),
+                                                                      ws_.data(),
                                                                       J_);
 
       J_.printMatrix("Genrou internal Jacobian");
@@ -45,13 +45,13 @@ namespace GridKit
                                                 ScalarT,
                                                 IdxT>::eval(this,
                                                             f_.size(),
-                                                            we_.size(),
+                                                            ws_.size(),
                                                             this->getResidualIndices(),
-                                                            we_indices_,
+                                                            ws_indices_,
                                                             y_.data(),
                                                             yp_.data(),
                                                             wb_.data(),
-                                                            we_.data(),
+                                                            ws_.data(),
                                                             J_);
 
       J_.printMatrix("Genrou Jacobian after signal evaluation");

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -397,7 +397,7 @@ namespace GridKit
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateInternalResidualWithSignal(
+    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateInternalResidual(
         ScalarT* y,
         ScalarT* yp,
         ScalarT* wb,
@@ -522,7 +522,7 @@ namespace GridKit
       wb_[1] = Vi();
 
       // Residual evaluation
-      evaluateInternalResidualWithSignal(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
+      evaluateInternalResidual(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
       evaluateBusResidual(y_.data(), yp_.data(), wb_.data(), h_.data());
 
       // Genrou contribution to bus algebraic equations

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -276,9 +276,9 @@ namespace GridKit
       h_.resize(2);
 
       // Resize external variable data
-      we_.resize(2);
-      we_indices_[0] = static_cast<IdxT>(-1);
-      we_indices_[1] = static_cast<IdxT>(-1);
+      ws_.resize(2);
+      ws_indices_[0] = static_cast<IdxT>(-1);
+      ws_indices_[1] = static_cast<IdxT>(-1);
 
       // Default variable and residual index mapping to local index
       for (IdxT j = 0; j < size_; ++j)
@@ -401,7 +401,7 @@ namespace GridKit
         ScalarT* y,
         ScalarT* yp,
         ScalarT* wb,
-        ScalarT* we,
+        ScalarT* ws,
         ScalarT* f)
     {
       /* Read variables */
@@ -438,8 +438,8 @@ namespace GridKit
       ScalarT vi = wb[1];
 
       // Set external variable aliases
-      ScalarT pmech = we[0];
-      ScalarT efd   = we[1];
+      ScalarT pmech = ws[0];
+      ScalarT efd   = ws[1];
 
       /* 6 Genrou differential equations */
       f[0] = delta_dot - omega * (2.0 * M_PI * 60.0);
@@ -502,19 +502,19 @@ namespace GridKit
     int Genrou<ScalarT, IdxT>::evaluateResidual()
     {
       // Mechanical Power
-      we_[0] = pmech_set_;
+      ws_[0] = pmech_set_;
       if (signals_.template isAttached<GenrouExternalVariables::PM>())
       {
-        we_[0]         = signals_.template readExternalVariable<GenrouExternalVariables::PM>();
-        we_indices_[0] = signals_.template readExternalVariableIndex<GenrouExternalVariables::PM>();
+        ws_[0]         = signals_.template readExternalVariable<GenrouExternalVariables::PM>();
+        ws_indices_[0] = signals_.template readExternalVariableIndex<GenrouExternalVariables::PM>();
       }
 
       // Exciter Efield
-      we_[1] = efd_set_;
+      ws_[1] = efd_set_;
       if (signals_.template isAttached<GenrouExternalVariables::EFD>())
       {
-        we_[1]         = signals_.template readExternalVariable<GenrouExternalVariables::EFD>();
-        we_indices_[1] = signals_.template readExternalVariableIndex<GenrouExternalVariables::EFD>();
+        ws_[1]         = signals_.template readExternalVariable<GenrouExternalVariables::EFD>();
+        ws_indices_[1] = signals_.template readExternalVariableIndex<GenrouExternalVariables::EFD>();
       }
 
       // Bus voltages
@@ -522,7 +522,7 @@ namespace GridKit
       wb_[1] = Vi();
 
       // Residual evaluation
-      evaluateInternalResidual(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
+      evaluateInternalResidual(y_.data(), yp_.data(), wb_.data(), ws_.data(), f_.data());
       evaluateBusResidual(y_.data(), yp_.data(), wb_.data(), h_.data());
 
       // Genrou contribution to bus algebraic equations

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -397,7 +397,7 @@ namespace GridKit
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateInternalResidualWithExternal(
+    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateInternalResidualWithSignal(
         ScalarT* y,
         ScalarT* yp,
         ScalarT* wb,
@@ -522,7 +522,7 @@ namespace GridKit
       wb_[1] = Vi();
 
       // Residual evaluation
-      evaluateInternalResidualWithExternal(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
+      evaluateInternalResidualWithSignal(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
       evaluateBusResidual(y_.data(), yp_.data(), wb_.data(), h_.data());
 
       // Genrou contribution to bus algebraic equations

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -272,8 +272,13 @@ namespace GridKit
       tag_.resize(static_cast<size_t>(size_));
 
       // Resize coupling data
-      w_.resize(2);
+      wb_.resize(2);
       h_.resize(2);
+
+      // Resize external variable data
+      we_.resize(2);
+      we_indices_[0] = static_cast<IdxT>(-1);
+      we_indices_[1] = static_cast<IdxT>(-1);
 
       // Default variable and residual index mapping to local index
       for (IdxT j = 0; j < size_; ++j)
@@ -282,10 +287,10 @@ namespace GridKit
         this->setResidualIndex(j, j);
       }
 
-      // Set output signal after allocation
+      // Set output signals
       if (signals_.template isAssigned<GenrouInternalVariables::OMEGA>())
       {
-        signals_.template getSignalNode<GenrouInternalVariables::OMEGA>()->set(&y_[1], this->getVariableIndex(1));
+        signals_.template getSignalNode<GenrouInternalVariables::OMEGA>()->set(&y_[1], &(this->getVariableIndex(1)));
       }
 
       return 0;
@@ -392,10 +397,11 @@ namespace GridKit
      *
      */
     template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateInternalResidual(
+    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateInternalResidualWithExternal(
         ScalarT* y,
         ScalarT* yp,
-        ScalarT* w,
+        ScalarT* wb,
+        ScalarT* we,
         ScalarT* f)
     {
       /* Read variables */
@@ -428,13 +434,17 @@ namespace GridKit
       ScalarT Edp_dot   = yp[5];
 
       // Set coupling variable aliases
-      ScalarT vr = w[0];
-      ScalarT vi = w[1];
+      ScalarT vr = wb[0];
+      ScalarT vi = wb[1];
+
+      // Set external variable aliases
+      ScalarT pmech = we[0];
+      ScalarT efd   = we[1];
 
       /* 6 Genrou differential equations */
       f[0] = delta_dot - omega * (2.0 * M_PI * 60.0);
-      f[1] = omega_dot - (1.0 / (2.0 * H_)) * ((pmech_ - D_ * omega) / (1.0 + omega) - telec);
-      f[2] = Eqp_dot - (1.0 / Tdop_) * (efd_ - (Eqp + Xd1_ * (id + Xd3_ * (Eqp - psidp - Xd2_ * id)) + psidpp * ksat));
+      f[1] = omega_dot - (1.0 / (2.0 * H_)) * ((pmech - D_ * omega) / (1.0 + omega) - telec);
+      f[2] = Eqp_dot - (1.0 / Tdop_) * (efd - (Eqp + Xd1_ * (id + Xd3_ * (Eqp - psidp - Xd2_ * id)) + psidpp * ksat));
       f[3] = psidp_dot - (1.0 / Tdopp_) * (Eqp - psidp - Xd2_ * id);
       f[4] = psiqp_dot - (1.0 / Tqopp_) * (Edp - psiqp + Xq2_ * iq);
       f[5] = Edp_dot - (1.0 / Tqop_) * (-Edp + Xqd_ * psiqpp * ksat + Xq1_ * (iq - Xq3_ * (Edp + iq * Xq2_ - psiqp)));
@@ -470,13 +480,13 @@ namespace GridKit
     __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateBusResidual(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
-        ScalarT*                  w,
+        ScalarT*                  wb,
         ScalarT*                  h)
     {
       ScalarT inr = y[17];
       ScalarT ini = y[18];
-      ScalarT vr  = w[0];
-      ScalarT vi  = w[1];
+      ScalarT vr  = wb[0];
+      ScalarT vi  = wb[1];
 
       h[0] = inr - vr * G_ + vi * B_;
       h[1] = ini - vr * B_ - vi * G_;
@@ -492,32 +502,28 @@ namespace GridKit
     int Genrou<ScalarT, IdxT>::evaluateResidual()
     {
       // Mechanical Power
+      we_[0] = pmech_set_;
       if (signals_.template isAttached<GenrouExternalVariables::PM>())
       {
-        pmech_ = signals_.template readExternalVariable<GenrouExternalVariables::PM>();
-      }
-      else
-      {
-        pmech_ = pmech_set_;
+        we_[0]         = signals_.template readExternalVariable<GenrouExternalVariables::PM>();
+        we_indices_[0] = signals_.template readExternalVariableIndex<GenrouExternalVariables::PM>();
       }
 
       // Exciter Efield
+      we_[1] = efd_set_;
       if (signals_.template isAttached<GenrouExternalVariables::EFD>())
       {
-        efd_ = signals_.template readExternalVariable<GenrouExternalVariables::EFD>();
-      }
-      else
-      {
-        efd_ = efd_set_;
+        we_[1]         = signals_.template readExternalVariable<GenrouExternalVariables::EFD>();
+        we_indices_[1] = signals_.template readExternalVariableIndex<GenrouExternalVariables::EFD>();
       }
 
       // Bus voltages
-      w_[0] = Vr();
-      w_[1] = Vi();
+      wb_[0] = Vr();
+      wb_[1] = Vi();
 
       // Residual evaluation
-      evaluateInternalResidual(y_.data(), yp_.data(), w_.data(), f_.data());
-      evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
+      evaluateInternalResidualWithExternal(y_.data(), yp_.data(), wb_.data(), we_.data(), f_.data());
+      evaluateBusResidual(y_.data(), yp_.data(), wb_.data(), h_.data());
 
       // Genrou contribution to bus algebraic equations
       Ir() += h_[0];

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -40,7 +40,7 @@ namespace GridKit
       using Component<ScalarT, IdxT>::time_;
       using Component<ScalarT, IdxT>::y_;
       using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::w_;
+      using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -34,7 +34,7 @@ namespace GridKit
                                                             this->getVariableIndices(),
                                                             y_.data(),
                                                             yp_.data(),
-                                                            w_.data(),
+                                                            wb_.data(),
                                                             J_);
 
       J_.printMatrix("GenClassical internal Jacobian");

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -134,7 +134,7 @@ namespace GridKit
       tag_.resize(size);
 
       // Resize coupling data
-      w_.resize(2);
+      wb_.resize(2);
       h_.resize(2);
 
       // Default variable and residual index mapping to local index
@@ -202,7 +202,7 @@ namespace GridKit
     __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateInternalResidual(
         ScalarT* y,
         ScalarT* yp,
-        ScalarT* w,
+        ScalarT* wb,
         ScalarT* f)
     {
       // Set variable aliases for better readability.
@@ -219,8 +219,8 @@ namespace GridKit
       const ScalarT omega_dot = yp[1];
 
       // Set coupling variable aliases
-      const ScalarT vr = w[0];
-      const ScalarT vi = w[1];
+      const ScalarT vr = wb[0];
+      const ScalarT vi = wb[1];
 
       // GenClassical differential equations
       f[0] = delta_dot - (omega - 1.0) * (2.0 * M_PI * 60.0);
@@ -243,7 +243,7 @@ namespace GridKit
     __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateBusResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
-        [[maybe_unused]] ScalarT* w,
+        [[maybe_unused]] ScalarT* wb,
         ScalarT*                  h)
     {
       const ScalarT ir = y[3];
@@ -261,11 +261,11 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int GenClassical<ScalarT, IdxT>::evaluateResidual()
     {
-      w_[0] = Vr();
-      w_[1] = Vi();
+      wb_[0] = Vr();
+      wb_[1] = Vi();
 
-      evaluateInternalResidual(y_.data(), yp_.data(), w_.data(), f_.data());
-      evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
+      evaluateInternalResidual(y_.data(), yp_.data(), wb_.data(), f_.data());
+      evaluateBusResidual(y_.data(), yp_.data(), wb_.data(), h_.data());
 
       Ir() += h_[0];
       Ii() += h_[1];

--- a/src/Utilities/Testing.hpp
+++ b/src/Utilities/Testing.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cmath>
+#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <map>
@@ -62,8 +63,8 @@ namespace GridKit
             fail++;
             std::cerr << "Mismatching map values! "
                       << "a.first = " << pair_a.first << ", "
-                      << "a.second = " << pair_a.second << ", and "
-                      << "b.second = " << it->second << "\n";
+                      << "a.second = " << std::setprecision(16) << pair_a.second << ", and "
+                      << "b.second = " << std::setprecision(16) << it->second << "\n";
           }
         }
         else

--- a/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
@@ -103,7 +103,7 @@ namespace GridKit
       }
 
       // A test to verify that the hard coded answers match those given by the residual functions
-      // Hard code parameters, differential, and algebraic terms
+      // Hard coded parameters, differential, and algebraic terms
       TestOutcome hard_coded_residual()
       {
         TestStatus success = true;
@@ -162,6 +162,9 @@ namespace GridKit
 
         // Allocate but not initialize generator model
         gen.allocate();
+        // TODO: Set pmech and efd. They are currently not set in this test, as we are not
+        // calling gen.initialize(). The private members are initialized to 0 as a workaround, 
+        // but this needs to be better handled in the model implementation.
 
         // Set variable values matching the answer key
         gen.y()[0]  = M_PI; // delta

--- a/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
@@ -163,7 +163,7 @@ namespace GridKit
         // Allocate but not initialize generator model
         gen.allocate();
         // TODO: Set pmech and efd. They are currently not set in this test, as we are not
-        // calling gen.initialize(). The private members are initialized to 0 as a workaround, 
+        // calling gen.initialize(). The private members are initialized to 0 as a workaround,
         // but this needs to be better handled in the model implementation.
 
         // Set variable values matching the answer key

--- a/tests/UnitTests/PhasorDynamics/GovernorTgov1Tests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GovernorTgov1Tests.hpp
@@ -182,13 +182,15 @@ namespace GridKit
         std::vector<DependencyTracking::Variable::DependencyMap> enzyme_jacobian = EnzymeJacobian(busdata, gendata);
 
         /// Compare DependencyTracking dependencies to Enzyme's
-        auto tol = 1000 * std::numeric_limits<real_type>::epsilon(); ///< Todo: Resolve mismatch from sigmoid approximation
+        auto tol = 10 * std::numeric_limits<real_type>::epsilon();
         for (size_t i = 0; i < dependency_tracking_residuals.size(); ++i)
         {
           DependencyTracking::Variable                       res           = dependency_tracking_residuals[i];
           const DependencyTracking::Variable::DependencyMap& dependencies  = res.getDependencies();
           success                                                         *= (GridKit::Testing::isEqual(dependencies, enzyme_jacobian[i], tol));
         }
+
+        success.expectFailure(); // TODO: Resolve mismatch from sigmoid approximation
 
         return success.report(__func__);
       }
@@ -215,13 +217,14 @@ namespace GridKit
 
         for (size_t i = 0; i < gov.size(); ++i)
         {
-          gov.y()[i].setVariableNumber(i); ///< Independent variables
+          gov.y()[i].setVariableNumber(i); // Governor independent variables
         }
+        gen.y()[1].setVariableNumber(gov.size()); // omega as an additional independent variable
 
         bus.evaluateResidual();
         gen.evaluateResidual();
-        gov.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
-                                ///< the dependencies
+        gov.evaluateResidual(); // Computes the residual and the Jacobian values by tracking
+                                // the dependencies
         std::vector<DependencyTracking::Variable> residual = gov.getResidual();
 
         /// Print the dependencies
@@ -249,6 +252,8 @@ namespace GridKit
         bus.allocate();
         gov.allocate();
         gen.allocate();
+
+        gen.setVariableIndex(1, gov.size()); // Reset omega index
 
         bus.initialize();
         gen.initialize();


### PR DESCRIPTION
## Description

This adds Jacobian evaluation for internal residuals with respect to external variables ($\partial{f}/\partial{w_e}$) with Enzyme.
cc @abdourahmanbarry @reid-g @alexander-novo 

 ## Proposed changes
- Added `we_` and `we_indices_` to store a copy of the external variables and their indices. The indices are initialize to a unique integer identifyier, such that nothing is stored in the Jacobian unless signal nodes are connected and the indices are updated.
- Updated GovernorTgov1Tests to test the derivative with respect to the external variable `omega`. Both the Enzyme and DependencyTracking Jacobians provide one more, off-diagonal, entry.
- Updated `GenrouEnzyme` to compute the additional Jacobian blocks and verified that it behaves as expected. This will be enabled when #234 is fixed.
- Updated `SignalNode` to store a pointer to the variable's global index. 
- Updated `ComponentSignals` with a method to read the index from the signals.

 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments