### PR TITLE
Install public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,15 +105,6 @@ if(GRIDKIT_ENABLE_ENZYME)
   include(FindEnzyme)
 endif()
 
-# The binary dir is already a global include directory
-configure_file(
-  ${CMAKE_SOURCE_DIR}/src/Definitions.hpp.in
-  ${CMAKE_BINARY_DIR}/Definitions.hpp)
-install(
-  FILES ${CMAKE_BINARY_DIR}/Definitions.hpp
-  DESTINATION include
-  )
-
 # Macro that adds libraries
 include(GridkitAddLibrary)
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -6,3 +6,10 @@
 @PACKAGE_INIT@
 
 include ( "${CMAKE_CURRENT_LIST_DIR}/GridKitTargets.cmake" )
+
+include(CMakeFindDependencyMacro)
+set(GridKit_ENABLE_SUNDIALS @GRIDKIT_ENABLE_SUNDIALS@)
+if(GridKit_ENABLE_SUNDIALS)
+  list(APPEND CMAKE_PREFIX_PATH @SUNDIALS_DIR@)
+  find_dependency(SUNDIALS)
+endif()

--- a/cmake/GridkitAddLibrary.cmake
+++ b/cmake/GridkitAddLibrary.cmake
@@ -51,7 +51,7 @@ macro(gridkit_add_library target)
   if(gridkit_add_library_INCLUDE_DIRECTORIES)
     target_include_directories(${target} PUBLIC
       $<BUILD_INTERFACE:${gridkit_add_library_INCLUDE_DIRECTORIES}>
-      $<INSTALL_INTERFACE:include>)
+      $<INSTALL_INTERFACE:include/GridKit>)
   endif()
 
   # add compile options
@@ -82,7 +82,7 @@ macro(gridkit_add_library target)
       BASE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
       OUTPUT_VARIABLE _rel_path)
     install(FILES ${gridkit_add_library_HEADERS}
-      DESTINATION include/${_rel_path})
+      DESTINATION include/GridKit/${_rel_path})
   endif()
 
 endmacro()

--- a/cmake/GridkitAddLibrary.cmake
+++ b/cmake/GridkitAddLibrary.cmake
@@ -48,10 +48,13 @@ macro(gridkit_add_library target)
   endif()
 
   # set include dirs
+  target_include_directories(${target} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include/GridKit>)
+
   if(gridkit_add_library_INCLUDE_DIRECTORIES)
-    target_include_directories(${target} PUBLIC
-      $<BUILD_INTERFACE:${gridkit_add_library_INCLUDE_DIRECTORIES}>
-      $<INSTALL_INTERFACE:include/GridKit>)
+    target_include_directories(${target}
+        ${gridkit_add_library_INCLUDE_DIRECTORIES})
   endif()
 
   # add compile options

--- a/src/AutomaticDifferentiation/CMakeLists.txt
+++ b/src/AutomaticDifferentiation/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+install(
+  FILES
+    DependencyTracking/Variable.hpp
+    DependencyTracking/VariableImplementation.hpp
+    DependencyTracking/VariableOperators.hpp
+  DESTINATION
+    include/GridKit/AutomaticDifferentiation/DependencyTracking)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,11 @@
+# The binary dir is already a global include directory
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/Definitions.hpp.in
+  ${CMAKE_BINARY_DIR}/Definitions.hpp)
+install(
+  FILES ${CMAKE_BINARY_DIR}/Definitions.hpp
+  DESTINATION include/GridKit)
+
 # Create component models
 add_subdirectory(Model)
 
@@ -7,5 +15,14 @@ add_subdirectory(Utilities)
 # Local Sparse matrix operations
 add_subdirectory(LinearAlgebra)
 
+# Dependency tracking
+add_subdirectory(AutomaticDifferentiation)
+
 # Create solvers
 add_subdirectory(Solver)
+
+install(
+  FILES
+    ScalarTraits.hpp
+  DESTINATION
+    include/GridKit)

