### PR TITLE
Introduce Logger class with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Upgraded to Spack 1.0.0.
 - Added `GenClassical` as supported device class in JSON parser.
 - Added more context information to JSON parser errors.
+- Added `Logger` class.
 
 ## v0.1
 

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -2,3 +2,5 @@ add_library(Utilities INTERFACE)
 target_include_directories(Utilities INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(GRIDKIT::Utilities ALIAS Utilities)
+
+add_subdirectory(Logger)

--- a/src/Utilities/Colors.hpp
+++ b/src/Utilities/Colors.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace GridKit
+{
+  namespace Utilities
+  {
+    namespace Colors
+    {
+      // must be const pointer and const dest for
+      // const string declarations to pass -Wwrite-strings
+      static const char* const RED    = "\033[1;31m";
+      static const char* const GREEN  = "\033[1;32m";
+      static const char* const YELLOW = "\033[33;1m";
+      static const char* const BLUE   = "\033[34;1m";
+      static const char* const ORANGE = "\u001b[38;5;208m";
+      static const char* const CLEAR  = "\033[0m";
+    } // namespace Colors
+  } // namespace Utilities
+} // namespace GridKit

--- a/src/Utilities/Logger/CMakeLists.txt
+++ b/src/Utilities/Logger/CMakeLists.txt
@@ -1,0 +1,7 @@
+gridkit_add_library(utilities_logger
+  SOURCES
+    Logger.cpp
+  OUTPUT_NAME
+    gridkit_utilities_logger)
+
+target_link_libraries(Utilities INTERFACE GRIDKIT::utilities_logger)

--- a/src/Utilities/Logger/Logger.cpp
+++ b/src/Utilities/Logger/Logger.cpp
@@ -1,0 +1,187 @@
+/**
+ * @file Logger.cpp
+ * @brief Contains definition of Logger class.
+ * @author Slaven Peles <peless@ornl.org>
+ */
+
+#include "Logger.hpp"
+
+#include <Utilities/Colors.hpp>
+
+namespace GridKit
+{
+  namespace Utilities
+  {
+    /// @brief Default verbosity is to print error and warning messages
+    Logger::Verbosity Logger::verbosity_ = Logger::WARNINGS;
+
+    /// @brief Default output is standard output
+    std::ostream* Logger::logger_ = &std::cout;
+
+    /// @brief User provided output file stream
+    std::ofstream Logger::file_;
+
+    /// @brief Stream to null device
+    std::ostream Logger::nullstream_(nullptr);
+
+    /// @brief Auxiliary vector of output streams
+    std::vector<std::ostream*> Logger::tmp_;
+
+    /// @brief Vector of different output streams
+    std::vector<std::ostream*> Logger::output_streams_(Logger::init());
+
+    /**
+     * @brief Sets verbosity level
+     *
+     * @pre `output_streams_` vector is allocated
+     * @post Verbosity level is set to user supplied value `v` and outputs
+     * for `output_streams_` are set accordingly.
+     */
+    void Logger::setVerbosity(Verbosity v)
+    {
+      verbosity_ = v;
+      updateVerbosity(output_streams_);
+    }
+
+    /// @brief Gets verbosity level
+    Logger::Verbosity Logger::verbosity()
+    {
+      return verbosity_;
+    }
+
+    /**
+     * @brief Private method to update verbosity.
+     *
+     * This function directs each output stream <= `verbosity_` to user
+     * selected output and sets all others to null device. Each output stream
+     * corresponds to different verbosity level.
+     *
+     * @param[in] output_streams - vector of pointers to output streams
+     *
+     * @pre Vector `output_streams` is allocated and correctly initialized.
+     * @post All streams `output_stream_[i]`, where `i <= verbosity_` are
+     * directed to stream `logger_`. The rest are sent to null device
+     * (not printed).
+     */
+    void Logger::updateVerbosity(std::vector<std::ostream*>& output_streams)
+    {
+      for (std::size_t i = NONE; i <= EVERYTHING; ++i)
+      {
+        output_streams[i] = i > verbosity_ ? &nullstream_ : logger_;
+      }
+    }
+
+    /**
+     * @brief Delivers default values for output streams.
+     */
+    std::vector<std::ostream*>& Logger::init()
+    {
+      tmp_.resize(Logger::EVERYTHING + 1);
+      updateVerbosity(tmp_);
+      return tmp_;
+    }
+
+    /**
+     * @brief Returns reference to output stream for error messages.
+     *
+     * @return Reference to error messages stream in `output_streams_`.
+     *
+     * @pre `output_streams_` vector is allocated and correctly initialized.
+     */
+    std::ostream& Logger::error()
+    {
+      using namespace Colors;
+      *(output_streams_[ERRORS]) << "[" << RED << "ERROR" << CLEAR << "] ";
+      return *(output_streams_[ERRORS]);
+    }
+
+    /**
+     * @brief Returns reference to output stream for warning messages.
+     *
+     * @return Reference to warning messages stream in `output_streams_`.
+     *
+     * @pre `output_streams_` vector is allocated and correctly initialized.
+     */
+    std::ostream& Logger::warning()
+    {
+      using namespace Colors;
+      *(output_streams_[WARNINGS]) << "[" << YELLOW << "WARNING" << CLEAR << "] ";
+      return *(output_streams_[WARNINGS]);
+    }
+
+    /**
+     * @brief Returns reference to analysis summary messages output stream.
+     *
+     * @return Reference to analysis summary messages stream in `output_streams_`.
+     *
+     * @pre `output_streams_` vector is allocated and correctly initialized.
+     */
+    std::ostream& Logger::summary()
+    {
+      *(output_streams_[SUMMARY]) << "[SUMMARY] ";
+      return *(output_streams_[SUMMARY]);
+    }
+
+    /**
+     * @brief Returns reference to output stream for all other messages.
+     *
+     * @return Reference to output stream to miscellaneous messages
+     * in `output_streams_`.
+     *
+     * @pre `output_streams_` vector is allocated and correctly initialized.
+     */
+    std::ostream& Logger::misc()
+    {
+      *(output_streams_[EVERYTHING]) << "[MESSAGE] ";
+      return *(output_streams_[EVERYTHING]);
+    }
+
+    /**
+     * @brief Open file `filename` and update outputs for different verbosities
+     * streams.
+     *
+     * @param[in] filename - The name of the output file.
+     *
+     * @pre `output_streams_` vector is allocated and correctly initialized.
+     * @post All active streams are directed to user supplied file `filename`.
+     */
+    void Logger::openOutputFile(std::string filename)
+    {
+      file_.open(filename);
+      logger_ = &file_;
+      updateVerbosity(output_streams_);
+    }
+
+    /**
+     * @brief Set outputs of active streams to user provided `std::ostream` object.
+     *
+     * All active outputs are redirected to `out` stream. All inactive ones are
+     * directed to null device.
+     *
+     * @param[in] out - User provided output stream.
+     *
+     * @pre `output_streams_` vector is allocated and correctly initialized.
+     * @post All active streams (`output_streams_[i]` where `i <= verbosity_`)
+     * are set to user provided `out` output stream.
+     */
+    void Logger::setOutput(std::ostream& out)
+    {
+      logger_ = &out;
+      updateVerbosity(output_streams_);
+    }
+
+    /**
+     * @brief Close output file.
+     *
+     * @pre Output file `file_` has been opened.
+     * @post Output file `file_` is closed and active output streams are
+     * set to default output `std::cout`.
+     */
+    void Logger::closeOutputFile()
+    {
+      file_.close();
+      logger_ = &std::cout;
+      updateVerbosity(output_streams_);
+    }
+  } // namespace Utilities
+} // namespace GridKit

--- a/src/Utilities/Logger/Logger.hpp
+++ b/src/Utilities/Logger/Logger.hpp
@@ -1,0 +1,63 @@
+/**
+ * @file Logger.hpp
+ */
+
+#pragma once
+
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+namespace GridKit
+{
+  namespace Utilities
+  {
+    /**
+     * @brief Manages and logs outputs from GridKit code.
+     *
+     * All methods and data in this class are static.
+     *
+     */
+    class Logger
+    {
+    public:
+      /// Enum specifying verbosity level for the output.
+      enum Verbosity
+      {
+        NONE = 0,
+        ERRORS,
+        WARNINGS,
+        SUMMARY,
+        EVERYTHING
+      };
+
+      // All methods and data are static so delete constructor and destructor.
+      Logger()  = delete;
+      ~Logger() = delete;
+
+      static std::ostream& error();
+      static std::ostream& warning();
+      static std::ostream& summary();
+      static std::ostream& misc();
+
+      static void      setOutput(std::ostream& out);
+      static void      openOutputFile(std::string filename);
+      static void      closeOutputFile();
+      static void      setVerbosity(Verbosity v);
+      static Verbosity verbosity();
+
+      static std::vector<std::ostream*>& init();
+
+    private:
+      static void updateVerbosity(std::vector<std::ostream*>& output_streams);
+
+    private:
+      static std::ostream               nullstream_;
+      static std::ofstream              file_;
+      static std::ostream*              logger_;
+      static std::vector<std::ostream*> output_streams_;
+      static std::vector<std::ostream*> tmp_;
+      static Verbosity                  verbosity_;
+    };
+  } // namespace Utilities
+} // namespace GridKit

--- a/src/Utilities/TestHelpers.hpp
+++ b/src/Utilities/TestHelpers.hpp
@@ -13,21 +13,10 @@
 #include <iostream>
 #include <limits>
 
+#include <Utilities/Colors.hpp>
+
 namespace GridKit
 {
-
-  namespace Colors
-  {
-    // must be const pointer and const dest for
-    // const string declarations to pass -Wwrite-strings
-    static const char* const RED    = "\033[1;31m";
-    static const char* const GREEN  = "\033[1;32m";
-    static const char* const YELLOW = "\033[33;1m";
-    static const char* const BLUE   = "\033[34;1m";
-    static const char* const ORANGE = "\u001b[38;5;208m";
-    static const char* const CLEAR  = "\033[0m";
-  } // namespace Colors
-
   namespace Testing
   {
     enum TestOutcome
@@ -95,7 +84,7 @@ namespace GridKit
 
       TestOutcome report(const char* funcname)
       {
-        using namespace Colors;
+        using namespace Utilities::Colors;
 
         if (expectFailure_)
         {

--- a/tests/UnitTests/Utilities/CMakeLists.txt
+++ b/tests/UnitTests/Utilities/CMakeLists.txt
@@ -1,6 +1,14 @@
 add_executable(test_case_format runCaseFormatTests.cpp)
-target_include_directories(test_case_format PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/nlohmann-json/single_include ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+target_include_directories(test_case_format
+    PRIVATE
+    ${GRIDKIT_THIRD_PARTY_DIR}/nlohmann-json/single_include
+    ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
 
-add_test(NAME UtilitiesCaseFormatTest COMMAND $<TARGET_FILE:test_case_format>)
+add_executable(test_logger runLoggerTests.cpp)
+target_link_libraries(test_logger PRIVATE GRIDKIT::utilities_logger)
+
+add_test(NAME UtilitiesCaseFormatTest COMMAND test_case_format)
+add_test(NAME UtilitiesLoggerTest COMMAND test_logger)
 
 install(TARGETS test_case_format)
+install(TARGETS test_logger)

--- a/tests/UnitTests/Utilities/LoggerTests.hpp
+++ b/tests/UnitTests/Utilities/LoggerTests.hpp
@@ -1,0 +1,206 @@
+/**
+ * @file LoggerTests.hpp
+ * @brief Contains definition of LoggerTests class.
+ * @author Slaven Peles <peless@ornl.org>
+ */
+
+#pragma once
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <Utilities/Logger/Logger.hpp>
+#include <Utilities/TestHelpers.hpp>
+#include <Utilities/Testing.hpp>
+
+namespace GridKit
+{
+  namespace Testing
+  {
+    /**
+     * @brief Class implementing unit tests for Logger class.
+     *
+     * The LoggerTests class is implemented entirely in this header file.
+     * Adding new unit test requires simply adding another method to this
+     * class.
+     */
+    class LoggerTests
+    {
+    public:
+      LoggerTests()
+      {
+      }
+
+      virtual ~LoggerTests()
+      {
+      }
+
+      /**
+       * @brief Test data stream for error log messages.
+       *
+       * This method tests streaming messages to `Logger::error()` data
+       * stream. The method streams messages to all available output streams,
+       * however only mesages streamed to the error stream should be logged.
+       */
+      TestOutcome errorOutput()
+      {
+        using out = GridKit::Utilities::Logger;
+        std::string s1("Test error output ...");
+        std::string s2("Another error output test ...\n");
+        std::string answer = error_text() + s1 + "\n" + error_text() + s2;
+
+        TestStatus status;
+
+        std::ostringstream file;
+
+        out::setOutput(file);
+        out::setVerbosity(out::ERRORS);
+        out::error() << s1 << std::endl;
+        out::error() << s2;
+
+        out::warning() << s1;
+        out::warning() << s2;
+        out::summary() << s1;
+        out::misc() << s1;
+
+        // std::cout << file.str();
+        // std::cout << answer;
+
+        status = (answer == file.str());
+
+        return status.report(__func__);
+      }
+
+      /**
+       * @brief Test data stream for warning log messages.
+       *
+       * This method tests streaming messages to `Logger::error()` data
+       * stream. The method streams messages to all available output streams,
+       * however only mesages streamed to the error and warning streams should
+       * be logged.
+       */
+      TestOutcome warningOutput()
+      {
+        using out = GridKit::Utilities::Logger;
+        std::string s1("Test error output ...\n");
+        std::string s2("Test warning output ...\n");
+        std::string answer = error_text() + s1 + warning_text() + s2;
+
+        TestStatus status;
+
+        std::ostringstream file;
+
+        out::setOutput(file);
+        out::setVerbosity(out::WARNINGS);
+
+        out::error() << s1;
+        out::warning() << s2;
+        out::summary() << s1;
+        out::misc() << s1;
+
+        // std::cout << file.str();
+
+        status = (answer == file.str());
+
+        return status.report(__func__);
+      }
+
+      /**
+       * @brief Test data stream for result summary log messages.
+       *
+       * This method tests streaming messages to `Logger::error()` data
+       * stream. The method streams messages to all available output streams,
+       * however only mesages streamed to the error, warning, and result summary
+       * streams should be logged.
+       */
+      TestOutcome summaryOutput()
+      {
+        using out = GridKit::Utilities::Logger;
+        std::string s1("Test error output ...\n");
+        std::string s2("Test warning output ...\n");
+        std::string s3("Test summary output ...\n");
+        std::string answer = error_text() + s1 + warning_text() + s2 + summary_ + s3;
+
+        TestStatus status;
+
+        std::ostringstream file;
+
+        out::setOutput(file);
+        out::setVerbosity(out::SUMMARY);
+
+        out::error() << s1;
+        out::warning() << s2;
+        out::summary() << s3;
+        out::misc() << s1;
+
+        // std::cout << file.str();
+
+        status = (answer == file.str());
+
+        return status.report(__func__);
+      }
+
+      /**
+       * @brief Test data stream for all other log messages.
+       *
+       * This method tests streaming messages to `Logger::error()` data
+       * stream. The method streams messages to all available output streams
+       * and all messages should be logged.
+       */
+      TestOutcome miscOutput()
+      {
+        using out = GridKit::Utilities::Logger;
+        std::string s1("Test error output ...\n");
+        std::string s2("Test warning output ...\n");
+        std::string s3("Test summary output ...\n");
+        std::string s4("Test any other output ...\n");
+        std::string answer = error_text() + s1 + warning_text() + s2 + summary_ + s3 + message_ + s4;
+
+        TestStatus status;
+
+        std::ostringstream file;
+
+        out::setOutput(file);
+        out::setVerbosity(out::EVERYTHING);
+
+        out::error() << s1;
+        out::warning() << s2;
+        out::summary() << s3;
+        out::misc() << s4;
+
+        // std::cout << file.str();
+
+        status = (answer == file.str());
+
+        return status.report(__func__);
+      }
+
+    private:
+      /// Private method to return the string preceding error output
+      std::string error_text()
+      {
+        using namespace Utilities::Colors;
+        std::ostringstream stream;
+        stream << "[" << RED << "ERROR" << CLEAR << "] ";
+        return stream.str();
+      }
+
+      /// Private method to return the string preceding warning output
+      std::string warning_text()
+      {
+        using namespace Utilities::Colors;
+        std::ostringstream stream;
+        stream << "[" << YELLOW << "WARNING" << CLEAR << "] ";
+        return stream.str();
+      }
+
+      /// String preceding output of a result summary
+      const std::string summary_ = "[SUMMARY] ";
+
+      /// String preceding miscellaneous output
+      const std::string message_ = "[MESSAGE] ";
+    }; // class LoggerTests
+
+  } // namespace Testing
+} // namespace GridKit

--- a/tests/UnitTests/Utilities/runLoggerTests.cpp
+++ b/tests/UnitTests/Utilities/runLoggerTests.cpp
@@ -1,0 +1,30 @@
+/**
+ * @file runLoggerTests.cpp
+ * @brief Driver for Logger class tests.
+ * @author Slaven Peles <peless@ornl.org>
+ */
+
+#include <iostream>
+#include <ostream>
+
+#include "LoggerTests.hpp"
+
+int main()
+{
+  using namespace GridKit;
+
+  // Create LoggerTests object
+  GridKit::Testing::LoggerTests test;
+
+  // Create test results accounting object
+  GridKit::Testing::TestingResults result;
+
+  // Run tests
+  result += test.errorOutput();
+  result += test.warningOutput();
+  result += test.summaryOutput();
+  result += test.miscOutput();
+
+  // Return tests summary
+  return result.summary();
+}


### PR DESCRIPTION
## Description
 
This introduces a logging tool so that we can move away from using `std::cout`/`std::cerr` directly.

 _Closes #270_ 
 _Closes #129_

 ## Proposed changes
 
The new class and its tests were lifted directly from Re::Solve, see [here](https://github.com/ORNL/ReSolve/tree/develop/resolve/utilities/logger) and [here](https://github.com/ORNL/ReSolve/tree/develop/tests/unit/utilities/logger).
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [X] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.