### PR TITLE
Performance improvements in PhasorDynamics component Jacobian evaluation.

### DIFF
--- a/GridKit/AutomaticDifferentiation/Enzyme/DfDwb.hpp
+++ b/GridKit/AutomaticDifferentiation/Enzyme/DfDwb.hpp
@@ -43,25 +43,38 @@ namespace GridKit
          * @param[in] wb - Bus variables
          * @param[in,out] jac - Jacobian
          */
-        static void eval(ModelT*                  model,
-                         size_t                   n_res,
-                         size_t                   n_var,
-                         const std::vector<IdxT>& res_indices,
-                         const std::vector<IdxT>& var_indices,
-                         ScalarT*                 y,
-                         ScalarT*                 yp,
-                         ScalarT*                 wb,
-                         MatrixT&                 jac)
+        static void eval(ModelT*     model,
+                         size_t      n_res,
+                         size_t      n_var,
+                         const IdxT* res_indices,
+                         const IdxT* var_indices,
+                         ScalarT*    y,
+                         ScalarT*    yp,
+                         ScalarT*    wb,
+                         IdxT*       rows,
+                         IdxT*       cols,
+                         RealT*      vals,
+                         MatrixT&    jac)
         {
           if (n_res > 0 && n_var > 0)
           {
-            std::vector<Triple<ScalarT>> triplets; //< @todo: Update once sparse storage format changes
-            std::vector<ScalarT>         elementary_v(n_var);
+            std::vector<ScalarT> elementary_v(n_var);
+            IdxT                 nnz = 0;
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage. @see LowerSparseStorage.hpp
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, IdxT>,
+                                                           (void*) ident_store<ScalarT, IdxT>,
+                                                           var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, IdxT>,
+                                                             (void*) sparse_store<ScalarT, IdxT>,
+                                                             var_i,
+                                                             res_indices,
+                                                             var_indices,
+                                                             rows,
+                                                             cols,
+                                                             vals,
+                                                             &nnz);
 
               // Elementary vector for Jacobian-vector product
               std::ranges::fill(elementary_v, 0.0);
@@ -84,16 +97,7 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
-            for (auto& tup : triplets)
-            {
-              rtemp.push_back(res_indices[static_cast<size_t>(tup.row)]);
-              ctemp.push_back(var_indices[static_cast<size_t>(tup.col)]);
-              valtemp.push_back(tup.val);
-            }
-            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+            jac.setValues(1.0, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
           }
         }
 
@@ -109,26 +113,39 @@ namespace GridKit
          * @param[in] ws - Signal variables
          * @param[in,out] jac - Jacobian
          */
-        static void eval(ModelT*                  model,
-                         size_t                   n_res,
-                         size_t                   n_var,
-                         const std::vector<IdxT>& res_indices,
-                         const std::vector<IdxT>& var_indices,
-                         ScalarT*                 y,
-                         ScalarT*                 yp,
-                         ScalarT*                 wb,
-                         ScalarT*                 ws,
-                         MatrixT&                 jac)
+        static void eval(ModelT*     model,
+                         size_t      n_res,
+                         size_t      n_var,
+                         const IdxT* res_indices,
+                         const IdxT* var_indices,
+                         ScalarT*    y,
+                         ScalarT*    yp,
+                         ScalarT*    wb,
+                         ScalarT*    ws,
+                         IdxT*       rows,
+                         IdxT*       cols,
+                         RealT*      vals,
+                         MatrixT&    jac)
         {
           if (n_res > 0 && n_var > 0)
           {
-            std::vector<Triple<ScalarT>> triplets; //< @todo: Update once sparse storage format changes
-            std::vector<ScalarT>         elementary_v(n_var);
+            std::vector<ScalarT> elementary_v(n_var);
+            IdxT                 nnz = 0;
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage. @see LowerSparseStorage.hpp
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, IdxT>,
+                                                           (void*) ident_store<ScalarT, IdxT>,
+                                                           var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, IdxT>,
+                                                             (void*) sparse_store<ScalarT, IdxT>,
+                                                             var_i,
+                                                             res_indices,
+                                                             var_indices,
+                                                             rows,
+                                                             cols,
+                                                             vals,
+                                                             &nnz);
 
               // Elementary vector for Jacobian-vector product
               std::ranges::fill(elementary_v, 0.0);
@@ -153,16 +170,7 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
-            for (auto& tup : triplets)
-            {
-              rtemp.push_back(res_indices[static_cast<size_t>(tup.row)]);
-              ctemp.push_back(var_indices[static_cast<size_t>(tup.col)]);
-              valtemp.push_back(tup.val);
-            }
-            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+            jac.setValues(1.0, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
           }
         }
       };

--- a/GridKit/AutomaticDifferentiation/Enzyme/DfDws.hpp
+++ b/GridKit/AutomaticDifferentiation/Enzyme/DfDws.hpp
@@ -9,7 +9,6 @@
 #include <GridKit/AutomaticDifferentiation/Enzyme/EnzymeDefinitions.hpp>
 #include <GridKit/AutomaticDifferentiation/Enzyme/LowerSparseStorage.hpp>
 #include <GridKit/AutomaticDifferentiation/Enzyme/ModelWrappers.hpp>
-#include <GridKit/Constants.hpp>
 #include <GridKit/LinearAlgebra/SparseMatrix/COO_Matrix.hpp>
 #include <GridKit/ScalarTraits.hpp>
 
@@ -45,26 +44,39 @@ namespace GridKit
          * @param[in] ws - Signal variables
          * @param[in,out] jac - Jacobian
          */
-        static void eval(ModelT*                  model,
-                         size_t                   n_res,
-                         size_t                   n_var,
-                         const std::vector<IdxT>& res_indices,
-                         const std::vector<IdxT>& var_indices,
-                         ScalarT*                 y,
-                         ScalarT*                 yp,
-                         ScalarT*                 wb,
-                         ScalarT*                 ws,
-                         MatrixT&                 jac)
+        static void eval(ModelT*     model,
+                         size_t      n_res,
+                         size_t      n_var,
+                         const IdxT* res_indices,
+                         const IdxT* var_indices,
+                         ScalarT*    y,
+                         ScalarT*    yp,
+                         ScalarT*    wb,
+                         ScalarT*    ws,
+                         IdxT*       rows,
+                         IdxT*       cols,
+                         RealT*      vals,
+                         MatrixT&    jac)
         {
           if (n_res > 0 && n_var > 0)
           {
-            std::vector<Triple<ScalarT>> triplets; //< @todo: Update once sparse storage format changes
-            std::vector<ScalarT>         elementary_v(n_var);
+            std::vector<ScalarT> elementary_v(n_var);
+            IdxT                 nnz = 0;
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage. @see LowerSparseStorage.hpp
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, IdxT>,
+                                                           (void*) ident_store<ScalarT, IdxT>,
+                                                           var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, IdxT>,
+                                                             (void*) sparse_store<ScalarT, IdxT>,
+                                                             var_i,
+                                                             res_indices,
+                                                             var_indices,
+                                                             rows,
+                                                             cols,
+                                                             vals,
+                                                             &nnz);
 
               // Elementary vector for Jacobian-vector product
               std::ranges::fill(elementary_v, 0.0);
@@ -89,21 +101,7 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
-            for (auto& tup : triplets)
-            {
-              IdxT row = res_indices[static_cast<size_t>(tup.row)];
-              IdxT col = var_indices[static_cast<size_t>(tup.col)];
-              if (col != INVALID_INDEX<IdxT>)
-              {
-                rtemp.push_back(row);
-                ctemp.push_back(col);
-                valtemp.push_back(tup.val);
-              }
-            }
-            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+            jac.setValues(1.0, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
           }
         }
       };

--- a/GridKit/AutomaticDifferentiation/Enzyme/DfDy.hpp
+++ b/GridKit/AutomaticDifferentiation/Enzyme/DfDy.hpp
@@ -44,27 +44,40 @@ namespace GridKit
          * @param[in] alpha - Time derivative jacobian coefficient
          * @param[in,out] jac - Jacobian
          */
-        static void eval(ModelT*                  model,
-                         size_t                   n_res,
-                         size_t                   n_var,
-                         const std::vector<IdxT>& res_indices,
-                         const std::vector<IdxT>& var_indices,
-                         ScalarT*                 y,
-                         ScalarT*                 yp,
-                         ScalarT*                 wb,
-                         RealT                    alpha,
-                         MatrixT&                 jac)
+        static void eval(ModelT*     model,
+                         size_t      n_res,
+                         size_t      n_var,
+                         const IdxT* res_indices,
+                         const IdxT* var_indices,
+                         ScalarT*    y,
+                         ScalarT*    yp,
+                         ScalarT*    wb,
+                         RealT       alpha,
+                         IdxT*       rows,
+                         IdxT*       cols,
+                         RealT*      vals,
+                         MatrixT&    jac)
         {
           if (n_res > 0 && n_var > 0)
           {
             // df/dy
-            std::vector<Triple<ScalarT>> triplets; //< @todo: Update once sparse storage format changes
-            std::vector<ScalarT>         elementary_v(n_var);
+            std::vector<ScalarT> elementary_v(n_var);
+            IdxT                 nnz = 0;
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage. @see LowerSparseStorage.hpp
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, IdxT>,
+                                                           (void*) ident_store<ScalarT, IdxT>,
+                                                           var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, IdxT>,
+                                                             (void*) sparse_store<ScalarT, IdxT>,
+                                                             var_i,
+                                                             res_indices,
+                                                             var_indices,
+                                                             rows,
+                                                             cols,
+                                                             vals,
+                                                             &nnz);
 
               // Elementary vector for Jacobian-vector product
               std::ranges::fill(elementary_v, 0.0);
@@ -87,24 +100,25 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
-            for (auto& tup : triplets)
-            {
-              rtemp.push_back(res_indices[static_cast<size_t>(tup.row)]);
-              ctemp.push_back(var_indices[static_cast<size_t>(tup.col)]);
-              valtemp.push_back(tup.val);
-            }
-            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+            jac.setValues(1.0, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
 
             // df/dy'
-            triplets.clear();
+            nnz = 0;
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage. @see LowerSparseStorage.hpp
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, IdxT>,
+                                                           (void*) ident_store<ScalarT, IdxT>,
+                                                           var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, IdxT>,
+                                                             (void*) sparse_store<ScalarT, IdxT>,
+                                                             var_i,
+                                                             res_indices,
+                                                             var_indices,
+                                                             rows,
+                                                             cols,
+                                                             vals,
+                                                             &nnz);
 
               // Elementary vector for Jacobian-vector product
               std::ranges::fill(elementary_v, 0.0);
@@ -127,16 +141,7 @@ namespace GridKit
             }
 
             // Store result
-            ctemp.clear();
-            rtemp.clear();
-            valtemp.clear();
-            for (auto& tup : triplets)
-            {
-              rtemp.push_back(res_indices[static_cast<size_t>(tup.row)]);
-              ctemp.push_back(var_indices[static_cast<size_t>(tup.col)]);
-              valtemp.push_back(tup.val);
-            }
-            jac.axpy(alpha, rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+            jac.setValues(alpha, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
           }
         }
 
@@ -153,28 +158,41 @@ namespace GridKit
          * @param[in] alpha - Time derivative jacobian coefficient
          * @param[in,out] jac - Jacobian
          */
-        static void eval(ModelT*                  model,
-                         size_t                   n_res,
-                         size_t                   n_var,
-                         const std::vector<IdxT>& res_indices,
-                         const std::vector<IdxT>& var_indices,
-                         ScalarT*                 y,
-                         ScalarT*                 yp,
-                         ScalarT*                 wb,
-                         ScalarT*                 ws,
-                         RealT                    alpha,
-                         MatrixT&                 jac)
+        static void eval(ModelT*     model,
+                         size_t      n_res,
+                         size_t      n_var,
+                         const IdxT* res_indices,
+                         const IdxT* var_indices,
+                         ScalarT*    y,
+                         ScalarT*    yp,
+                         ScalarT*    wb,
+                         ScalarT*    ws,
+                         RealT       alpha,
+                         IdxT*       rows,
+                         IdxT*       cols,
+                         RealT*      vals,
+                         MatrixT&    jac)
         {
           if (n_res > 0 && n_var > 0)
           {
             // df/dy
-            std::vector<Triple<ScalarT>> triplets; //< @todo: Update once sparse storage format changes
-            std::vector<ScalarT>         elementary_v(n_var);
+            std::vector<ScalarT> elementary_v(n_var);
+            IdxT                 nnz = 0;
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage. @see LowerSparseStorage.hpp
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, IdxT>,
+                                                           (void*) ident_store<ScalarT, IdxT>,
+                                                           var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, IdxT>,
+                                                             (void*) sparse_store<ScalarT, IdxT>,
+                                                             var_i,
+                                                             res_indices,
+                                                             var_indices,
+                                                             rows,
+                                                             cols,
+                                                             vals,
+                                                             &nnz);
 
               // Elementary vector for Jacobian-vector product
               std::ranges::fill(elementary_v, 0.0);
@@ -199,24 +217,25 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
-            for (auto& tup : triplets)
-            {
-              rtemp.push_back(res_indices[static_cast<size_t>(tup.row)]);
-              ctemp.push_back(var_indices[static_cast<size_t>(tup.col)]);
-              valtemp.push_back(tup.val);
-            }
-            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+            jac.setValues(1.0, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
 
             // df/dy'
-            triplets.clear();
+            nnz = 0;
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage. @see LowerSparseStorage.hpp
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, IdxT>,
+                                                           (void*) ident_store<ScalarT, IdxT>,
+                                                           var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, IdxT>,
+                                                             (void*) sparse_store<ScalarT, IdxT>,
+                                                             var_i,
+                                                             res_indices,
+                                                             var_indices,
+                                                             rows,
+                                                             cols,
+                                                             vals,
+                                                             &nnz);
 
               // Elementary vector for Jacobian-vector product
               std::ranges::fill(elementary_v, 0.0);
@@ -241,16 +260,7 @@ namespace GridKit
             }
 
             // Store result
-            ctemp.clear();
-            rtemp.clear();
-            valtemp.clear();
-            for (auto& tup : triplets)
-            {
-              rtemp.push_back(res_indices[static_cast<size_t>(tup.row)]);
-              ctemp.push_back(var_indices[static_cast<size_t>(tup.col)]);
-              valtemp.push_back(tup.val);
-            }
-            jac.axpy(alpha, rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+            jac.setValues(alpha, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
           }
         }
       };

--- a/GridKit/AutomaticDifferentiation/Enzyme/DhDwb.hpp
+++ b/GridKit/AutomaticDifferentiation/Enzyme/DhDwb.hpp
@@ -42,26 +42,41 @@ namespace GridKit
          * @param[in] yp - Internal variable derivatives
          * @param[in] wb - Bus variables
          * @param[in,out] jac - Jacobian
+         * @param[in] flag - To append values or deduplicate right away (bus-owned values)
          */
