### PR TITLE
Consumer Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added `Logger` class.
 - Added `CliOptions` for simple command-line parsing.
 - Added public function to encapsulate use of nlohmann/json and magic_enum from users.
+- Added complete basic consumer example project used for testing installation
 
 ## v0.1
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -54,3 +54,5 @@ endif()
 if(GRIDKIT_ENABLE_ENZYME)
   add_subdirectory(Enzyme)
 endif()
+
+add_subdirectory(Consumer)

--- a/examples/Consumer/CMakeLists.txt
+++ b/examples/Consumer/CMakeLists.txt
@@ -33,10 +33,11 @@ endif()
 
 # Install CMakeLists.txt for example project
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/GridKitConsumer/CMakeLists.txt.in
-    ${CMAKE_CURRENT_BINARY_DIR}/GridKitConsumer/CMakeLists.txt)
+    ${CMAKE_CURRENT_BINARY_DIR}/GridKitConsumer/CMakeLists.txt
+    @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/GridKitConsumer/CMakeLists.txt
   DESTINATION ${_rel_consumer_path})
 
 # Add target to build and test the example project after install
-add_custom_target(test_install
-    COMMAND ${_abs_consumer_path}/test.sh ${CMAKE_INSTALL_PREFIX})
+add_custom_target(test_install COMMAND
+    ${_abs_consumer_path}/test.sh ${CMAKE_INSTALL_PREFIX} ${CMAKE_CXX_COMPILER})

--- a/examples/Consumer/CMakeLists.txt
+++ b/examples/Consumer/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Path where the consumer test code will be installed
+set(_rel_consumer_path ${GRIDKIT_EXAMPLES_INSTALL_ROOT}/GridKitConsumer)
+set(_abs_consumer_path ${CMAKE_INSTALL_PREFIX}/${_rel_consumer_path})
+
+# Install script as example of how to build and test consumer project
+install(PROGRAMS test.sh DESTINATION ${_rel_consumer_path})
+
+# Install consumer code and set link libraries
+set(_examples_dir ${CMAKE_SOURCE_DIR}/examples)
+if(GRIDKIT_ENABLE_SUNDIALS)
+  install(
+    FILES ${_examples_dir}/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
+    DESTINATION ${_rel_consumer_path}
+    RENAME consumer.cpp)
+  install(
+    FILES
+      ${_examples_dir}/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.hpp
+      ${_examples_dir}/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.json
+    DESTINATION ${_rel_consumer_path})
+  list(APPEND GRIDKIT_CONSUMER_TEST_LINK_LIBRARIES
+    GRIDKIT::phasor_dynamics_components
+    GRIDKIT::solvers_dyn)
+else()
+  install(
+    FILES ${_examples_dir}/PowerElectronics/DistributedGeneratorTest/DGTest.cpp
+    DESTINATION ${_rel_consumer_path}
+    RENAME consumer.cpp)
+  list(APPEND GRIDKIT_CONSUMER_TEST_LINK_LIBRARIES
+    GRIDKIT::power_elec_disgen
+    GRIDKIT::power_elec_microline
+    GRIDKIT::power_elec_microload)
+endif()
+
+# Install CMakeLists.txt for example project
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/GridKitConsumer/CMakeLists.txt.in
+    ${CMAKE_CURRENT_BINARY_DIR}/GridKitConsumer/CMakeLists.txt)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/GridKitConsumer/CMakeLists.txt
+  DESTINATION ${_rel_consumer_path})
+
+# Add target to build and test the example project after install
+add_custom_target(test_install
+    COMMAND ${_abs_consumer_path}/test.sh ${CMAKE_INSTALL_PREFIX})

