### PR TITLE
Update experimental models to build with new tolerance settings

### DIFF
--- a/GridKit/Model/PowerFlow/Generator2/Generator2.cpp
+++ b/GridKit/Model/PowerFlow/Generator2/Generator2.cpp
@@ -61,6 +61,25 @@ namespace GridKit
     return 0;
   }
 
+  /**
+   * @brief Compute the absolute tolerance for each variable in the model
+   *
+   * @param rel_tol The relative tolerance which can be used to pick the
+   *        absolute tolerance.
+   * @tparam ScalarT Scalar data type
+   * @tparam IdxT Index data type
+   * @return int 0 if successful, non-zero otherwise.
+   *
+   * This represents a "noise" level close to zero for which pure relative
+   * error cannot be used.
+   */
+  template <class ScalarT, typename IdxT>
+  int Generator2<ScalarT, IdxT>::setAbsoluteTolerance(RealT rel_tol)
+  {
+    std::fill(abs_tol_.begin(), abs_tol_.end(), rel_tol);
+    return 0;
+  }
+
   template <class ScalarT, typename IdxT>
   int Generator2<ScalarT, IdxT>::initialize()
   {

--- a/GridKit/Model/PowerFlow/Generator2/Generator2.hpp
+++ b/GridKit/Model/PowerFlow/Generator2/Generator2.hpp
@@ -46,6 +46,7 @@ namespace GridKit
     int allocate();
     int initialize();
     int tagDifferentiable();
+    int setAbsoluteTolerance(RealT);
     int evaluateResidual();
     int evaluateJacobian();
     int evaluateIntegrand();

--- a/GridKit/Model/PowerFlow/Generator4Governor/Generator4Governor.cpp
+++ b/GridKit/Model/PowerFlow/Generator4Governor/Generator4Governor.cpp
@@ -169,6 +169,25 @@ namespace GridKit
   }
 
   /**
+   * @brief Compute the absolute tolerance for each variable in the model
+   *
+   * @param rel_tol The relative tolerance which can be used to pick the
+   *        absolute tolerance.
+   * @tparam ScalarT Scalar data type
+   * @tparam IdxT Index data type
+   * @return int 0 if successful, non-zero otherwise.
+   *
+   * This represents a "noise" level close to zero for which pure relative
+   * error cannot be used.
+   */
+  template <class ScalarT, typename IdxT>
+  int Generator4Governor<ScalarT, IdxT>::setAbsoluteTolerance(RealT rel_tol)
+  {
+    std::fill(abs_tol_.begin(), abs_tol_.end(), rel_tol);
+    return 0;
+  }
+
+  /**
    * @brief Computes residual vector for the generator model.
    *
    * Residual equations are given as:

--- a/GridKit/Model/PowerFlow/Generator4Governor/Generator4Governor.hpp
+++ b/GridKit/Model/PowerFlow/Generator4Governor/Generator4Governor.hpp
@@ -47,6 +47,7 @@ namespace GridKit
     int allocate();
     int initialize();
     int tagDifferentiable();
+    int setAbsoluteTolerance(RealT);
     int evaluateResidual();
     int evaluateJacobian();
     int evaluateIntegrand();

--- a/GridKit/Model/PowerFlow/Generator4Param/Generator4Param.cpp
+++ b/GridKit/Model/PowerFlow/Generator4Param/Generator4Param.cpp
@@ -151,6 +151,25 @@ namespace GridKit
   }
 
   /**
+   * @brief Compute the absolute tolerance for each variable in the model
+   *
+   * @param rel_tol The relative tolerance which can be used to pick the
+   *        absolute tolerance.
+   * @tparam ScalarT Scalar data type
+   * @tparam IdxT Index data type
+   * @return int 0 if successful, non-zero otherwise.
+   *
+   * This represents a "noise" level close to zero for which pure relative
+   * error cannot be used.
+   */
+  template <class ScalarT, typename IdxT>
+  int Generator4Param<ScalarT, IdxT>::setAbsoluteTolerance(RealT rel_tol)
+  {
+    std::fill(abs_tol_.begin(), abs_tol_.end(), rel_tol);
+    return 0;
+  }
+
+  /**
    * @brief Computes residual vector for the generator model.
    *
    * Residual equations are given per model in Power System Modeling and

--- a/GridKit/Model/PowerFlow/Generator4Param/Generator4Param.hpp
+++ b/GridKit/Model/PowerFlow/Generator4Param/Generator4Param.hpp
@@ -46,6 +46,7 @@ namespace GridKit
     int allocate();
     int initialize();
     int tagDifferentiable();
+    int setAbsoluteTolerance(RealT);
     int evaluateResidual();
     int evaluateJacobian();
     int evaluateIntegrand();

--- a/examples/Experimental/DynamicConstrainedOpt/DynamicConstrainedOpt.cpp
+++ b/examples/Experimental/DynamicConstrainedOpt/DynamicConstrainedOpt.cpp
@@ -42,6 +42,7 @@ int main()
 
   // setup simulation
   idas.configureSimulation();
+  idas.setTolerance(1e-7, 1e-9);
   idas.configureAdjoint();
   idas.getDefaultInitialCondition();
   idas.initializeSimulation(t_init);

--- a/examples/Experimental/GenConstLoad/GenConstLoad.cpp
+++ b/examples/Experimental/GenConstLoad/GenConstLoad.cpp
@@ -46,6 +46,7 @@ int main()
 
   // setup simulation
   idas->configureSimulation();
+  idas->setTolerance(1e-7, 1e-9);
   idas->configureAdjoint();
   idas->getDefaultInitialCondition();
   idas->initializeSimulation(t_init, true);

--- a/examples/Experimental/GenInfiniteBus/GenInfiniteBus.cpp
+++ b/examples/Experimental/GenInfiniteBus/GenInfiniteBus.cpp
@@ -42,6 +42,7 @@ int main()
 
   // setup simulation
   idas.configureSimulation();
+  idas.setTolerance(1e-7, 1e-9);
   idas.configureAdjoint();
   idas.getDefaultInitialCondition();
   idas.initializeSimulation(t_init);

--- a/examples/Experimental/ParameterEstimation/ParameterEstimation.cpp
+++ b/examples/Experimental/ParameterEstimation/ParameterEstimation.cpp
@@ -52,6 +52,7 @@ int main()
 
   // setup simulation
   idas.configureSimulation();
+  idas.setTolerance(1e-7, 1e-9);
   idas.configureAdjoint();
   idas.getDefaultInitialCondition();
   idas.initializeSimulation(t_init);


### PR DESCRIPTION
## Description
 
 Update experimental power flow models and related examples to build with the new method for setting tolerances.
 
 
 ## Proposed changes
 
Add method `setAbsoluteTolerance(RealT)` to component models `Generator2`, `Generator4Governor`,  and `Generator4Param`.

Update related examples to set solver tolerances and max number of steps as:
```c++
  idas.setTolerance(1e-7, 1e-9);
  idas.setMaxSteps(2000);
```
 
 ## Checklist
  
- [N/A] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
Experimental examples are not expected to run successfully. This PR will just enable building these examples correctly in the target branch. For these examples to run correctly [issue](https://github.com/llnl/sundials/pull/888) in SUNDIALS needs to be addressed.
 