--- a/src/LinearAlgebra/DenseMatrix/CMakeLists.txt
+++ b/src/LinearAlgebra/DenseMatrix/CMakeLists.txt
@@ -3,3 +3,9 @@ add_library(DenseMatrix INTERFACE)
 include_directories(DenseMatrix INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
 add_library(GRIDKIT::DenseMatrix ALIAS DenseMatrix)
+
+install(
+  FILES
+    DenseMatrix.hpp
+  DESTINATION
+    include/GridKit/LinearAlgebra/DenseMatrix)

--- a/src/LinearAlgebra/SparseMatrix/CMakeLists.txt
+++ b/src/LinearAlgebra/SparseMatrix/CMakeLists.txt
@@ -3,3 +3,9 @@ add_library(SparseMatrix INTERFACE)
 include_directories(SparseMatrix INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
 add_library(GRIDKIT::SparseMatrix ALIAS SparseMatrix)
+
+install(
+  FILES
+    COO_Matrix.hpp
+  DESTINATION
+    include/GridKit/LinearAlgebra/SparseMatrix)

--- a/src/Model/CMakeLists.txt
+++ b/src/Model/CMakeLists.txt
@@ -8,3 +8,5 @@
 add_subdirectory(PhasorDynamics)
 add_subdirectory(PowerFlow)
 add_subdirectory(PowerElectronics)
+
+install(FILES Evaluator.hpp DESTINATION include/GridKit/Model)

--- a/src/Model/PhasorDynamics/Branch/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Branch/CMakeLists.txt
@@ -5,16 +5,26 @@
 #    - Slaven Peles <peless@ornl.gov>
 # ]]
 
+set(_install_headers
+  Branch.hpp
+  BranchData.hpp)
+
 if(GRIDKIT_ENABLE_ENZYME)
   gridkit_add_library(phasor_dynamics_branch
     SOURCES
       BranchEnzyme.cpp
+    HEADERS
+      ${_install_headers}
     LINK_LIBRARIES
       ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
-  gridkit_add_library(phasor_dynamics_branch SOURCES Branch.cpp)
+  gridkit_add_library(phasor_dynamics_branch
+    SOURCES
+      Branch.cpp
+    HEADERS
+      ${_install_headers})
 endif()
 
 gridkit_add_library(phasor_dynamics_branch_dependency_tracking

--- a/src/Model/PhasorDynamics/Branch/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Branch/CMakeLists.txt
@@ -31,7 +31,7 @@ gridkit_add_library(phasor_dynamics_branch_dependency_tracking
   SOURCES BranchDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components
+target_link_libraries(phasor_dynamics_components
   INTERFACE GRIDKIT::phasor_dynamics_branch)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GRIDKIT::phasor_dynamics_branch_dependency_tracking)

--- a/src/Model/PhasorDynamics/Bus/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Bus/CMakeLists.txt
@@ -7,7 +7,6 @@
 set(_install_headers
   Bus.hpp
   BusData.hpp
-  BusDataJSONParser.hpp
   BusFactory.hpp
   BusInfinite.hpp)
 
@@ -33,7 +32,7 @@ gridkit_add_library(phasor_dynamics_bus_dependency_tracking
     BusInfiniteDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components
+target_link_libraries(phasor_dynamics_components
   INTERFACE GRIDKIT::phasor_dynamics_bus)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GRIDKIT::phasor_dynamics_bus_dependency_tracking)

--- a/src/Model/PhasorDynamics/Bus/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Bus/CMakeLists.txt
@@ -4,16 +4,27 @@
 #    - Slaven Peles <peless@ornl.gov>
 #]]
 
+set(_install_headers
+  Bus.hpp
+  BusData.hpp
+  BusDataJSONParser.hpp
+  BusFactory.hpp
+  BusInfinite.hpp)
+
 if(GRIDKIT_ENABLE_ENZYME)
   gridkit_add_library(phasor_dynamics_bus
     SOURCES
       BusEnzyme.cpp
-      BusInfinite.cpp)
+      BusInfinite.cpp
+    HEADERS
+      ${_install_headers})
 else()
   gridkit_add_library(phasor_dynamics_bus
     SOURCES
       Bus.cpp
-      BusInfinite.cpp)
+      BusInfinite.cpp
+    HEADERS
+      ${_install_headers})
 endif()
 
 gridkit_add_library(phasor_dynamics_bus_dependency_tracking

--- a/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
@@ -25,7 +25,7 @@ gridkit_add_library(phasor_dynamics_bus_fault_dependency_tracking
   SOURCES BusFaultDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components
+target_link_libraries(phasor_dynamics_components
   INTERFACE GRIDKIT::phasor_dynamics_bus_fault)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GRIDKIT::phasor_dynamics_bus_fault_dependency_tracking)

--- a/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
@@ -1,14 +1,24 @@
 
+set(_install_headers
+  BusFault.hpp
+  BusFaultData.hpp)
+
 if(GRIDKIT_ENABLE_ENZYME)
   gridkit_add_library(phasor_dynamics_bus_fault
     SOURCES
       BusFaultEnzyme.cpp
+    HEADERS
+      ${_install_headers}
     LINK_LIBRARIES
       ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
-  gridkit_add_library(phasor_dynamics_bus_fault SOURCES BusFault.cpp)
+  gridkit_add_library(phasor_dynamics_bus_fault
+    SOURCES
+      BusFault.cpp
+    HEADERS
+      ${_install_headers})
 endif()
 
 gridkit_add_library(phasor_dynamics_bus_fault_dependency_tracking

--- a/src/Model/PhasorDynamics/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/CMakeLists.txt
@@ -20,3 +20,17 @@ add_library(GRIDKIT::phasor_dynamics_components
   ALIAS gridkit_phasor_dynamics_components)
 add_library(GRIDKIT::phasor_dynamics_components_dependency_tracking
   ALIAS gridkit_phasor_dynamics_components_dependency_tracking)
+
+install(
+  FILES
+    BusBase.hpp
+    Component.hpp
+    ComponentData.hpp
+    ComponentDataJSONParser.hpp
+    ComponentLibrary.hpp
+    ComponentSignals.hpp
+    SystemModel.hpp
+    SystemModelData.hpp
+    SystemModelDataJSONParser.hpp
+  DESTINATION
+    include/GridKit/Model/PhasorDynamics)

--- a/src/Model/PhasorDynamics/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/CMakeLists.txt
@@ -3,8 +3,8 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-add_library(gridkit_phasor_dynamics_components INTERFACE)
-add_library(gridkit_phasor_dynamics_components_dependency_tracking INTERFACE)
+add_library(phasor_dynamics_components INTERFACE)
+add_library(phasor_dynamics_components_dependency_tracking INTERFACE)
 
 add_subdirectory(Branch)
 add_subdirectory(Bus)
@@ -16,21 +16,24 @@ add_subdirectory(SynchronousMachine)
 
 add_subdirectory(SignalNode)
 
-add_library(GRIDKIT::phasor_dynamics_components
-  ALIAS gridkit_phasor_dynamics_components)
-add_library(GRIDKIT::phasor_dynamics_components_dependency_tracking
-  ALIAS gridkit_phasor_dynamics_components_dependency_tracking)
-
 install(
   FILES
     BusBase.hpp
     Component.hpp
     ComponentData.hpp
-    ComponentDataJSONParser.hpp
     ComponentLibrary.hpp
     ComponentSignals.hpp
     SystemModel.hpp
     SystemModelData.hpp
-    SystemModelDataJSONParser.hpp
   DESTINATION
     include/GridKit/Model/PhasorDynamics)
+
+add_library(GRIDKIT::phasor_dynamics_components
+  ALIAS phasor_dynamics_components)
+add_library(GRIDKIT::phasor_dynamics_components_dependency_tracking
+  ALIAS phasor_dynamics_components_dependency_tracking)
+
+install(TARGETS
+  phasor_dynamics_components
+  phasor_dynamics_components_dependency_tracking
+  EXPORT gridkit-targets)

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
@@ -4,9 +4,15 @@
 #    - Adam Birchfield <abirchfield@tamu.edu>
 # ]]
 
+set(_install_headers
+  Ieeet1.hpp
+  Ieeet1Data.hpp)
+
 gridkit_add_library(phasor_dynamics_exciter_ieeet1
   SOURCES
     Ieeet1.cpp
+  HEADERS
+    ${_install_headers}
   LINK_LIBRARIES
     GRIDKIT::phasor_dynamics_signal)
 

--- a/src/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
@@ -23,7 +23,7 @@ gridkit_add_library(phasor_dynamics_exciter_ieeet1_dependency_tracking
     GRIDKIT::phasor_dynamics_signal_dependency_tracking)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components
+target_link_libraries(phasor_dynamics_components
   INTERFACE GRIDKIT::phasor_dynamics_exciter_ieeet1)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GRIDKIT::phasor_dynamics_exciter_ieeet1_dependency_tracking)

--- a/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
@@ -36,7 +36,7 @@ gridkit_add_library(phasor_dynamics_governortgov1_dependency_tracking
     PUBLIC GRIDKIT::phasor_dynamics_signal_dependency_tracking)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components
+target_link_libraries(phasor_dynamics_components
   INTERFACE GRIDKIT::phasor_dynamics_governortgov1)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GRIDKIT::phasor_dynamics_governortgov1_dependency_tracking)

--- a/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
@@ -4,10 +4,16 @@
 #    - Adam Birchfield <abirchfield@tamu.edu>
 # ]]
 
+set(_install_headers
+  Tgov1.hpp
+  Tgov1Data.hpp)
+
 if(GRIDKIT_ENABLE_ENZYME)
   gridkit_add_library(phasor_dynamics_governortgov1
     SOURCES
       Tgov1Enzyme.cpp
+    HEADERS
+      ${_install_headers}
     LINK_LIBRARIES
       GRIDKIT::phasor_dynamics_signal
       ClangEnzymeFlags
@@ -17,6 +23,8 @@ else()
   gridkit_add_library(phasor_dynamics_governortgov1
     SOURCES
       Tgov1.cpp
+    HEADERS
+      ${_install_headers}
     LINK_LIBRARIES
       GRIDKIT::phasor_dynamics_signal)
 endif()

--- a/src/Model/PhasorDynamics/Load/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Load/CMakeLists.txt
@@ -5,17 +5,26 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 # ]]
 
+set(_install_headers
+  Load.hpp
+  LoadData.hpp)
 
 if(GRIDKIT_ENABLE_ENZYME)
   gridkit_add_library(phasor_dynamics_load
     SOURCES
       LoadEnzyme.cpp
+    HEADERS
+      ${_install_headers}
     LINK_LIBRARIES
       ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
-  gridkit_add_library(phasor_dynamics_load SOURCES Load.cpp)
+  gridkit_add_library(phasor_dynamics_load
+    SOURCES
+      Load.cpp
+    HEADERS
+      ${_install_headers})
 endif()
 
 gridkit_add_library(phasor_dynamics_load_dependency_tracking

--- a/src/Model/PhasorDynamics/Load/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Load/CMakeLists.txt
@@ -31,7 +31,7 @@ gridkit_add_library(phasor_dynamics_load_dependency_tracking
   SOURCES LoadDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components
+target_link_libraries(phasor_dynamics_components
   INTERFACE GRIDKIT::phasor_dynamics_load)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GRIDKIT::phasor_dynamics_load_dependency_tracking)

--- a/src/Model/PhasorDynamics/SignalNode/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SignalNode/CMakeLists.txt
@@ -10,14 +10,13 @@ gridkit_add_library(phasor_dynamics_signal
     SignalNode.cpp
   HEADERS
     SignalNode.hpp
-    SignalNodeData.hpp
-    SignalNodeDataJSONParser.hpp)
+    SignalNodeData.hpp)
 
 gridkit_add_library(phasor_dynamics_signal_dependency_tracking
   SOURCES SignalNodeDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components
+target_link_libraries(phasor_dynamics_components
   INTERFACE GRIDKIT::phasor_dynamics_signal)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GRIDKIT::phasor_dynamics_signal_dependency_tracking)

--- a/src/Model/PhasorDynamics/SignalNode/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SignalNode/CMakeLists.txt
@@ -5,7 +5,13 @@
 #    - Slaven Peles <peless@ornl.gov>
 # ]]
 
-gridkit_add_library(phasor_dynamics_signal SOURCES SignalNode.cpp)
+gridkit_add_library(phasor_dynamics_signal
+  SOURCES
+    SignalNode.cpp
+  HEADERS
+    SignalNode.hpp
+    SignalNodeData.hpp
+    SignalNodeDataJSONParser.hpp)
 
 gridkit_add_library(phasor_dynamics_signal_dependency_tracking
   SOURCES SignalNodeDependencyTracking.cpp)

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
@@ -1,9 +1,15 @@
 
+set(_install_headers
+  Genrou.hpp
+  GenrouData.hpp)
+
 # Disabled GenrouEnzyme because of an intermittent build issue
 #if(GRIDKIT_ENABLE_ENZYME)
 #  gridkit_add_library(phasor_dynamics_genrou
 #    SOURCES
 #      GenrouEnzyme.cpp
+#    HEADERS
+#      ${_install_headers}
 #    LINK_LIBRARIES
 #      PUBLIC GRIDKIT::phasor_dynamics_signal ClangEnzymeFlags
 #    COMPILE_OPTIONS
@@ -12,6 +18,8 @@
   gridkit_add_library(phasor_dynamics_genrou
     SOURCES
       Genrou.cpp
+    HEADERS
+      ${_install_headers}
     LINK_LIBRARIES
       PUBLIC GRIDKIT::phasor_dynamics_signal)
 #endif()

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
@@ -31,7 +31,7 @@ gridkit_add_library(phasor_dynamics_genrou_dependency_tracking
     PUBLIC GRIDKIT::phasor_dynamics_signal_dependency_tracking)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components
+target_link_libraries(phasor_dynamics_components
   INTERFACE GRIDKIT::phasor_dynamics_genrou)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GRIDKIT::phasor_dynamics_genrou_dependency_tracking)

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
@@ -4,16 +4,26 @@
 #    - Slaven Peles <peless@ornl.gov>
 # ]]
 
+set(_install_headers
+  GenClassical.hpp
+  GenClassicalData.hpp)
+
 if(GRIDKIT_ENABLE_ENZYME)
   gridkit_add_library(phasor_dynamics_gen_classical
     SOURCES
       GenClassicalEnzyme.cpp
+    HEADERS
+      ${_install_headers}
     LINK_LIBRARIES
       ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
-  gridkit_add_library(phasor_dynamics_gen_classical SOURCES GenClassical.cpp)
+  gridkit_add_library(phasor_dynamics_gen_classical
+    SOURCES
+      GenClassical.cpp
+    HEADERS
+      ${_install_headers})
 endif()
 
   gridkit_add_library(phasor_dynamics_gen_classical_dependency_tracking

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
     SOURCES GenClassicalDependencyTracking.cpp)
 
 # Link to interface target for all components
-target_link_libraries(gridkit_phasor_dynamics_components
+target_link_libraries(phasor_dynamics_components
   INTERFACE GRIDKIT::phasor_dynamics_gen_classical)
-target_link_libraries(gridkit_phasor_dynamics_components_dependency_tracking
+target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GRIDKIT::phasor_dynamics_gen_classical_dependency_tracking)

--- a/src/Model/PowerElectronics/CMakeLists.txt
+++ b/src/Model/PowerElectronics/CMakeLists.txt
@@ -12,3 +12,11 @@ add_subdirectory(TransmissionLine)
 add_subdirectory(MicrogridLoad)
 add_subdirectory(MicrogridLine)
 add_subdirectory(MicrogridBusDQ)
+
+install(
+  FILES
+    CircuitComponent.hpp
+    CircuitGraph.hpp
+    SystemModelPowerElectronics.hpp
+  DESTINATION
+    include/GridKit/Model/PowerElectronics)

--- a/src/Model/PowerElectronics/Capacitor/CMakeLists.txt
+++ b/src/Model/PowerElectronics/Capacitor/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_capacitor SOURCES Capacitor.cpp)
+gridkit_add_library(power_elec_capacitor
+  SOURCES
+    Capacitor.cpp
+  HEADERS
+    Capacitor.hpp)

--- a/src/Model/PowerElectronics/DistributedGenerator/CMakeLists.txt
+++ b/src/Model/PowerElectronics/DistributedGenerator/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_disgen SOURCES DistributedGenerator.cpp)
+gridkit_add_library(power_elec_disgen
+  SOURCES
+    DistributedGenerator.cpp
+  HEADERS
+    DistributedGenerator.hpp)

--- a/src/Model/PowerElectronics/InductionMotor/CMakeLists.txt
+++ b/src/Model/PowerElectronics/InductionMotor/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_inductionmotor SOURCES InductionMotor.cpp)
+gridkit_add_library(power_elec_inductionmotor
+  SOURCES
+    InductionMotor.cpp
+  HEADERS
+    InductionMotor.hpp)

--- a/src/Model/PowerElectronics/Inductor/CMakeLists.txt
+++ b/src/Model/PowerElectronics/Inductor/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_inductor SOURCES Inductor.cpp)
+gridkit_add_library(power_elec_inductor
+  SOURCES
+    Inductor.cpp
+  HEADERS
+    Inductor.hpp)

--- a/src/Model/PowerElectronics/LinearTransformer/CMakeLists.txt
+++ b/src/Model/PowerElectronics/LinearTransformer/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_lineartrasnformer SOURCES LinearTransformer.cpp)
+gridkit_add_library(power_elec_lineartrasnformer
+  SOURCES
+    LinearTransformer.cpp
+  HEADERS
+    LinearTransformer.hpp)

--- a/src/Model/PowerElectronics/MicrogridBusDQ/CMakeLists.txt
+++ b/src/Model/PowerElectronics/MicrogridBusDQ/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_microbusdq SOURCES MicrogridBusDQ.cpp)
+gridkit_add_library(power_elec_microbusdq
+  SOURCES
+    MicrogridBusDQ.cpp
+  HEADERS
+    MicrogridBusDQ.hpp)

