### PR TITLE
Modify Smooth Approximation of Limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Updated Jacobian value storage from `ScalarT` to `RealT`.
 - Added a header file defining constants to be used throughout the code.
 - Added `GridKitDocs` target for Doxygen documentation.
+- Added a header file defining common math functions (e.g., sigmoid) to be used throughout the code.
 
 ## v0.1
 

--- a/GridKit/CMakeLists.txt
+++ b/GridKit/CMakeLists.txt
@@ -28,6 +28,7 @@ add_subdirectory(Solver)
 install(
   FILES
     Constants.hpp
+    CommonMath.hpp
     ScalarTraits.hpp
   DESTINATION
     include/GridKit)

--- a/GridKit/CommonMath.hpp
+++ b/GridKit/CommonMath.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cmath>
+
+#include <GridKit/Constants.hpp>
+#include <GridKit/ScalarTraits.hpp>
+
+namespace GridKit
+{
+  namespace Math
+  {
+    /**
+     * @brief Scaled sigmoid activation function
+     *
+     * @note The sigmoid constant (mu) value of the constant to balance accuracy
+     * and finite derivatives. Large values more closely approximate a step
+     * function, but lead to inf or NaN derivatives. The value of 240 corresponds
+     * to a time step of 1/4 of a 60Hz cycle.
+     *
+     * @tparam ScalarT - scalar data type
+     *
+     * @param[in] x
+     * @return value of the sigmoid function
+     */
+    template <class ScalarT>
+    __attribute__((always_inline)) inline ScalarT sigmoid(ScalarT x)
+    {
+      using RealT = typename GridKit::ScalarTraits<ScalarT>::RealT;
+      static constexpr RealT MU = 240.0;
+      return ONE<RealT> / (ONE<RealT> + std::exp(-MU * x));
+    }
+  } // namespace Math
+} // namespace GridKit

--- a/GridKit/CommonMath.hpp
+++ b/GridKit/CommonMath.hpp
@@ -14,7 +14,7 @@ namespace GridKit
      *
      * @note The sigmoid constant (mu) value is chosen to balance accuracy
      * and finite derivatives. Large values more closely approximate a step
-     * function, but lead to inf or NaN derivatives. 
+     * function, but lead to inf or NaN derivatives.
      * The value of 240 corresponds to a time step of 1/4 of a 60Hz cycle.
      * From experiments, numerical derivatives break down for mu above 700.
      *

--- a/GridKit/CommonMath.hpp
+++ b/GridKit/CommonMath.hpp
@@ -25,7 +25,7 @@ namespace GridKit
     template <class ScalarT>
     __attribute__((always_inline)) inline ScalarT sigmoid(const ScalarT x)
     {
-      using RealT = typename GridKit::ScalarTraits<ScalarT>::RealT;
+      using RealT               = typename GridKit::ScalarTraits<ScalarT>::RealT;
       static constexpr RealT MU = 240.0;
       return ONE<RealT> / (ONE<RealT> + std::exp(-MU * x));
     }
