### PR TITLE
Machine MVA Bases

### DIFF
--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -173,14 +173,14 @@ namespace GridKit
 
       IdxT max_steps_;
 
-      /* 
-      
+      /*
+
       ------ WARNING: Temporary ------
 
       The protexted variable mva_system_base_ is temporarily
       hard coded. This eventually needs to be configured
       from the input JSON format, which specifies the system MVA base.
-      
+
       */
 
       real_type mva_system_base_{100.0};

--- a/src/Model/PhasorDynamics/Component.hpp
+++ b/src/Model/PhasorDynamics/Component.hpp
@@ -173,6 +173,18 @@ namespace GridKit
 
       IdxT max_steps_;
 
+      /* 
+      
+      ------ WARNING: Temporary ------
+
+      The protexted variable mva_system_base_ is temporarily
+      hard coded. This eventually needs to be configured
+      from the input JSON format, which specifies the system MVA base.
+      
+      */
+
+      real_type mva_system_base_{100.0};
+
       //
       // Adjoint sensitivity members
       //

--- a/src/Model/PhasorDynamics/ComponentData.hpp
+++ b/src/Model/PhasorDynamics/ComponentData.hpp
@@ -39,9 +39,6 @@ namespace GridKit
       /// Set of variables being monitored
       std::set<MonitorableVariables> monitored_variables;
 
-      std::optional<RealT> freq_base; ///< Override for the system-wide base frequency
-      std::optional<RealT> va_base;   ///< Override for the system-wide power base
-
       std::string disambiguation_string; ///< Disambiguation string for this device
 
     protected:

--- a/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
+++ b/src/Model/PhasorDynamics/ComponentDataJSONParser.hpp
@@ -87,16 +87,6 @@ namespace GridKit
         }
       }
 
