### PR TITLE
Remove `OUTPUT_NAME` argument where the convention is already followed

### DIFF
--- a/src/Model/PhasorDynamics/Branch/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Branch/CMakeLists.txt
@@ -12,23 +12,16 @@ if(GRIDKIT_ENABLE_ENZYME)
     LINK_LIBRARIES
       ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_branch)
+      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
-  gridkit_add_library(phasor_dynamics_branch
-    SOURCES
-      Branch.cpp
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_branch)
+  gridkit_add_library(phasor_dynamics_branch SOURCES Branch.cpp)
 endif()
 
 gridkit_add_library(phasor_dynamics_branch_dependency_tracking
-  SOURCES
-    BranchDependencyTracking.cpp
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_branch_dependency_tracking)
+  SOURCES BranchDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_branch)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_branch_dependency_tracking)
+target_link_libraries(gridkit_phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_branch)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_branch_dependency_tracking)

--- a/src/Model/PhasorDynamics/Bus/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Bus/CMakeLists.txt
@@ -8,25 +8,21 @@ if(GRIDKIT_ENABLE_ENZYME)
   gridkit_add_library(phasor_dynamics_bus
     SOURCES
       BusEnzyme.cpp
-      BusInfinite.cpp
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_bus)
+      BusInfinite.cpp)
 else()
   gridkit_add_library(phasor_dynamics_bus
     SOURCES
       Bus.cpp
-      BusInfinite.cpp
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_bus)
+      BusInfinite.cpp)
 endif()
 
 gridkit_add_library(phasor_dynamics_bus_dependency_tracking
   SOURCES
     BusDependencyTracking.cpp
-    BusInfiniteDependencyTracking.cpp
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_bus_dependency_tracking)
+    BusInfiniteDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_bus)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_bus_dependency_tracking)
+target_link_libraries(gridkit_phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_bus)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_bus_dependency_tracking)

--- a/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
@@ -6,23 +6,16 @@ if(GRIDKIT_ENABLE_ENZYME)
     LINK_LIBRARIES
       ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_bus_fault)
+      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
-  gridkit_add_library(phasor_dynamics_bus_fault
-    SOURCES
-      BusFault.cpp
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_bus_fault)
+  gridkit_add_library(phasor_dynamics_bus_fault SOURCES BusFault.cpp)
 endif()
 
 gridkit_add_library(phasor_dynamics_bus_fault_dependency_tracking
-  SOURCES
-    BusFaultDependencyTracking.cpp
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_bus_fault_dependency_tracking)
+  SOURCES BusFaultDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_bus_fault)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_bus_fault_dependency_tracking)
+target_link_libraries(gridkit_phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_bus_fault)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_bus_fault_dependency_tracking)

--- a/src/Model/PhasorDynamics/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/CMakeLists.txt
@@ -16,5 +16,7 @@ add_subdirectory(SynchronousMachine)
 
 add_subdirectory(SignalNode)
 
-add_library(GRIDKIT::phasor_dynamics_components ALIAS gridkit_phasor_dynamics_components)
-add_library(GRIDKIT::phasor_dynamics_components_dependency_tracking ALIAS gridkit_phasor_dynamics_components_dependency_tracking)
+add_library(GRIDKIT::phasor_dynamics_components
+  ALIAS gridkit_phasor_dynamics_components)
+add_library(GRIDKIT::phasor_dynamics_components_dependency_tracking
+  ALIAS gridkit_phasor_dynamics_components_dependency_tracking)

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
@@ -8,18 +8,16 @@ gridkit_add_library(phasor_dynamics_exciter_ieeet1
   SOURCES
     Ieeet1.cpp
   LINK_LIBRARIES
-    GRIDKIT::phasor_dynamics_signal
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_exciter_ieeet1)
+    GRIDKIT::phasor_dynamics_signal)
 
 gridkit_add_library(phasor_dynamics_exciter_ieeet1_dependency_tracking
   SOURCES
     Ieeet1DependencyTracking.cpp
   LINK_LIBRARIES
-    GRIDKIT::phasor_dynamics_signal_dependency_tracking
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_exciter_ieeet1_dependency_tracking)
+    GRIDKIT::phasor_dynamics_signal_dependency_tracking)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_exciter_ieeet1)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_exciter_ieeet1_dependency_tracking)
+target_link_libraries(gridkit_phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_exciter_ieeet1)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_exciter_ieeet1_dependency_tracking)

--- a/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
@@ -12,27 +12,23 @@ if(GRIDKIT_ENABLE_ENZYME)
       GRIDKIT::phasor_dynamics_signal
       ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_governortgov1)