--- a/src/Model/PowerElectronics/MicrogridLine/CMakeLists.txt
+++ b/src/Model/PowerElectronics/MicrogridLine/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_microline SOURCES MicrogridLine.cpp)
+gridkit_add_library(power_elec_microline
+  SOURCES
+    MicrogridLine.cpp
+  HEADERS
+    MicrogridLine.hpp)

--- a/src/Model/PowerElectronics/MicrogridLoad/CMakeLists.txt
+++ b/src/Model/PowerElectronics/MicrogridLoad/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_microload SOURCES MicrogridLoad.cpp)
+gridkit_add_library(power_elec_microload
+  SOURCES
+    MicrogridLoad.cpp
+  HEADERS
+    MicrogridLoad.hpp)

--- a/src/Model/PowerElectronics/Resistor/CMakeLists.txt
+++ b/src/Model/PowerElectronics/Resistor/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_resistor SOURCES Resistor.cpp)
+gridkit_add_library(power_elec_resistor
+  SOURCES
+    Resistor.cpp
+  HEADERS
+    Resistor.hpp)

--- a/src/Model/PowerElectronics/SynchronousMachine/CMakeLists.txt
+++ b/src/Model/PowerElectronics/SynchronousMachine/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_synmachine SOURCES SynchronousMachine.cpp)
+gridkit_add_library(power_elec_synmachine
+  SOURCES
+    SynchronousMachine.cpp
+  HEADERS
+    SynchronousMachine.hpp)

