### PR TITLE
Add IDA Stat struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Added `GridKitDocs` target for Doxygen documentation.
 - Added a header file defining common math functions (e.g., sigmoid) to be used throughout the code.
 - Added capability to print monitored variables in multiple formats, triggered from `Ida::runSimulation`.
+- Added IDA statistics object which can be accumulated over multiple simulations.
 
 ## v0.1
 

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -979,7 +979,7 @@ namespace AnalysisManager
       num_residual_evals_              += other.num_residual_evals_;
       num_linear_decompositions_       += other.num_linear_decompositions_;
       num_error_test_fails_            += other.num_error_test_fails_;
-      num_linear_solves_               += other.num_linear_solves_;
+      num_nonlinear_iters_             += other.num_nonlinear_iters_;
       num_nonlinear_convergence_fails_ += other.num_nonlinear_convergence_fails_;
 
       return *this;
@@ -1000,7 +1000,7 @@ namespace AnalysisManager
           << std::setw(label_width) << "Residual evals" << " : " << std::setw(stat_width) << num_linear_decompositions_ << '\n'
           << std::setw(label_width) << "Linear decompositions" << " : " << std::setw(stat_width) << num_linear_decompositions_ << '\n'
           << std::setw(label_width) << "Error test failures" << " : " << std::setw(stat_width) << num_error_test_fails_ << '\n'
-          << std::setw(label_width) << "Linear solves" << " : " << std::setw(stat_width) << num_linear_solves_ << '\n'
+          << std::setw(label_width) << "Nonlinear iterations" << " : " << std::setw(stat_width) << num_nonlinear_iters_ << '\n'
           << std::setw(label_width) << "Nonlinear convergence failures" << " : " << std::setw(stat_width) << num_nonlinear_convergence_fails_;
 
       return out.str();
@@ -1033,7 +1033,7 @@ namespace AnalysisManager
                                          &dummy2);
       checkOutput(retval, "IDAGetIntegratorStats");
 
-      retval = IDAGetNonlinSolvStats(solver_, &stats.num_linear_solves_, &stats.num_nonlinear_convergence_fails_);
+      retval = IDAGetNonlinSolvStats(solver_, &stats.num_nonlinear_iters_, &stats.num_nonlinear_convergence_fails_);
       checkOutput(retval, "IDAGetNonlinSolvStats");
 
       return stats;

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -1,6 +1,7 @@
 
 #include "Ida.hpp"
 
+#include <format>
 #include <iomanip>
 #include <iostream>
 