+      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
   gridkit_add_library(phasor_dynamics_governortgov1
     SOURCES
       Tgov1.cpp
     LINK_LIBRARIES
-      GRIDKIT::phasor_dynamics_signal
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_governortgov1)
+      GRIDKIT::phasor_dynamics_signal)
 endif()
 
 gridkit_add_library(phasor_dynamics_governortgov1_dependency_tracking
   SOURCES
     Tgov1DependencyTracking.cpp
   LINK_LIBRARIES
-    PUBLIC GRIDKIT::phasor_dynamics_signal_dependency_tracking
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_governortgov1_dependency_tracking)
+    PUBLIC GRIDKIT::phasor_dynamics_signal_dependency_tracking)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_governortgov1)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_governortgov1_dependency_tracking)
+target_link_libraries(gridkit_phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_governortgov1)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_governortgov1_dependency_tracking)

--- a/src/Model/PhasorDynamics/Load/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Load/CMakeLists.txt
@@ -13,23 +13,16 @@ if(GRIDKIT_ENABLE_ENZYME)
     LINK_LIBRARIES
       ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_load)
+      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
-  gridkit_add_library(phasor_dynamics_load
-    SOURCES
-      Load.cpp
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_load)
+  gridkit_add_library(phasor_dynamics_load SOURCES Load.cpp)
 endif()
 
 gridkit_add_library(phasor_dynamics_load_dependency_tracking
-  SOURCES
-    LoadDependencyTracking.cpp
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_load_dependency_tracking)
+  SOURCES LoadDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_load)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_load_dependency_tracking)
+target_link_libraries(gridkit_phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_load)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_load_dependency_tracking)

--- a/src/Model/PhasorDynamics/SignalNode/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SignalNode/CMakeLists.txt
@@ -5,18 +5,13 @@
 #    - Slaven Peles <peless@ornl.gov>
 # ]]
 
-gridkit_add_library(phasor_dynamics_signal
-  SOURCES
-    SignalNode.cpp
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_signal)
+gridkit_add_library(phasor_dynamics_signal SOURCES SignalNode.cpp)
 
 gridkit_add_library(phasor_dynamics_signal_dependency_tracking
-  SOURCES
-    SignalNodeDependencyTracking.cpp
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_signal_dependency_tracking)
+  SOURCES SignalNodeDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_signal)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_signal_dependency_tracking)
+target_link_libraries(gridkit_phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_signal)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_signal_dependency_tracking)

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
@@ -7,27 +7,23 @@
 #    LINK_LIBRARIES
 #      PUBLIC GRIDKIT::phasor_dynamics_signal ClangEnzymeFlags
 #    COMPILE_OPTIONS
-#      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno -fno-vectorize
-#    OUTPUT_NAME
-#      gridkit_phasor_dynamics_genrou)
+#      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno -fno-vectorize)
 #else()
   gridkit_add_library(phasor_dynamics_genrou
     SOURCES
       Genrou.cpp
     LINK_LIBRARIES
-      PUBLIC GRIDKIT::phasor_dynamics_signal
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_genrou)
+      PUBLIC GRIDKIT::phasor_dynamics_signal)
 #endif()
 
 gridkit_add_library(phasor_dynamics_genrou_dependency_tracking
   SOURCES
     GenrouDependencyTracking.cpp
   LINK_LIBRARIES
-    PUBLIC GRIDKIT::phasor_dynamics_signal_dependency_tracking
-  OUTPUT_NAME
-    gridkit_phasor_dynamics_genrou_dependency_tracking)
+    PUBLIC GRIDKIT::phasor_dynamics_signal_dependency_tracking)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_genrou)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_genrou_dependency_tracking)
+target_link_libraries(gridkit_phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_genrou)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_genrou_dependency_tracking)

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
@@ -11,23 +11,16 @@ if(GRIDKIT_ENABLE_ENZYME)
     LINK_LIBRARIES
       ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_gen_classical)
+      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
-  gridkit_add_library(phasor_dynamics_gen_classical
-    SOURCES
-      GenClassical.cpp
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_gen_classical)
+  gridkit_add_library(phasor_dynamics_gen_classical SOURCES GenClassical.cpp)
 endif()
 
   gridkit_add_library(phasor_dynamics_gen_classical_dependency_tracking
-    SOURCES
-      GenClassicalDependencyTracking.cpp
-    OUTPUT_NAME
-      gridkit_phasor_dynamics_gen_classical_dependency_tracking)
+    SOURCES GenClassicalDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components INTERFACE GRIDKIT::phasor_dynamics_gen_classical)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE GRIDKIT::phasor_dynamics_gen_classical_dependency_tracking)
+target_link_libraries(gridkit_phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_gen_classical)
+target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_gen_classical_dependency_tracking)

--- a/src/Model/PowerElectronics/Capacitor/CMakeLists.txt
+++ b/src/Model/PowerElectronics/Capacitor/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_capacitor
-  SOURCES
-    Capacitor.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_capacitor)
+gridkit_add_library(power_elec_capacitor SOURCES Capacitor.cpp)