--- a/src/Model/PowerElectronics/TransmissionLine/CMakeLists.txt
+++ b/src/Model/PowerElectronics/TransmissionLine/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_tranline SOURCES TransmissionLine.cpp)
+gridkit_add_library(power_elec_tranline
+  SOURCES
+    TransmissionLine.cpp
+  HEADERS
+    TransmissionLine.hpp)

--- a/src/Model/PowerElectronics/VoltageSource/CMakeLists.txt
+++ b/src/Model/PowerElectronics/VoltageSource/CMakeLists.txt
@@ -1,4 +1,5 @@
-
-
-
-gridkit_add_library(power_elec_voltagesource SOURCES VoltageSource.cpp)
+gridkit_add_library(power_elec_voltagesource
+  SOURCES
+    VoltageSource.cpp
+  HEADERS
+    VoltageSource.hpp)

--- a/src/Model/PowerFlow/Branch/CMakeLists.txt
+++ b/src/Model/PowerFlow/Branch/CMakeLists.txt
@@ -3,4 +3,8 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(branch SOURCES Branch.cpp)
+gridkit_add_library(branch
+  SOURCES
+    Branch.cpp
+  HEADERS
+    Branch.hpp)

--- a/src/Model/PowerFlow/Bus/CMakeLists.txt
+++ b/src/Model/PowerFlow/Bus/CMakeLists.txt
@@ -9,4 +9,10 @@ gridkit_add_library(bus
   SOURCES
     BusPQ.cpp
     BusPV.cpp
-    BusSlack.cpp)
+    BusSlack.cpp
+  HEADERS
+    BaseBus.hpp
+    BusFactory.hpp
+    BusPQ.hpp
+    BusPV.hpp
+    BusSlack.hpp)