@@ -966,6 +967,87 @@ namespace AnalysisManager
     {
       int retval = IDAPrintAllStats(solver_, stdout, SUN_OUTPUTFORMAT_TABLE);
       checkOutput(retval, "IDAPrintAllStats");
+    }
+
+    /**
+     * @brief Accumulate another stats object into this one, allowing for stats to be kept
+     *        across multiple simulations with IDA.
+     */
+    IdaStats& IdaStats::operator+=(const IdaStats& other)
+    {
+      num_steps_                       += other.num_steps_;
+      num_residual_evals_              += other.num_residual_evals_;
+      num_linear_decompositions_       += other.num_linear_decompositions_;
+      num_error_test_fails_            += other.num_error_test_fails_;
+      num_linear_solves_               += other.num_linear_solves_;
+      num_nonlinear_convergence_fails_ += other.num_nonlinear_convergence_fails_;
+
+      return *this;
+    }
+
+    /**
+     * @brief Generate a string containing all of the stats in a formatted report.
+     *        All columns are aligned. To change the width of a column,
+     *        modify `label_width` or `stat_width`.
+     */
+    std::string IdaStats::report() const
+    {
+      unsigned label_width = 30;
+      unsigned stat_width  = 12;
+      return std::format(
+          "{2:>{0}} : {3:{1}}\n"    // steps
+          "{4:>{0}} : {5:{1}}\n"    // residual evals
+          "{6:>{0}} : {7:{1}}\n"    // linear decomps
+          "{8:>{0}} : {9:{1}}\n"    // error test fails
+          "{10:>{0}} : {11:{1}}\n"  // linear solves
+          "{12:>{0}} : {13:{1}}\n", // nonlinear conv fails
+          label_width,
+          stat_width,
+          "Steps",
+          num_steps_,
+          "Residual evals",
+          num_residual_evals_,
+          "Linear decompositions",
+          num_linear_decompositions_,
+          "Error test failures",
+          num_error_test_fails_,
+          "Linear solves",
+          num_linear_solves_,
+          "Nonlinear convergence failures",
+          num_nonlinear_convergence_fails_);
+    }
+
+    /**
+     * @brief Construct and return an `IdaStats` object containing the statistics of the current IDA workspace.
+     *        Several statistics returned by IDA are ignored because they are about the current state of IDA,
+     *        rather than about the simulation at large.
+     */
+    template <class ScalarT, typename IdxT>
+    IdaStats Ida<ScalarT, IdxT>::getStats() const
+    {
+      IdaStats stats;
+
+      // Dummies for ignoring stats
+      int         dummy;
+      sunrealtype dummy2;
+
+      int retval = IDAGetIntegratorStats(solver_,
+                                         &stats.num_steps_,
+                                         &stats.num_residual_evals_,
+                                         &stats.num_linear_decompositions_,
+                                         &stats.num_error_test_fails_,
+                                         &dummy,
+                                         &dummy,
+                                         &dummy2,
+                                         &dummy2,
+                                         &dummy2,
+                                         &dummy2);
+      checkOutput(retval, "IDAGetIntegratorStats");
+
+      retval = IDAGetNonlinSolvStats(solver_, &stats.num_linear_solves_, &stats.num_nonlinear_convergence_fails_);
+      checkOutput(retval, "IDAGetNonlinSolvStats");
+
+      return stats;
     }
 
     /**

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -1,9 +1,9 @@
 
 #include "Ida.hpp"
 
-#include <format>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
 #include <idas/idas.h>
 #include <idas/idas_ls.h>
@@ -992,29 +992,18 @@ namespace AnalysisManager
      */
     std::string IdaStats::report() const
     {
-      unsigned label_width = 30;
-      unsigned stat_width  = 12;
-      return std::format(
-          "{2:>{0}} : {3:{1}}\n"    // steps
-          "{4:>{0}} : {5:{1}}\n"    // residual evals
-          "{6:>{0}} : {7:{1}}\n"    // linear decomps
-          "{8:>{0}} : {9:{1}}\n"    // error test fails
-          "{10:>{0}} : {11:{1}}\n"  // linear solves
-          "{12:>{0}} : {13:{1}}\n", // nonlinear conv fails
-          label_width,
-          stat_width,
-          "Steps",
-          num_steps_,
-          "Residual evals",
-          num_residual_evals_,
-          "Linear decompositions",
-          num_linear_decompositions_,
-          "Error test failures",
-          num_error_test_fails_,
-          "Linear solves",
-          num_linear_solves_,
-          "Nonlinear convergence failures",
-          num_nonlinear_convergence_fails_);
+      int               label_width = 30;
+      int               stat_width  = 12;
+      std::stringstream out;
+
+      out << std::setw(label_width) << "Steps" << " : " << std::setw(stat_width) << num_residual_evals_ << '\n'
+          << std::setw(label_width) << "Residual evals" << " : " << std::setw(stat_width) << num_linear_decompositions_ << '\n'
+          << std::setw(label_width) << "Linear decompositions" << " : " << std::setw(stat_width) << num_linear_decompositions_ << '\n'
+          << std::setw(label_width) << "Error test failures" << " : " << std::setw(stat_width) << num_error_test_fails_ << '\n'
+          << std::setw(label_width) << "Linear solves" << " : " << std::setw(stat_width) << num_linear_solves_ << '\n'
+          << std::setw(label_width) << "Nonlinear convergence failures" << " : " << std::setw(stat_width) << num_nonlinear_convergence_fails_;
+
+      return out.str();
     }
 
     /**

--- a/GridKit/Solver/Dynamic/Ida.hpp
+++ b/GridKit/Solver/Dynamic/Ida.hpp
@@ -30,7 +30,7 @@ namespace AnalysisManager
       long int num_residual_evals_              = 0;
       long int num_linear_decompositions_       = 0;
       long int num_error_test_fails_            = 0;
-      long int num_linear_solves_               = 0;
+      long int num_nonlinear_iters_             = 0;
       long int num_nonlinear_convergence_fails_ = 0;
 
       IdaStats&   operator+=(const IdaStats& other);

--- a/GridKit/Solver/Dynamic/Ida.hpp
+++ b/GridKit/Solver/Dynamic/Ida.hpp
@@ -188,8 +188,8 @@ namespace AnalysisManager
       static void copyVec(const std::vector<bool>& x, N_Vector y);
 
       // int check_flag(void *flagvalue, const char *funcname, int opt);
-      inline void checkAllocation(void* v, const char* functionName);
-      inline void checkOutput(int retval, const char* functionName);
+      static void checkAllocation(void* v, const char* functionName);
+      static void checkOutput(int retval, const char* functionName);
     };
 
     /// Simple exception to use within Ida class.

--- a/GridKit/Solver/Dynamic/Ida.hpp
+++ b/GridKit/Solver/Dynamic/Ida.hpp
@@ -24,6 +24,19 @@ namespace AnalysisManager
 {
   namespace Sundials
   {
+    struct IdaStats
+    {
+      long int num_steps_                       = 0;
+      long int num_residual_evals_              = 0;
+      long int num_linear_decompositions_       = 0;
+      long int num_error_test_fails_            = 0;
+      long int num_linear_solves_               = 0;
+      long int num_nonlinear_convergence_fails_ = 0;
+
+      IdaStats&   operator+=(const IdaStats& other);
+      std::string report() const;
+    };
+
     template <class ScalarT, typename IdxT>
     class Ida : public DynamicSolver<ScalarT, IdxT>
     {
@@ -114,6 +127,8 @@ namespace AnalysisManager
       void printOutput(RealT t);
       void printSpecial(RealT t, N_Vector x);
       void printFinalStats();
+
+      IdaStats getStats() const;
 
     private:
       static int Residual(RealT    t,

--- a/examples/PowerElectronics/RLCircuit/RLCircuit.cpp
+++ b/examples/PowerElectronics/RLCircuit/RLCircuit.cpp
@@ -134,5 +134,7 @@ int main(int /* argc */, char const** /* argv */)
     std::cout << abs((yfinial[i] - yexact[i]) / yexact[i]) << "\n";
   }
 
+  std::cerr << idas.getStats().report() << '\n';
+
   return 0;
 }


### PR DESCRIPTION
## Description
 
Adds a new structure, `IdaStats`, which keeps track of several statistics returned by IDA. A user can query these statistics from IDA by calling `Ida::getStats()` and can accumulate several runs of stats in the structure. There is also functionality to print a report, similar to the `Ida::printFinalStats()` function after the stats have been accumulated together.
 
 Closes #322
 
@Steven-Roberts let me know if there's anything else you think I should put in.
 
 ## Proposed changes

It makes sense for `Ida::getStats()` to be `const`, but then `Ida::checkAllocation()` and `Ida::checkOutput()` are inaccessible. These functions never touch any IDA state, so it makes sense for these functions to be `static` anyway.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.

There are not unit tests, but I have added a printout of the report to the `rlcircuit` example:

```
                         Steps :           70
                Residual evals :           86
         Linear decompositions :           19
           Error test failures :            0
                 Linear solves :           86
Nonlinear convergence failures :            0
```
 
 ## Further comments

 