@@ -43,8 +43,8 @@ namespace GridKit
      */
     template <class ScalarT, typename RealT>
     __attribute__((always_inline)) inline ScalarT indicator_low(
-        const RealT limit_min, 
-        const ScalarT x, 
+        const RealT   limit_min,
+        const ScalarT x,
         const ScalarT f)
     {
       return sigmoid(limit_min - x) * sigmoid(-f);
@@ -63,8 +63,8 @@ namespace GridKit
      */
     template <class ScalarT, typename RealT>
     __attribute__((always_inline)) inline ScalarT indicator_high(
-        const RealT limit_max, 
-        const ScalarT x, 
+        const RealT   limit_max,
+        const ScalarT x,
         const ScalarT f)
     {
       return sigmoid(x - limit_max) * sigmoid(f);
@@ -84,9 +84,9 @@ namespace GridKit
      */
     template <class ScalarT, typename RealT>
     __attribute__((always_inline)) inline ScalarT indicator(
-        const RealT limit_min, 
-        const RealT limit_max, 
-        const ScalarT x, 
+        const RealT   limit_min,
+        const RealT   limit_max,
+        const ScalarT x,
         const ScalarT f)
     {
       return (ONE<RealT> - indicator_low(limit_min, x, f)) * (ONE<RealT> - indicator_high(limit_max, x, f));

--- a/GridKit/CommonMath.hpp
+++ b/GridKit/CommonMath.hpp
@@ -14,8 +14,9 @@ namespace GridKit
      *
      * @note The sigmoid constant (mu) value of the constant to balance accuracy
      * and finite derivatives. Large values more closely approximate a step
-     * function, but lead to inf or NaN derivatives. The value of 240 corresponds
-     * to a time step of 1/4 of a 60Hz cycle.
+     * function, but lead to inf or NaN derivatives. 
+     * The value of 240 corresponds to a time step of 1/4 of a 60Hz cycle.
+     * From experiments, numerical derivatives break down for mu above 700.
      *
      * @tparam ScalarT - scalar data type
      *

--- a/GridKit/CommonMath.hpp
+++ b/GridKit/CommonMath.hpp
@@ -12,7 +12,7 @@ namespace GridKit
     /**
      * @brief Scaled sigmoid activation function
      *
-     * @note The sigmoid constant (mu) value of the constant to balance accuracy
+     * @note The sigmoid constant (mu) value is chosen to balance accuracy
      * and finite derivatives. Large values more closely approximate a step
      * function, but lead to inf or NaN derivatives. 
      * The value of 240 corresponds to a time step of 1/4 of a 60Hz cycle.

--- a/GridKit/CommonMath.hpp
+++ b/GridKit/CommonMath.hpp
@@ -23,11 +23,73 @@ namespace GridKit
      * @return value of the sigmoid function
      */
     template <class ScalarT>
-    __attribute__((always_inline)) inline ScalarT sigmoid(ScalarT x)
+    __attribute__((always_inline)) inline ScalarT sigmoid(const ScalarT x)
     {
       using RealT = typename GridKit::ScalarTraits<ScalarT>::RealT;
       static constexpr RealT MU = 240.0;
       return ONE<RealT> / (ONE<RealT> + std::exp(-MU * x));
+    }
+
+    /**
+     * @brief Low indicator function for regulator limits
+     *
+     * @tparam ScalarT - Scalar data type
+     * @tparam RealT - Real data type (see GridKit::ScalarTraits<ScalarT>::RealT)
+     *
+     * @param[in] limit_min - Minimum limit
+     * @param[in] x - State variable
+     * @param[in] f - Conditional derivative of state variable
+     * @return Scalar value indicating limit activation
+     */
+    template <class ScalarT, typename RealT>
+    __attribute__((always_inline)) inline ScalarT indicator_low(
+        const RealT limit_min, 
+        const ScalarT x, 
+        const ScalarT f)
+    {
+      return sigmoid(limit_min - x) * sigmoid(-f);
+    }
+
+    /**
+     * @brief High indicator function for regulator limits
+     *
+     * @tparam ScalarT - Scalar data type
+     * @tparam RealT - Real data type (see GridKit::ScalarTraits<ScalarT>::RealT)
+     *
+     * @param[in] limit_max - Maximum limit
+     * @param[in] x - State variable
+     * @param[in] f - Conditional derivative of state variable
+     * @return Scalar value indicating limit activation
+     */
+    template <class ScalarT, typename RealT>
+    __attribute__((always_inline)) inline ScalarT indicator_high(
+        const RealT limit_max, 
+        const ScalarT x, 
+        const ScalarT f)
+    {
+      return sigmoid(x - limit_max) * sigmoid(f);
+    }
+
+    /**
+     * @brief Net Indicator function for regulator limits
+     *
+     * @tparam ScalarT - Scalar data type
+     * @tparam RealT - Real data type (see GridKit::ScalarTraits<ScalarT>::RealT)
+     *
+     * @param[in] limit_min - Minimum limit
+     * @param[in] limit_max - Maximum limit
+     * @param[in] x - State variable
+     * @param[in] f - Conditional derivative of state variable
+     * @return Scalar value indicating limit activation
+     */
+    template <class ScalarT, typename RealT>
+    __attribute__((always_inline)) inline ScalarT indicator(
+        const RealT limit_min, 
+        const RealT limit_max, 
+        const ScalarT x, 
+        const ScalarT f)
+    {
+      return (ONE<RealT> - indicator_low(limit_min, x, f)) * (ONE<RealT> - indicator_high(limit_max, x, f));
     }
   } // namespace Math
 } // namespace GridKit

--- a/GridKit/Model/Evaluator.hpp
+++ b/GridKit/Model/Evaluator.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include <GridKit/Constants.hpp>
+#include <GridKit/CommonMath.hpp>
 #include <GridKit/LinearAlgebra/SparseMatrix/COO_Matrix.hpp>
 #include <GridKit/ScalarTraits.hpp>
 

--- a/GridKit/Model/Evaluator.hpp
+++ b/GridKit/Model/Evaluator.hpp
@@ -2,8 +2,8 @@
 
 #include <vector>
 
-#include <GridKit/Constants.hpp>
 #include <GridKit/CommonMath.hpp>
+#include <GridKit/Constants.hpp>
 #include <GridKit/LinearAlgebra/SparseMatrix/COO_Matrix.hpp>
 #include <GridKit/ScalarTraits.hpp>
 

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -150,9 +150,6 @@ namespace GridKit
         /// Component signal extension
         ComponentSignals<ScalarT, IdxT, Ieeet1InternalVariables, Ieeet1ExternalVariables> signals_;
 
-        // Indicator 
-        ScalarT indicator(ScalarT x, ScalarT f);
-
         // Parameter initialization function
         void initModelParams(const model_data_type& data);
       };

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -150,13 +150,7 @@ namespace GridKit
         /// Component signal extension
         ComponentSignals<ScalarT, IdxT, Ieeet1InternalVariables, Ieeet1ExternalVariables> signals_;
 