--- a/src/Model/PowerFlow/CMakeLists.txt
+++ b/src/Model/PowerFlow/CMakeLists.txt
@@ -12,3 +12,12 @@ add_subdirectory(Generator4Governor)
 add_subdirectory(Generator4Param)
 add_subdirectory(Load)
 add_subdirectory(MiniGrid)
+
+install(
+  FILES
+    MatpowerParser.hpp
+    PowerFlowData.hpp
+    SystemModel.hpp
+    SystemModelPowerFlow.hpp
+  DESTINATION
+    include/GridKit/Model/PowerFlow)

--- a/src/Model/PowerFlow/Generator/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator/CMakeLists.txt
@@ -7,4 +7,10 @@ gridkit_add_library(generator
   SOURCES
     GeneratorSlack.cpp
     GeneratorPV.cpp
-    GeneratorPQ.cpp)
+    GeneratorPQ.cpp
+  HEADERS
+    GeneratorBase.hpp
+    GeneratorFactory.hpp
+    GeneratorPQ.hpp
+    GeneratorPV.hpp
+    GeneratorSlack.hpp)

--- a/src/Model/PowerFlow/Generator2/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator2/CMakeLists.txt
@@ -3,4 +3,8 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(generator2 SOURCES Generator2.cpp)
+gridkit_add_library(generator2
+  SOURCES
+    Generator2.cpp
+  HEADERS
+    Generator2.hpp)

