### PR TITLE
test_install in CI

### DIFF
--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -179,10 +179,10 @@ jobs:
         run: spack -e . install --keep-stage --no-check-signature --no-cache --fresh
 
       - name: Test Build
-        run: cd $(spack -e . location --build-dir gridkit@develop) && ctest -VV
+        run: cd $(spack -e . location --build-dir gridkit@develop) && spack -e ${OLDPWD} build-env gridkit ctest -VV
 
       - name: Test Installation
-        run: cd $(spack -e . location --build-dir gridkit@develop) && make test_install
+        run: cd $(spack -e . location --build-dir gridkit@develop) && spack -e ${OLDPWD} build-env gridkit make test_install
 
       # Push with force to override existing binaries...
       - name: Push to binaries to buildcache

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -181,6 +181,9 @@ jobs:
       - name: Test Build
         run: cd $(spack -e . location --build-dir gridkit@develop) && ctest -VV
 
+      - name: Test Installation
+        run: cd $(spack -e . location --build-dir gridkit@develop) && make test_install
+
       # Push with force to override existing binaries...
       - name: Push to binaries to buildcache
         run: |

--- a/.github/workflows/spack_default_build.yaml
+++ b/.github/workflows/spack_default_build.yaml
@@ -102,6 +102,7 @@ jobs:
           - gridkit@develop ~asan~enzyme~ipopt~klu~sundials~ubsan
           - gridkit@develop ~asan~enzyme~ipopt~klu+sundials~ubsan
           - gridkit@develop ~asan+enzyme+ipopt+klu+sundials~ubsan build_type=RelWithDebInfo
+            ^enzyme@0.0.206
           - gridkit@develop +asan~enzyme+ipopt+klu+sundials+ubsan
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,14 +46,15 @@ foreach(_opt IN LISTS _gridkit_enable_options)
   endif()
 endforeach()
 
+# Sanitizers
 if(GRIDKIT_ENABLE_ASAN)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+  set(GRIDKIT_COMPILE_OPTIONS ${GRIDKIT_COMPILE_OPTIONS} -fsanitize=address -fno-omit-frame-pointer CACHE INTERNAL STRING)
+  set(GRIDKIT_LINK_OPTIONS ${GRIDKIT_LINK_OPTIONS} -fsanitize=address CACHE INTERNAL STRING)
 endif()
 
 if(GRIDKIT_ENABLE_UBSAN)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined")
+  set(GRIDKIT_COMPILE_OPTIONS ${GRIDKIT_COMPILE_OPTIONS} -fsanitize=undefined -fno-omit-frame-pointer CACHE INTERNAL STRING)
+  set(GRIDKIT_LINK_OPTIONS ${GRIDKIT_LINK_OPTIONS} -fsanitize=undefined CACHE INTERNAL STRING)
 endif()
 
 set(CMAKE_MACOSX_RPATH 1)
@@ -80,7 +81,6 @@ list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib"
 if("${isSystemDir}" STREQUAL "-1")
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif("${isSystemDir}" STREQUAL "-1")
-
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_BINARY_DIR})
 

--- a/cmake/GridkitAddLibrary.cmake
+++ b/cmake/GridkitAddLibrary.cmake
@@ -43,6 +43,7 @@ macro(gridkit_add_library target)
   add_library(${target} ${gridkit_add_library_SOURCES})
 
   # add link libraries
+  target_link_options(${target} INTERFACE ${GRIDKIT_LINK_OPTIONS})
   if(gridkit_add_library_LINK_LIBRARIES)
     target_link_libraries(${target} ${gridkit_add_library_LINK_LIBRARIES})
   endif()
@@ -59,6 +60,7 @@ macro(gridkit_add_library target)
 
   # add compile options
   target_compile_features(${target} PUBLIC cxx_std_20)
+  target_compile_options(${target} INTERFACE ${GRIDKIT_COMPILE_OPTIONS})
   if(gridkit_add_library_COMPILE_OPTIONS)
     target_compile_options(${target} ${gridkit_add_library_COMPILE_OPTIONS})
   endif()

--- a/cmake/GridkitAddLibrary.cmake
+++ b/cmake/GridkitAddLibrary.cmake
@@ -60,7 +60,7 @@ macro(gridkit_add_library target)
   # add compile options
   target_compile_features(${target} PUBLIC cxx_std_20)
   if(gridkit_add_library_COMPILE_OPTIONS)