-        // Scale of Sigmoid function
-        // (temporary local implementation)
-        // mu set to 4*60, to provide accuracy and finite derivatives.
-        const RealT mu_{240.0};
-
-        // Activation function (sigmoid approximation)
-        ScalarT sigmoid(ScalarT x);
+        // Indicator 
         ScalarT indicator(ScalarT x, ScalarT f);
 
         // Parameter initialization function

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -152,8 +152,8 @@ namespace GridKit
 
         // Scale of Sigmoid function
         // (temporary local implementation)
-        // This value gave higher precision.
-        const RealT mu_{400000.0};
+        // mu set to 4*60, to provide accuracy and finite derivatives.
+        const RealT mu_{240.0};
 
         // Activation function (sigmoid approximation)
         ScalarT sigmoid(ScalarT x);

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -253,7 +253,7 @@ namespace GridKit
       template <class ScalarT, typename IdxT>
       ScalarT Ieeet1<ScalarT, IdxT>::sigmoid(ScalarT x)
       {
-        return ((HALF<RealT> * mu_ * x) / (ONE<RealT> + std::abs(mu_ * x))) + HALF<RealT>;
+        return ONE<RealT> / (ONE<RealT> + std::exp(- mu_ * x));
       }
 
       /**

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -340,11 +340,8 @@ namespace GridKit
         f_[6] = -ve + ksat * efdp;
         f_[7] = -efd + efdp + omega * efdp * Ispdlim_;
 
-        // TODO smooth approaximation for Enzyme
-        // NOTE seems about double PW saturation.
-        f_[8] = -ksat;
-        if (efdp > SA_)
-          f_[8] += SB_ * (efdp - SA_) * (efdp - SA_);
+        ScalarT efd_sat  = (efdp - SA_) * ( this->sigmoid(efdp-SA_) );
+        f_[8] = -ksat + SB_ * efd_sat * efd_sat;
 
         return 0;
       }

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -237,28 +237,6 @@ namespace GridKit
       }
 
       /**
-       * @brief Net Indicator function for regulator limits
-       *
-       * @param[in] x State variable
-       * @param[in] f Conditional derivative of state variable
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
-       * @return Scalar value indicating limit activation.
-       *
-       * @warning This needs to be abstracted to be used
-       *          across phasor dynamics. Identical pattern is
-       *          being used in TGOV1 model.
-       */
-      template <class ScalarT, typename IdxT>
-      ScalarT Ieeet1<ScalarT, IdxT>::indicator(ScalarT x, ScalarT f)
-      {
-
-        ScalarT ind_low  = (Math::sigmoid(Vrmin_ - x)) * (Math::sigmoid(-f));
-        ScalarT ind_high = (Math::sigmoid(x - Vrmax_)) * (Math::sigmoid(f));
-        return (ONE<RealT> - ind_low) * (ONE<RealT> - ind_high);
-      }
-
-      /**
        * @brief Residuals of system equations
        *
        */