--- a/src/Model/PowerFlow/Generator4/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator4/CMakeLists.txt
@@ -5,4 +5,8 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(generator4 SOURCES Generator4.cpp)
+gridkit_add_library(generator4
+  SOURCES
+    Generator4.cpp
+  HEADERS
+    Generator4.hpp)

--- a/src/Model/PowerFlow/Generator4Governor/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator4Governor/CMakeLists.txt
@@ -5,4 +5,8 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(generator4governor SOURCES Generator4Governor.cpp)
+gridkit_add_library(generator4governor
+  SOURCES
+    Generator4Governor.cpp
+  HEADERS
+    Generator4Governor.hpp)

--- a/src/Model/PowerFlow/Generator4Param/CMakeLists.txt
+++ b/src/Model/PowerFlow/Generator4Param/CMakeLists.txt
@@ -5,4 +5,8 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(generator4param SOURCES Generator4Param.cpp)
+gridkit_add_library(generator4param
+  SOURCES
+    Generator4Param.cpp
+  HEADERS
+    Generator4Param.hpp)

--- a/src/Model/PowerFlow/Load/CMakeLists.txt
+++ b/src/Model/PowerFlow/Load/CMakeLists.txt
@@ -3,4 +3,8 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(load SOURCES Load.cpp)
+gridkit_add_library(load
+  SOURCES
+    Load.cpp
+  HEADERS
+    Load.hpp)

