### PR TITLE
Misc Documentation Cleanup

### DIFF
--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
@@ -190,8 +190,8 @@ int main()
     std::vector<double>& y_val = sys.y();
 
     output.push_back(OutputData{t,
-                                y_val[5],
-                                y_val[10],
+                                1 + y_val[5],
+                                1 + y_val[10],
                                 std::hypot(y_val[0], y_val[1]),
                                 std::hypot(y_val[2], y_val[3])});
   };

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassicalJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassicalJson.cpp
@@ -136,8 +136,8 @@ int main(int argc, const char* argv[])
     std::vector<double>& y_val = sys.y();
 
     output.push_back(OutputData{t,
-                                y_val[5],
-                                y_val[10],
+                                1 + y_val[5],
+                                1 + y_val[10],
                                 std::hypot(y_val[0], y_val[1]),
                                 std::hypot(y_val[2], y_val[3])});
   };

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
@@ -41,13 +41,14 @@ $S_{12}$   | [p.u.]  | Saturation factor at 1.2 pu flux | 0 |
 ### Model Derived Parameters
 ``` math
 \begin{aligned}
-  G   &=\dfrac{R_a}{R_a^2+(X_q'')^2}&
-  B   &= -\dfrac{X_q''}{R_a^2+(X_q'')^2}\\
-  S_A &= \dfrac{1.2\sqrt{S_{10}/S_{12}} +1}{\sqrt{S_{10}/S_{12}} +1} & 
-  S_B &= \dfrac{1.2\sqrt{S_{10}/S_{12}} -1}{\sqrt{S_{10}/S_{12}} -1} \\
-  X_{d1} &= X_d-X_d'      & X_{q1} &= X_q-X_q' \\
-  X_{d2} &= X_d'-X_\ell  & X_{q2} &= X_q'-X_\ell\\
-  X_{d3} &= (X_d'-X_d'')/X_{d2}^2 & X_{q3} &= (X_q'-X_q'')/X_{q2}^2 \\
+  G      &=  \dfrac{R_a}{R_a^2+(X_q'')^2} &
+  B      &= -\dfrac{X_q''}{R_a^2+(X_q'')^2}\\
+  S_A    &= \dfrac{1.2\sqrt{S_{10}/S_{12}} +1}{\sqrt{S_{10}/S_{12}} +1} & 
+  S_B    &= \dfrac{1.2\sqrt{S_{10}/S_{12}} -1}{\sqrt{S_{10}/S_{12}} -1} \\
+  X_{d1} &= X_d-X_d'                 & X_{q1} &= X_q-X_q' \\
+  X_{d2} &= X_d'-X_\ell              & X_{q2} &= X_q'-X_\ell\\
+  X_{d3} &= (X_d'-X_d'')/X_{d2}^2    & X_{q3} &= (X_q'-X_q'')/X_{q2}^2 \\
+  X_{d4} &= (X_d'-X_d'')/X_{d2}      & X_{q4} &= (X_q'-X_q'')/X_{q2} \\
   X_{d5} &= (X_d''-X_\ell)/X_{d2}    & X_{q5} &= (X_q''-X_\ell)/X_{q2}\\
   X_{qd} &= (X_q-X_\ell)/(X_d-X_\ell)
 \end{aligned}

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
@@ -142,7 +142,7 @@ Note that for implementation purposes, some of these equations may be simplified
 ## Initialization
 
 ### Without Saturation
-Presume there is no saturation to simplify solution procedure for initial 
+Presume there is no saturation to simplify the solution procedure for the initial 
 conditions.
 
 Using the power-flow solution, we have explicit solutions for the following 
@@ -151,7 +151,7 @@ from the network interface equations. The remaining are algebraically solved
 from the steady-state initial conditions.
 ``` math
 \begin{aligned}
-\omega &= 1 \\
+\omega &= 0 \\
 \delta &= \text{arg} \left[V_r + jV_i + (R_a + jX_q) (I_r + jI_i)\right] \\
   \psi^{''}_{d} &= V_q \\
   \psi^{''}_{q} &= -V_d \\
