### PR TITLE
Add basic command-line parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Added `GenClassical` as supported device class in JSON parser.
 - Added more context information to JSON parser errors.
 - Added `Logger` class.
+- Added `CliOptions` for simple command-line parsing.
 
 ## v0.1
 

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -4,3 +4,4 @@ target_include_directories(Utilities INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(GRIDKIT::Utilities ALIAS Utilities)
 
 add_subdirectory(Logger)
+add_subdirectory(CliOptions)

--- a/src/Utilities/CliOptions/CMakeLists.txt
+++ b/src/Utilities/CliOptions/CMakeLists.txt
@@ -1,0 +1,7 @@
+gridkit_add_library(utilities_cli_options
+  SOURCES
+    CliOptions.cpp
+  OUTPUT_NAME
+    gridkit_utilities_cli_options)
+
+target_link_libraries(Utilities INTERFACE GRIDKIT::utilities_cli_options)

--- a/src/Utilities/CliOptions/CliOptions.cpp
+++ b/src/Utilities/CliOptions/CliOptions.cpp
@@ -1,0 +1,133 @@
+#include "CliOptions.hpp"
+
+namespace GridKit
+{
+  namespace Utilities
+  {
+
+    CliOptions::CliOptions(int argc, const char* argv[])
+      : argc_(argc),
+        argv_(argv)
+    {
+      app_name_ = argv_[0];
+      parse();
+    }
+
+    CliOptions::~CliOptions()
+    {
+    }
+
+    std::string CliOptions::getAppName() const
+    {
+      return app_name_;
+    }
+
+    bool CliOptions::hasKey(const std::string& key) const
+    {
+      return options_.find(key) != options_.end();
+    }
+
+    const std::string& CliOptions::getOptionFromKey(const std::string& key) const
+    {
+      auto it = options_.find(key);
+
+      if (it == options_.end())
+      {
+        throw std::runtime_error("CliOptions: Key not found: " + key);
+      }
+
+      return it->second;
+    }
+
+    void CliOptions::printOptionsList(std::ostream& os) const
+    {
+      OptionsList::const_iterator m = options_.begin();
+      int                         i = 0;
+      if (options_.empty())
+      {
+        os << "No parameters\n";
+      }
+      for (; m != options_.end(); m++, ++i)
+      {
+        os << "Parameter [" << i << "] ["
+           << (*m).first << " "
+           << (*m).second << "]\n";
+      }
+    }
+
+    //
+    // Private methods
+    //
+
+    /**
+     * @brief Parse command line input and store it in a map
+     *
+     * @pre Pointer to command line options is copied to `argv_`
+     * @post Command line options are parsed and stored in map `options_`
+     */
+    void CliOptions::parse()
+    {
+      std::pair<std::string, std::string> option;
+      // Loop over argv entries skipping the first one (executable name)
+      for (const char* const* i = this->begin() + 1; i != this->end(); i++)
+      {
+        const std::string p = *i;
+        if (option.first == "" && p[0] == '-')
+        {
+          // Set option ID and continue
+          option.first = p;
+          if (i == this->last())
+          {
+            // If this is last entry, there is nothing else to do; set option.
+            options_.insert(option);
+          }
+          continue;
+        }
+        else if (option.first != "" && p[0] == '-')
+        {
+          // Option ID has been set in prior cycle, string p is also option ID.
+          // Leave option value empty, since what follows is the next option ID.
+          option.second = "";
+          // Set option without parameter value
+          options_.insert(option);
+          // Set parameter ID for the next option and continue
+          option.first  = p;
+          option.second = "";
+          if (i == this->last())
+          {
+            // If this is last entry, there is nothing else to do; set option.
+            options_.insert(option);
+          }
+          continue;
+        }
+        else if (option.first != "")
+        {
+          // String p does not start with '-', contains parameter value
+          option.second = p;
+          // Set option with parameter value
+          options_.insert(option);
+          // Reset 'option' pair to receive the next entry and continue
+          option.first  = "";
+          option.second = "";
+          continue;
+        }
+      }
+    }
+
+    const char* const* CliOptions::begin() const
+    {
+      return argv_;
+    }
+
+    const char* const* CliOptions::end() const
+    {
+      return argv_ + argc_;
+    }
+
+    const char* const* CliOptions::last() const
+    {
+      return argv_ + argc_ - 1;
+    }
+
+  } // namespace Utilities
+} // namespace GridKit

--- a/src/Utilities/CliOptions/CliOptions.hpp
+++ b/src/Utilities/CliOptions/CliOptions.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace GridKit
+{
+  namespace Utilities
+  {
+
+    /**
+     * @brief Parser for command line input
+     *
+     * @note Based on StackOverflow answer by Luca Davanzo
+     */
+    class CliOptions
+    {
+    public:
+      CliOptions(int argc, const char* argv[]);
+      virtual ~CliOptions();
+      std::string        getAppName() const;
+      bool               hasKey(const std::string&) const;
+      const std::string& getOptionFromKey(const std::string&) const;
+      void               printOptionsList(std::ostream& os = std::cout) const;
+
+      template <typename T = std::string>
+      T get(const std::string& key) const
+      {
+        T ret;
+        std::stringstream(this->getOptionFromKey(key)) >> ret;
+        return ret;
+      }
+
+    private:
+      using OptionsList = std::map<std::string, std::string>;
+      void               parse();
+      const char* const* begin() const;
+      const char* const* end() const;
+      const char* const* last() const;
+      OptionsList        options_;
+      int                argc_;
+      const char**       argv_;
+      std::string        app_name_;
+    };
+
+  } // namespace Utilities
+} // namespace GridKit

--- a/src/Utilities/TestHelpers.hpp
+++ b/src/Utilities/TestHelpers.hpp
@@ -9,6 +9,7 @@
 
 #define THROW_NULL_DEREF throw std::runtime_error("error")
 
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -254,6 +255,89 @@ namespace GridKit
     //     }
 
     // };
+
+    namespace Detail
+    {
+      template <typename TErr>
+      struct ThrowsHelper
+      {
+        template <typename F>
+        bool operator()(F f)
+        {
+          try
+          {
+            f();
+          }
+          catch (const TErr&)
+          {
+            return true;
+          }
+          return false;
+        }
+      };
+
+      template <>
+      struct ThrowsHelper<void>
+      {
+        template <typename F>
+        bool operator()(F f)
+        {
+          try
+          {
+            f();
+          }
+          catch (...)
+          {
+            return true;
+          }
+          return false;
+        }
+      };
+    } // namespace Detail
+
+    template <typename TErr = void, typename TFunc, typename... TArgs>
+    inline bool
+    throws(TFunc func, TArgs&&... args)
+    {
+      return Detail::ThrowsHelper<TErr>{}(
+          [&]()
+          { func(std::forward<TArgs>(args)...); });
+    }
+
+    /**
+     * @brief Conveniently create a command-line string
+     *
+     * \example[33] CliOptionsTests.cpp
+     */
+    template <int NArgs>
+    struct CommandLine
+    {
+      CommandLine() = default;
+
+      CommandLine(const std::array<std::string, NArgs>& args)
+        : args_(args)
+      {
+        for (std::size_t i = 0; i < static_cast<std::size_t>(argc); ++i)
+        {
+          argv[i] = args_[i].c_str();
+        }
+      }
+
+      template <typename... TT>
+      CommandLine(const std::string& arg0, TT&&... args)
+        : CommandLine(std::array<std::string, NArgs>{arg0, args...})
+      {
+      }
+
+      int         argc{NArgs};
+      const char* argv[NArgs + 1]{nullptr};
+
+    private:
+      const std::array<std::string, NArgs> args_;
+    };
+
+    template <typename... TT>
+    CommandLine(const std::string&, TT...) -> CommandLine<1 + sizeof...(TT)>;
 
   } // namespace Testing
 } // namespace GridKit