--- a/examples/Consumer/GridKitConsumer/CMakeLists.txt.in
+++ b/examples/Consumer/GridKitConsumer/CMakeLists.txt.in
@@ -1,0 +1,28 @@
+# Example of how to consume GridKit as a package via cmake
+# Below is a standard example of a CMakeLists.txt file that ultizies GridKit
+# See the Readme on how to build and install GridKie
+#-------------------------------------------------------------------------------
+cmake_minimum_required(VERSION 3.20)
+
+# Project name
+project(GridKitConsumer LANGUAGES CXX)
+# GridKit uses C++20 features in its public headers
+set(CMAKE_CXX_STANDARD 20)
+
+# Call find_package to get GridKit targets
+# NOTE: The GridKit installation prefix needs to be provided in either
+# GridKit_DIR or CMAKE_PREFIX_PATH
+find_package(GridKit REQUIRED)
+
+# Create an executable target from our example code
+add_executable(consumer consumer.cpp)
+# Link against a GridKit library target
+target_link_libraries(consumer
+    @GRIDKIT_CONSUMER_TEST_LINK_LIBRARIES@
+)
+
+# Create a test that can be run via ctest
+include(CTest)
+add_test(NAME GridKitConsumer
+    COMMAND consumer
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/examples/Consumer/GridKitConsumer/CMakeLists.txt.in
+++ b/examples/Consumer/GridKitConsumer/CMakeLists.txt.in
@@ -25,4 +25,4 @@ target_link_libraries(consumer
 include(CTest)
 add_test(NAME GridKitConsumer
     COMMAND consumer
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})

--- a/examples/Consumer/test.sh
+++ b/examples/Consumer/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This script gets executed in `make test_install`. 
+
+# GridKit install prefix used for CMake dependency finding
+export GridKit_DIR=${1}
+echo ${GridKit_DIR}
+
+# Locate source of the consumer test app
+export INSTALL_BUILD_CONSUME=${GridKit_DIR}/share/gridkit/examples/GridKitConsumer
+echo ${INSTALL_BUILD_CONSUME}
+
+# Create build directory
+mkdir -p ${INSTALL_BUILD_CONSUME}/build
+
+rm -rf ${INSTALL_BUILD_CONSUME}/build/* &&
+
+# Configure consumer project
+cmake -B ${INSTALL_BUILD_CONSUME}/build \
+    -S ${INSTALL_BUILD_CONSUME} \
+    -DGridKit_DIR=${GridKit_DIR} &&
+
+# Build and install
+cmake --build ${INSTALL_BUILD_CONSUME}/build &&
+
+cmake --install ${INSTALL_BUILD_CONSUME}/build &&
+
+# Check
+cd ${INSTALL_BUILD_CONSUME}/build &&
+
+ctest --output-on-failure
+
+exit $?

--- a/examples/Consumer/test.sh
+++ b/examples/Consumer/test.sh
@@ -4,11 +4,13 @@
 
 # GridKit install prefix used for CMake dependency finding
 export GridKit_DIR=${1}
-echo ${GridKit_DIR}
+echo "GridKit_DIR: ${GridKit_DIR}"
+
+export COMPILER=${2}
 
 # Locate source of the consumer test app
 export INSTALL_BUILD_CONSUME=${GridKit_DIR}/share/gridkit/examples/GridKitConsumer
-echo ${INSTALL_BUILD_CONSUME}
+echo "Consumer directory: ${INSTALL_BUILD_CONSUME}"
 
 # Create build directory
 mkdir -p ${INSTALL_BUILD_CONSUME}/build
@@ -18,6 +20,7 @@ rm -rf ${INSTALL_BUILD_CONSUME}/build/* &&
 # Configure consumer project
 cmake -B ${INSTALL_BUILD_CONSUME}/build \
     -S ${INSTALL_BUILD_CONSUME} \
+    -DCMAKE_CXX_COMPILER=${COMPILER} \
     -DGridKit_DIR=${GridKit_DIR} &&
 
 # Build and install

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
@@ -17,7 +17,6 @@
 #include <Model/PhasorDynamics/SystemModel.hpp>
 #include <Model/PhasorDynamics/SystemModelData.hpp>
 #include <Solver/Dynamic/Ida.hpp>
-#include <Utilities/Testing.hpp>
 
 int main(int argc, const char* argv[])
 {


### PR DESCRIPTION
## Description
 
Introduce code to test the installation
 
 _Closes #253_
 
 ## Proposed changes
 
Install a standalone CMake project that links against GridKit library targets and a script to build and test this project. The test is added as a custom target `test_install` and is NOT included with ctest (because it requires installing GridKit).
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [X] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.