### PR TITLE
Clean up the `gridkit_add_library` cmake macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,7 @@ endif("${isSystemDir}" STREQUAL "-1")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_BINARY_DIR})
 
-option(GRIDKIT_BUILD_SHARED "Build shared libraries" ON)
-option(GRIDKIT_BUILD_STATIC "Build static libraries" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 if(GRIDKIT_ENABLE_IPOPT)
   include(FindIpopt)

--- a/cmake/GridkitAddLibrary.cmake
+++ b/cmake/GridkitAddLibrary.cmake
@@ -4,102 +4,85 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-# add_library macro loosely based on https://github.com/LLNL/sundials/blob/master/cmake/macros/SundialsAddLibrary.cmake
+#
+# gridkit_add_library(<target> SOURCES <file>...
+#   [HEADERS <file>...]
+#   [LINK_LIBRARIES <item>...]
+#   [INCLUDE_DIRECTORIES <dir>...]
+#   [COMPILE_OPTIONS <op>...]
+#   [OUTPUT_NAME <name>])
+#
+# Arguments
+# - `SOURCES`: source files
+# - `HEADERS`: header files that should be installed
+# - `LINK_LIBRARIES`: library dependencies
+# - `INCLUDE_DIRECTORIES`: header locations
+# - `COMPILE_OPTIONS`: extra compiler options
+# - `OUTPUT_NAME`: custom library file name (default: `gridkit_<target>`)
+#
+# loosely based on
+# https://github.com/LLNL/sundials/blob/master/cmake/macros/SundialsAddLibrary.cmake
+#
 
 macro(gridkit_add_library target)
 
-  set(options STATIC_ONLY SHARED_ONLY)
+  set(options "")
   set(oneValueArgs OUTPUT_NAME)
-  set(multiValueArgs SOURCES LINK_LIBRARIES INCLUDE_DIRECTORIES COMPILE_OPTIONS)
+  set(multiValueArgs
+      SOURCES
+      HEADERS
+      LINK_LIBRARIES
+      INCLUDE_DIRECTORIES
+      COMPILE_OPTIONS)
 
   # parse arguments
   cmake_parse_arguments(gridkit_add_library
     "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  # library types to create
-  set(_libtypes "")
-  if(GRIDKIT_BUILD_STATIC AND (NOT gridkit_add_library_SHARED_ONLY))
-    set(_libtypes "STATIC")
+  # add library with sources
+  add_library(${target} ${gridkit_add_library_SOURCES})
+
+  # add link libraries
+  if(gridkit_add_library_LINK_LIBRARIES)
+    target_link_libraries(${target} ${gridkit_add_library_LINK_LIBRARIES})
   endif()
-  if(GRIDKIT_BUILD_SHARED AND (NOT gridkit_add_library_STATIC_ONLY))
-    set(_libtypes "${_libtypes};SHARED")
+
+  # set include dirs
+  if(gridkit_add_library_INCLUDE_DIRECTORIES)
+    target_include_directories(${target} PUBLIC
+      $<BUILD_INTERFACE:${gridkit_add_library_INCLUDE_DIRECTORIES}>
+      $<INSTALL_INTERFACE:include>)
   endif()
 
-  # build libraries
-  foreach(_libtype ${_libtypes})
-    # library suffix
-    if(${_libtype} MATCHES "STATIC")
-      set(_lib_suffix "_static")
-    else()
-      set(_lib_suffix "_shared")
-    endif()
+  # add compile options
+  if(gridkit_add_library_COMPILE_OPTIONS)
+    target_compile_options(${target} PUBLIC ${gridkit_add_library_COMPILE_OPTIONS})
+  endif()
 
-    # source files
-    set(sources ${gridkit_add_library_SOURCES})
+  # add alias library
+  add_library(GRIDKIT::${target} ALIAS ${target})
 
-    # obj target needs a unique name
-    set(obj_target ${target}_obj${_lib_suffix})
+  # set output name
+  if(gridkit_add_library_OUTPUT_NAME)
+    set(_output_name ${gridkit_add_library_OUTPUT_NAME})
+  else()
+    set(_output_name gridkit_${target})
+  endif()
+  set_target_properties(${target} PROPERTIES OUTPUT_NAME ${_output_name})
 
-    # -- Create object library --
+  # set the library version
+  set_target_properties(${target} PROPERTIES
+    VERSION ${PACKAGE_VERSION}
+    SOVERSION ${PACKAGE_VERSION_MAJOR})
 
-    add_library(${obj_target} OBJECT ${sources})
+  # install
+  install(TARGETS ${target} DESTINATION lib EXPORT gridkit-targets)
+  if(gridkit_add_library_HEADERS)
+    cmake_path(RELATIVE_PATH CMAKE_CURRENT_SOURCE_DIR
+      BASE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+      OUTPUT_VARIABLE _rel_path)
+    install(FILES ${gridkit_add_library_HEADERS}
+      DESTINATION include/${_rel_path})
+  endif()
 
-    if(gridkit_add_library_COMPILE_OPTIONS)
-      target_compile_options(${obj_target} PUBLIC ${gridkit_add_library_COMPILE_OPTIONS})
-    endif()
-    
-    if(gridkit_add_library_LINK_LIBRARIES)
-      if(${_lib_type} MATCHES "STATIC")
-        append_static_suffix(gridkit_add_library_LINK_LIBRARIES _all_libs)
-      else()
-        set(_all_libs ${gridkit_add_library_LINK_LIBRARIES})
-      endif()
-      target_link_libraries(${obj_target} ${_all_libs})
-    endif()
-    
-    # object files going into shared libs need PIC code
-    set_target_properties(${obj_target} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-
-    # set target name
-    set(_actual_target_name ${target}${_lib_suffix})
-
-    add_library(${_actual_target_name} ${_libtype} $<TARGET_OBJECTS:${obj_target}>)
-
-    if(gridkit_add_library_LINK_LIBRARIES)
-      target_link_libraries(${_actual_target_name} ${gridkit_add_library_LINK_LIBRARIES})
-    endif()
-
-    add_library(GRIDKIT::${target} ALIAS ${_actual_target_name})
-
-    # Set output name
-    if(gridkit_add_library_OUTPUT_NAME)
-      set_target_properties(${_actual_target_name} PROPERTIES
-        OUTPUT_NAME ${gridkit_add_library_OUTPUT_NAME}
-        CLEAN_DIRECT_OUTPUT 1)
-    else()
-      set_target_properties(${_actual_target_name} PROPERTIES
-        OUTPUT_NAME ${target}
-        CLEAN_DIRECT_OUTPUT 1)
-    endif()
-
-    # Set the library version
-    set_target_properties(${_actual_target_name} PROPERTIES
-      VERSION ${PACKAGE_VERSION}
-      SOVERSION ${PACKAGE_VERSION_MAJOR})
-
-    install(TARGETS ${_actual_target_name} DESTINATION lib EXPORT gridkit-targets)
-  endforeach()
-endmacro()
-
-
-macro(append_static_suffix libs_in libs_out)
-  set(${libs_out} "")
-  set(_STATIC_LIB_SUFFIX "_static")
-  foreach(_lib ${${libs_in}})
-    if(TARGET ${_lib}${_STATIC_LIB_SUFFIX})
-      list(APPEND ${libs_out} ${_lib}${_STATIC_LIB_SUFFIX})
-    else()
-      list(APPEND ${libs_out} ${_lib})
-    endif()
-  endforeach()
 endmacro()


### PR DESCRIPTION
## Description
 
Apply several changes to simplify and improve the `gridkit_add_library` macro
 
 _Closes #276_
 
 ## Proposed changes
 
1. Let `BUILD_SHARED_LIBS` option handle shared vs static (only build one type and drop the suffix)
2. Set `OUTPUT_NAME` property to `gridkit_<target>` by default
3. Install `HEADERS`
4. Actually use `INCLUDE_DIRECTORIES`
5. Added simple documentation
 
 ## Checklist

- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.