--- a/tests/UnitTests/Utilities/CMakeLists.txt
+++ b/tests/UnitTests/Utilities/CMakeLists.txt
@@ -6,9 +6,13 @@ target_include_directories(test_case_format
 
 add_executable(test_logger runLoggerTests.cpp)
 target_link_libraries(test_logger PRIVATE GRIDKIT::utilities_logger)
+add_executable(test_cli_options runCliOptionsTests.cpp)
+target_link_libraries(test_cli_options PRIVATE GRIDKIT::utilities_cli_options)
 
 add_test(NAME UtilitiesCaseFormatTest COMMAND test_case_format)
 add_test(NAME UtilitiesLoggerTest COMMAND test_logger)
+add_test(NAME UtilitiesCliOptionsTest COMMAND test_cli_options)
 
 install(TARGETS test_case_format)
 install(TARGETS test_logger)
+install(TARGETS test_cli_options)

--- a/tests/UnitTests/Utilities/CliOptionsTests.hpp
+++ b/tests/UnitTests/Utilities/CliOptionsTests.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <Utilities/CliOptions/CliOptions.hpp>
+#include <Utilities/TestHelpers.hpp>
+#include <Utilities/Testing.hpp>
+
+namespace GridKit
+{
+  namespace Testing
+  {
+
+    class CliOptionsTests
+    {
+    public:
+      CliOptionsTests()
+      {
+      }
+
+      virtual ~CliOptionsTests()
+      {
+      }
+
+      /**
+       * @brief Test for keys after parsing
+       *
+       * This method tests for specific keys after supplying a command-line
+       * string to the CliOptions parser.
+       */
+      TestOutcome simpleParse()
+      {
+        using GridKit::Utilities::CliOptions;
+
+        CommandLine cl{"app", "--file", "fakefile.txt", "-N", "16"};
+
+        CliOptions options(cl.argc, cl.argv);
+
+        TestStatus status{true};
+
+        status *= options.getAppName() == "app";
+        status *= options.hasKey("--file");
+        status *= options.get<>("--file") == "fakefile.txt";
+        status *= options.hasKey("-N");
+        status *= options.get<int>("-N") == 16;
+
+        status *= !options.hasKey("--bad");
+
+        status *= throws<std::runtime_error>(
+            [&]()
+            { options.get<>("--bad"); });
+
+        return status.report(__func__);
+      }
+
+    }; // class CliOptionsTests
+
+  } // namespace Testing
+} // namespace GridKit

--- a/tests/UnitTests/Utilities/runCliOptionsTests.cpp
+++ b/tests/UnitTests/Utilities/runCliOptionsTests.cpp
@@ -1,0 +1,11 @@
+#include "CliOptionsTests.hpp"
+
+int main()
+{
+  GridKit::Testing::TestingResults  result;
+  GridKit::Testing::CliOptionsTests test;
+
+  result += test.simpleParse();
+
+  return result.summary();
+}


### PR DESCRIPTION
## Description
  
This gives users the ability to query the command-line arguments for specific expected options.

_Closes #249_
_Closes #112_
 
 ## Proposed changes
 
Lifted `CliOptions` class from Re::Solve and modified to simplify interface (user doesn't have to parse manually or use a `std::unique_ptr<std::pair<std::string, std::string>>`)
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [X] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
This provides the same basic functionality as it did for Re::Solve. However, I think it would be nice to expand the design to make using it in apps less cumbersome. Specifics should go in a new issue.