### PR TITLE
Add missing include for `VariableMonitor` class

### DIFF
--- a/GridKit/Model/VariableMonitor.hpp
+++ b/GridKit/Model/VariableMonitor.hpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <variant>


### PR DESCRIPTION
## Description
 
 Closes #331
 
 CC @nkoukpaizan 
 
 ## Proposed changes
 
 Include both, `sstream` and `string` in `VariableMonitor.hpp`.

 ## Checklist
  
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- N/A The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- N/A I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 