-        static void eval(ModelT*                  model,
-                         size_t                   n_res,
-                         size_t                   n_var,
-                         const std::vector<IdxT>& res_indices,
-                         const std::vector<IdxT>& var_indices,
-                         ScalarT*                 y,
-                         ScalarT*                 yp,
-                         ScalarT*                 wb,
-                         MatrixT&                 jac)
+        static void eval(ModelT*     model,
+                         size_t      n_res,
+                         size_t      n_var,
+                         const IdxT* res_indices,
+                         const IdxT* var_indices,
+                         ScalarT*    y,
+                         ScalarT*    yp,
+                         ScalarT*    wb,
+                         IdxT*       rows,
+                         IdxT*       cols,
+                         RealT*      vals,
+                         MatrixT&    jac,
+                         const bool  flag = false)
         {
           if (n_res > 0 && n_var > 0)
           {
-            std::vector<Triple<ScalarT>> triplets; //< @todo: Update once sparse storage format changes
-            std::vector<ScalarT>         elementary_v(n_var);
+            std::vector<ScalarT> elementary_v(n_var);
+            IdxT                 nnz = 0;
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage. @see LowerSparseStorage.hpp
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, IdxT>,
+                                                           (void*) ident_store<ScalarT, IdxT>,
+                                                           var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, IdxT>,
+                                                             (void*) sparse_store<ScalarT, IdxT>,
+                                                             var_i,
+                                                             res_indices,
+                                                             var_indices,
+                                                             rows,
+                                                             cols,
+                                                             vals,
+                                                             &nnz);
 
               // Elementary vector for Jacobian-vector product
               std::ranges::fill(elementary_v, 0.0);
@@ -84,16 +99,14 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
-            for (auto& tup : triplets)
+            if (flag)
             {
-              rtemp.push_back(res_indices[static_cast<size_t>(tup.row)]);
-              ctemp.push_back(var_indices[static_cast<size_t>(tup.col)]);
-              valtemp.push_back(tup.val);
+              jac.setValues(1.0, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
             }
-            jac.axpy(1.0, rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+            else
+            {
+              jac.axpy(1.0, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
+            }
           }
         }
       };

--- a/GridKit/AutomaticDifferentiation/Enzyme/DhDy.hpp
+++ b/GridKit/AutomaticDifferentiation/Enzyme/DhDy.hpp
@@ -43,25 +43,38 @@ namespace GridKit
          * @param[in] wb - Bus variables
          * @param[in,out] jac - Jacobian
          */
-        static void eval(ModelT*                  model,
-                         size_t                   n_res,
-                         size_t                   n_var,
-                         const std::vector<IdxT>& res_indices,
-                         const std::vector<IdxT>& var_indices,
-                         ScalarT*                 y,
-                         ScalarT*                 yp,
-                         ScalarT*                 wb,
-                         MatrixT&                 jac)
+        static void eval(ModelT*     model,
+                         size_t      n_res,
+                         size_t      n_var,
+                         const IdxT* res_indices,
+                         const IdxT* var_indices,
+                         ScalarT*    y,
+                         ScalarT*    yp,
+                         ScalarT*    wb,
+                         IdxT*       rows,
+                         IdxT*       cols,
+                         RealT*      vals,
+                         MatrixT&    jac)
         {
           if (n_res > 0 && n_var > 0)
           {
-            std::vector<Triple<ScalarT>> triplets; //< @todo: Update once sparse storage format changes
-            std::vector<ScalarT>         elementary_v(n_var);
+            std::vector<ScalarT> elementary_v(n_var);
+            IdxT                 nnz = 0;
             for (size_t var_i = 0; var_i < n_var; ++var_i)
             {
               // Sparse storage. @see LowerSparseStorage.hpp
-              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, var_i);
-              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, var_i, &triplets);
+              ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, IdxT>,
+                                                           (void*) ident_store<ScalarT, IdxT>,
+                                                           var_i);
+              ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, IdxT>,
+                                                             (void*) sparse_store<ScalarT, IdxT>,
+                                                             var_i,
+                                                             res_indices,
+                                                             var_indices,
+                                                             rows,
+                                                             cols,
+                                                             vals,
+                                                             &nnz);
 
               // Elementary vector for Jacobian-vector product
               std::ranges::fill(elementary_v, 0.0);
@@ -84,16 +97,7 @@ namespace GridKit
             }
 
             // Store result
-            std::vector<IdxT>    ctemp{};
-            std::vector<IdxT>    rtemp{};
-            std::vector<ScalarT> valtemp{};
-            for (auto& tup : triplets)
-            {
-              rtemp.push_back(res_indices[static_cast<size_t>(tup.row)]);
-              ctemp.push_back(var_indices[static_cast<size_t>(tup.col)]);
-              valtemp.push_back(tup.val);
-            }
-            jac.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+            jac.setValues(1.0, rows, cols, vals, nnz); //< @todo: Update once sparse storage format changes
           }
         }
       };

--- a/GridKit/AutomaticDifferentiation/Enzyme/LowerSparseStorage.hpp
+++ b/GridKit/AutomaticDifferentiation/Enzyme/LowerSparseStorage.hpp
@@ -3,8 +3,6 @@
  *
  * @details This file contains functions used by Enzyme to store sparse Jacobians.
  *
- * @todo Replace this inner/lower storage by a more CSR-efficient approach.
- *
  * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
  *
  */
@@ -12,6 +10,8 @@
 #pragma once
 
 #include <vector>
+
+#include <GridKit/Constants.hpp>
 
 namespace GridKit
 {
@@ -31,74 +31,217 @@ namespace GridKit
       extern T __enzyme_todense(void*...) noexcept;
 
       /**
-       * @brief Enzyme inner sparse storage in triplet format
+       * @brief Enzyme sparse accumulation for float and size_t
        *
-       * @tparam ScalarT - scalar data type
+       * @note __attribute__((enzyme_sparse_accumulate)) does not support templates yet
+       *
+       * @param[in] row - row to be stored
+       * @param[in] col - column to be stored
+       * @param[in] val - value to be stored
+       * @param[in] res_indices - Global residual indices
+       * @param[in] var_indices - Global variable indices
+       * @param[in,out] rows - buffer where row will be stored
+       * @param[in,out] cols - buffer where col will be stored
+       * @param[in,out] vals - buffer where val will be stored
+       * @param[in,out] nnz - number of nonzeros
        */
-      template <typename ScalarT>
-      struct Triple
+      [[maybe_unused]] __attribute__((enzyme_sparse_accumulate)) static void inner_store_float_size_t(
+          size_t        row,
+          size_t        col,
+          float         val,
+          const size_t* row_indices,
+          const size_t* col_indices,
+          size_t*       rows,
+          size_t*       cols,
+          float*        vals,
+          size_t&       nnz)
       {
-        size_t  row;
-        size_t  col;
-        ScalarT val;
-        Triple(Triple&&) = default;
-
-        Triple(size_t row, size_t col, ScalarT val)
-          : row(row),
-            col(col),
-            val(val)
+        const auto row_mapped = row_indices[static_cast<size_t>(row)];
+        const auto col_mapped = col_indices[static_cast<size_t>(col)];
+        if (col_mapped != INVALID_INDEX<size_t>)
         {
+          rows[static_cast<size_t>(nnz)] = row_mapped;
+          cols[static_cast<size_t>(nnz)] = col_mapped;
+          vals[static_cast<size_t>(nnz)] = val;
+          nnz++;
         }
-      };
-
-      /**
-       * @brief Enzyme sparse accumulation for float
-       *
-       * @todo Separate sparsity analyis from value storage for a known sparsity structure.
-       *       The current implementation always performs sparsity analysis.
-       */
-      [[maybe_unused]] __attribute__((enzyme_sparse_accumulate)) static void inner_storeflt(size_t row, size_t col, float val, std::vector<Triple<float>>& triplets)
-      {
-        triplets.emplace_back(row, col, val);
       }
 
       /**
-       * @brief Enzyme sparse accumulation for double
+       * @brief Enzyme sparse accumulation for float and long int
        *
-       * @todo Separate sparsity analyis from value storage for a known sparsity structure.
-       *       The current implementation always performs sparsity analysis.
+       * @note __attribute__((enzyme_sparse_accumulate)) does not support templates yet
+       *
+       * @param[in] row - row to be stored
+       * @param[in] col - column to be stored
+       * @param[in] val - value to be stored
+       * @param[in] res_indices - Global residual indices
+       * @param[in] var_indices - Global variable indices
+       * @param[in,out] rows - buffer where row will be stored
+       * @param[in,out] cols - buffer where col will be stored
+       * @param[in,out] vals - buffer where val will be stored
+       * @param[in,out] nnz - number of nonzeros
        */
-      [[maybe_unused]] __attribute__((enzyme_sparse_accumulate)) static void inner_storedbl(size_t row, size_t col, double val, std::vector<Triple<double>>& triplets)
+      [[maybe_unused]] __attribute__((enzyme_sparse_accumulate)) static void inner_store_float_long_int(
+          long int        row,
+          long int        col,
+          float           val,
+          const long int* row_indices,
+          const long int* col_indices,
+          long int*       rows,
+          long int*       cols,
+          float*          vals,
+          long int&       nnz)
       {
-        triplets.emplace_back(row, col, val);
+        const auto row_mapped = row_indices[static_cast<size_t>(row)];
+        const auto col_mapped = col_indices[static_cast<size_t>(col)];
+        if (col_mapped != INVALID_INDEX<long int>)
+        {
+          rows[static_cast<size_t>(nnz)] = row_mapped;
+          cols[static_cast<size_t>(nnz)] = col_mapped;
+          vals[static_cast<size_t>(nnz)] = val;
+          nnz++;
+        }
+      }
+
+      /**
+       * @brief Enzyme sparse accumulation for double and size_t
+       *
+       * @note __attribute__((enzyme_sparse_accumulate)) does not support templates yet
+       *
+       * @param[in] row - row to be stored
+       * @param[in] col - column to be stored
+       * @param[in] val - value to be stored
+       * @param[in] res_indices - Global residual indices
+       * @param[in] var_indices - Global variable indices
+       * @param[in,out] rows - buffer where row will be stored
+       * @param[in,out] cols - buffer where col will be stored
+       * @param[in,out] vals - buffer where val will be stored
+       * @param[in,out] nnz - number of nonzeros
+       */
+      [[maybe_unused]] __attribute__((enzyme_sparse_accumulate)) static void inner_store_double_size_t(
+          size_t        row,
+          size_t        col,
+          double        val,
+          const size_t* row_indices,
+          const size_t* col_indices,
+          size_t*       rows,
+          size_t*       cols,
+          double*       vals,
+          size_t&       nnz)
+      {
+        const auto row_mapped = row_indices[static_cast<size_t>(row)];
+        const auto col_mapped = col_indices[static_cast<size_t>(col)];
+        if (col_mapped != INVALID_INDEX<size_t>)
+        {
+          rows[static_cast<size_t>(nnz)] = row_mapped;
+          cols[static_cast<size_t>(nnz)] = col_mapped;
+          vals[static_cast<size_t>(nnz)] = val;
+          nnz++;
+        }
+      }
+
+      /**
+       * @brief Enzyme sparse accumulation for double and long int
+       *
+       * @note __attribute__((enzyme_sparse_accumulate)) does not support templates yet
+       *
+       * @param[in] row - row to be stored
+       * @param[in] col - column to be stored
+       * @param[in] val - value to be stored
+       * @param[in] res_indices - Global residual indices
+       * @param[in] var_indices - Global variable indices
+       * @param[in,out] rows - buffer where row will be stored
+       * @param[in,out] cols - buffer where col will be stored
+       * @param[in,out] vals - buffer where val will be stored
+       * @param[in,out] nnz - number of nonzeros
+       */
+      [[maybe_unused]] __attribute__((enzyme_sparse_accumulate)) static void inner_store_double_long_int(
+          long int        row,
+          long int        col,
+          double          val,
+          const long int* row_indices,
+          const long int* col_indices,
+          long int*       rows,
+          long int*       cols,
+          double*         vals,
+          long int&       nnz)
+      {
+        const auto row_mapped = row_indices[static_cast<size_t>(row)];
+        const auto col_mapped = col_indices[static_cast<size_t>(col)];
+        if (col_mapped != INVALID_INDEX<long int>)
+        {
+          rows[static_cast<size_t>(nnz)] = row_mapped;
+          cols[static_cast<size_t>(nnz)] = col_mapped;
+          vals[static_cast<size_t>(nnz)] = val;
+          nnz++;
+        }
       }
 
       /**
        * @brief Enzyme sparse store
        *
-       * @details This takes in a row, column and value and stores them in a vector of triplets
+       * @details This takes in a row, column and value and stores them in buffers
        *
        * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
+       *
+       * @param[in] val - value to be stored
+       * @param[in] row - row to be stored
+       * @param[in] col - column to be stored
+       * @param[in] res_indices - Global residual indices
+       * @param[in] var_indices - Global variable indices
+       * @param[in,out] rows - buffer where row will be stored
+       * @param[in,out] cols - buffer where col will be stored
+       * @param[in,out] vals - buffer where val will be stored
+       * @param[in,out] nnz - number of nonzeros
        */
-      template <typename ScalarT>
-      __attribute__((always_inline)) static void sparse_store(ScalarT val, size_t idx, size_t i, std::vector<Triple<ScalarT>>& triplets)
+      template <typename ScalarT, typename IdxT>
+      __attribute__((always_inline)) static void sparse_store(
+          ScalarT     val,
+          IdxT        row,
+          IdxT        col,
+          const IdxT* row_indices,
+          const IdxT* col_indices,
+          IdxT*       rows,
+          IdxT*       cols,
+          ScalarT*    vals,
+          IdxT&       nnz)
       {
         if (val == 0.0)
           return;
-        idx /= sizeof(ScalarT);
-        if constexpr (sizeof(ScalarT) == 4)
-          inner_storeflt(idx, i, val, triplets);
+
+        row /= sizeof(ScalarT);
+
+        // this template nightmare is because __attribute__((enzyme_sparse_accumulate)) does not support templates yet
+        if constexpr (std::is_same<IdxT, size_t>::value)
+        {
+          if constexpr (std::is_same<IdxT, float>::value)
+            inner_store_float_size_t(row, col, val, row_indices, col_indices, rows, cols, vals, nnz);
+          else
+            inner_store_double_size_t(row, col, val, row_indices, col_indices, rows, cols, vals, nnz);
+        }
+        else if constexpr (std::is_same<IdxT, long int>::value)
+        {
+          if constexpr (std::is_same<IdxT, double>::value)
+            inner_store_float_long_int(row, col, val, row_indices, col_indices, rows, cols, vals, nnz);
+          else
+            inner_store_double_long_int(row, col, val, row_indices, col_indices, rows, cols, vals, nnz);
+        }
         else
-          inner_storedbl(idx, i, val, triplets);
+        {
+          assert(0 && "unsupported type");
+        }
       }
 
       /**
        * @brief Enzyme sparse load
        *
        * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
        */
-      template <typename ScalarT>
-      __attribute__((always_inline)) static ScalarT sparse_load(size_t, size_t, std::vector<Triple<ScalarT>>&)
+      template <typename ScalarT, typename IdxT>
+      __attribute__((always_inline)) static ScalarT sparse_load(IdxT, IdxT, IdxT*, IdxT*, ScalarT*)
       {
         return 0.0;
       }
@@ -107,9 +250,10 @@ namespace GridKit
        * @brief Enzyme identity store
        *
        * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
        */
-      template <typename ScalarT>
-      __attribute__((always_inline)) static void ident_store(ScalarT, size_t, size_t)
+      template <typename ScalarT, typename IdxT>
+      __attribute__((always_inline)) static void ident_store(ScalarT, IdxT, IdxT)
       {
         assert(0 && "should never store");
       }
@@ -118,12 +262,13 @@ namespace GridKit
        * @brief Enzyme identity load
        *
        * @tparam ScalarT - scalar data type
+       * @tparam IdxT - matrix index data type
        */
-      template <typename ScalarT>
-      __attribute__((always_inline)) static ScalarT ident_load(size_t idx, size_t i)
+      template <typename ScalarT, typename IdxT>
+      __attribute__((always_inline)) static ScalarT ident_load(IdxT row, IdxT col)
       {
-        idx /= sizeof(ScalarT);
-        return (ScalarT) (idx == i);
+        row /= sizeof(ScalarT);
+        return (ScalarT) (row == col);
       }
     } // namespace Sparse
   } // namespace Enzyme