--- a/src/Model/PowerFlow/MiniGrid/CMakeLists.txt
+++ b/src/Model/PowerFlow/MiniGrid/CMakeLists.txt
@@ -3,4 +3,8 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
-gridkit_add_library(minigrid SOURCES MiniGrid.cpp)
+gridkit_add_library(minigrid
+  SOURCES
+    MiniGrid.cpp
+  HEADERS
+    MiniGrid.hpp)

--- a/src/Solver/Dynamic/CMakeLists.txt
+++ b/src/Solver/Dynamic/CMakeLists.txt
@@ -5,10 +5,16 @@
 #    - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 #]]
 
+set(_install_headers
+  DynamicSolver.hpp
+  Ida.hpp)
+
 if (GRIDKIT_ENABLE_SUNDIALS_SPARSE)
   gridkit_add_library(solvers_dyn
     SOURCES
       Ida.cpp
+    HEADERS
+      ${_install_headers}
     LINK_LIBRARIES
       PUBLIC SUNDIALS::nvecserial
       PUBLIC SUNDIALS::idas
@@ -17,6 +23,8 @@ else()
   gridkit_add_library(solvers_dyn
     SOURCES
       Ida.cpp
+    HEADERS
+      ${_install_headers}
     LINK_LIBRARIES
       PUBLIC SUNDIALS::nvecserial
       PUBLIC SUNDIALS::idas)

--- a/src/Solver/Dynamic/Ida.hpp
+++ b/src/Solver/Dynamic/Ida.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include <nvector/nvector_serial.h>
+#include <sundials/sundials_context.h>
 #include <sunlinsol/sunlinsol_dense.h>  /* access to dense linear solver        */
 #include <sunmatrix/sunmatrix_sparse.h> /* access to sparse SUNMatrix           */
 

--- a/src/Solver/Optimization/CMakeLists.txt
+++ b/src/Solver/Optimization/CMakeLists.txt
@@ -9,6 +9,10 @@ gridkit_add_library(solvers_opt
   SOURCES
     DynamicObjective.cpp
     DynamicConstraint.cpp
+  HEADERS
+    DynamicConstraint.hpp
+    DynamicObjective.hpp
+    OptimizationSolver.hpp
   LINK_LIBRARIES
     PUBLIC IPOPT
     PUBLIC GRIDKIT::solvers_dyn)

--- a/src/Solver/SteadyState/CMakeLists.txt
+++ b/src/Solver/SteadyState/CMakeLists.txt
@@ -8,5 +8,8 @@
 gridkit_add_library(solvers_steady
   SOURCES
     Kinsol.cpp
+  HEADERS
+    Kinsol.hpp
+    SteadyStateSolver.hpp
   LINK_LIBRARIES
     PUBLIC SUNDIALS::kinsol)

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -5,3 +5,11 @@ add_library(GRIDKIT::Utilities ALIAS Utilities)
 
 add_subdirectory(Logger)
 add_subdirectory(CliOptions)
+
+install(
+  FILES
+    Colors.hpp
+    FileIO.hpp
+    MapFromCOO.hpp
+  DESTINATION
+    include/GridKit/Utilities)

--- a/src/Utilities/CliOptions/CMakeLists.txt
+++ b/src/Utilities/CliOptions/CMakeLists.txt
@@ -1,7 +1,7 @@
 gridkit_add_library(utilities_cli_options
   SOURCES
     CliOptions.cpp
-  OUTPUT_NAME
-    gridkit_utilities_cli_options)
+  HEADERS
+    CliOptions.hpp)
 
 target_link_libraries(Utilities INTERFACE GRIDKIT::utilities_cli_options)

--- a/src/Utilities/Logger/CMakeLists.txt
+++ b/src/Utilities/Logger/CMakeLists.txt
@@ -1,5 +1,7 @@
 gridkit_add_library(utilities_logger
   SOURCES
-    Logger.cpp)
+    Logger.cpp
+  HEADERS
+    Logger.hpp)
 
 target_link_libraries(Utilities INTERFACE GRIDKIT::utilities_logger)


### PR DESCRIPTION
## Description
 
Install headers needed for writing code against installed libraries
 
 _Closes #278_

 ## Proposed changes
 
Install headers via either the `HEADERS` parameter to `gridkit_add_library` or manually with `install(FILES` as necessary.
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [N/A] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
This PR does NOT install the headers for the magic_enum and json libraries. I think those should be handled in a better way, and that will be for a different PR.