@@ -170,9 +170,9 @@ from the steady-state initial conditions.
 
 ### With Saturation
 It is important to point out that finding the initial value of $\delta$ for
-the model without saturation direct method can be used. In case when saturation
-is considered some "clever" math is needed. Key insight for determining initial
-$\delta$ is that the magnitude of the saturation depends upon the magnitude
+the model without saturation, the direct method can be used. In case saturation
+is considered, some "clever" math is needed. Key insight for determining initial
+$\delta$ is that the magnitude of the saturation, which depends upon the magnitude
 of $\psi''$, which is independent of $\delta$.
 
 ``` math

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -170,7 +170,7 @@ namespace GridKit
       ScalarT Er    = Ra_ * ir - Xdp_ * ii + vr;
       ScalarT Ei    = Ra_ * ii + Xdp_ * ir + vi;
       ScalarT delta = std::atan2(Ei, Er);
-      ScalarT omega = static_cast<ScalarT>(1.0);
+      ScalarT omega = static_cast<ScalarT>(0.0);
       ScalarT Ep    = std::sqrt(Er * Er + Ei * Ei);
       ScalarT Te    = G_ * Ep * Ep - Ep * ((G_ * vr - B_ * vi) * std::cos(delta) + (B_ * vr + G_ * vi) * std::sin(delta));
 
@@ -230,8 +230,8 @@ namespace GridKit
       const ScalarT vi = wb[1];
 
       // GenClassical differential equations
-      f[0] = delta_dot - (omega - 1.0) * (2.0 * M_PI * 60.0);
-      f[1] = omega_dot - (1.0 / (2.0 * H_)) * ((pmech - D_ * (omega - 1.0)) / omega - telec);
+      f[0] = delta_dot - omega * (2.0 * M_PI * 60.0);
+      f[1] = omega_dot - (1.0 / (2.0 * H_)) * ((pmech - D_ * omega) / (1 + omega) - telec);
 
       // GenClassical algebraic equations
       f[2] = telec - (G_ * ep * ep - ep * ((G_ * vr - B_ * vi) * std::cos(delta) + (B_ * vr + G_ * vi) * std::sin(delta)));

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
@@ -1,7 +1,7 @@
 # Classical Generator
 
-An electrical machine model with two differential variables (i.e. second order
-model) is often called classical generator model. While its predicitve ability
+An electrical machine model with two differential variables (i.e. second-order
+model) is often called classical generator model. While its predictive ability
 is limited, it is useful for studies of grid network properties. Mathematically,
 it is equivalent to a driven damped pendulum model.
 
@@ -41,7 +41,7 @@ $T_{e}$ | [p.u.] | electrical torque                   |
 $I_r$   | [p.u.] | machine real injection current      | read by bus
 $I_i$   | [p.u.] | machine imaginary injection current | read by bus
 
-Note: All three can be expressed as function called by model equations. We add
+Note: All three can be expressed as a function called by the model equations. We add
 these as variables as they are needed for outputs.
 
 <br>
@@ -117,7 +117,7 @@ I_i &= \frac{PV_i - QV_r}{V_r^2 + V_i^2}
 \end{aligned} 
 ```
 
-We substitute expressions above into equations for current injections and
+We substitute the expressions above into equations for current injections and
 obtain
 ```math
 \begin{aligned}
@@ -125,12 +125,12 @@ E_p \sin\delta &= \dfrac{-B I_r + G I_i}{G^2 + B^2} + V_i \\
 E_p \cos\delta &= \dfrac{G I_r + B I_i}{G^2 + B^2} + V_r
 \end{aligned}
 ```
-By dividing these two equations we get expression for machine angle at the
-steady state
+By dividing these two equations, we get an expression for the machine angle at the
+steady state:
 ```math
 \delta = \arctan \dfrac{E_i}{E_r} \, ,
 ```