@@ -306,7 +284,7 @@ namespace GridKit
 
         // The 'pre-limit' derivative of Pv
         ScalarT f      = -vr + Ka_ * vtr;
-        ScalarT vr_ind = this->indicator(vr, f);
+        ScalarT vr_ind = Math::indicator(Vrmin_, Vrmax_, vr, f);
 
         // Internal Differential Equations
         f_[0] = -vts_dot + (Ec_ - vts) / Tr_;

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -253,7 +253,7 @@ namespace GridKit
       template <class ScalarT, typename IdxT>
       ScalarT Ieeet1<ScalarT, IdxT>::sigmoid(ScalarT x)
       {
-        return ONE<RealT> / (ONE<RealT> + std::exp(- mu_ * x));
+        return ONE<RealT> / (ONE<RealT> + std::exp(-mu_ * x));
       }
 
       /**

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -237,26 +237,6 @@ namespace GridKit
       }
 
       /**
-       * @brief  Scaled sigmoid activation function
-       *
-       * @param[in] x State variable
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
-       * @return Sigmoid approximation evaluated at x
-       *
-       * @warning This needs to be abstracted to be used
-       *          across phasor dynamics. Identical pattern is
-       *          being used in TGOV1 model.
-       *
-       *   Algebraic approximation of transcendental sigmoid.
-       */
-      template <class ScalarT, typename IdxT>
-      ScalarT Ieeet1<ScalarT, IdxT>::sigmoid(ScalarT x)
-      {
-        return ONE<RealT> / (ONE<RealT> + std::exp(-mu_ * x));
-      }
-
-      /**
        * @brief Net Indicator function for regulator limits
        *
        * @param[in] x State variable
@@ -273,8 +253,8 @@ namespace GridKit
       ScalarT Ieeet1<ScalarT, IdxT>::indicator(ScalarT x, ScalarT f)
       {
 
-        ScalarT ind_low  = (this->sigmoid(Vrmin_ - x)) * (this->sigmoid(-f));
-        ScalarT ind_high = (this->sigmoid(x - Vrmax_)) * (this->sigmoid(f));
+        ScalarT ind_low  = (Math::sigmoid(Vrmin_ - x)) * (Math::sigmoid(-f));
+        ScalarT ind_high = (Math::sigmoid(x - Vrmax_)) * (Math::sigmoid(f));
         return (ONE<RealT> - ind_low) * (ONE<RealT> - ind_high);
       }
 
@@ -340,7 +320,7 @@ namespace GridKit
         f_[6] = -ve + ksat * efdp;
         f_[7] = -efd + efdp + omega * efdp * Ispdlim_;
 
-        ScalarT efd_sat = (efdp - SA_) * (this->sigmoid(efdp - SA_));
+        ScalarT efd_sat = (efdp - SA_) * (Math::sigmoid(efdp - SA_));
         f_[8]           = -ksat + SB_ * efd_sat * efd_sat;
 
         return 0;

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -340,8 +340,8 @@ namespace GridKit
         f_[6] = -ve + ksat * efdp;
         f_[7] = -efd + efdp + omega * efdp * Ispdlim_;
 
-        ScalarT efd_sat  = (efdp - SA_) * ( this->sigmoid(efdp-SA_) );
-        f_[8] = -ksat + SB_ * efd_sat * efd_sat;
+        ScalarT efd_sat = (efdp - SA_) * (this->sigmoid(efdp - SA_));
+        f_[8]           = -ksat + SB_ * efd_sat * efd_sat;
 
         return 0;
       }

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/README.md
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/README.md
@@ -160,11 +160,6 @@ The scale of the sigmoid function ($\alpha$ on the order of $10^3$) should be ch
 \begin{aligned}
    \sigma(x) = 
       \dfrac{1}{1+\exp(-\alpha x)}
-   \approx 
-      \dfrac{1}{2}
-      \left(
-         \dfrac{\alpha x}{1+|\alpha x|} + 1
-      \right)
 \end{aligned}
 ```
 

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/README.md
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/README.md
@@ -155,34 +155,11 @@ The indicator function $\phi$ can be defined in terms of a scaled activation fun
 \end{aligned}
 ```
 
-The scale of the sigmoid function ($\alpha$ on the order of $10^3$) should be chosen so that for all practical parameters of the IEEET1 model, the sigmoid acts as a step function. This is further approximated by an algebraic form to obtain a practical function during implementation.
+The scale of the sigmoid function ($\alpha$ on the order of $10^3$) should be chosen so that for all practical parameters of the IEEET1 model, the sigmoid acts as a step function.
 ```math
 \begin{aligned}
    \sigma(x) = 
       \dfrac{1}{1+\exp(-\alpha x)}
-\end{aligned}
-```
-
-Applying these approximations produces a smooth approximation of the explicit differential equation of $V_R$. The approximation written out below approaches an exact solution as $\alpha\to\infty$.
-
-```math
-\begin{aligned}
-   \dot{V}_R 
-   &\approx f
-      \left[
-         1 +
-         \dfrac{\alpha^2}{4}
-         \dfrac{V_{rmin}\text{-}V_R}
-         {1+\alpha |V_{rmin}\text{-}V_R|}
-         \dfrac{f}{1+\alpha |f|}
-      \right]
-      \left[
-         1-
-         \dfrac{\alpha^2}{4}
-         \dfrac{V_R\text{-}V_{rmax}}
-            {1+\alpha| V_R\text{-}V_{rmax}|}
-            \dfrac{f}{1+\alpha |f|}
-      \right]\\
 \end{aligned}
 ```
 
@@ -210,9 +187,9 @@ For the algebraic piecewise functions (non-flags), this implementation is straig
 ```math
 \begin{aligned}
     E_{fd}
-    &= E_{fd}' + \omega E_{fd}' I_{spdlm} \\ 
+    &=(1 + \omega I_{spdlm})E_{fd}' \\ 
     k_{sat}
-    &=S_B\left[\sigma (E_{fd}' -S_A) \cdot (E_{fd}' -S_A)\right]^2   
+    &=S_B\left[(E_{fd}' -S_A) \cdot \sigma (E_{fd}' -S_A)\right]^2   
 \end{aligned}
 ```
 

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/README.md
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/README.md
@@ -165,25 +165,6 @@ The scale of the sigmoid function ($\alpha$ on the order of $10^3$) should be ch
 
 Applying these approximations produces a smooth approximation of the explicit differential equation of $V_R$. The approximation written out below approaches an exact solution as $\alpha\to\infty$.
 
-<!--
-Very explicit version, if prefered
-```math
-\begin{aligned}
-   \dot{V}_R 
-   &\approx \dfrac{K_{a}V_{tr}-V_{R}}{T_A}
-      \left[
-         1 +
-         \dfrac{\alpha^2(V_{rmin}\text{-}V_R)(K_{a}V_{tr}-V_{R})}
-         {4(1+\alpha |V_{rmin}\text{-}V_R|)(T_A+\alpha |K_{a}V_{tr}-V_{R}|)}
-      \right]
-      \left[
-         1-
-            \dfrac{\alpha^2(V_R\text{-}V_{rmax})(K_{a}V_{tr}-V_{R})}
-            {4(1+\alpha| V_R\text{-}V_{rmax}|)(T_A+\alpha |K_{a}V_{tr}-V_{R}|)}
-      \right]\\
-\end{aligned}
-```
--->
 ```math
 \begin{aligned}
    \dot{V}_R 
@@ -223,22 +204,19 @@ The algebraic equations of the exciter.
    \end{cases} \\
 \end{aligned}
 ```
-
 #### Smooth Piecewise Approximation (Algebraic) 
 
 For the algebraic piecewise functions (non-flags), this implementation is straightforward when the approximation above is used.
 ```math
 \begin{aligned}
+    E_{fd}
+    &= E_{fd}' + \omega E_{fd}' I_{spdlm} \\ 
     k_{sat}
-    &=\sigma (E_{fd}' -S_A) \cdot S_B(E_{fd}' -S_A)^2   
+    &=S_B\left[\sigma (E_{fd}' -S_A) \cdot (E_{fd}' -S_A)\right]^2   
 \end{aligned}
 ```
-The approximation written out below approaches an exact solution as $\alpha\to\infty$.
-```math
-\begin{aligned}
-    k_{sat}&\approx\dfrac{\alpha S_B}{2} \dfrac{(E_{fd}' -S_A)^3}{1+\alpha|E_{fd}' -S_A|}
-\end{aligned}
-```
+
+The approximation approaches an exact solution as $\alpha\to\infty$.
 
 ## Initialization
 

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/README.md
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/README.md
@@ -93,15 +93,15 @@ smooth approximation (smooth indicator $\phi$) expressed generically as follows.
 ```
 
 The indicator function $\phi$ can be defined in terms of a scaled activation function ($\sigma$, sigmoid) and the $P_v$ limits $(P_{vmin}, P_{vmax})$.
-$$
+```math
 \begin{aligned}
    \phi_L(P_v,f)&= \sigma(P_{vmin}-P_v)\sigma(-f)            \\
    \phi_U(P_v,f)&= \sigma(P_v-P_{vmax})\sigma(f)             \\
    \phi(P_v,f)  &= \left[1-\phi_L\right]\left[1-\phi_U\right]\\
 \end{aligned}
-$$
+```
 
-The scale of the sigmoid function ($\alpha$ on the order of $10^3$) should be chosen so that for all practical parameters of the TGOV1 model, the sigmoid acts as a step function. This is further approximated by an algebraic form to obtain a practical function during implementation.
+The scale of the sigmoid function ($\alpha$ on the order of $10^3$) should be chosen so that for all practical parameters of the TGOV1 model, the sigmoid acts as a step function.
 ```math
 \begin{aligned}
    \sigma(x) =\dfrac{1}{1+\exp(-\alpha x)}

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/README.md
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/README.md
@@ -93,13 +93,13 @@ smooth approximation (smooth indicator $\phi$) expressed generically as follows.
 ```
 
 The indicator function $\phi$ can be defined in terms of a scaled activation function ($\sigma$, sigmoid) and the $P_v$ limits $(P_{vmin}, P_{vmax})$.
-```math
+$$
 \begin{aligned}
    \phi_L(P_v,f)&= \sigma(P_{vmin}-P_v)\sigma(-f)            \\
    \phi_U(P_v,f)&= \sigma(P_v-P_{vmax})\sigma(f)             \\
    \phi(P_v,f)  &= \left[1-\phi_L\right]\left[1-\phi_U\right]\\
 \end{aligned}
-```
+$$
 
 The scale of the sigmoid function ($\alpha$ on the order of $10^3$) should be chosen so that for all practical parameters of the TGOV1 model, the sigmoid acts as a step function. This is further approximated by an algebraic form to obtain a practical function during implementation.
 ```math

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/README.md
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/README.md
@@ -104,7 +104,7 @@ The indicator function $\phi$ can be defined in terms of a scaled activation fun
 The scale of the sigmoid function ($\alpha$ on the order of $10^3$) should be chosen so that for all practical parameters of the TGOV1 model, the sigmoid acts as a step function. This is further approximated by an algebraic form to obtain a practical function during implementation.
 ```math
 \begin{aligned}
-   \sigma(x) =\dfrac{1}{1+\exp(-\alpha x)}\approx \dfrac{1}{2}\left(\dfrac{\alpha x}{1+|\alpha x|}\right)
+   \sigma(x) =\dfrac{1}{1+\exp(-\alpha x)}
 \end{aligned}
 ```
 

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -122,7 +122,8 @@ namespace GridKit
         ScalarT pref_{0};
 
         // Scale of Sigmoid function (temporary local implementation)
-        const ScalarT mu_{4000.0};
+        // mu set to 4*60, to provide accuracy and finite derivatives.
+        const ScalarT mu_{240.0};
 
         /// Component signal extension
         ComponentSignals<ScalarT, IdxT, Tgov1InternalVariables, Tgov1ExternalVariables> signals_;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -124,11 +124,7 @@ namespace GridKit
         /// Component signal extension
         ComponentSignals<ScalarT, IdxT, Tgov1InternalVariables, Tgov1ExternalVariables> signals_;
 
-        // Indicator of Valve limit states
-        ScalarT indicator_low(ScalarT x, ScalarT f);
-        ScalarT indicator_high(ScalarT x, ScalarT f);
-        ScalarT indicator(ScalarT x, ScalarT f);
-
+        // Parameter initialization function
         void initializeParameters(const model_data_type& data);
 
         /* Local copies of external variables */

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -121,15 +121,8 @@ namespace GridKit
         // Input States (which can be parameters)
         ScalarT pref_{0};
 