--- a/GridKit/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/GridKit/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -48,7 +48,7 @@ namespace GridKit
 
       // --- Functions which call sort ---
       std::tuple<std::vector<IdxT>, std::vector<RealT>>                       getRowCopy(IdxT r);
-      std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> getEntries();
+      std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> getEntries(const bool sort = true);
       std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<RealT>>    getEntryCopies();
       std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<RealT>>    getEntryCopiesSubMatrix(std::vector<IdxT> submap);
 
@@ -57,10 +57,12 @@ namespace GridKit
 
       // Set values from vector storage. Will sort before storing
       void setValues(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<RealT> v);
+      void setValues(RealT alpha, IdxT* r, IdxT* c, RealT* v, IdxT nnz);
 
       // BLAS. Will sort before running
       void  axpy(RealT alpha, COO_Matrix<RealT, IdxT>& a, const bool sort = true);
       void  axpy(RealT alpha, std::vector<IdxT> r, std::vector<IdxT> c, std::vector<RealT> v, const bool sort = true);
+      void  axpy(RealT alpha, IdxT* r, IdxT* c, RealT* v, IdxT nnz);
       void  scal(RealT alpha);
       RealT frobNorm();
 
@@ -78,6 +80,7 @@ namespace GridKit
       void sortSparse();
       bool isSorted();
       IdxT nnz();
+      void deduplicate();
 
       std::tuple<IdxT, IdxT> getDimensions();
 
@@ -85,7 +88,7 @@ namespace GridKit
 
       void printMatrixMarket(const std::string& filename, const std::string& comment);
 
-      static void sortSparseCOO(std::vector<IdxT>& rows, std::vector<IdxT>& columns, std::vector<RealT>& values);
+      static void sortSparseCOO(std::vector<IdxT>& rows, std::vector<IdxT>& columns, std::vector<RealT>& values, size_t nnz);
 
     private:
       IdxT indexStartRow(const std::vector<IdxT>& rows, IdxT r);
@@ -135,9 +138,9 @@ namespace GridKit
      * @return std::tuple<std::vector<IdxT>, std::vector<IdxT>, std::vector<RealT>>
      */
     template <typename RealT, typename IdxT>
-    inline std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> COO_Matrix<RealT, IdxT>::getEntries()
+    inline std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> COO_Matrix<RealT, IdxT>::getEntries(const bool sort)
     {
-      if (!this->sorted_)
+      if (!this->sorted_ && sort)
       {
         this->sortSparse();
       }
@@ -239,7 +242,7 @@ namespace GridKit
     inline void COO_Matrix<RealT, IdxT>::setValues(std::vector<IdxT> r, std::vector<IdxT> c, std::vector<RealT> v)
     {
       // sort input
-      this->sortSparseCOO(r, c, v);
+      this->sortSparseCOO(r, c, v, r.size());
 
       // Duplicated with axpy. Could replace with function depdent on lambda expression
       size_t a_iter = 0;
@@ -276,6 +279,32 @@ namespace GridKit
         this->checkIncreaseSize(r[i], c[i]);
       }
 
+      this->sorted_ = false;
+    }
+
+    /**
+     * @brief Append coordinates and values of the matrix without sorting or deduplicating.
+     *
+     * @tparam RealT - Real type for Jacobian entries
+     * @tparam IdxT - Integer data type for matrix indices
+     *
+     * @param[in] r row indices to be stored
+     * @param[in] c column indices to be stored
+     * @param[in] v values to be stored
+     * @param[in] nnz to be stored 
+     *
+     */
+    template <typename RealT, typename IdxT>
+    inline void COO_Matrix<RealT, IdxT>::setValues(RealT alpha, IdxT* r, IdxT* c, RealT* v, IdxT nnz)
+    {
+      for (size_t i = 0; i < static_cast<size_t>(nnz); i++)
+      {
+        this->row_indices_.emplace_back(r[i]);
+        this->column_indices_.emplace_back(c[i]);
+        this->values_.emplace_back(alpha * v[i]);
+
+        this->checkIncreaseSize(r[i], c[i]);
+      }
       this->sorted_ = false;
     }
 
@@ -378,7 +407,7 @@ namespace GridKit
       }
 
       // sort input
-      this->sortSparseCOO(r, c, v);
+      this->sortSparseCOO(r, c, v, r.size());
 
       size_t a_iter = 0;
       // iterate for all current values_ in matrix
@@ -420,6 +449,94 @@ namespace GridKit
       }
 
       this->sorted_ = false;
+    }
+
+    /**
+     * @brief Append coordinates and values of the matrix without sorting or deduplicating.
+     *
+     * Need to deduplicate bus entries right away to get around the new mappings introduced by bus faults.
+     *
+     * Only use for buses, which are 2x2, so the cost of loops is not uncontrolled. Don't allow resizing.
+     *
+     * @tparam RealT - Real type for Jacobian entries
+     * @tparam IdxT - Integer data type for matrix indices
+     *
+     * @param[in] r row indices to be stored
+     * @param[in] c column indices to be stored
+     * @param[in] v values to be stored
+     * @param[in] nnz to be stored 
+     *
+     */
+    template <typename RealT, typename IdxT>
+    inline void COO_Matrix<RealT, IdxT>::axpy(RealT alpha, IdxT* r, IdxT* c, RealT* v, IdxT nnz)
+    {
+      if (this->row_indices_.size() == 0) // Do nothing for infinite bus
+      {
+      }
+      else if (this->row_indices_.size() == 4)
+      {
+        for (size_t i = 0; i < this->row_indices_.size(); i++)
+        {
+          for (size_t j = 0; j < static_cast<size_t>(nnz); j++)
+          {
+            if (this->row_indices_[i] == r[j] && this->column_indices_[i] == c[j])
+            {
+              this->values_[i] += alpha * v[j];
+            }
+          }
+        }
+      }
+      else
+      {
+        std::cout << "Warning: Unexpected size in axpy\n";
+      }
+
+      this->sorted_ = false;
+    }
+
+    /**
+     * @brief Deduplicate matrix entries
+     *
+     * @node This is currently only used in component-level Jacobian tests,
+     * which don't use CooMatrix or CsrMatrix yet, to compare with Dependency::Tracking maps.
+     *
+     * @tparam RealT - Real type for Jacobian entries
+     * @tparam IdxT - Integer data type for matrix indices
+     */
+    template <typename RealT, typename IdxT>
+    inline void COO_Matrix<RealT, IdxT>::deduplicate()
+    {
+      std::vector<IdxT>  row_temp = this->row_indices_;
+      std::vector<IdxT>  col_temp = this->column_indices_;
+      std::vector<RealT> val_temp = this->values_;
+
+      this->row_indices_.clear();
+      this->column_indices_.clear();
+      this->values_.clear();
+
+      IdxT nnz = 0;
+      for (size_t i = 0; i < row_temp.size(); i++)
+      {
+        IdxT  row    = row_temp[i];
+        IdxT  col    = col_temp[i];
+        RealT val    = val_temp[i];
+        bool  exists = false;
+        for (size_t j = 0; j < nnz; j++)
+        {
+          if (this->row_indices_[j] == row && this->column_indices_[j] == col)
+          {
+            this->values_[j] += val;
+            exists            = true;
+          }
+        }
+        if (!exists)
+        {
+          this->row_indices_.emplace_back(row);
+          this->column_indices_.emplace_back(col);
+          this->values_.emplace_back(val);
+          nnz++;
+        }
+      }
     }
 
     /**
@@ -595,7 +712,7 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     inline void COO_Matrix<RealT, IdxT>::sortSparse()
     {
-      this->sortSparseCOO(this->row_indices_, this->column_indices_, this->values_);
+      this->sortSparseCOO(this->row_indices_, this->column_indices_, this->values_, (this->row_indices_).size());
       this->sorted_ = true;
     }
 
@@ -873,13 +990,13 @@ namespace GridKit
      * @param values
      */
     template <typename RealT, typename IdxT>