-and by squaring and adding them, we get expression for field
+And by squaring and adding them, we get an expression for the field
 winding voltage at the steady state
 ```math
 E_p = \sqrt{E_r^2 + E_i^2}   \, ,
@@ -143,12 +143,12 @@ E_i &= \dfrac{-B I_r + G I_i}{G^2 + B^2} + V_i \, .
 \end{aligned}
 ```
 
-Next, we set machine speed to the synchronous speed:
+Next, we set the machine speed deviation to zero:
 ```math
-\omega = 1
+\omega = 0
 ```
 
-Now, we can compute electrical torque and set mechanical torque to be equal
+Now, we can compute the electrical torque and set the mechanical torque to be equal
 to the electrical:
 ```math
 \begin{aligned}
@@ -158,3 +158,4 @@ P_{m} &= T_{e}
 ```
 
 With this, we initialize the machine at a steady state.
+

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
@@ -158,4 +158,3 @@ P_{m} &= T_{e}
 ```
 
 With this, we initialize the machine at a steady state.
-

--- a/src/Model/PhasorDynamics/SynchronousMachine/README.md
+++ b/src/Model/PhasorDynamics/SynchronousMachine/README.md
@@ -7,9 +7,9 @@
 
 <div align="center">
   <img align="center" src="../../../../docs/Figures/SM1.JPG">
-  Figure 1: Synchronous Machine.
-  Figure courtesy of
-  [PowerWorld](https://www.powerworld.com/files/Synchronous-Machines.pdf)
+  
+  Figure 1: Synchronous Machine. Figure courtesy of
+  [PowerWorld](https://www.powerworld.com/files/Synchronous-Machines.pdf/)
 </div>
 
 The following conventions are used for the d-q reference frame.
@@ -18,18 +18,18 @@ The following conventions are used for the d-q reference frame.
 
 ## Types
 
+- Classical Generator (See [GenClassical](GenClassical/README.md))
 - Round Rotor (See [GENROU](GENROUwS/README.md))
 - Salient Rotor/Pole (See [GENSAL](GENSALwS/README.md))
 - GENPWS
 - GENTPF
 - GENTPJ
 - GENQEC
-- GenClassical
 
 ### Per-Unit Basis
 
-In relevant models, the terminal impedences are on the generator impedance base.
-To convert to network base, the following must be performed.
+In relevant models, the terminal impedances are on the generator impedance base.
+To convert to the network base, the following must be performed.
 
 ```math
 \begin{aligned}
@@ -40,7 +40,7 @@ To convert to network base, the following must be performed.
 
 For example, say the terminal impedence is $Z=0.05$ in per-unit on the
 machine's base of $S_{base,machine}=50$  MW, and the system base is
-$S_{base,sys}=100$ MW. Then the terminal impedence on the the system
+$S_{base,sys}=100$ MW. Then the terminal impedance on the system
 base is calculated as follows.
 
 ``` math

--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -94,7 +94,7 @@ namespace GridKit
 
         // Set variable values matching the answer key
         gen.y()[0] = M_PI; // delta
-        gen.y()[1] = 2.0;  // omega
+        gen.y()[1] = 1.0;  // omega
         gen.y()[2] = 2.0;  // telec
         gen.y()[3] = -2.0; // ir
         gen.y()[4] = -4.0; // ii
@@ -145,7 +145,7 @@ namespace GridKit
         // Test answer keys
         const std::vector<ScalarT> var_answer = {
             3.0 * M_PI / 4.0, // delta
-            1.0,              // omega
+            0.0,              // omega
             3.5,              // Te
             1.0,              // Ir
             2.0,              // Ii


### PR DESCRIPTION
## Description
 
Correcting some documentation issues between Genrou and Classical Generator machine models that I thought had previously been fixed.
 
 
 ## Proposed changes
 
- Document two derived formulas in Genrou
- Make GenClassical and Genrou use of $\omega$ consistent for speed deviation
- Update the tests to be aligned with these changes

 ## Checklist

- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.

 