--- a/src/Model/PowerElectronics/DistributedGenerator/CMakeLists.txt
+++ b/src/Model/PowerElectronics/DistributedGenerator/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_disgen
-  SOURCES
-    DistributedGenerator.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_disgen)
+gridkit_add_library(power_elec_disgen SOURCES DistributedGenerator.cpp)

--- a/src/Model/PowerElectronics/InductionMotor/CMakeLists.txt
+++ b/src/Model/PowerElectronics/InductionMotor/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_inductionmotor
-  SOURCES
-    InductionMotor.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_inductionmotor)
+gridkit_add_library(power_elec_inductionmotor SOURCES InductionMotor.cpp)

--- a/src/Model/PowerElectronics/Inductor/CMakeLists.txt
+++ b/src/Model/PowerElectronics/Inductor/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_inductor
-  SOURCES
-    Inductor.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_inductor)
+gridkit_add_library(power_elec_inductor SOURCES Inductor.cpp)

--- a/src/Model/PowerElectronics/LinearTransformer/CMakeLists.txt
+++ b/src/Model/PowerElectronics/LinearTransformer/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_lineartrasnformer
-  SOURCES
-    LinearTransformer.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_lineartrasnformer)
+gridkit_add_library(power_elec_lineartrasnformer SOURCES LinearTransformer.cpp)

--- a/src/Model/PowerElectronics/MicrogridBusDQ/CMakeLists.txt
+++ b/src/Model/PowerElectronics/MicrogridBusDQ/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_microbusdq
-  SOURCES
-    MicrogridBusDQ.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_microbusdq)
+gridkit_add_library(power_elec_microbusdq SOURCES MicrogridBusDQ.cpp)

--- a/src/Model/PowerElectronics/MicrogridLine/CMakeLists.txt
+++ b/src/Model/PowerElectronics/MicrogridLine/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_microline
-  SOURCES
-    MicrogridLine.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_microline)
+gridkit_add_library(power_elec_microline SOURCES MicrogridLine.cpp)

--- a/src/Model/PowerElectronics/MicrogridLoad/CMakeLists.txt
+++ b/src/Model/PowerElectronics/MicrogridLoad/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_microload
-  SOURCES
-    MicrogridLoad.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_microload)
+gridkit_add_library(power_elec_microload SOURCES MicrogridLoad.cpp)

--- a/src/Model/PowerElectronics/Resistor/CMakeLists.txt
+++ b/src/Model/PowerElectronics/Resistor/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_resistor
-  SOURCES
-    Resistor.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_resistor)
+gridkit_add_library(power_elec_resistor SOURCES Resistor.cpp)

--- a/src/Model/PowerElectronics/SynchronousMachine/CMakeLists.txt
+++ b/src/Model/PowerElectronics/SynchronousMachine/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_synmachine
-  SOURCES
-    SynchronousMachine.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_synmachine)
+gridkit_add_library(power_elec_synmachine SOURCES SynchronousMachine.cpp)

--- a/src/Model/PowerElectronics/TransmissionLine/CMakeLists.txt
+++ b/src/Model/PowerElectronics/TransmissionLine/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_tranline
-  SOURCES
-    TransmissionLine.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_tranline)
+gridkit_add_library(power_elec_tranline SOURCES TransmissionLine.cpp)

--- a/src/Model/PowerElectronics/VoltageSource/CMakeLists.txt
+++ b/src/Model/PowerElectronics/VoltageSource/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 
 
-gridkit_add_library(power_elec_voltagesource
-  SOURCES
-  VoltageSource.cpp
-  OUTPUT_NAME
-    gridkit_power_elec_voltagesource)
+gridkit_add_library(power_elec_voltagesource SOURCES VoltageSource.cpp)

--- a/src/Model/PowerFlow/Branch/CMakeLists.txt
+++ b/src/Model/PowerFlow/Branch/CMakeLists.txt
@@ -3,8 +3,4 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(branch
-  SOURCES
-    Branch.cpp
-  OUTPUT_NAME
-    gridkit_branch)
+gridkit_add_library(branch SOURCES Branch.cpp)

--- a/src/Model/PowerFlow/Bus/CMakeLists.txt
+++ b/src/Model/PowerFlow/Bus/CMakeLists.txt
@@ -9,6 +9,4 @@ gridkit_add_library(bus
   SOURCES
     BusPQ.cpp
     BusPV.cpp
-    BusSlack.cpp
-  OUTPUT_NAME
-    gridkit_bus)
+    BusSlack.cpp)

--- a/src/Model/PowerFlow/Generator/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator/CMakeLists.txt
@@ -7,6 +7,4 @@ gridkit_add_library(generator
   SOURCES
     GeneratorSlack.cpp
     GeneratorPV.cpp
-    GeneratorPQ.cpp
-  OUTPUT_NAME
-    gridkit_generator)
+    GeneratorPQ.cpp)