-    inline void COO_Matrix<RealT, IdxT>::sortSparseCOO(std::vector<IdxT>& rows, std::vector<IdxT>& columns, std::vector<RealT>& values)
+    inline void COO_Matrix<RealT, IdxT>::sortSparseCOO(std::vector<IdxT>& rows, std::vector<IdxT>& columns, std::vector<RealT>& values, size_t nnz)
     {
 
       // index based sort code
       //  https://stackoverflow.com/questions/25921706/creating-a-vector-of-indices-of-a-sorted_-vector
       // cannot call sort since two arrays are used instead
-      std::vector<size_t> ordervec(rows.size());
+      std::vector<size_t> ordervec(nnz);
       std::size_t         n(0);
       std::generate(std::begin(ordervec), std::end(ordervec), [&]
                     { return n++; });

--- a/GridKit/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
+++ b/GridKit/LinearAlgebra/SparseMatrix/COO_Matrix.hpp
@@ -291,7 +291,7 @@ namespace GridKit
      * @param[in] r row indices to be stored
      * @param[in] c column indices to be stored
      * @param[in] v values to be stored
-     * @param[in] nnz to be stored 
+     * @param[in] nnz to be stored
      *
      */
     template <typename RealT, typename IdxT>
@@ -464,7 +464,7 @@ namespace GridKit
      * @param[in] r row indices to be stored
      * @param[in] c column indices to be stored
      * @param[in] v values to be stored
-     * @param[in] nnz to be stored 
+     * @param[in] nnz to be stored
      *
      */
     template <typename RealT, typename IdxT>

--- a/GridKit/LinearAlgebra/SparseMatrix/CooMatrix.cpp
+++ b/GridKit/LinearAlgebra/SparseMatrix/CooMatrix.cpp
@@ -180,8 +180,8 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     CooMatrix<RealT, IdxT>::~CooMatrix()
     {
-      this->destroyMatrixData(memory::HOST);
-      this->destroyMatrixData(memory::DEVICE);
+      destroyMatrixData(memory::HOST);
+      destroyMatrixData(memory::DEVICE);
       delete[] map_to_sorted_;
       delete[] map_to_dedup_;
     }
@@ -204,7 +204,7 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     IdxT CooMatrix<RealT, IdxT>::getNumRows() const
     {
-      return this->n_;
+      return n_;
     }
 
     /**
@@ -215,7 +215,7 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     IdxT CooMatrix<RealT, IdxT>::getNumColumns() const
     {
-      return this->m_;
+      return m_;
     }
 
     /**
@@ -226,7 +226,7 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     IdxT CooMatrix<RealT, IdxT>::getNnz() const
     {
-      return this->nnz_;
+      return nnz_;
     }
 
     /**
@@ -460,9 +460,9 @@ namespace GridKit
       switch (memspace)
       {
       case HOST:
-        return this->h_row_data_;
+        return h_row_data_;
       case DEVICE:
-        return this->d_row_data_;
+        return d_row_data_;
       default:
         return nullptr;
       }
@@ -476,9 +476,9 @@ namespace GridKit
       switch (memspace)
       {
       case HOST:
-        return this->h_col_data_;
+        return h_col_data_;
       case DEVICE:
-        return this->d_col_data_;
+        return d_col_data_;
       default:
         return nullptr;
       }
@@ -492,9 +492,9 @@ namespace GridKit
       switch (memspace)
       {
       case HOST:
-        return this->h_val_data_;
+        return h_val_data_;
       case DEVICE:
-        return this->d_val_data_;
+        return d_val_data_;
       default:
         return nullptr;
       }
@@ -595,14 +595,11 @@ namespace GridKit
     void CooMatrix<RealT, IdxT>::print(std::ostream& out, IdxT indexing_base)
     {
       out << std::scientific << std::setprecision(std::numeric_limits<RealT>::digits10);
-      for (IdxT i = 0; i < n_; ++i)
+      for (IdxT i = 0; i < nnz_; ++i)
       {
-        for (IdxT j = h_row_data_[i]; j < h_row_data_[i + 1]; ++j)
-        {
-          out << i + indexing_base << " "
-              << h_col_data_[j] + indexing_base << " "
-              << h_val_data_[j] << "\n";
-        }
+        out << h_row_data_[i] + indexing_base << " "
+            << h_col_data_[i] + indexing_base << " "
+            << h_val_data_[i] << "\n";
       }
     }
 

--- a/GridKit/LinearAlgebra/SparseMatrix/CsrMatrix.cpp
+++ b/GridKit/LinearAlgebra/SparseMatrix/CsrMatrix.cpp
@@ -178,8 +178,8 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     CsrMatrix<RealT, IdxT>::~CsrMatrix()
     {
-      this->destroyMatrixData(memory::HOST);
-      this->destroyMatrixData(memory::DEVICE);
+      destroyMatrixData(memory::HOST);
+      destroyMatrixData(memory::DEVICE);
     }
 
     /**
@@ -198,9 +198,9 @@ namespace GridKit
      * @return number of matrix rows.
      */
     template <typename RealT, typename IdxT>
-    IdxT CsrMatrix<RealT, IdxT>::getNumRows()
+    IdxT CsrMatrix<RealT, IdxT>::getNumRows() const
     {
-      return this->n_;
+      return n_;
     }
 
     /**
@@ -209,9 +209,9 @@ namespace GridKit
      * @return number of matrix columns.
      */
     template <typename RealT, typename IdxT>
-    IdxT CsrMatrix<RealT, IdxT>::getNumColumns()
+    IdxT CsrMatrix<RealT, IdxT>::getNumColumns() const
     {
-      return this->m_;
+      return m_;
     }
 
     /**
@@ -220,9 +220,9 @@ namespace GridKit
      * @return number of non-zeros.
      */
     template <typename RealT, typename IdxT>
-    IdxT CsrMatrix<RealT, IdxT>::getNnz()
+    IdxT CsrMatrix<RealT, IdxT>::getNnz() const
     {
-      return this->nnz_;
+      return nnz_;
     }
 
     /**
@@ -233,7 +233,7 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     void CsrMatrix<RealT, IdxT>::setNnz(IdxT nnz_new)
     {
-      this->nnz_ = nnz_new;
+      nnz_ = nnz_new;
     }
 
     /**
@@ -435,8 +435,8 @@ namespace GridKit
         // check if cpu data allocated
         if (h_val_data_ == nullptr)
         {
-          this->h_val_data_ = new RealT[static_cast<size_t>(nnz_current)];
-          owns_cpu_values_  = true;
+          h_val_data_      = new RealT[static_cast<size_t>(nnz_current)];
+          owns_cpu_values_ = true;
         }
       }
 
@@ -531,9 +531,9 @@ namespace GridKit
       switch (memspace)
       {
       case HOST:
-        return this->h_row_data_;
+        return h_row_data_;
       case DEVICE:
-        return this->d_row_data_;
+        return d_row_data_;
       default:
         return nullptr;
       }
@@ -547,9 +547,9 @@ namespace GridKit
       switch (memspace)
       {
       case HOST:
-        return this->h_col_data_;
+        return h_col_data_;
       case DEVICE:
-        return this->d_col_data_;
+        return d_col_data_;
       default:
         return nullptr;
       }
@@ -563,9 +563,9 @@ namespace GridKit
       switch (memspace)
       {
       case HOST:
-        return this->h_val_data_;
+        return h_val_data_;
       case DEVICE:
-        return this->d_val_data_;
+        return d_val_data_;
       default:
         return nullptr;
       }
@@ -606,14 +606,14 @@ namespace GridKit
 
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr))
         {
-          this->h_row_data_          = new IdxT[static_cast<size_t>(n_ + 1)];
-          this->h_col_data_          = new IdxT[static_cast<size_t>(nnz_current)];
+          h_row_data_                = new IdxT[static_cast<size_t>(n_ + 1)];
+          h_col_data_                = new IdxT[static_cast<size_t>(nnz_current)];
           owns_cpu_sparsity_pattern_ = true;
         }
         if (h_val_data_ == nullptr)
         {
-          this->h_val_data_ = new RealT[static_cast<size_t>(nnz_current)];
-          owns_cpu_values_  = true;
+          h_val_data_      = new RealT[static_cast<size_t>(nnz_current)];
+          owns_cpu_values_ = true;
         }
       }
 
@@ -689,11 +689,11 @@ namespace GridKit
 
       if (memspace == memory::HOST)
       {
-        this->h_row_data_ = new IdxT[static_cast<size_t>(n_ + 1)];
+        h_row_data_ = new IdxT[static_cast<size_t>(n_ + 1)];
         std::fill(h_row_data_, h_row_data_ + n_ + 1, 0);
-        this->h_col_data_ = new IdxT[static_cast<size_t>(nnz_current)];
+        h_col_data_ = new IdxT[static_cast<size_t>(nnz_current)];
         std::fill(h_col_data_, h_col_data_ + nnz_current, 0);
-        this->h_val_data_ = new RealT[static_cast<size_t>(nnz_current)];
+        h_val_data_ = new RealT[static_cast<size_t>(nnz_current)];
         std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);
         owns_cpu_sparsity_pattern_ = true;
         owns_cpu_values_           = true;

--- a/GridKit/LinearAlgebra/SparseMatrix/CsrMatrix.hpp
+++ b/GridKit/LinearAlgebra/SparseMatrix/CsrMatrix.hpp
@@ -31,9 +31,9 @@ namespace GridKit
       ~CsrMatrix();
 
       // accessors
-      IdxT getNumRows();
-      IdxT getNumColumns();
-      IdxT getNnz();
+      IdxT getNumRows() const;
+      IdxT getNumColumns() const;
+      IdxT getNnz() const;
 
       void setNnz(IdxT nnz_new); // for resetting when removing duplicates
       int  setUpdated(memory::MemorySpace what);

--- a/GridKit/Model/Evaluator.hpp
+++ b/GridKit/Model/Evaluator.hpp
@@ -21,9 +21,9 @@ namespace GridKit
     class Evaluator
     {
     public:
-      using RealT     = typename GridKit::ScalarTraits<ScalarT>::RealT;
-      using MatrixT   = GridKit::LinearAlgebra::COO_Matrix<RealT, IdxT>; //\todo Use CsrMatrix
-      using CsrMatrix = GridKit::LinearAlgebra::CsrMatrix<RealT, IdxT>;
+      using RealT      = typename GridKit::ScalarTraits<ScalarT>::RealT;
+      using MatrixT    = GridKit::LinearAlgebra::COO_Matrix<RealT, IdxT>; //\todo Use CsrMatrix
+      using CsrMatrixT = GridKit::LinearAlgebra::CsrMatrix<RealT, IdxT>;
 
       Evaluator()
       {
@@ -90,7 +90,7 @@ namespace GridKit
        *
        * @todo Remove this and use CsrMatirx for jac_
        */
-      virtual CsrMatrix* getCsrJacobian() const
+      virtual CsrMatrixT* getCsrJacobian() const
       {
         return nullptr;
       }

--- a/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
@@ -52,6 +52,9 @@ namespace GridKit
       using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
+      using Component<ScalarT, IdxT>::J_rows_buffer_;
+      using Component<ScalarT, IdxT>::J_cols_buffer_;
+      using Component<ScalarT, IdxT>::J_vals_buffer_;
       using Component<ScalarT, IdxT>::variable_indices_;
       using Component<ScalarT, IdxT>::residual_indices_;
 
@@ -66,14 +69,14 @@ namespace GridKit
       Branch(bus_type* bus1, bus_type* bus2, const model_data_type& data);
       virtual ~Branch();
 
-      virtual int setGridKitComponentID(IdxT) override;
-      virtual int allocate() override;
-      virtual int initialize() override;
-      virtual int tagDifferentiable() override;
-      virtual int evaluateResidual() override;
-      virtual int evaluateJacobian() override;
+      virtual int setGridKitComponentID(IdxT) override final;
+      virtual int allocate() override final;
+      virtual int initialize() override final;
+      virtual int tagDifferentiable() override final;
+      virtual int evaluateResidual() override final;
+      virtual int evaluateJacobian() override final;
 
-      virtual int verify() const override
+      virtual int verify() const override final
       {
         return 0;
       }

--- a/GridKit/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
@@ -26,6 +26,12 @@ namespace GridKit
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;
 
       J_.zeroMatrix();
+      if (J_rows_buffer_ == nullptr)
+      {
+        J_rows_buffer_ = new IdxT[4];
+        J_cols_buffer_ = new IdxT[4];
+        J_vals_buffer_ = new RealT[4];
+      }
 
       // Bus 1 diagonal Jacobian block owned by the bus
       GridKit::Enzyme::Sparse::DhDwb<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
@@ -34,11 +40,14 @@ namespace GridKit
                                      IdxT>::eval(this,
                                                  static_cast<size_t>(bus1_->size()),
                                                  static_cast<size_t>((bus1_->y()).size()),
-                                                 bus1_->getResidualIndices(),
-                                                 bus1_->getVariableIndices(),
+                                                 (bus1_->getResidualIndices()).data(),
+                                                 (bus1_->getVariableIndices()).data(),
                                                  y_.data(),
                                                  yp_.data(),
                                                  (bus1_->y()).data(),
+                                                 J_rows_buffer_,
+                                                 J_cols_buffer_,
+                                                 J_vals_buffer_,
                                                  bus1_->getJacobian());
 
       // Bus 2 diagonal Jacobian block owned by the bus
@@ -48,11 +57,14 @@ namespace GridKit
                                      IdxT>::eval(this,
                                                  static_cast<size_t>(bus2_->size()),
                                                  static_cast<size_t>((bus2_->y()).size()),
-                                                 bus2_->getResidualIndices(),
-                                                 bus2_->getVariableIndices(),
+                                                 (bus2_->getResidualIndices()).data(),
+                                                 (bus2_->getVariableIndices()).data(),
                                                  y_.data(),
                                                  yp_.data(),
                                                  (bus2_->y()).data(),
+                                                 J_rows_buffer_,
+                                                 J_cols_buffer_,
+                                                 J_vals_buffer_,
                                                  bus2_->getJacobian());
 
       // Off-diagonal Jacobian block (Bus2 variables) owned by the branch
@@ -62,12 +74,16 @@ namespace GridKit
                                      IdxT>::eval(this,
                                                  static_cast<size_t>(bus1_->size()),
                                                  static_cast<size_t>((bus2_->y()).size()),
-                                                 bus1_->getResidualIndices(),
-                                                 bus2_->getVariableIndices(),
+                                                 (bus1_->getResidualIndices()).data(),
+                                                 (bus2_->getVariableIndices()).data(),
                                                  y_.data(),
                                                  yp_.data(),
                                                  (bus2_->y()).data(),
-                                                 J_);
+                                                 J_rows_buffer_,
+                                                 J_cols_buffer_,
+                                                 J_vals_buffer_,
+                                                 J_,
+                                                 true);
 
       // Off-diagonal Jacobian block (Bus1 variables) owned by the branch
       GridKit::Enzyme::Sparse::DhDwb<GridKit::PhasorDynamics::Branch<ScalarT, IdxT>,
@@ -76,12 +92,16 @@ namespace GridKit
                                      IdxT>::eval(this,
                                                  static_cast<size_t>(bus2_->size()),
                                                  static_cast<size_t>((bus1_->y()).size()),
-                                                 bus2_->getResidualIndices(),
-                                                 bus1_->getVariableIndices(),
+                                                 (bus2_->getResidualIndices()).data(),
+                                                 (bus1_->getVariableIndices()).data(),
                                                  y_.data(),
                                                  yp_.data(),
                                                  (bus1_->y()).data(),
-                                                 J_);
+                                                 J_rows_buffer_,
+                                                 J_cols_buffer_,
+                                                 J_vals_buffer_,
+                                                 J_,
+                                                 true);
 
       return 0;
     }

--- a/GridKit/Model/PhasorDynamics/Bus/Bus.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/Bus.hpp
@@ -24,6 +24,9 @@ namespace GridKit
       using BusBase<ScalarT, IdxT>::yp_;
       using BusBase<ScalarT, IdxT>::f_;
       using BusBase<ScalarT, IdxT>::J_;
+      using BusBase<ScalarT, IdxT>::J_rows_buffer_;
+      using BusBase<ScalarT, IdxT>::J_cols_buffer_;
+      using BusBase<ScalarT, IdxT>::J_vals_buffer_;
       using BusBase<ScalarT, IdxT>::tag_;
       using BusBase<ScalarT, IdxT>::variable_indices_;
       using BusBase<ScalarT, IdxT>::residual_indices_;
@@ -38,58 +41,57 @@ namespace GridKit
       Bus(const DataT& data);
       virtual ~Bus();
 
-      virtual int setBusID(IdxT) override;
-      virtual int allocate() override;
-      virtual int tagDifferentiable() override;
-      virtual int initialize() override;
-      virtual int evaluateResidual() override;
-      virtual int evaluateJacobian() override;
+      virtual int setBusID(IdxT) override final;
+      virtual int allocate() override final;
+      virtual int tagDifferentiable() override final;
+      virtual int initialize() override final;
+      virtual int evaluateResidual() override final;
+      virtual int evaluateJacobian() override final;
 
-      virtual BusTypeT BusType() const override
+      virtual BusTypeT BusType() const override final
       {
         return BusTypeT::DEFAULT;
       }
 
-      virtual ScalarT& Vr() override
+      virtual ScalarT& Vr() override final
       {
         return y_[0];
       }
 
-      virtual const ScalarT& Vr() const override
+      virtual const ScalarT& Vr() const override final
       {
         return y_[0];
       }
 
-      virtual ScalarT& Vi() override
+      virtual ScalarT& Vi() override final
       {
         return y_[1];
       }
 
-      virtual const ScalarT& Vi() const override
+      virtual const ScalarT& Vi() const override final
       {
         return y_[1];
       }
 
-      virtual ScalarT& Ir() override
+      virtual ScalarT& Ir() override final
       {
         return f_[0];
       }
 
-      virtual const ScalarT& Ir() const override
+      virtual const ScalarT& Ir() const override final
       {
         return f_[0];
       }
 
-      virtual ScalarT& Ii() override
+      virtual ScalarT& Ii() override final
       {
         return f_[1];
       }
 
-      virtual const ScalarT& Ii() const override
+      virtual const ScalarT& Ii() const override final
       {
         return f_[1];
       }
-
     private:
       ScalarT Vr0_{0.0};
       ScalarT Vi0_{0.0};

--- a/GridKit/Model/PhasorDynamics/Bus/Bus.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/Bus.hpp
@@ -92,6 +92,7 @@ namespace GridKit
       {
         return f_[1];
       }
+
     private:
       ScalarT Vr0_{0.0};
       ScalarT Vi0_{0.0};

--- a/GridKit/Model/PhasorDynamics/Bus/BusEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusEnzyme.cpp
@@ -27,12 +27,34 @@ namespace GridKit
       Log::misc() << "Evaluate Jacobian for Bus..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;
 
-      J_.zeroMatrix();
+      if (J_rows_buffer_ == nullptr)
+      {
+        J_.zeroMatrix();
 
-      std::vector<IdxT>    rtemp   = {residual_indices_.at(0), residual_indices_.at(0), residual_indices_.at(1), residual_indices_.at(1)};
-      std::vector<IdxT>    ctemp   = {variable_indices_.at(0), variable_indices_.at(1), variable_indices_.at(0), variable_indices_.at(1)};
-      std::vector<ScalarT> valtemp = {0.0, 0.0, 0.0, 0.0};
-      J_.setValues(rtemp, ctemp, valtemp); //< @todo: Update once sparse storage format changes
+        // Reserve space for a dense matrix of size_*size_.
+        // Enyme will compute the appropriate nnz from sparsification.
+        J_rows_buffer_ = new IdxT[4];
+        J_cols_buffer_ = new IdxT[4];
+        J_vals_buffer_ = new RealT[4];
+
+        J_rows_buffer_[0] = residual_indices_.at(0);
+        J_rows_buffer_[1] = residual_indices_.at(0);
+        J_rows_buffer_[2] = residual_indices_.at(1);
+        J_rows_buffer_[3] = residual_indices_.at(1);
+        J_cols_buffer_[0] = variable_indices_.at(0);
+        J_cols_buffer_[1] = variable_indices_.at(1);
+        J_cols_buffer_[2] = variable_indices_.at(0);
+        J_cols_buffer_[3] = variable_indices_.at(1);
+        J_vals_buffer_[0] = 0.0;
+        J_vals_buffer_[1] = 0.0;
+        J_vals_buffer_[2] = 0.0;
+        J_vals_buffer_[3] = 0.0;
+        J_.setValues(1.0, J_rows_buffer_, J_cols_buffer_, J_vals_buffer_, 4); //< @todo: Update once sparse storage format changes
+      }
+      else
+      {
+        J_.zeroValuedMatrix();
+      }
       return 0;
     }
 

--- a/GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp
@@ -35,54 +35,54 @@ namespace GridKit
       BusInfinite(const DataT& data);
       virtual ~BusInfinite();
 
-      virtual int setBusID(IdxT) override;
-      virtual int allocate() override;
-      virtual int tagDifferentiable() override;
-      virtual int initialize() override;
-      virtual int evaluateResidual() override;
-      virtual int evaluateJacobian() override;
+      virtual int setBusID(IdxT) override final;
+      virtual int allocate() override final;
+      virtual int tagDifferentiable() override final;
+      virtual int initialize() override final;
+      virtual int evaluateResidual() override final;
+      virtual int evaluateJacobian() override final;
 