-      if (j.contains("freq_base"))
-      {
-        j.at("freq_base").get_to(c.freq_base);
-      }
-
-      if (j.contains("va_base"))
-      {
-        j.at("va_base").get_to(c.va_base);
-      }
-
       if (j.contains("mon"))
       {
         for (auto& raw_monitored_variable : j.at("mon"))

--- a/src/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/src/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -111,8 +111,6 @@ represent a device and has the following fields:
   `id`              | A string disambiguating the device from others. Each device in a class must have a unique combination of required port bus numbers and this string. This string should be 1 or 2 characters long.
   `params`          | An object mapping initialization parameters to numerical values, depending on the class. See the table below for more information
   `mon`             | Optional field, which is an array specifying variables to record the value of in an output channel. Available variables are determined by the device class, as specified in the table below
-  `va_base`         | Optional field to override the system power base for this device
-  `freq_base`       | Optional field to override the system frequency base for this device
   `extension`       | Optional field containing an object with implementation-defined keys
 
 For more information, see the detailed documentation for each device class containing equations, electrical bus configuration, and signal inlets/outlets specifications.

--- a/src/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/src/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -124,10 +124,10 @@ are specified:
 
   Device class  | Description                                          | Ports                            | Initialization parameters   | Variables available to monitor
   --------------|------------------------------------------------------|----------------------------------|---------------------------- | -------------------------
-  `Branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`          | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
+  `Branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`           | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
   `Load`        | a basic static impedence load model                  | `bus`                            | `R`, `X` | `p`, `q`
-  `Genrou`      | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`
-  `GenClassical`| the classical machine model                          | `bus`, `pmech`\*, `speed`\*, `efd`\*  | `p0`, `q0`, `H`, `D`, `Ra`, `Xdp` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
+  `Genrou`      | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12`, `mva_base`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`
+  `GenClassical`| the classical machine model                          | `bus`, `pmech`\*, `speed`\*, `efd`\*  | `p0`, `q0`, `H`, `D`, `Ra`, `Xdp`, `mva_base` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
   `Tgov1 `      | the TGOV1 governor model                             | `pmech`, `speed`                 | `R`, `T1`, `T2`, `T3`, `Pvmax`, `Pvmin`, `Dt` | `none`
   `Ieeet1`      | the IEEET1 exciter model                             | `bus`, `speed`, `efd`            | `Tr`, `Ka`, `Ta`, `Ke`, `Te`, `Kf`, `Tf`, `Vrmin`, `Vrmax`, `E1`, `E2`, `Se1`, `Se2`, `Ispdlim` | `efd`, `ksat`
   `BusFault`    | simple impedance-based fault at a bus                | `bus`, `status`\*                | `state0`, `R`, `X` | `state`, `ir`, `ii`

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -231,6 +231,9 @@ namespace GridKit
       /* Local copies of signal variables */
       ScalarT pmech_;
       ScalarT efd_;
+
+      /* Constant/external parameters */
+      real_type mva_system_base_{100.0};
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -79,6 +79,7 @@ namespace GridKit
       using Component<ScalarT, IdxT>::w_;
       using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
+      using Component<ScalarT, IdxT>::mva_system_base_;
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;
       using bus_type        = BusBase<ScalarT, IdxT>;
@@ -232,8 +233,7 @@ namespace GridKit
       ScalarT pmech_;
       ScalarT efd_;
 
-      /* Constant/external parameters */
-      real_type mva_system_base_{100.0};
+      
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -22,9 +22,6 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     class SignalNode;
 
-    template <class ScalarT, typename IdxT>
-    class GovernorBase; // <- TODO: Temporary, to be removed.
-
     template <typename RealT, typename IdxT>
     struct GenrouData;
   } // namespace PhasorDynamics
@@ -84,7 +81,6 @@ namespace GridKit
       using Component<ScalarT, IdxT>::J_;
 
       using real_type       = typename Component<ScalarT, IdxT>::real_type;
-      using gov_type        = GovernorBase<ScalarT, IdxT>;
       using bus_type        = BusBase<ScalarT, IdxT>;
       using model_data_type = GenrouData<real_type, IdxT>;
       using signal_type     = SignalNode<ScalarT, IdxT>;
@@ -209,6 +205,7 @@ namespace GridKit
       real_type Xl_{0.0};
       real_type S10_{0.0};
       real_type S12_{0.0};
+      real_type mva_base_{100.0};
 
       /* Derivied parameters */
       real_type SA_;

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -232,8 +232,6 @@ namespace GridKit
       /* Local copies of signal variables */
       ScalarT pmech_;
       ScalarT efd_;
-
-      
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
@@ -33,6 +33,7 @@ namespace GridKit
       Xl,    ///< Stator leakage reactance
       S10,   ///< Saturation factor at 1.0 pu flux
       S12,   ///< Saturation factor at 1.2 pu flux
+      mva_base, ///< MVA base of the genrou model (TODO usa Component class parameter `mva`)
     };
 
     /// Ports for a Genrou generator model

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
@@ -15,24 +15,24 @@ namespace GridKit
     /// Initial parameters for a Genrou generator model
     enum class GenrouParameters
     {
-      p0,    ///< Initial active power
-      q0,    ///< Initial reactive power
-      H,     ///< Rotor inertia
-      D,     ///< Damping coefficient
-      Ra,    ///< Winding resistance
-      Tdop,  ///< Open circuit direct axis transient time
-      Tdopp, ///< Open circuit direct axis sub-transient time
-      Tqop,  ///< Open circuit quadrature axis transient
-      Tqopp, ///< Open circuit quadrature axis sub-transient time
-      Xd,    ///< Direct axis synchronous reactance
-      Xdp,   ///< Direct axis transient reactance
-      Xdpp,  ///< Direct axis sub-transient reactance
-      Xq,    ///< Quadrature axis synchronous reactance
-      Xqp,   ///< Quadrature axis transient reactance
-      Xqpp,  ///< Quadrature axis sub-transient reactance
-      Xl,    ///< Stator leakage reactance
-      S10,   ///< Saturation factor at 1.0 pu flux
-      S12,   ///< Saturation factor at 1.2 pu flux
+      p0,       ///< Initial active power
+      q0,       ///< Initial reactive power
+      H,        ///< Rotor inertia
+      D,        ///< Damping coefficient
+      Ra,       ///< Winding resistance
+      Tdop,     ///< Open circuit direct axis transient time
+      Tdopp,    ///< Open circuit direct axis sub-transient time
+      Tqop,     ///< Open circuit quadrature axis transient
+      Tqopp,    ///< Open circuit quadrature axis sub-transient time
+      Xd,       ///< Direct axis synchronous reactance
+      Xdp,      ///< Direct axis transient reactance
+      Xdpp,     ///< Direct axis sub-transient reactance
+      Xq,       ///< Quadrature axis synchronous reactance
+      Xqp,      ///< Quadrature axis transient reactance
+      Xqpp,     ///< Quadrature axis sub-transient reactance
+      Xl,       ///< Stator leakage reactance
+      S10,      ///< Saturation factor at 1.0 pu flux
+      S12,      ///< Saturation factor at 1.2 pu flux
       mva_base, ///< MVA base of the genrou model (TODO usa Component class parameter `mva`)
     };
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -526,7 +526,7 @@ namespace GridKit
       evaluateInternalResidual(y_.data(), yp_.data(), w_.data(), f_.data());
       evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
 
-      // Genrou contribution to bus algebraic equations 
+      // Genrou contribution to bus algebraic equations
       Ir() += h_[0];
       Ii() += h_[1];
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -307,8 +307,8 @@ namespace GridKit
       /* Initialization tricks -- assuming NO saturation */
       ScalarT vr    = Vr();
       ScalarT vi    = Vi();
-      ScalarT p     = static_cast<ScalarT>(p0_) * 100.0 / mva_base_;
-      ScalarT q     = static_cast<ScalarT>(q0_) * 100.0 / mva_base_;
+      ScalarT p     = static_cast<ScalarT>(p0_) * mva_system_base_ / mva_base_;
+      ScalarT q     = static_cast<ScalarT>(q0_) * mva_system_base_ / mva_base_;
       ScalarT vm2   = vr * vr + vi * vi;
       ScalarT Er    = vr + (Ra_ * p * vr + Ra_ * q * vi - Xq_ * p * vi + Xq_ * q * vr) / vm2;
       ScalarT Ei    = vi + (Ra_ * p * vi - Ra_ * q * vr + Xq_ * p * vr + Xq_ * q * vi) / vm2;
@@ -485,8 +485,8 @@ namespace GridKit
       ScalarT vi  = w[1];
 
       // Current base conversion. Assumes generator and bus are same V base
-      h[0] = (inr - vr * G_ + vi * B_) * mva_base_ / 100.0;
-      h[1] = (ini - vr * B_ - vi * G_) * mva_base_ / 100.0;
+      h[0] = (inr - vr * G_ + vi * B_) * mva_base_ / mva_system_base_;
+      h[1] = (ini - vr * B_ - vi * G_) * mva_base_ / mva_system_base_;
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -6,7 +6,6 @@
 
 #include "Genrou.hpp"
 #include <Model/PhasorDynamics/Bus/Bus.hpp>
-#include <Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp> // <- TODO: Temporary, to be removed.
 #include <Model/PhasorDynamics/SignalNode/SignalNode.hpp>
 #include <Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
 
@@ -45,7 +44,8 @@ namespace GridKit
         Xqpp_(.18),
         Xl_(.15),
         S10_(0.),
-        S12_(0.)
+        S12_(0.),
+        mva_base_(100.)
     {
       size_ = 19;
       setDerivedParams();
@@ -95,7 +95,8 @@ namespace GridKit
         Xqpp_(Xqpp),
         Xl_(Xl),
         S10_(S10),
-        S12_(S12)
+        S12_(S12),
+        mva_base_(100.)
     {
       size_ = 19;
       setDerivedParams();
@@ -243,6 +244,11 @@ namespace GridKit
         S12_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::S12));
       }
 
+      if (data.parameters.contains(model_data_type::Parameters::mva_base))
+      {
+        mva_base_ = std::get<real_type>(data.parameters.at(model_data_type::Parameters::mva_base));
+      }
+
       if (data.ports.contains(model_data_type::Ports::bus))
       {
         bus_id_ = data.ports.at(model_data_type::Ports::bus);
@@ -301,8 +307,8 @@ namespace GridKit
       /* Initialization tricks -- assuming NO saturation */
       ScalarT vr    = Vr();
       ScalarT vi    = Vi();
-      ScalarT p     = static_cast<ScalarT>(p0_);
-      ScalarT q     = static_cast<ScalarT>(q0_);
+      ScalarT p     = static_cast<ScalarT>(p0_) * 100.0 / mva_base_;
+      ScalarT q     = static_cast<ScalarT>(q0_) * 100.0 / mva_base_;
       ScalarT vm2   = vr * vr + vi * vi;
       ScalarT Er    = vr + (Ra_ * p * vr + Ra_ * q * vi - Xq_ * p * vi + Xq_ * q * vr) / vm2;
       ScalarT Ei    = vi + (Ra_ * p * vi - Ra_ * q * vr + Xq_ * p * vr + Xq_ * q * vi) / vm2;
@@ -478,8 +484,9 @@ namespace GridKit
       ScalarT vr  = w[0];
       ScalarT vi  = w[1];
 
-      h[0] = inr - vr * G_ + vi * B_;
-      h[1] = ini - vr * B_ - vi * G_;
+      // Current base conversion. Assumes generator and bus are same V base
+      h[0] = (inr - vr * G_ + vi * B_) * mva_base_ / 100.0;
+      h[1] = (ini - vr * B_ - vi * G_) * mva_base_ / 100.0;
 
       return 0;
     }
@@ -519,7 +526,7 @@ namespace GridKit
       evaluateInternalResidual(y_.data(), yp_.data(), w_.data(), f_.data());
       evaluateBusResidual(y_.data(), yp_.data(), w_.data(), h_.data());
 
-      // Genrou contribution to bus algebraic equations
+      // Genrou contribution to bus algebraic equations 
       Ir() += h_[0];
       Ii() += h_[1];
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -126,6 +126,7 @@ namespace GridKit
       real_type D_{0.0};
       real_type Ra_{0.0};
       real_type Xdp_{0.0};
+      real_type mva_base_{100.0};
 
       /* Derivied parameters */
       real_type G_;

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -43,6 +43,7 @@ namespace GridKit
       using Component<ScalarT, IdxT>::w_;
       using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
+      using Component<ScalarT, IdxT>::mva_system_base_;
 
       using bus_type  = BusBase<ScalarT, IdxT>;
       using real_type = typename Component<ScalarT, IdxT>::real_type;
@@ -136,8 +137,6 @@ namespace GridKit
       ScalarT pmech_set_;
       ScalarT ep_set_;
 
-      /* Constant/external parameters */
-      real_type mva_system_base_{100.0};
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -138,7 +138,6 @@ namespace GridKit
 
       /* Constant/external parameters */
       real_type mva_system_base_{100.0};
-
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -136,7 +136,6 @@ namespace GridKit
       /* Setpoints for control variables (determined at initialization) */
       ScalarT pmech_set_;
       ScalarT ep_set_;
-
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -135,6 +135,10 @@ namespace GridKit
       /* Setpoints for control variables (determined at initialization) */
       ScalarT pmech_set_;
       ScalarT ep_set_;
+
+      /* Constant/external parameters */
+      real_type mva_system_base_{100.0};
+
     };
 
   } // namespace PhasorDynamics

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
@@ -15,12 +15,12 @@ namespace GridKit
     /// Initial parameters for a classical generator model
     enum class GenClassicalParameters
     {
-      p0,  ///< Initial active power
-      q0,  ///< Initial reactive power
-      H,   ///< Rotor inertia
-      D,   ///< Damping coefficient
-      Ra,  ///< Winding resistance
-      Xdp, ///< Direct axis transient reactance
+      p0,      ///< Initial active power
+      q0,      ///< Initial reactive power
+      H,       ///< Rotor inertia
+      D,       ///< Damping coefficient
+      Ra,      ///< Winding resistance
+      Xdp,     ///< Direct axis transient reactance
       mva_base ///< MVA Base of the generator
     };
 

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
@@ -21,6 +21,7 @@ namespace GridKit
       D,   ///< Damping coefficient
       Ra,  ///< Winding resistance
       Xdp, ///< Direct axis transient reactance
+      mva_base ///< MVA Base of the generator
     };
 
     /// Ports supported for a classical generator model

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -31,7 +31,8 @@ namespace GridKit
         H_(3.0),
         D_(0.0),
         Ra_(0.0),
-        Xdp_(0.5)
+        Xdp_(0.5),
+        mva_base_(100.)
     {
       size_ = 5;
       setDerivedParams();
@@ -57,7 +58,8 @@ namespace GridKit
         H_(H),
         D_(D),
         Ra_(Ra),
-        Xdp_(Xdp)
+        Xdp_(Xdp),
+        mva_base_(100.)
     {
       size_ = 5;
       setDerivedParams();
@@ -99,6 +101,11 @@ namespace GridKit
       if (data.parameters.contains(DataT::Parameters::Xdp))
       {
         Xdp_ = std::get<real_type>(data.parameters.at(DataT::Parameters::Xdp));
+      }
+
+      if (data.parameters.contains(DataT::Parameters::mva_base))
+      {
+        mva_base_ = std::get<real_type>(data.parameters.at(DataT::Parameters::mva_base));
       }
 
       if (data.ports.contains(DataT::Ports::bus))
@@ -155,8 +162,8 @@ namespace GridKit
     {
       ScalarT vr    = Vr();
       ScalarT vi    = Vi();
-      ScalarT p     = static_cast<ScalarT>(p0_);
-      ScalarT q     = static_cast<ScalarT>(q0_);
+      ScalarT p     = static_cast<ScalarT>(p0_) * 100.0 / mva_base_;
+      ScalarT q     = static_cast<ScalarT>(q0_) * 100.0 / mva_base_;
       ScalarT vm2   = vr * vr + vi * vi;
       ScalarT ir    = (p * vr + q * vi) / vm2;
       ScalarT ii    = (p * vi - q * vr) / vm2;
@@ -248,8 +255,8 @@ namespace GridKit
     {
       const ScalarT ir = y[3];
       const ScalarT ii = y[4];
-      h[0]             = ir;
-      h[1]             = ii;
+      h[0]             = ir * mva_base_ / 100.0;
+      h[1]             = ii * mva_base_ / 100.0;
 
       return 0;
     }

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -162,8 +162,8 @@ namespace GridKit
     {
       ScalarT vr    = Vr();
       ScalarT vi    = Vi();
-      ScalarT p     = static_cast<ScalarT>(p0_) * 100.0 / mva_base_;
-      ScalarT q     = static_cast<ScalarT>(q0_) * 100.0 / mva_base_;
+      ScalarT p     = static_cast<ScalarT>(p0_) * mva_system_base_ / mva_base_;
+      ScalarT q     = static_cast<ScalarT>(q0_) * mva_system_base_ / mva_base_;
       ScalarT vm2   = vr * vr + vi * vi;
       ScalarT ir    = (p * vr + q * vi) / vm2;
       ScalarT ii    = (p * vi - q * vr) / vm2;
@@ -255,8 +255,8 @@ namespace GridKit
     {
       const ScalarT ir = y[3];
       const ScalarT ii = y[4];
-      h[0]             = ir * mva_base_ / 100.0;
-      h[1]             = ii * mva_base_ / 100.0;
+      h[0]             = ir * mva_base_ / mva_system_base_;
+      h[1]             = ii * mva_base_ / mva_system_base_;
 
       return 0;
     }


### PR DESCRIPTION
## Description
 
Add support for machine models to have a different MVA base than the system.
 
 ## Proposed changes
 
- Add `mva_base` parameter to GenClassical and Genrou
- Remove `va_base` and  `freq_base` from the general Component class (every model handles this differently, and it could actually be misleading to offer this as an option for models like exciter and governor)
- Default mva_base is 100 MVA.
- Updated the respective INPUT_FORMAT specifications
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
 
 ## Further comments
 
This is a minor fix and does not need to be included as a change feature.
 