--- a/src/Model/PowerFlow/Generator2/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator2/CMakeLists.txt
@@ -3,8 +3,4 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(generator2
-  SOURCES
-    Generator2.cpp
-  OUTPUT_NAME
-    gridkit_generator2)
+gridkit_add_library(generator2 SOURCES Generator2.cpp)

--- a/src/Model/PowerFlow/Generator4/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator4/CMakeLists.txt
@@ -5,8 +5,4 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(generator4
-  SOURCES
-    Generator4.cpp
-  OUTPUT_NAME
-    gridkit_generator4)
+gridkit_add_library(generator4 SOURCES Generator4.cpp)

--- a/src/Model/PowerFlow/Generator4Governor/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator4Governor/CMakeLists.txt
@@ -5,8 +5,4 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(generator4governor
-  SOURCES
-    Generator4Governor.cpp
-  OUTPUT_NAME
-    gridkit_generator4governor)
+gridkit_add_library(generator4governor SOURCES Generator4Governor.cpp)

--- a/src/Model/PowerFlow/Generator4Param/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator4Param/CMakeLists.txt
@@ -5,8 +5,4 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(generator4param
-  SOURCES
-    Generator4Param.cpp
-  OUTPUT_NAME
-    gridkit_generator4param)
+gridkit_add_library(generator4param SOURCES Generator4Param.cpp)

--- a/src/Model/PowerFlow/Load/CMakeLists.txt
+++ b/src/Model/PowerFlow/Load/CMakeLists.txt
@@ -3,8 +3,4 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(load
-  SOURCES
-    Load.cpp
-  OUTPUT_NAME
-    gridkit_load)
+gridkit_add_library(load SOURCES Load.cpp)

--- a/src/Model/PowerFlow/MiniGrid/CMakeLists.txt
+++ b/src/Model/PowerFlow/MiniGrid/CMakeLists.txt
@@ -3,8 +3,4 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(minigrid
-  SOURCES
-    MiniGrid.cpp
-  OUTPUT_NAME
-    gridkit_minigrid)
+gridkit_add_library(minigrid SOURCES MiniGrid.cpp)

--- a/src/Solver/Dynamic/CMakeLists.txt
+++ b/src/Solver/Dynamic/CMakeLists.txt
@@ -12,16 +12,12 @@ if (GRIDKIT_ENABLE_SUNDIALS_SPARSE)
     LINK_LIBRARIES
       PUBLIC SUNDIALS::nvecserial
       PUBLIC SUNDIALS::idas
-      PUBLIC SUNDIALS::sunlinsolklu
-    OUTPUT_NAME
-      gridkit_solvers_dyn)
+      PUBLIC SUNDIALS::sunlinsolklu)
 else()
   gridkit_add_library(solvers_dyn
     SOURCES
       Ida.cpp
     LINK_LIBRARIES
       PUBLIC SUNDIALS::nvecserial
-      PUBLIC SUNDIALS::idas
-    OUTPUT_NAME
-      gridkit_solvers_dyn)
+      PUBLIC SUNDIALS::idas)
 endif()

--- a/src/Solver/Optimization/CMakeLists.txt
+++ b/src/Solver/Optimization/CMakeLists.txt
@@ -11,6 +11,4 @@ gridkit_add_library(solvers_opt
     DynamicConstraint.cpp
   LINK_LIBRARIES
     PUBLIC IPOPT
-    PUBLIC GRIDKIT::solvers_dyn
-  OUTPUT_NAME
-    gridkit_solvers_opt)
+    PUBLIC GRIDKIT::solvers_dyn)

--- a/src/Solver/SteadyState/CMakeLists.txt
+++ b/src/Solver/SteadyState/CMakeLists.txt
@@ -9,6 +9,4 @@ gridkit_add_library(solvers_steady
   SOURCES
     Kinsol.cpp
   LINK_LIBRARIES
-    PUBLIC SUNDIALS::kinsol
-  OUTPUT_NAME
-    gridkit_solvers_steady)
+    PUBLIC SUNDIALS::kinsol)

--- a/src/Utilities/Logger/CMakeLists.txt
+++ b/src/Utilities/Logger/CMakeLists.txt
@@ -1,7 +1,5 @@
 gridkit_add_library(utilities_logger
   SOURCES
-    Logger.cpp
-  OUTPUT_NAME
-    gridkit_utilities_logger)
+    Logger.cpp)
 
 target_link_libraries(Utilities INTERFACE GRIDKIT::utilities_logger)


### PR DESCRIPTION
## Description

_Closes #277_

## Proposed changes
 
Remove explicit `OUTPUT_NAME` specification everywhere the convention is being used (which happens to be everywhere).
 
 ## Checklist

- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [N/A] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.