-      virtual BusTypeT BusType() const override
+      virtual BusTypeT BusType() const override final
       {
         return BusTypeT::SLACK;
       }
 
-      virtual ScalarT& Vr() override
+      virtual ScalarT& Vr() override final
       {
         return Vr_;
       }
 
-      virtual const ScalarT& Vr() const override
+      virtual const ScalarT& Vr() const override final
       {
         return Vr_;
       }
 
-      virtual ScalarT& Vi() override
+      virtual ScalarT& Vi() override final
       {
         return Vi_;
       }
 
-      virtual const ScalarT& Vi() const override
+      virtual const ScalarT& Vi() const override final
       {
         return Vi_;
       }
 
-      virtual ScalarT& Ir() override
+      virtual ScalarT& Ir() override final
       {
         return Ir_;
       }
 
-      virtual const ScalarT& Ir() const override
+      virtual const ScalarT& Ir() const override final
       {
         return Ir_;
       }
 
-      virtual ScalarT& Ii() override
+      virtual ScalarT& Ii() override final
       {
         return Ii_;
       }
 
-      virtual const ScalarT& Ii() const override
+      virtual const ScalarT& Ii() const override final
       {
         return Ii_;
       }

--- a/GridKit/Model/PhasorDynamics/BusBase.hpp
+++ b/GridKit/Model/PhasorDynamics/BusBase.hpp
@@ -180,9 +180,9 @@ namespace GridKit
       std::vector<ScalarT> f_;
 
       MatrixT J_;
-      IdxT*  J_rows_buffer_{nullptr};
-      IdxT*  J_cols_buffer_{nullptr};
-      RealT* J_vals_buffer_{nullptr};
+      IdxT*   J_rows_buffer_{nullptr};
+      IdxT*   J_cols_buffer_{nullptr};
+      RealT*  J_vals_buffer_{nullptr};
 
       RealT rtol_;
       RealT atol_;

--- a/GridKit/Model/PhasorDynamics/BusBase.hpp
+++ b/GridKit/Model/PhasorDynamics/BusBase.hpp
@@ -180,6 +180,9 @@ namespace GridKit
       std::vector<ScalarT> f_;
 
       MatrixT J_;
+      IdxT*  J_rows_buffer_{nullptr};
+      IdxT*  J_cols_buffer_{nullptr};
+      RealT* J_vals_buffer_{nullptr};
 
       RealT rtol_;
       RealT atol_;

--- a/GridKit/Model/PhasorDynamics/BusBaseImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/BusBaseImpl.hpp
@@ -26,6 +26,15 @@ namespace GridKit
     template <typename ScalarT, typename IdxT>
     BusBase<ScalarT, IdxT>::~BusBase()
     {
+      if (J_rows_buffer_ != nullptr)
+      {
+        delete[] J_rows_buffer_;
+        delete[] J_cols_buffer_;
+        delete[] J_vals_buffer_;
+        J_rows_buffer_ = nullptr;
+        J_cols_buffer_ = nullptr;
+        J_vals_buffer_ = nullptr;
+      }
     }
 
     template <typename ScalarT, typename IdxT>

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -33,6 +33,9 @@ namespace GridKit
       using Component<ScalarT, IdxT>::yp_;
       using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
+      using Component<ScalarT, IdxT>::J_rows_buffer_;
+      using Component<ScalarT, IdxT>::J_cols_buffer_;
+      using Component<ScalarT, IdxT>::J_vals_buffer_;
 
     public:
       using bus_type = BusBase<ScalarT, IdxT>;
@@ -45,19 +48,19 @@ namespace GridKit
       BusFault(bus_type* bus, const DataT& data);
       ~BusFault();
 
-      int setGridKitComponentID(IdxT) override;
-      int allocate() override;
-      int initialize() override;
-      int tagDifferentiable() override;
-      int evaluateResidual() override;
-      int evaluateJacobian() override;
+      int setGridKitComponentID(IdxT) override final;
+      int allocate() override final;
+      int initialize() override final;
+      int tagDifferentiable() override final;
+      int evaluateResidual() override final;
+      int evaluateJacobian() override final;
 
-      int verify() const override
+      int verify() const override final
       {
         return 0;
       }
 
-      void updateTime(RealT /* t */, RealT /* a */) override
+      void updateTime(RealT /* t */, RealT /* a */) override final
       {
       }
 

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
@@ -27,17 +27,26 @@ namespace GridKit
 
       if (status_)
       {
+        if (J_rows_buffer_ == nullptr)
+        {
+          J_rows_buffer_ = new IdxT[4];
+          J_cols_buffer_ = new IdxT[4];
+          J_vals_buffer_ = new RealT[4];
+        }
         GridKit::Enzyme::Sparse::DhDwb<GridKit::PhasorDynamics::BusFault<ScalarT, IdxT>,
                                        GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
                                        ScalarT,
                                        IdxT>::eval(this,
                                                    static_cast<size_t>(bus_->size()),
                                                    static_cast<size_t>(bus_->size()),
-                                                   bus_->getResidualIndices(),
-                                                   bus_->getVariableIndices(),
+                                                   (bus_->getResidualIndices()).data(),
+                                                   (bus_->getVariableIndices()).data(),
                                                    y_.data(),
                                                    yp_.data(),
                                                    (bus_->y()).data(),
+                                                   J_rows_buffer_,
+                                                   J_cols_buffer_,
+                                                   J_vals_buffer_,
                                                    bus_->getJacobian());
       }
 

--- a/GridKit/Model/PhasorDynamics/Component.hpp
+++ b/GridKit/Model/PhasorDynamics/Component.hpp
@@ -182,9 +182,9 @@ namespace GridKit
       std::vector<ScalarT> h_;
 
       MatrixT J_;
-      IdxT*  J_rows_buffer_{nullptr};
-      IdxT*  J_cols_buffer_{nullptr};
-      RealT* J_vals_buffer_{nullptr};
+      IdxT*   J_rows_buffer_{nullptr};
+      IdxT*   J_cols_buffer_{nullptr};
+      RealT*  J_vals_buffer_{nullptr};
 
       RealT time_;
       RealT alpha_;

--- a/GridKit/Model/PhasorDynamics/Component.hpp
+++ b/GridKit/Model/PhasorDynamics/Component.hpp
@@ -28,6 +28,19 @@ namespace GridKit
       {
       }
 
+      virtual ~Component()
+      {
+        if (J_rows_buffer_ != nullptr)
+        {
+          delete[] J_rows_buffer_;
+          delete[] J_cols_buffer_;
+          delete[] J_vals_buffer_;
+          J_rows_buffer_ = nullptr;
+          J_cols_buffer_ = nullptr;
+          J_vals_buffer_ = nullptr;
+        }
+      }
+
       virtual int verify() const = 0;
 
       virtual IdxT size() override
@@ -169,6 +182,9 @@ namespace GridKit
       std::vector<ScalarT> h_;
 
       MatrixT J_;
+      IdxT*  J_rows_buffer_{nullptr};
+      IdxT*  J_cols_buffer_{nullptr};
+      RealT* J_vals_buffer_{nullptr};
 
       RealT time_;
       RealT alpha_;

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -77,6 +77,9 @@ namespace GridKit
         using Component<ScalarT, IdxT>::yp_;
         using Component<ScalarT, IdxT>::wb_;
         using Component<ScalarT, IdxT>::J_;
+        using Component<ScalarT, IdxT>::J_rows_buffer_;
+        using Component<ScalarT, IdxT>::J_cols_buffer_;
+        using Component<ScalarT, IdxT>::J_vals_buffer_;
         using Component<ScalarT, IdxT>::variable_indices_;
         using Component<ScalarT, IdxT>::residual_indices_;
 
@@ -96,13 +99,13 @@ namespace GridKit
                const model_data_type& data);
         ~Ieeet1();
 
-        int setGridKitComponentID(IdxT) override;
-        int allocate() override;
-        int verify() const override;
-        int initialize() override;
-        int tagDifferentiable() override;
-        int evaluateResidual() override;
-        int evaluateJacobian() override;
+        int setGridKitComponentID(IdxT) override final;
+        int allocate() override final;
+        int verify() const override final;
+        int initialize() override final;
+        int tagDifferentiable() override final;
+        int evaluateResidual() override final;
+        int evaluateJacobian() override final;
 
         /// Get the `ComponentSignals` from this `Ieeet1`
         auto getSignals()

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Enzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Enzyme.cpp
@@ -28,6 +28,14 @@ namespace GridKit
         Log::misc() << "Jacobian evaluation is experimental!" << std::endl;
 
         J_.zeroMatrix();
+        if (J_rows_buffer_ == nullptr)
+        {
+          // Reserve space for a dense matrix of size_*size_.
+          // Enyme will compute the appropriate nnz from sparsification.
+          J_rows_buffer_ = new IdxT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+          J_cols_buffer_ = new IdxT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+          J_vals_buffer_ = new RealT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+        }
 
         GridKit::Enzyme::Sparse::DfDy<GridKit::PhasorDynamics::Exciter::Ieeet1<ScalarT, IdxT>,
                                       GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
@@ -35,13 +43,16 @@ namespace GridKit
                                       IdxT>::eval(this,
                                                   f_.size(),
                                                   y_.size(),
-                                                  this->getResidualIndices(),
-                                                  this->getVariableIndices(),
+                                                  (this->getResidualIndices()).data(),
+                                                  (this->getVariableIndices()).data(),
                                                   y_.data(),
                                                   yp_.data(),
                                                   wb_.data(),
                                                   ws_.data(),
                                                   alpha_,
+                                                  J_rows_buffer_,
+                                                  J_cols_buffer_,
+                                                  J_vals_buffer_,
                                                   J_);
 
         GridKit::Enzyme::Sparse::DfDwb<GridKit::PhasorDynamics::Exciter::Ieeet1<ScalarT, IdxT>,
@@ -50,12 +61,15 @@ namespace GridKit
                                        IdxT>::eval(this,
                                                    f_.size(),
                                                    static_cast<size_t>(bus_->size()),
-                                                   this->getResidualIndices(),
-                                                   bus_->getVariableIndices(),
+                                                   (this->getResidualIndices()).data(),
+                                                   (bus_->getVariableIndices()).data(),
                                                    y_.data(),
                                                    yp_.data(),
                                                    (bus_->y()).data(),
                                                    ws_.data(),
+                                                   J_rows_buffer_,
+                                                   J_cols_buffer_,
+                                                   J_vals_buffer_,
                                                    J_);
 
         GridKit::Enzyme::Sparse::DfDws<GridKit::PhasorDynamics::Exciter::Ieeet1<ScalarT, IdxT>,
@@ -64,12 +78,15 @@ namespace GridKit
                                        IdxT>::eval(this,
                                                    f_.size(),
                                                    ws_.size(),
-                                                   this->getResidualIndices(),
-                                                   ws_indices_,
+                                                   (this->getResidualIndices()).data(),
+                                                   ws_indices_.data(),
                                                    y_.data(),
                                                    yp_.data(),
                                                    wb_.data(),
                                                    ws_.data(),
+                                                   J_rows_buffer_,
+                                                   J_cols_buffer_,
+                                                   J_vals_buffer_,
                                                    J_);
 
         return 0;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -70,6 +70,9 @@ namespace GridKit
         using Component<ScalarT, IdxT>::wb_;
         using Component<ScalarT, IdxT>::h_;
         using Component<ScalarT, IdxT>::J_;
+        using Component<ScalarT, IdxT>::J_rows_buffer_;
+        using Component<ScalarT, IdxT>::J_cols_buffer_;
+        using Component<ScalarT, IdxT>::J_vals_buffer_;
         using Component<ScalarT, IdxT>::variable_indices_;
         using Component<ScalarT, IdxT>::residual_indices_;
 
@@ -83,15 +86,15 @@ namespace GridKit
         Tgov1(const model_data_type&);
         ~Tgov1() = default;
 
-        int setGridKitComponentID(IdxT) override;
-        int allocate() override;
-        int verify() const override;
-        int initialize() override;
-        int tagDifferentiable() override;
-        int evaluateResidual() override;
+        int setGridKitComponentID(IdxT) override final;
+        int allocate() override final;
+        int verify() const override final;
+        int initialize() override final;
+        int tagDifferentiable() override final;
+        int evaluateResidual() override final;
 
         // Still to be implemented
-        int evaluateJacobian() override;
+        int evaluateJacobian() override final;
 
         /// Get the `ComponentSignals` from this `Tgov1`
         auto getSignals()

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -28,6 +28,14 @@ namespace GridKit
         Log::misc() << "Jacobian evaluation is experimental!" << std::endl;
 
         J_.zeroMatrix();
+        if (J_rows_buffer_ == nullptr)
+        {
+          // Reserve space for a dense matrix of size_*size_.
+          // Enyme will compute the appropriate nnz from sparsification.
+          J_rows_buffer_ = new IdxT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+          J_cols_buffer_ = new IdxT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+          J_vals_buffer_ = new RealT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+        }
 
         GridKit::Enzyme::Sparse::DfDy<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
                                       GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
@@ -35,13 +43,16 @@ namespace GridKit
                                       IdxT>::eval(this,
                                                   f_.size(),
                                                   y_.size(),
-                                                  this->getResidualIndices(),
-                                                  this->getVariableIndices(),
+                                                  (this->getResidualIndices()).data(),
+                                                  (this->getVariableIndices()).data(),
                                                   y_.data(),
                                                   yp_.data(),
                                                   wb_.data(),
                                                   ws_.data(),
                                                   alpha_,
+                                                  J_rows_buffer_,
+                                                  J_cols_buffer_,
+                                                  J_vals_buffer_,
                                                   J_);
 
         GridKit::Enzyme::Sparse::DfDws<GridKit::PhasorDynamics::Governor::Tgov1<ScalarT, IdxT>,
@@ -50,12 +61,15 @@ namespace GridKit
                                        IdxT>::eval(this,
                                                    f_.size(),
                                                    ws_.size(),
-                                                   this->getResidualIndices(),
-                                                   ws_indices_,
+                                                   (this->getResidualIndices()).data(),
+                                                   ws_indices_.data(),
                                                    y_.data(),
                                                    yp_.data(),
                                                    wb_.data(),
                                                    ws_.data(),
+                                                   J_rows_buffer_,
+                                                   J_cols_buffer_,
+                                                   J_vals_buffer_,
                                                    J_);
 
         return 0;

--- a/GridKit/Model/PhasorDynamics/Load/Load.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/Load.hpp
@@ -39,6 +39,9 @@ namespace GridKit
       using Component<ScalarT, IdxT>::tag_;
       using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
+      using Component<ScalarT, IdxT>::J_rows_buffer_;
+      using Component<ScalarT, IdxT>::J_cols_buffer_;
+      using Component<ScalarT, IdxT>::J_vals_buffer_;
       using Component<ScalarT, IdxT>::variable_indices_;
       using Component<ScalarT, IdxT>::residual_indices_;
 