-        // Scale of Sigmoid function (temporary local implementation)
-        // mu set to 4*60, to provide accuracy and finite derivatives.
-        const ScalarT mu_{240.0};
-
         /// Component signal extension
         ComponentSignals<ScalarT, IdxT, Tgov1InternalVariables, Tgov1ExternalVariables> signals_;
-
-        // Activation function (sigmoid approximation)
-        ScalarT sigmoid(ScalarT x);
 
         // Indicator of Valve limit states
         ScalarT indicator_low(ScalarT x, ScalarT f);

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -241,7 +241,7 @@ namespace GridKit
       template <class ScalarT, typename IdxT>
       ScalarT Tgov1<ScalarT, IdxT>::sigmoid(ScalarT x)
       {
-        return ((HALF<RealT> * mu_ * x) / (ONE<RealT> + std::abs(mu_ * x))) + HALF<RealT>;
+        return ONE<RealT> / (ONE<RealT> + std::exp(- mu_ * x));
       }
 
       /**

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -230,27 +230,12 @@ namespace GridKit
       }
 
       /**
-       * @brief Scaled sigmoid activation function
-       *
-       * Temporary local implementation of smooth approximation
-       * of a piecewise differential equation. Ideally this is
-       * a more abstracted capability with GK.
-       *
-       * Algebraic approximation of transcendental sigmoid.
-       */
-      template <class ScalarT, typename IdxT>
-      ScalarT Tgov1<ScalarT, IdxT>::sigmoid(ScalarT x)
-      {
-        return ONE<RealT> / (ONE<RealT> + std::exp(-mu_ * x));
-      }
-
-      /**
        * @brief Indicator function for lower valve limit violation.
        */
       template <class ScalarT, typename IdxT>
       ScalarT Tgov1<ScalarT, IdxT>::indicator_low(ScalarT x, ScalarT f)
       {
-        return (this->sigmoid(Pvmin_ - x)) * (this->sigmoid(-f));
+        return (Math::sigmoid(Pvmin_ - x)) * (Math::sigmoid(-f));
       }
 
       /**
@@ -259,7 +244,7 @@ namespace GridKit
       template <class ScalarT, typename IdxT>
       ScalarT Tgov1<ScalarT, IdxT>::indicator_high(ScalarT x, ScalarT f)
       {
-        return (this->sigmoid(x - Pvmax_)) * (this->sigmoid(f));
+        return (Math::sigmoid(x - Pvmax_)) * (Math::sigmoid(f));
       }
 
       /**

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -230,33 +230,6 @@ namespace GridKit
       }
 
       /**
-       * @brief Indicator function for lower valve limit violation.
-       */
-      template <class ScalarT, typename IdxT>
-      ScalarT Tgov1<ScalarT, IdxT>::indicator_low(ScalarT x, ScalarT f)
-      {
-        return (Math::sigmoid(Pvmin_ - x)) * (Math::sigmoid(-f));
-      }
-
-      /**
-       * @brief Indicator function for high valve limit violation.
-       */
-      template <class ScalarT, typename IdxT>
-      ScalarT Tgov1<ScalarT, IdxT>::indicator_high(ScalarT x, ScalarT f)
-      {
-        return (Math::sigmoid(x - Pvmax_)) * (Math::sigmoid(f));
-      }
-
-      /**
-       * @brief Net Indicator function for valve limits.
-       */
-      template <class ScalarT, typename IdxT>
-      ScalarT Tgov1<ScalarT, IdxT>::indicator(ScalarT x, ScalarT f)
-      {
-        return (ONE<RealT> - this->indicator_low(x, f)) * (ONE<RealT> - this->indicator_high(x, f));
-      }
-
-      /**
        * @brief Internal residuals
        *
        */