-    target_compile_options(${target} PRIVATE ${gridkit_add_library_COMPILE_OPTIONS})
+    target_compile_options(${target} ${gridkit_add_library_COMPILE_OPTIONS})
   endif()
 
   # add alias library

--- a/cmake/GridkitAddLibrary.cmake
+++ b/cmake/GridkitAddLibrary.cmake
@@ -60,7 +60,7 @@ macro(gridkit_add_library target)
   # add compile options
   target_compile_features(${target} PUBLIC cxx_std_20)
   if(gridkit_add_library_COMPILE_OPTIONS)
-    target_compile_options(${target} PUBLIC ${gridkit_add_library_COMPILE_OPTIONS})
+    target_compile_options(${target} PRIVATE ${gridkit_add_library_COMPILE_OPTIONS})
   endif()
 
   # add alias library

--- a/src/Model/PhasorDynamics/Branch/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Branch/CMakeLists.txt
@@ -16,7 +16,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     HEADERS
       ${_install_headers}
     LINK_LIBRARIES
-      ClangEnzymeFlags
+      PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()

--- a/src/Model/PhasorDynamics/Branch/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Branch/CMakeLists.txt
@@ -18,7 +18,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     LINK_LIBRARIES
       PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
+      PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
   gridkit_add_library(phasor_dynamics_branch
     SOURCES

--- a/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
@@ -10,7 +10,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     HEADERS
       ${_install_headers}
     LINK_LIBRARIES
-      ClangEnzymeFlags
+      PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()

--- a/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/BusFault/CMakeLists.txt
@@ -12,7 +12,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     LINK_LIBRARIES
       PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
+      PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
   gridkit_add_library(phasor_dynamics_bus_fault
     SOURCES

--- a/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
@@ -15,8 +15,8 @@ if(GRIDKIT_ENABLE_ENZYME)
     HEADERS
       ${_install_headers}
     LINK_LIBRARIES
-      GridKit::phasor_dynamics_signal
-      ClangEnzymeFlags
+      PUBLIC GridKit::phasor_dynamics_signal
+      PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()

--- a/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
@@ -18,7 +18,7 @@ if(GRIDKIT_ENABLE_ENZYME)
       PUBLIC GridKit::phasor_dynamics_signal
       PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
+      PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
   gridkit_add_library(phasor_dynamics_governortgov1
     SOURCES

--- a/src/Model/PhasorDynamics/Load/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Load/CMakeLists.txt
@@ -18,7 +18,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     LINK_LIBRARIES
       PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
+      PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
   gridkit_add_library(phasor_dynamics_load
     SOURCES

--- a/src/Model/PhasorDynamics/Load/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/Load/CMakeLists.txt
@@ -16,7 +16,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     HEADERS
       ${_install_headers}
     LINK_LIBRARIES
-      ClangEnzymeFlags
+      PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
@@ -10,7 +10,8 @@ if(GRIDKIT_ENABLE_ENZYME)
     HEADERS
       ${_install_headers}
     LINK_LIBRARIES
-      PUBLIC GridKit::phasor_dynamics_signal ClangEnzymeFlags
+      PUBLIC GridKit::phasor_dynamics_signal 
+      PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno -fno-vectorize)
 else()

--- a/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
@@ -13,7 +13,7 @@ if(GRIDKIT_ENABLE_ENZYME)
       PUBLIC GridKit::phasor_dynamics_signal 
       PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno -fno-vectorize)
+      PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno -fno-vectorize)
 else()
   gridkit_add_library(phasor_dynamics_genrou
     SOURCES

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
@@ -17,7 +17,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     LINK_LIBRARIES
       PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
-      -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
+      PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
   gridkit_add_library(phasor_dynamics_gen_classical
     SOURCES

--- a/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
+++ b/src/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
@@ -15,7 +15,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     HEADERS
       ${_install_headers}
     LINK_LIBRARIES
-      ClangEnzymeFlags
+      PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
       -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()


### PR DESCRIPTION
## Description
 
This adds the consumer test to CI and fixes a related bug due to public Enzyme options.
 
 ## Proposed changes
 
- Added a `Test Installation` step to CI that runs `make test_install`
- Made Enzyme-related `target_compile_options` and `target_link_libraries` `PRIVATE`.
- Added a workaround to export sanitizers without creating separate targets. Thanks @PhilipFackler. We may want to find a more elegant solution, but that likely requires more significant changes to the `gridkit_add_library` macro or a different approach altogether.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [N/A] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 CMake and CI changes.
