### PR TITLE
Specify `CXX` to avoid unnecessary C language checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-project(gridkit)
+project(gridkit CXX)
 
 set(PACKAGE_NAME "GRIDKIT")
 set(PACKAGE_STRING "GRIDKIT 0.1.0")


### PR DESCRIPTION
## Description

Since GridKit doesn't use C, we can leave it out of the build configuration.
 
 ## Proposed changes
 
Specify `CXX` as the project language.
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.