@@ -53,14 +56,14 @@ namespace GridKit
       Load(bus_type* bus, const model_data_type& data);
       virtual ~Load();
 
-      virtual int setGridKitComponentID(IdxT) override;
-      virtual int allocate() override;
-      virtual int initialize() override;
-      virtual int tagDifferentiable() override;
-      virtual int evaluateResidual() override;
-      virtual int evaluateJacobian() override;
+      virtual int setGridKitComponentID(IdxT) override final;
+      virtual int allocate() override final;
+      virtual int initialize() override final;
+      virtual int tagDifferentiable() override final;
+      virtual int evaluateResidual() override final;
+      virtual int evaluateJacobian() override final;
 
-      virtual int verify() const override
+      virtual int verify() const override final
       {
         return 0;
       }

--- a/GridKit/Model/PhasorDynamics/Load/LoadEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadEnzyme.cpp
@@ -25,17 +25,26 @@ namespace GridKit
       Log::misc() << "Evaluate Jacobian for Load..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;
 
+      if (J_rows_buffer_ == nullptr)
+      {
+        J_rows_buffer_ = new IdxT[4];
+        J_cols_buffer_ = new IdxT[4];
+        J_vals_buffer_ = new RealT[4];
+      }
       GridKit::Enzyme::Sparse::DhDwb<GridKit::PhasorDynamics::Load<ScalarT, IdxT>,
                                      GridKit::Enzyme::Sparse::MemberFunctions::BusResidual,
                                      ScalarT,
                                      IdxT>::eval(this,
                                                  static_cast<size_t>(bus_->size()),
                                                  static_cast<size_t>(bus_->size()),
-                                                 bus_->getResidualIndices(),
-                                                 bus_->getVariableIndices(),
+                                                 (bus_->getResidualIndices()).data(),
+                                                 (bus_->getVariableIndices()).data(),
                                                  y_.data(),
                                                  yp_.data(),
                                                  (bus_->y()).data(),
+                                                 J_rows_buffer_,
+                                                 J_cols_buffer_,
+                                                 J_vals_buffer_,
                                                  bus_->getJacobian());
 
       return 0;

--- a/GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp
@@ -34,11 +34,11 @@ namespace GridKit
 
       virtual ~SignalNode() = default;
 
-      virtual int allocate() override;
-      virtual int initialize() override;
-      virtual int tagDifferentiable() override;
-      virtual int evaluateResidual() override;
-      virtual int evaluateJacobian() override;
+      virtual int allocate() override final;
+      virtual int initialize() override final;
+      virtual int tagDifferentiable() override final;
+      virtual int evaluateResidual() override final;
+      virtual int evaluateJacobian() override final;
 
       void    set(ScalarT* signal_in, IdxT* global_index);
       bool    linked() const;
@@ -50,73 +50,73 @@ namespace GridKit
         return signal_id_;
       }
 
-      virtual IdxT size() override
+      virtual IdxT size() override final
       {
         return size_;
       }
 
-      virtual IdxT nnz() override
+      virtual IdxT nnz() override final
       {
         return nnz_;
       }
 
-      virtual bool hasJacobian() override
+      virtual bool hasJacobian() override final
       {
         return false;
       }
 
-      virtual void updateTime(RealT /* t */, RealT /* a */) override
+      virtual void updateTime(RealT /* t */, RealT /* a */) override final
       {
         // No time to update in signal nodes
       }
 
-      virtual void setTolerances(RealT& rtol, RealT& atol) const override
+      virtual void setTolerances(RealT& rtol, RealT& atol) const override final
       {
         rtol = rtol_;
         atol = atol_;
       }
 
-      virtual void setMaxSteps(IdxT& msa) const override
+      virtual void setMaxSteps(IdxT& msa) const override final
       {
         msa = max_steps_;
       }
 
-      std::vector<ScalarT>& y() override
+      std::vector<ScalarT>& y() override final
       {
         return y_;
       }
 
-      const std::vector<ScalarT>& y() const override
+      const std::vector<ScalarT>& y() const override final
       {
         return y_;
       }
 
-      std::vector<ScalarT>& yp() override
+      std::vector<ScalarT>& yp() override final
       {
         return yp_;
       }
 
-      const std::vector<ScalarT>& yp() const override
+      const std::vector<ScalarT>& yp() const override final
       {
         return yp_;
       }
 
-      std::vector<bool>& tag() override
+      std::vector<bool>& tag() override final
       {
         return tag_;
       }
 
-      const std::vector<bool>& tag() const override
+      const std::vector<bool>& tag() const override final
       {
         return tag_;
       }
 
-      MatrixT& getJacobian() override
+      MatrixT& getJacobian() override final
       {
         return J_;
       }
 
-      const MatrixT& getJacobian() const override
+      const MatrixT& getJacobian() const override final
       {
         return J_;
       }
@@ -168,143 +168,143 @@ namespace GridKit
       //
 
     public:
-      virtual IdxT sizeQuadrature() override
+      virtual IdxT sizeQuadrature() override final
       {
         throw "ERROR: Method not implemented!\n";
         return 0;
       }
 
-      virtual IdxT sizeParams() override
+      virtual IdxT sizeParams() override final
       {
         throw "ERROR: Method not implemented!\n";
         return 0;
       }
 
-      std::vector<ScalarT>& yB() override
+      std::vector<ScalarT>& yB() override final
       {
         throw "ERROR: Method not implemented!\n";
         return yB_;
       }
 
-      const std::vector<ScalarT>& yB() const override
+      const std::vector<ScalarT>& yB() const override final
       {
         throw "ERROR: Method not implemented!\n";
         return yB_;
       }
 
-      std::vector<ScalarT>& ypB() override
+      std::vector<ScalarT>& ypB() override final
       {
         throw "ERROR: Method not implemented!\n";
         return ypB_;
       }
 
-      const std::vector<ScalarT>& ypB() const override
+      const std::vector<ScalarT>& ypB() const override final
       {
         throw "ERROR: Method not implemented!\n";
         return ypB_;
       }
 
-      std::vector<ScalarT>& param() override
+      std::vector<ScalarT>& param() override final
       {
         throw "ERROR: Method not implemented!\n";
         return param_;
       }
 
-      const std::vector<ScalarT>& param() const override
+      const std::vector<ScalarT>& param() const override final
       {
         throw "ERROR: Method not implemented!\n";
         return param_;
       }
 
-      std::vector<ScalarT>& param_up() override
+      std::vector<ScalarT>& param_up() override final
       {
         throw "ERROR: Method not implemented!\n";
         return param_up_;
       }
 
-      const std::vector<ScalarT>& param_up() const override
+      const std::vector<ScalarT>& param_up() const override final
       {
         throw "ERROR: Method not implemented!\n";
         return param_up_;
       }
 
-      std::vector<ScalarT>& param_lo() override
+      std::vector<ScalarT>& param_lo() override final
       {
         throw "ERROR: Method not implemented!\n";
         return param_lo_;
       }
 
-      const std::vector<ScalarT>& param_lo() const override
+      const std::vector<ScalarT>& param_lo() const override final
       {
         throw "ERROR: Method not implemented!\n";
         return param_lo_;
       }
 
-      int evaluateIntegrand() override
+      int evaluateIntegrand() override final
       {
         throw "ERROR: Method not implemented!\n";
         return 1;
       }
 
-      int initializeAdjoint() override
+      int initializeAdjoint() override final
       {
         throw "ERROR: Method not implemented!\n";
         return 1;
       }
 
-      int evaluateAdjointResidual() override
+      int evaluateAdjointResidual() override final
       {
         throw "ERROR: Method not implemented!\n";
         return 1;
       }
 
-      int evaluateAdjointIntegrand() override
+      int evaluateAdjointIntegrand() override final
       {
         throw "ERROR: Method not implemented!\n";
         return 1;
       }
 
-      std::vector<ScalarT>& getResidual() override
+      std::vector<ScalarT>& getResidual() override final
       {
         return f_;
       }
 
-      const std::vector<ScalarT>& getResidual() const override
+      const std::vector<ScalarT>& getResidual() const override final
       {
         return f_;
       }
 
-      std::vector<ScalarT>& getIntegrand() override
+      std::vector<ScalarT>& getIntegrand() override final
       {
         throw "ERROR: Method not implemented!\n";
         return g_;
       }
 
-      const std::vector<ScalarT>& getIntegrand() const override
+      const std::vector<ScalarT>& getIntegrand() const override final
       {
         throw "ERROR: Method not implemented!\n";
         return g_;
       }
 
-      std::vector<ScalarT>& getAdjointResidual() override
+      std::vector<ScalarT>& getAdjointResidual() override final
       {
         throw "ERROR: Method not implemented!\n";
         return fB_;
       }
 
-      const std::vector<ScalarT>& getAdjointResidual() const override
+      const std::vector<ScalarT>& getAdjointResidual() const override final
       {
         throw "ERROR: Method not implemented!\n";
         return fB_;
       }
 
-      std::vector<ScalarT>& getAdjointIntegrand() override
+      std::vector<ScalarT>& getAdjointIntegrand() override final
       {
         throw "ERROR: Method not implemented!\n";
         return gB_;
       }
 
-      const std::vector<ScalarT>& getAdjointIntegrand() const override
+      const std::vector<ScalarT>& getAdjointIntegrand() const override final
       {
         throw "ERROR: Method not implemented!\n";
         return gB_;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -81,6 +81,9 @@ namespace GridKit
       using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
+      using Component<ScalarT, IdxT>::J_rows_buffer_;
+      using Component<ScalarT, IdxT>::J_cols_buffer_;
+      using Component<ScalarT, IdxT>::J_vals_buffer_;
       using Component<ScalarT, IdxT>::mva_system_base_;
       using Component<ScalarT, IdxT>::variable_indices_;
       using Component<ScalarT, IdxT>::residual_indices_;
@@ -125,15 +128,15 @@ namespace GridKit
              RealT     S12);
       ~Genrou();
 
-      int setGridKitComponentID(IdxT) override;
-      int allocate() override;
-      int verify() const override;
-      int initialize() override;
-      int tagDifferentiable() override;
-      int evaluateResidual() override;
+      int setGridKitComponentID(IdxT) override final;
+      int allocate() override final;
+      int verify() const override final;
+      int initialize() override final;
+      int tagDifferentiable() override final;
+      int evaluateResidual() override final;
 
       // Still to be implemented
-      int evaluateJacobian() override;
+      int evaluateJacobian() override final;
 
       // Temporary access functions for governor
       // Should be abstracted

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -26,6 +26,14 @@ namespace GridKit
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;
 
       J_.zeroMatrix();
+      if (J_rows_buffer_ == nullptr)
+      {
+        // Reserve space for a dense matrix of size_*size_.
+        // Enyme will compute the appropriate nnz from sparsification.
+        J_rows_buffer_ = new IdxT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+        J_cols_buffer_ = new IdxT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+        J_vals_buffer_ = new RealT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+      }
 
       GridKit::Enzyme::Sparse::DfDy<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
                                     GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal,
@@ -33,13 +41,16 @@ namespace GridKit
                                     IdxT>::eval(this,
                                                 f_.size(),
                                                 y_.size(),
-                                                this->getResidualIndices(),
-                                                this->getVariableIndices(),
+                                                (this->getResidualIndices()).data(),
+                                                (this->getVariableIndices()).data(),
                                                 y_.data(),
                                                 yp_.data(),
                                                 wb_.data(),
                                                 ws_.data(),
                                                 alpha_,
+                                                J_rows_buffer_,
+                                                J_cols_buffer_,
+                                                J_vals_buffer_,
                                                 J_);
 
       GridKit::Enzyme::Sparse::DfDwb<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
@@ -48,12 +59,15 @@ namespace GridKit
                                      IdxT>::eval(this,
                                                  f_.size(),
                                                  static_cast<size_t>(bus_->size()),
-                                                 this->getResidualIndices(),
-                                                 bus_->getVariableIndices(),
+                                                 (this->getResidualIndices()).data(),
+                                                 (bus_->getVariableIndices()).data(),
                                                  y_.data(),
                                                  yp_.data(),
                                                  wb_.data(),
                                                  ws_.data(),
+                                                 J_rows_buffer_,
+                                                 J_cols_buffer_,
+                                                 J_vals_buffer_,
                                                  J_);
 
       GridKit::Enzyme::Sparse::DfDws<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
@@ -62,12 +76,15 @@ namespace GridKit
                                      IdxT>::eval(this,
                                                  f_.size(),
                                                  ws_.size(),
-                                                 this->getResidualIndices(),
-                                                 ws_indices_,
+                                                 (this->getResidualIndices()).data(),
+                                                 ws_indices_.data(),
                                                  y_.data(),
                                                  yp_.data(),
                                                  wb_.data(),
                                                  ws_.data(),
+                                                 J_rows_buffer_,
+                                                 J_cols_buffer_,
+                                                 J_vals_buffer_,
                                                  J_);
 
       GridKit::Enzyme::Sparse::DhDwb<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
@@ -76,11 +93,14 @@ namespace GridKit
                                      IdxT>::eval(this,
                                                  static_cast<size_t>(bus_->size()),
                                                  static_cast<size_t>(bus_->size()),
-                                                 bus_->getResidualIndices(),
-                                                 bus_->getVariableIndices(),
+                                                 (bus_->getResidualIndices()).data(),
+                                                 (bus_->getVariableIndices()).data(),
                                                  y_.data(),
                                                  yp_.data(),
                                                  (bus_->y()).data(),
+                                                 J_rows_buffer_,
+                                                 J_cols_buffer_,
+                                                 J_vals_buffer_,
                                                  bus_->getJacobian());
 
       GridKit::Enzyme::Sparse::DhDy<GridKit::PhasorDynamics::Genrou<ScalarT, IdxT>,
@@ -89,11 +109,14 @@ namespace GridKit
                                     IdxT>::eval(this,
                                                 static_cast<size_t>(bus_->size()),
                                                 y_.size(),
-                                                bus_->getResidualIndices(),
-                                                this->getVariableIndices(),
+                                                (bus_->getResidualIndices()).data(),
+                                                (this->getVariableIndices()).data(),
                                                 y_.data(),
                                                 yp_.data(),
                                                 wb_.data(),
+                                                J_rows_buffer_,
+                                                J_cols_buffer_,
+                                                J_vals_buffer_,
                                                 J_);
 
       return 0;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -45,6 +45,9 @@ namespace GridKit
       using Component<ScalarT, IdxT>::wb_;
       using Component<ScalarT, IdxT>::h_;
       using Component<ScalarT, IdxT>::J_;
+      using Component<ScalarT, IdxT>::J_rows_buffer_;
+      using Component<ScalarT, IdxT>::J_cols_buffer_;
+      using Component<ScalarT, IdxT>::J_vals_buffer_;
       using Component<ScalarT, IdxT>::mva_system_base_;
       using Component<ScalarT, IdxT>::variable_indices_;
       using Component<ScalarT, IdxT>::residual_indices_;
@@ -67,19 +70,19 @@ namespace GridKit
       GenClassical(bus_type* bus, const DataT& data);
       ~GenClassical();
 
