### PR TITLE
Make tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_subdirectory(src)
 
 # Create examples and tests
-enable_testing()
+include(CTest)
 add_subdirectory(examples)
 add_subdirectory(tests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
-
+if(NOT BUILD_TESTING)
+    return()
+endif()
 
 add_subdirectory(UnitTests)


### PR DESCRIPTION
## Description
 
This is a simple change to allow users to disable building tests by turning off `BUILD_TESTING` (examples build regardless).
 
 _Closes #241_
 
 ## Checklist

- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [N/A] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.