@@ -282,7 +255,7 @@ namespace GridKit
 
         // The 'pre-limit' derivative of Pv
         ScalarT func     = (-pv + (pref_ - omega) / R_) / T1_;
-        ScalarT valv_ind = this->indicator(pv, func);
+        ScalarT valv_ind = Math::indicator(Pvmin_, Pvmax_, pv, func);
 
         // Internal Differential Equations
         f[0] = -ptx_dot + pv - (ptx + T2_ * pv) / T3_;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -241,7 +241,7 @@ namespace GridKit
       template <class ScalarT, typename IdxT>
       ScalarT Tgov1<ScalarT, IdxT>::sigmoid(ScalarT x)
       {
-        return ONE<RealT> / (ONE<RealT> + std::exp(- mu_ * x));
+        return ONE<RealT> / (ONE<RealT> + std::exp(-mu_ * x));
       }
 
       /**


### PR DESCRIPTION
## Description
 
Change the smooth limit approximation used in the IEEET1 Exciter and TGOV1 Governor so that it is twice differentiable. Additionally, the exciter saturation equation now has a smooth approximation. This is for Enzyme compatibility.
 
 ## Proposed changes
 
The logistic function is now used instead of the approximation of the logistic function
```math
\dfrac{\alpha x}{1+|\alpha x|} \to \dfrac{1}{1+\exp(-\alpha x)}
```
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [x] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- N/A: I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further Comments

Needed for Enzyme to work on larger cases