-      int setGridKitComponentID(IdxT) override;
-      int allocate() override;
-      int initialize() override;
-      int tagDifferentiable() override;
-      int evaluateResidual() override;
+      int setGridKitComponentID(IdxT) override final;
+      int allocate() override final;
+      int initialize() override final;
+      int tagDifferentiable() override final;
+      int evaluateResidual() override final;
 
-      int verify() const override
+      int verify() const override final
       {
         return 0;
       }
 
       // Still to be implemented
-      int evaluateJacobian() override;
+      int evaluateJacobian() override final;
 
       void setPmech(RealT pmech)
       {

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -26,6 +26,14 @@ namespace GridKit
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;
 
       J_.zeroMatrix();
+      if (J_rows_buffer_ == nullptr)
+      {
+        // Reserve space for a dense matrix of size_*size_.
+        // Enyme will compute the appropriate nnz from sparsification.
+        J_rows_buffer_ = new IdxT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+        J_cols_buffer_ = new IdxT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+        J_vals_buffer_ = new RealT[static_cast<size_t>(size_) * static_cast<size_t>(size_)];
+      }
 
       GridKit::Enzyme::Sparse::DfDy<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
                                     GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual,
@@ -33,12 +41,15 @@ namespace GridKit
                                     IdxT>::eval(this,
                                                 f_.size(),
                                                 y_.size(),
-                                                this->getResidualIndices(),
-                                                this->getVariableIndices(),
+                                                (this->getResidualIndices()).data(),
+                                                (this->getVariableIndices()).data(),
                                                 y_.data(),
                                                 yp_.data(),
                                                 wb_.data(),
                                                 alpha_,
+                                                J_rows_buffer_,
+                                                J_cols_buffer_,
+                                                J_vals_buffer_,
                                                 J_);
 
       GridKit::Enzyme::Sparse::DfDwb<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
@@ -47,11 +58,14 @@ namespace GridKit
                                      IdxT>::eval(this,
                                                  f_.size(),
                                                  static_cast<size_t>(bus_->size()),
-                                                 this->getResidualIndices(),
-                                                 bus_->getVariableIndices(),
+                                                 (this->getResidualIndices()).data(),
+                                                 (bus_->getVariableIndices()).data(),
                                                  y_.data(),
                                                  yp_.data(),
                                                  (bus_->y()).data(),
+                                                 J_rows_buffer_,
+                                                 J_cols_buffer_,
+                                                 J_vals_buffer_,
                                                  J_);
 
       GridKit::Enzyme::Sparse::DhDy<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
@@ -60,11 +74,14 @@ namespace GridKit
                                     IdxT>::eval(this,
                                                 static_cast<size_t>(bus_->size()),
                                                 y_.size(),
-                                                bus_->getResidualIndices(),
-                                                this->getVariableIndices(),
+                                                (bus_->getResidualIndices()).data(),
+                                                (this->getVariableIndices()).data(),
                                                 y_.data(),
                                                 yp_.data(),
                                                 wb_.data(),
+                                                J_rows_buffer_,
+                                                J_cols_buffer_,
+                                                J_vals_buffer_,
                                                 J_);
 
       return 0;

--- a/GridKit/Model/PhasorDynamics/SystemModel.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModel.hpp
@@ -36,7 +36,7 @@ namespace GridKit
       using signal_type    = PhasorDynamics::SignalNode<ScalarT, IdxT>;
       using component_type = PhasorDynamics::Component<ScalarT, IdxT>;
       using RealT          = typename Model::Evaluator<ScalarT, IdxT>::RealT;
-      using CsrMatrix      = typename Model::Evaluator<ScalarT, IdxT>::CsrMatrix;
+      using CsrMatrixT     = typename Model::Evaluator<ScalarT, IdxT>::CsrMatrixT;
 
       using PhasorDynamics::Component<ScalarT, IdxT>::gridkit_component_id_;
       using PhasorDynamics::Component<ScalarT, IdxT>::size_;
@@ -637,7 +637,7 @@ namespace GridKit
           {
             auto component_jacobian = component->getJacobian();
 
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries();
+            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries(false);
             const auto [rows, columns, values]                                                                 = component_jacobian_entries;
             for (size_t i = 0; i < rows.size(); ++i)
             {
@@ -648,7 +648,7 @@ namespace GridKit
           {
             auto bus_jacobian = bus->getJacobian();
 
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries();
+            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries(false);
             const auto [rows, columns, values]                                                           = bus_jacobian_entries;
             for (size_t i = 0; i < rows.size(); ++i)
             {
@@ -666,7 +666,7 @@ namespace GridKit
           {
             auto component_jacobian = component->getJacobian();
 
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries();
+            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries(false);
             const auto [rows, columns, values]                                                                 = component_jacobian_entries;
             for (size_t i = 0; i < rows.size(); ++i)
             {
@@ -680,7 +680,7 @@ namespace GridKit
           {
             auto bus_jacobian = bus->getJacobian();
 
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries();
+            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries(false);
             const auto [rows, columns, values]                                                           = bus_jacobian_entries;
             for (size_t i = 0; i < rows.size(); ++i)
             {
@@ -708,7 +708,7 @@ namespace GridKit
           std::copy(jac.getValues(), jac.getValues() + nnz_, vals);
 
           // Create the CSR Jacobian
-          csr_jac_ = new CsrMatrix(size_, size_, nnz_, &row_ptrs, &cols, &vals);
+          csr_jac_ = new CsrMatrixT(size_, size_, nnz_, &row_ptrs, &cols, &vals);
 
           const IdxT* map_to_sorted = jac.getMapToSorted();
           const IdxT* map_to_dedup  = jac.getMapToDeduplicated();
@@ -735,7 +735,7 @@ namespace GridKit
           {
             auto component_jacobian = component->getJacobian();
 
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries();
+            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries(false);
             const auto [rows, columns, values]                                                                 = component_jacobian_entries;
             for (size_t i = 0; i < rows.size(); ++i)
             {
@@ -747,7 +747,7 @@ namespace GridKit
           {
             auto bus_jacobian = bus->getJacobian();
 
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries();
+            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries(false);
             const auto [rows, columns, values]                                                           = bus_jacobian_entries;
             for (size_t i = 0; i < rows.size(); ++i)
             {
@@ -762,7 +762,7 @@ namespace GridKit
         return 0;
       }
 
-      CsrMatrix* getCsrJacobian() const override
+      CsrMatrixT* getCsrJacobian() const override
       {
         return csr_jac_;
       }
@@ -931,8 +931,8 @@ namespace GridKit
 
       bool owns_components_{false};
 
-      IdxT*      map_to_csr_{nullptr};
-      CsrMatrix* csr_jac_{nullptr};
+      IdxT*       map_to_csr_{nullptr};
+      CsrMatrixT* csr_jac_{nullptr};
 
       /// Variable monitor
       Model::VariableMonitorController<ScalarT> monitor_;

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -18,9 +18,9 @@ namespace GridKit
   class CircuitComponent : public Model::Evaluator<ScalarT, IdxT>
   {
   public:
-    using RealT     = typename Model::Evaluator<ScalarT, IdxT>::RealT;
-    using MatrixT   = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
-    using CsrMatrix = typename Model::Evaluator<ScalarT, IdxT>::CsrMatrix;
+    using RealT      = typename Model::Evaluator<ScalarT, IdxT>::RealT;
+    using MatrixT    = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
+    using CsrMatrixT = typename Model::Evaluator<ScalarT, IdxT>::CsrMatrixT;
 
     CircuitComponent() = default;
 

--- a/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -62,7 +62,7 @@ namespace GridKit
   {
     using RealT          = typename CircuitComponent<ScalarT, IdxT>::RealT;
     using MatrixT        = typename CircuitComponent<ScalarT, IdxT>::MatrixT;
-    using CsrMatrix      = typename CircuitComponent<ScalarT, IdxT>::CsrMatrix;
+    using CsrMatrixT     = typename CircuitComponent<ScalarT, IdxT>::CsrMatrixT;
     using component_type = CircuitComponent<ScalarT, IdxT>;
     using node_type      = CircuitNode<ScalarT, IdxT>;
 
@@ -257,7 +257,7 @@ namespace GridKit
       std::copy(jac.getValues(), jac.getValues() + nnz_, vals);
 
       // Create the CSR Jacobian
-      csr_jac_ = new CsrMatrix(size_, size_, nnz_, &row_ptrs, &cols, &vals);
+      csr_jac_ = new CsrMatrixT(size_, size_, nnz_, &row_ptrs, &cols, &vals);
 
       const IdxT* map_to_sorted = jac.getMapToSorted();
       const IdxT* map_to_dedup  = jac.getMapToDeduplicated();
@@ -484,7 +484,7 @@ namespace GridKit
       jac_.printMatrixMarket(filename, title);
     }
 
-    CsrMatrix* getCsrJacobian() const override
+    CsrMatrixT* getCsrJacobian() const override
     {
       return csr_jac_;
     }
@@ -499,8 +499,8 @@ namespace GridKit
 
     std::vector<component_type*> components_;
 
-    IdxT*      map_to_csr_{nullptr};
-    CsrMatrix* csr_jac_{nullptr};
+    IdxT*       map_to_csr_{nullptr};
+    CsrMatrixT* csr_jac_{nullptr};
 
     int  jac_call_count_{0};
     bool use_jac_;

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -782,8 +782,8 @@ namespace AnalysisManager
 
       model->evaluateJacobian();
 
-      using CsrMatrix = GridKit::LinearAlgebra::CsrMatrix<RealT, IdxT>;
-      CsrMatrix* Jac  = model->getCsrJacobian();
+      using CsrMatrixT = GridKit::LinearAlgebra::CsrMatrix<RealT, IdxT>;
+      CsrMatrixT* Jac  = model->getCsrJacobian();
 
       SUNMatZero(J);
 

--- a/examples/Enzyme/Standalone/CMakeLists.txt
+++ b/examples/Enzyme/Standalone/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(EnzymeStandaloneSparseCheck EnzymeSparse.cpp)
 target_compile_options(EnzymeStandaloneSparseCheck PUBLIC -mllvm -enzyme-auto-sparsity=1)
 target_link_libraries(EnzymeStandaloneSparseCheck
     ClangEnzymeFlags
+    GridKit::sparse_matrix
     GridKit::Utilities)
 
 add_test(NAME "EnzymeStandaloneScalarCheck" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/EnzymeStandaloneScalarCheck)

--- a/examples/Enzyme/Standalone/EnzymeSparse.cpp
+++ b/examples/Enzyme/Standalone/EnzymeSparse.cpp
@@ -58,6 +58,7 @@ SparseMatrix* jac_f_ref(std::vector<ScalarT> x, std::vector<ScalarT> y)
       }
     }
   }
+  // Hijacking constructor sets rows, cols and vals to nullptr
   return new SparseMatrix(N, N, current_nnz, &rows, &cols, &vals);
 }
 

--- a/examples/Enzyme/Standalone/EnzymeSparse.cpp
+++ b/examples/Enzyme/Standalone/EnzymeSparse.cpp
@@ -65,7 +65,7 @@ SparseMatrix* jac_f_ref(std::vector<ScalarT> x, std::vector<ScalarT> y)
 template <typename ScalarT>
 __attribute__((noinline)) SparseMatrix* jac_f(size_t N, ScalarT* input)
 {
-  size_t*  index_maps = new size_t[N];
+  size_t* index_maps = new size_t[N];
   for (size_t i = 0; i < N; i++)
   {
     index_maps[i] = i;
@@ -74,7 +74,7 @@ __attribute__((noinline)) SparseMatrix* jac_f(size_t N, ScalarT* input)
   size_t*  rows_buffer = new size_t[N * N];
   size_t*  cols_buffer = new size_t[N * N];
   ScalarT* vals_buffer = new ScalarT[N * N];
-  size_t               current_nnz = 0;
+  size_t   current_nnz = 0;
   for (size_t i = 0; i < N; i++)
   {
     ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, size_t>,
@@ -149,7 +149,7 @@ void check(SparseMatrix* matrix_1, SparseMatrix* matrix_2, int& fail)
 int main()
 {
   /// Vector and matrix declarations
-  size_t              N   = 5;
+  size_t              N = 5;
   std::vector<double> x(N);
   std::vector<double> sq(N);
 

--- a/examples/Enzyme/Standalone/EnzymeSparse.cpp
+++ b/examples/Enzyme/Standalone/EnzymeSparse.cpp
@@ -4,85 +4,21 @@
 #include <cmath>
 #include <vector>
 
-#include <GridKit/LinearAlgebra/SparseMatrix/COO_Matrix.hpp>
+#include <GridKit/AutomaticDifferentiation/Enzyme/EnzymeDefinitions.hpp>
+#include <GridKit/AutomaticDifferentiation/Enzyme/LowerSparseStorage.hpp>
+#include <GridKit/LinearAlgebra/MemoryUtils.hpp>
+#include <GridKit/LinearAlgebra/SparseMatrix/CooMatrix.hpp>
 #include <GridKit/Testing/Testing.hpp>
 
 /**
  * @brief Standalone example that computes the sparse Jacobian of a vector-valued function
  * by automatic differentiation via Enzyme.
  *
- * TODO: Modify the sparse storage provided to Enzyme to directly operate on std::vector and COO_Matrix
  * TODO: Convert this into a unit test.
  */
 
-using SparseMatrix = GridKit::LinearAlgebra::COO_Matrix<double, size_t>;
-extern int enzyme_dup;
-extern int enzyme_const;
-extern int enzyme_dupnoneed;
-
-template <typename T, typename... Tys>
-extern T __enzyme_fwddiff(void*, Tys...) noexcept;
-
-template <typename T, typename... Tys>
-extern T __enzyme_todense(Tys...) noexcept;
-
-/// Sparse storage for Enzyme
-template <typename ScalarT>
-struct Triple
-{
-  size_t  row;
-  size_t  col;
-  ScalarT val;
-  Triple(Triple&&) = default;
-
-  Triple(size_t row, size_t col, ScalarT val)
-    : row(row),
-      col(col),
-      val(val)
-  {
-  }
-};
-
-[[maybe_unused]] __attribute__((enzyme_sparse_accumulate)) static void inner_storeflt(size_t row, size_t col, float val, std::vector<Triple<float>>& triplets)
-{
-  triplets.emplace_back(row, col, val);
-}
-
-[[maybe_unused]] __attribute__((enzyme_sparse_accumulate)) static void inner_storedbl(size_t row, size_t col, double val, std::vector<Triple<double>>& triplets)
-{
-  triplets.emplace_back(row, col, val);
-}
-
-template <typename ScalarT>
-__attribute__((always_inline)) static void sparse_store(ScalarT val, size_t idx, size_t i, std::vector<Triple<ScalarT>>& triplets)
-{
-  if (val == 0.0)
-    return;
-  idx /= sizeof(ScalarT);
-  if constexpr (sizeof(ScalarT) == 4)
-    inner_storeflt(idx, i, val, triplets);
-  else
-    inner_storedbl(idx, i, val, triplets);
-}
-
-template <typename ScalarT>
-__attribute__((always_inline)) static ScalarT sparse_load(size_t, size_t, std::vector<Triple<ScalarT>>&)
-{
-  return 0.0;
-}
-
-template <typename ScalarT>
-__attribute__((always_inline)) static void ident_store(ScalarT, size_t, size_t)
-{
-  assert(0 && "should never store");
-}
-
-template <typename ScalarT>
-__attribute__((always_inline)) static ScalarT ident_load(size_t idx, size_t i)
-{
-  idx /= sizeof(ScalarT);
-  return (ScalarT) (idx == i);
-}
+using SparseMatrix = GridKit::LinearAlgebra::CooMatrix<double, size_t>;
+using namespace GridKit::Enzyme::Sparse;
 
 /// Vector-valued function to differentiate
 template <typename ScalarT>
@@ -100,35 +36,59 @@ __attribute__((always_inline)) static void f(size_t N, ScalarT* input, ScalarT* 
 
 /// Reference Jacobian
 template <typename ScalarT>
-void jac_f_ref(std::vector<ScalarT> x, std::vector<ScalarT> y, SparseMatrix& jac)
+SparseMatrix* jac_f_ref(std::vector<ScalarT> x, std::vector<ScalarT> y)
 {
-  std::vector<size_t>  ctemp{};
-  std::vector<size_t>  rtemp{};
-  std::vector<ScalarT> valtemp{};
+  assert(x.size() == y.size());
+  size_t   N           = x.size();
+  size_t   nnz         = N * (N + 1) / 2; // lower triangular matrix, given the function above
+  size_t*  rows        = new size_t[nnz];
+  size_t*  cols        = new size_t[nnz];
+  ScalarT* vals        = new ScalarT[nnz];
+  size_t   current_nnz = 0;
   for (size_t idy = 0; idy < y.size(); ++idy)
   {
     for (size_t idx = 0; idx < x.size(); ++idx)
     {
-      if (idy <= idx)
+      if (idy <= idx && current_nnz < nnz)
       {
-        rtemp.push_back(idx);
-        ctemp.push_back(idy);
-        valtemp.push_back(2.0 * x[idy]);
+        rows[current_nnz] = idx;
+        cols[current_nnz] = idy;
+        vals[current_nnz] = 2.0 * x[idy];
+        current_nnz++;
       }
     }
   }
-  jac.setValues(rtemp, ctemp, valtemp);
+  return new SparseMatrix(N, N, current_nnz, &rows, &cols, &vals);
 }
 
 /// Function that computes the Jacobian via automatic differentiation
 template <typename ScalarT>
-__attribute__((noinline)) void jac_f(size_t N, ScalarT* input, SparseMatrix& jac)
+__attribute__((noinline)) SparseMatrix* jac_f(size_t N, ScalarT* input)
 {
-  std::vector<Triple<ScalarT>> triplets;
+  size_t*  index_maps = new size_t[N];
   for (size_t i = 0; i < N; i++)
   {
-    ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT>, (void*) ident_store<ScalarT>, i);
-    ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT>, (void*) sparse_store<ScalarT>, i, &triplets);
+    index_maps[i] = i;
+  }
+
+  size_t*  rows_buffer = new size_t[N * N];
+  size_t*  cols_buffer = new size_t[N * N];
+  ScalarT* vals_buffer = new ScalarT[N * N];
+  size_t               current_nnz = 0;
+  for (size_t i = 0; i < N; i++)
+  {
+    ScalarT* output   = __enzyme_todense<ScalarT*>((void*) ident_load<ScalarT, size_t>,
+                                                 (void*) ident_store<ScalarT, size_t>,
+                                                 i);
+    ScalarT* d_output = __enzyme_todense<ScalarT*>((void*) sparse_load<ScalarT, size_t>,
+                                                   (void*) sparse_store<ScalarT, size_t>,
+                                                   i,
+                                                   index_maps,
+                                                   index_maps,
+                                                   rows_buffer,
+                                                   cols_buffer,
+                                                   vals_buffer,
+                                                   &current_nnz);
 
     __enzyme_fwddiff<void>((void*) f<ScalarT>,
                            enzyme_const,
@@ -141,30 +101,45 @@ __attribute__((noinline)) void jac_f(size_t N, ScalarT* input, SparseMatrix& jac
                            d_output);
   }
 
-  std::vector<size_t>  ctemp{};
-  std::vector<size_t>  rtemp{};
-  std::vector<ScalarT> valtemp{};
-  for (auto& tup : triplets)
+  size_t*  rows = new size_t[current_nnz];
+  size_t*  cols = new size_t[current_nnz];
+  ScalarT* vals = new ScalarT[current_nnz];
+  for (size_t ind = 0; ind < current_nnz; ++ind)
   {
-    rtemp.push_back(tup.row);
-    ctemp.push_back(tup.col);
-    valtemp.push_back(tup.val);
+    rows[ind] = rows_buffer[ind];
+    cols[ind] = cols_buffer[ind];
+    vals[ind] = vals_buffer[ind];
   }
-  jac.setValues(rtemp, ctemp, valtemp);
+  delete[] index_maps;
+  delete[] rows_buffer;
+  delete[] cols_buffer;
+  delete[] vals_buffer;
+  return new SparseMatrix(N, N, current_nnz, &rows, &cols, &vals);
 }
 
 /// Compare two sparse matrices
-void check(SparseMatrix matrix_1, SparseMatrix matrix_2, int& fail)
+void check(SparseMatrix* matrix_1, SparseMatrix* matrix_2, int& fail)
 {
-  std::tuple<std::vector<size_t>&, std::vector<size_t>&, std::vector<double>&> entries_1 = matrix_1.getEntries();
-  const auto [rcord_1, ccord_1, vals_1]                                                  = entries_1;
-  std::tuple<std::vector<size_t>&, std::vector<size_t>&, std::vector<double>&> entries_2 = matrix_2.getEntries();
-  const auto [rcord_2, ccord_2, vals_2]                                                  = entries_2;
-  for (size_t ind = 0; ind < vals_1.size(); ++ind)
+  size_t  nnz_1  = matrix_1->getNnz();
+  size_t* rows_1 = matrix_1->getRowData(GridKit::LinearAlgebra::memory::HOST);
+  size_t* cols_1 = matrix_1->getColData(GridKit::LinearAlgebra::memory::HOST);
+  double* vals_1 = matrix_1->getValues(GridKit::LinearAlgebra::memory::HOST);
+
+  size_t  nnz_2  = matrix_2->getNnz();
+  size_t* rows_2 = matrix_2->getRowData(GridKit::LinearAlgebra::memory::HOST);
+  size_t* cols_2 = matrix_2->getColData(GridKit::LinearAlgebra::memory::HOST);
+  double* vals_2 = matrix_2->getValues(GridKit::LinearAlgebra::memory::HOST);
+
+  if (nnz_1 != nnz_2)
+    fail++;
+
+  for (size_t ind = 0; ind < nnz_1; ++ind)
   {
-    if (rcord_1[ind] != rcord_2[ind])
+    std::cout << rows_1 << ", " << cols_1 << ", " << vals_1 << "\n";
+    std::cout << rows_2 << ", " << cols_2 << ", " << vals_2 << "\n";
+    if (rows_1[ind] != rows_2[ind])
       fail++;
-    if (ccord_1[ind] != ccord_2[ind])
+    if (cols_1[ind] != cols_2[ind])
       fail++;
     if (!GridKit::Testing::isEqual(vals_1[ind], vals_2[ind]))
       fail++;
@@ -174,11 +149,9 @@ void check(SparseMatrix matrix_1, SparseMatrix matrix_2, int& fail)
 int main()
 {
   /// Vector and matrix declarations
-  size_t              N = 5;
+  size_t              N   = 5;
   std::vector<double> x(N);
   std::vector<double> sq(N);
-  SparseMatrix        dsq     = SparseMatrix(N, N);
-  SparseMatrix        dsq_ref = SparseMatrix(N, N);
 
   /// Input initialization
   double val = 0.0;
@@ -192,10 +165,10 @@ int main()
   f(x.size(), x.data(), sq.data());
 
   /// Reference Jacobian
-  jac_f_ref(x, sq, dsq_ref);
+  SparseMatrix* dsq_ref = jac_f_ref(x, sq);
 
   /// Enzyme Jacobian
-  jac_f<double>(N, x.data(), dsq);
+  SparseMatrix* dsq = jac_f<double>(N, x.data());
 
   /// Check
   int fail = 0;
@@ -203,9 +176,14 @@ int main()
   bool verbose = true;
   if (verbose)
   {
-    dsq.printMatrix("Autodiff Jacobian");
-    dsq_ref.printMatrix("Reference Jacobian");
+    std::cout << "Autodiff Jacobian\n";
+    dsq->print();
+    std::cout << "Reference Jacobian\n";
+    dsq_ref->print();
   }
+
+  delete dsq_ref;
+  delete dsq;
 
   return fail;
 }

--- a/examples/PowerElectronics/DistributedGeneratorTest/DGTest.cpp
+++ b/examples/PowerElectronics/DistributedGeneratorTest/DGTest.cpp
@@ -50,13 +50,6 @@ int main(int /* argc */, char const** /* argv */)
 
   dg.evaluateResidual();
 
-  // std::cout << "Output: {";
-  // for (double i : dg.getResidual())
-  // {
-  //   printf("%e ,", i);
-  // }
-  // std::cout << "}\n";
-
   // Generated from matlab code with same parameters and inputs
   std::vector<double> true_vec{3.141592277589793e+02,
                                8.941907747838389e-01,

--- a/examples/PowerElectronics/Microgrid/Microgrid.cpp
+++ b/examples/PowerElectronics/Microgrid/Microgrid.cpp
@@ -321,10 +321,10 @@ int main(int /* argc */, char const** /* argv */)
   if (debug_output)
   {
     std::vector<double>& fres = sysmodel->getResidual();
-    std::cout << "Verify initial Resisdual is Zero: {\n";
+    std::cout << "Verify initial resisdual is zero: {\n";
     for (size_t i = 0; i < fres.size(); i++)
     {
-      printf("%lu : %e \n", i, fres[i]);
+      std::cout << i << " :" << fres[i] << "\n";
     }
     std::cout << "}\n";
   }
@@ -357,7 +357,7 @@ int main(int /* argc */, char const** /* argv */)
   // Optional debugging output
   if (debug_output)
   {
-    std::cout << "Final Vector y\n";
+    std::cout << "Final vector y\n";
     for (size_t i = 0; i < yfinial.size(); i++)
     {
       std::cout << yfinial[i] << "\n";
@@ -437,13 +437,7 @@ int main(int /* argc */, char const** /* argv */)
       3.604108939430972e+02,
       -3.492842627398574e+01};
 
-  // std::cout << "Test the Relative Error\n";
-  // for (size_t i = 0; i < true_vec.size(); i++)
-  // {
-  //   printf("%lu : %e ,\n", i, abs(true_vec[i] - yfinial[i]) / abs(true_vec[i]));
-  // }
-
-  std::cout << "Testing the DistributedGenerator model ...\n";
+  std::cout << "Testing Migrogrid ...\n";
   double error_allowed = 1e-4;
   double max_error     = 0.0;
   for (size_t i = 0; i < true_vec.size(); i++)

--- a/examples/PowerElectronics/RLCircuit/RLCircuit.cpp
+++ b/examples/PowerElectronics/RLCircuit/RLCircuit.cpp
@@ -114,7 +114,7 @@ int main(int /* argc */, char const** /* argv */)
 
   std::vector<double>& yfinial = sysmodel.y();
 
-  std::cout << "Final Vector y\n";
+  std::cout << "Final vector y\n";
   for (size_t i = 0; i < yfinial.size(); i++)
   {
     std::cout << yfinial[i] << "\n";
@@ -128,7 +128,7 @@ int main(int /* argc */, char const** /* argv */)
   yexact[3] = yexact[2];
   yexact[1] = vinit + rinit * yexact[2];
 
-  std::cout << "Element-wise Relative error at t=" << t_final << "\n";
+  std::cout << "Element-wise relative error at t=" << t_final << "\n";
   for (size_t i = 0; i < yfinial.size(); i++)
   {
     std::cout << abs((yfinial[i] - yexact[i]) / yexact[i]) << "\n";

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
@@ -358,7 +358,7 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
   real_type sum_bottom = 0.0;
 
   // check relative error
-  std::cout << "Test the Relative Error for N = " << Nsize << "\n";
+  std::cout << "Test the relative error for N = " << Nsize << "\n";
   for (index_type i = 0; i < true_vec->size(); i++)
   {
     // Print the Elementwise Relative Error
@@ -370,7 +370,7 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
   }
 
   real_type norm2error = (sqrt(sum_top) / sqrt(sum_bottom));
-  std::cout << "2-Norm Relative Error: " << norm2error << std::endl;
+  std::cout << "2-Norm relative error: " << norm2error << std::endl;
   test_pass = norm2error < error_tol;
 
   delete idas;

--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -371,8 +371,10 @@ namespace GridKit
         bus.evaluateResidual();
         gen.evaluateResidual();
 
+        bus.evaluateJacobian();
         gen.evaluateJacobian();
-        GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> model_jacobian = gen.getJacobian();
+        GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& model_jacobian = gen.getJacobian();
+        model_jacobian.deduplicate();
         model_jacobian.printMatrix("Model Jacobian");
 
         return GridKit::Testing::MapFromCOO(model_jacobian);

--- a/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
@@ -400,8 +400,10 @@ namespace GridKit
         bus.evaluateResidual();
         gen.evaluateResidual();
 
+        bus.evaluateJacobian();
         gen.evaluateJacobian();
-        GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> model_jacobian = gen.getJacobian();
+        GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& model_jacobian = gen.getJacobian();
+        model_jacobian.deduplicate();
         model_jacobian.printMatrix("Model Jacobian");
 
         return GridKit::Testing::MapFromCOO(model_jacobian);

--- a/tests/UnitTests/PhasorDynamics/LoadTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/LoadTests.hpp
@@ -119,6 +119,7 @@ namespace GridKit
         PhasorDynamics::Load<ScalarT, IdxT> load(&bus, R, X);
         bus.allocate();
         load.allocate();
+        bus.evaluateJacobian();
         load.evaluateJacobian();
         GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT> model_jacobian = bus.getJacobian();
         model_jacobian.printMatrix("Model Jacobian");


### PR DESCRIPTION
## Description
 
This improves the performance of component Jacobian evaluation in PhasorDynamics. On ma Mac, this brings the runtime down from ~4.5sec to ~1.5sec for Hawaii.
 
 ## Proposed changes
 - Modified sparse storage approach in the Enzyme wrappers to directly update `rows`, `columns` and `values` and keep track on `nnz` (as opposed to using `emplace_back` on `std::vectors`).
 - Pre-allocate buffers for `rows`, `columns` and `values` to save on allocation/deallocations.
 - Store unsorted entries in `J_` to save on sorting overhead. Instead, rely on the one-time sort and deduplication in `CooMatrix`.
 - For bus Jacobian, perform the reduction into the 2x2 matrices right away at the component level. This remains low overhead for such a small matrix.

 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 The main obstacle to removing `COO_Matrix` from the component level is the current need to deduplicate bus Jacobian entries right away. First, because the bus is not yet able to allocate a large enough buffer. Second, because faults introduce new entries that would break the System-level mappings. Perhaps something for a follow-up PR.
 
