### PR TITLE
Add more information and context to JSON parser errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added signal node connectivity tools.
 - Upgraded to Spack 1.0.0.
 - Added `GenClassical` as supported device class in JSON parser.
+- Added more context information to JSON parser errors.
 
 ## v0.1
 

--- a/src/Model/PhasorDynamics/Bus/BusDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/Bus/BusDataJSONParser.hpp
@@ -19,6 +19,11 @@ namespace GridKit
     {
       j.at("name").get_to(bd.name);
 
+      std::stringstream error_context;
+      error_context << "\n\tSee bus number " << bd.bus_id
+                    << " (\"name\": \"" << bd.name << "\") "
+                    << "in the \"buses\" list of your JSON file.";
+
       if (j.contains("init"))
       {
         for (auto& raw_parameter : j.at("init").items())
@@ -33,7 +38,10 @@ namespace GridKit
           }
           else
           {
-            throw std::runtime_error("Invalid initial parameter");
+            std::stringstream msg;
+            msg << "\n\tInvalid initial parameter \"" << raw_parameter.key()
+                << "\" in \"init\" section." << error_context.str();
+            throw std::runtime_error(msg.str());
           }
         }
       }
@@ -51,7 +59,10 @@ namespace GridKit
       }
       else
       {
-        throw std::runtime_error("Invalid bus class");
+        std::stringstream msg;
+        msg << "\n\tInvalid bus class: \"" << string_class << "\"."
+            << error_context.str();
+        throw std::runtime_error(msg.str());
       }
 
       j.at("v_base").get_to(bd.v_base);
@@ -93,7 +104,10 @@ namespace GridKit
           }
           else
           {
-            throw std::runtime_error("Invalid monitored variable");
+            std::stringstream msg;
+            msg << "\n\tInvalid monitored variable: \"" << monitored
+                << "\" in \"mon\" list." << error_context.str();
+            throw std::runtime_error(msg.str());
           }
         }
       }

--- a/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
@@ -25,13 +25,20 @@ namespace GridKit
     {
       j.at("class").get_to(c.device_class);
 
+      j.at("id").get_to(c.disambiguation_string);
+
+      std::stringstream error_context;
+      error_context << "\n\tSee the \"" << c.device_class
+                    << "\" device with \"id\": \"" << c.disambiguation_string
+                    << "\" in the \"devices\" list of your JSON file.";
+
       for (auto& raw_parameter : j.at("params").items())
       {
         auto key = magic_enum::enum_cast<Parameters>(raw_parameter.key());
         if (key.has_value())
         {
-          // NOTE: this is necessary because it doesn't seem like nlohmann/json handles std::variant
-          //       out of the box
+          // NOTE: this is necessary because it doesn't seem like nlohmann/json
+          //       handles std::variant out of the box
           if (raw_parameter.value().is_boolean())
           {
             c.parameters[key.value()] = raw_parameter.value().template get<bool>();
@@ -46,13 +53,20 @@ namespace GridKit
           }
           else
           {
-            throw std::runtime_error("Invalid initial parameter");
+            std::stringstream msg;
+            msg << "\n\tInvalid initial parameter value type: "
+                << "\"" << raw_parameter.key() << "\": " << raw_parameter.value()
+                << " (typed as \"" << raw_parameter.value().type_name() << "\")."
+                << error_context.str();
+            throw std::runtime_error(msg.str());
           }
         }
         else
         {
-          // std::cout << "Key " << raw_parameter.key() << " has no value!\n";
-          throw std::runtime_error("Invalid initial parameter");
+          std::stringstream msg;
+          msg << "\n\tInitial parameter \"" << raw_parameter.key()
+              << "\" has no value." << error_context.str();
+          throw std::runtime_error(msg.str());
         }
       }
 
@@ -65,8 +79,10 @@ namespace GridKit
         }
         else
         {
-          // std::cout << raw_port.key() << "\n";
-          throw std::runtime_error("Invalid port mapping");
+          std::stringstream msg;
+          msg << "\n\tInvalid port mapping: \"" << raw_port.key()
+              << "\" has no value." << error_context.str();
+          throw std::runtime_error(msg.str());
         }
       }
 
@@ -80,8 +96,6 @@ namespace GridKit
         j.at("va_base").get_to(c.va_base);
       }
 
-      j.at("id").get_to(c.disambiguation_string);
-
       if (j.contains("mon"))
       {
         for (auto& raw_monitored_variable : j.at("mon"))
@@ -94,7 +108,10 @@ namespace GridKit
           }
           else
           {
-            throw std::runtime_error("Invalid monitored variable \"" + var_name + '\"');
+            std::stringstream msg;
+            msg << "\n\tInvalid monitored variable: \"" << var_name
+                << "\" in \"mon\" list." << error_context.str();
+            throw std::runtime_error(msg.str());
           }
         }
       }

--- a/src/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
@@ -107,7 +107,10 @@ namespace GridKit
         }
         else
         {
-          throw std::runtime_error("Invalid device class \"" + kind + '\"');
+          std::stringstream msg;
+          msg << "\n\tInvalid device class: \"" << kind << "\". "
+              << "\n\tSee the \"devices\" list in your JSON file.";
+          throw std::runtime_error(msg.str());
         }
       }
     }


### PR DESCRIPTION
## Description
 
Error messages gave no helpful information to users.
 
 _Closes #263_
 
 ## Proposed changes
 
Provide relevant information about the error and the context by which to locate it in the JSON file.
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [X] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.