### PR TITLE
Encapsulate `nlohmann/json` and `magic_enum` as implementation details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Added more context information to JSON parser errors.
 - Added `Logger` class.
 - Added `CliOptions` for simple command-line parsing.
+- Added public function to encapsulate use of nlohmann/json and magic_enum from users.
 
 ## v0.1
 

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/CMakeLists.txt
@@ -10,10 +10,6 @@ add_executable(ThreeBusBasicJson ThreeBusBasicJson.cpp)
 target_link_libraries(ThreeBusBasicJson
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::solvers_dyn)
-target_include_directories(ThreeBusBasicJson
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
-target_include_directories(ThreeBusBasicJson
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
 install(TARGETS ThreeBusBasicJson RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(ThreeBusBasic.json)
 

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
@@ -17,10 +17,8 @@
 #include <Model/PhasorDynamics/ComponentLibrary.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Model/PhasorDynamics/SystemModelData.hpp>
-#include <Model/PhasorDynamics/SystemModelDataJSONParser.hpp>
 #include <Solver/Dynamic/Ida.hpp>
 #include <Utilities/Testing.hpp>
-#include <nlohmann/json.hpp>
 
 using scalar_type = double;
 using real_type   = double;
@@ -117,7 +115,7 @@ int main(int argc, const char* argv[])
   // Create model data
   //
 
-  SystemModelData<scalar_type, index_type> data(json::parse(std::ifstream(input_file)));
+  auto data = parseSystemModelData(input_file);
 
   //
   // Instantiate system

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/CMakeLists.txt
@@ -15,10 +15,6 @@ add_executable(ThreeBusClassicalJson ThreeBusClassicalJson.cpp)
 target_link_libraries(ThreeBusClassicalJson
     GRIDKIT::phasor_dynamics_components
     GRIDKIT::solvers_dyn)
-target_include_directories(ThreeBusClassicalJson
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
-target_include_directories(ThreeBusClassicalJson
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
 install(TARGETS ThreeBusClassicalJson RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(ThreeBusClassical.json)
 

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassicalJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassicalJson.cpp
@@ -17,10 +17,8 @@
 #include <Model/PhasorDynamics/ComponentLibrary.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Model/PhasorDynamics/SystemModelData.hpp>
-#include <Model/PhasorDynamics/SystemModelDataJSONParser.hpp>
 #include <Solver/Dynamic/Ida.hpp>
 #include <Utilities/Testing.hpp>
-#include <nlohmann/json.hpp>
 
 using scalar_type = double;
 using real_type   = double;
@@ -117,7 +115,7 @@ int main(int argc, const char* argv[])
   // Create model data
   //
 
-  SystemModelData<scalar_type, index_type> data(json::parse(std::ifstream(input_file)));
+  auto data = parseSystemModelData(input_file);
 
   //
   // Instantiate system

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/CMakeLists.txt
@@ -10,10 +10,6 @@ add_executable(TwoBusBasicJson TwoBusBasicJson.cpp)
 target_link_libraries(TwoBusBasicJson
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::solvers_dyn)
-target_include_directories(TwoBusBasicJson
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
-target_include_directories(TwoBusBasicJson
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
 install(TARGETS TwoBusBasicJson RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusBasic.json)
 

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
@@ -16,10 +16,8 @@
 #include <Model/PhasorDynamics/ComponentLibrary.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Model/PhasorDynamics/SystemModelData.hpp>
-#include <Model/PhasorDynamics/SystemModelDataJSONParser.hpp>
 #include <Solver/Dynamic/Ida.hpp>
 #include <Utilities/Testing.hpp>
-#include <nlohmann/json.hpp>
 
 int main(int argc, const char* argv[])
 {
@@ -70,7 +68,7 @@ int main(int argc, const char* argv[])
   // Create model data
   //
 
-  SystemModelData<scalar_type, index_type> data(json::parse(std::ifstream(input_file)));
+  auto data = parseSystemModelData(input_file);
 
   //
   // Instantiate system model

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
@@ -12,10 +12,6 @@ target_link_libraries(TwoBusIeeet1Json
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::phasor_dynamics_signal
 	GRIDKIT::solvers_dyn)
-target_include_directories(TwoBusIeeet1Json
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
-target_include_directories(TwoBusIeeet1Json
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
 install(TARGETS TwoBusIeeet1Json RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusIeeet1.json)
 

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
@@ -13,10 +13,8 @@
 #include <Model/PhasorDynamics/ComponentLibrary.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Model/PhasorDynamics/SystemModelData.hpp>
-#include <Model/PhasorDynamics/SystemModelDataJSONParser.hpp>
 #include <Solver/Dynamic/Ida.hpp>
 #include <Utilities/Testing.hpp>
-#include <nlohmann/json.hpp>
 
 int main(int argc, const char* argv[])
 {
@@ -69,7 +67,7 @@ int main(int argc, const char* argv[])
   // Create model data
   //
 
-  SystemModelData<scalar_type, index_type> data = json::parse(std::ifstream(input_file));
+  auto data = parseSystemModelData(input_file);
 
   //
   // Instantiate and configure the system model

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
@@ -12,10 +12,6 @@ target_link_libraries(TwoBusTgov1Json
 	GRIDKIT::phasor_dynamics_components
 	GRIDKIT::phasor_dynamics_signal
 	GRIDKIT::solvers_dyn)
-target_include_directories(TwoBusTgov1Json
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include)
-target_include_directories(TwoBusTgov1Json
-    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
 install(TARGETS TwoBusTgov1Json RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusTgov1.json)
 

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
@@ -18,10 +18,8 @@
 #include <Model/PhasorDynamics/ComponentLibrary.hpp>
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Model/PhasorDynamics/SystemModelData.hpp>
-#include <Model/PhasorDynamics/SystemModelDataJSONParser.hpp>
 #include <Solver/Dynamic/Ida.hpp>
 #include <Utilities/Testing.hpp>
-#include <nlohmann/json.hpp>
 
 int main(int argc, const char* argv[])
 {
@@ -73,7 +71,7 @@ int main(int argc, const char* argv[])
   // Create model data
   //
 
-  SystemModelData<scalar_type, index_type> data = json::parse(std::ifstream(input_file));
+  auto data = parseSystemModelData(input_file);
 
   //
   // Instantiate and allocate the system model

--- a/src/Model/PhasorDynamics/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/CMakeLists.txt
@@ -16,8 +16,10 @@ add_subdirectory(SynchronousMachine)
 
 add_subdirectory(SignalNode)
 
-install(
-  FILES
+gridkit_add_library(phasor_dynamics_core
+  SOURCES
+    SystemModelData.cpp
+  HEADERS
     BusBase.hpp
     Component.hpp
     ComponentData.hpp
@@ -25,8 +27,14 @@ install(
     ComponentSignals.hpp
     SystemModel.hpp
     SystemModelData.hpp
-  DESTINATION
-    include/GridKit/Model/PhasorDynamics)
+  INCLUDE_DIRECTORIES
+    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nlohmann-json/include
+    PRIVATE ${CMAKE_SOURCE_DIR}/third-party/magic-enum/include)
+
+target_link_libraries(phasor_dynamics_components
+  INTERFACE GRIDKIT::phasor_dynamics_core)
+target_link_libraries(phasor_dynamics_components_dependency_tracking
+  INTERFACE GRIDKIT::phasor_dynamics_core)
 
 add_library(GRIDKIT::phasor_dynamics_components
   ALIAS phasor_dynamics_components)

--- a/src/Model/PhasorDynamics/SystemModelData.cpp
+++ b/src/Model/PhasorDynamics/SystemModelData.cpp
@@ -1,0 +1,34 @@
+#include "SystemModelData.hpp"
+
+#include <fstream>
+
+#include <Model/PhasorDynamics/SystemModelDataJSONParser.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    SystemModelData<double, size_t> parseSystemModelData(std::istream& stream)
+    {
+      SystemModelData<double, size_t> data(json::parse(stream));
+      return data;
+    }
+
+    SystemModelData<double, size_t> parseSystemModelData(std::istream&& stream)
+    {
+      SystemModelData<double, size_t> data(json::parse(stream));
+      return data;
+    }
+
+    SystemModelData<double, size_t> parseSystemModelData(const std::filesystem::path& filePath)
+    {
+      auto stream = std::ifstream(filePath);
+      return parseSystemModelData(stream);
+    }
+
+    SystemModelData<double, size_t> parseSystemModelData(const std::string& fileName)
+    {
+      return parseSystemModelData(std::ifstream(fileName));
+    }
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/src/Model/PhasorDynamics/SystemModelData.hpp
+++ b/src/Model/PhasorDynamics/SystemModelData.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <filesystem>
+#include <istream>
 #include <optional>
 #include <string>
 #include <vector>
@@ -83,5 +85,15 @@ namespace GridKit
       std::vector<Ieeet1DataT>       exciter;      ///< Exciters within the model
       std::vector<SignalDataT>       signal;       ///< Signal nodes
     };
+
+    ///@{
+    /**
+     * @brief Generate system model data from a JSON input file
+     */
+    SystemModelData<double, size_t> parseSystemModelData(std::istream&);
+    SystemModelData<double, size_t> parseSystemModelData(std::istream&&);
+    SystemModelData<double, size_t> parseSystemModelData(const std::filesystem::path&);
+    SystemModelData<double, size_t> parseSystemModelData(const std::string&);
+    ///@}
   } // namespace PhasorDynamics
 } // namespace GridKit


### PR DESCRIPTION
## Description
 
These two third-party libraries don't need to be exposed to the user

Relates to #278
Needed for #253 

 ## Proposed changes
 
Introduce a simple function `parseSystemModelData` (which can take `std::istream`, `std::filesystem::path`, or `std::string`) to generate a `SystemModelData<double, size_t>` object from JSON input.
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [X] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.