### PR TITLE
Remove `COO_Matrix` from PowerElectronics module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 - Added `Node` class to the PowerElectronics module to separate nodes from circuit components.
 - Refactored Jacobian assembly in `PowerElectronics` module to reuse the CSR pattern.
 - Refactored Jacobian assembly in `PhasorDyanmcics` module to reuse the CSR pattern.
+- Removed `COO_Matrix` class use in `PowerElectronics` module.
+
 ## v0.1
 
 - Refactored code to support adding different model families.

--- a/GridKit/LinearAlgebra/DenseMatrix/DenseMatrix.hpp
+++ b/GridKit/LinearAlgebra/DenseMatrix/DenseMatrix.hpp
@@ -38,6 +38,7 @@ namespace GridKit
       RealT                    getValue(const IdxT i, const IdxT j) const;
       void                     setValue(const IdxT i, const IdxT j, const RealT value);
       void                     setValues(COO_Matrix<RealT, IdxT> values_COO);
+      void                     setValues(size_t nnz, const IdxT* rows_coo, const IdxT* cols_coo, const RealT* vals_coo);
       std::vector<RealT>*      getValues();
       COO_Matrix<RealT, IdxT>* getValuesCOO();
 
@@ -120,6 +121,23 @@ namespace GridKit
       for (IdxT idx = 0; idx < values_COO.nnz(); ++idx)
       {
         this->setValue(rcord[idx], ccord[idx], vals[idx]);
+      }
+    }
+
+    /**
+     * @brief DenseMatrix value setter from individual COO arrays. Calls \ref setValue() for each input.
+     *
+     * @param nnz Size of array inputs
+     * @param rows_coo Row indices
+     * @param cols_coo Column indices
+     * @param vals_coo Values
+     */
+    template <typename RealT, typename IdxT>
+    void DenseMatrix<RealT, IdxT>::setValues(size_t nnz, const IdxT* rows_coo, const IdxT* cols_coo, const RealT* vals_coo)
+    {
+      for (size_t idx = 0; idx < nnz; ++idx)
+      {
+        this->setValue(rows_coo[idx], cols_coo[idx], vals_coo[idx]);
       }
     }
 

--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
@@ -26,24 +26,12 @@ namespace GridKit
     n_extern_       = 2;
     extern_indices_ = {0, 1};
     idc_            = id;
+    nnz_            = 5;
   }
 
   template <class ScalarT, typename IdxT>
   Capacitor<ScalarT, IdxT>::~Capacitor()
   {
-  }
-
-  /*!
-   * @brief allocate method creates memory for vectors
-   */
-  template <class ScalarT, typename IdxT>
-  int Capacitor<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-
-    return 0;
   }
 
   /**
@@ -91,21 +79,12 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int Capacitor<ScalarT, IdxT>::evaluateJacobian()
   {
-    jac_.zeroMatrix();
+    this->zeroJacMatrix();
     // Create dF/dy
-    std::vector<IdxT>  rcord{2, 2, 2};
-    std::vector<IdxT>  ccord{0, 1, 2};
-    std::vector<RealT> vals{1.0, -1.0, -1.0};
-    jac_.setValues(rcord, ccord, vals);
-
-    // Create dF/dy'
-    std::vector<IdxT>  rcordder{0, 1, 2};
-    std::vector<IdxT>  ccordder{2, 2, 2};
-    std::vector<RealT> valsder{C_, -C_, -C_};
-    MatrixT            Jacder = MatrixT(rcordder, ccordder, valsder, 3, 3);
-
-    // Perform dF/dy + \alpha dF/dy'
-    jac_.axpy(alpha_, Jacder);
+    std::vector<IdxT>  rcord{0, 1, 2, 2, 2};
+    std::vector<IdxT>  ccord{2, 2, 0, 1, 2};
+    std::vector<RealT> vals{C_ * alpha_, -C_ * alpha_, 1.0, -1.0, -1.0 - C_ * alpha_};
+    this->setJacValues(rcord, ccord, vals);
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.hpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.hpp
@@ -19,8 +19,7 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   class Capacitor : public CircuitComponent<ScalarT, IdxT>
   {
-    using RealT   = typename CircuitComponent<ScalarT, IdxT>::RealT;
-    using MatrixT = typename CircuitComponent<RealT, IdxT>::MatrixT;
+    using RealT = typename CircuitComponent<ScalarT, IdxT>::RealT;
 
     using CircuitComponent<ScalarT, IdxT>::size_;
     using CircuitComponent<ScalarT, IdxT>::nnz_;
@@ -35,7 +34,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -47,7 +45,6 @@ namespace GridKit
     Capacitor(IdxT id, RealT C);
     virtual ~Capacitor();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -92,6 +92,16 @@ namespace GridKit
       return connection_nodes_[local_index];
     }
 
+    /**
+     * @brief Allocates all of the internal buffers for the component.
+     * If a components needs a more specialized allocation (such as by having additional internal buffers),
+     * it should override this function and then call it in the body to ensure it stays up-to-date with
+     * new implementations.
+     *
+     * @pre \ref nnz_ and \ref size_ must be set. Typically these are set by the child object in its constructor.
+     *
+     * @return An error code, or 0 if success
+     */
     int allocate() override
     {
       jacobian_coo_rows_   = std::make_unique<IdxT[]>(nnz_);
@@ -136,11 +146,26 @@ namespace GridKit
     }
 
   protected:
+    /**
+     * @brief Reset the Jacobian so it can be constructed. Helper method for \ref setJacValues().
+     * Sets \ref current_jac_size_ to 0 so that future calls to `setJacValues()` will override previous values.
+     *
+     */
     void zeroJacMatrix()
     {
       current_jac_size_ = 0;
     }
 
+    /**
+     * @brief Helper method for adding values to the Jacobian. Copies the rows, cols, and vals buffers and appends
+     * them to the end of the corresponding Jacobian buffers. Uses \ref current_jac_size_ to tell where the end of
+     * the Jacobian currently is.
+     *
+     * @pre `rows`, `cols`, `vals` must all be the same size
+     * @pre \ref allocate() must be called first.
+     * @pre Must call \ref zeroJacMatrix() before starting construction of a new Jacobian
+     * @pre The must be enough room for the values in the allocated buffers, i.e. `current_jac_size_ + rows.size() <= nnz_`
+     */
     void setJacValues(const std::vector<IdxT>& rows, const std::vector<IdxT>& cols, const std::vector<RealT>& vals)
     {
       assert(rows.size() == cols.size());
@@ -149,7 +174,6 @@ namespace GridKit
 
       for (size_t i = 0; i < rows.size(); i++)
       {
-
         jacobian_coo_rows_[current_jac_size_]   = rows[i];
         jacobian_coo_cols_[current_jac_size_]   = cols[i];
         jacobian_coo_values_[current_jac_size_] = vals[i];
@@ -359,10 +383,12 @@ namespace GridKit
     IdxT size_quad_{0};
     IdxT size_opt_{0};
 
+    // COO Jacobian buffers
     std::unique_ptr<IdxT[]>  jacobian_coo_rows_;
     std::unique_ptr<IdxT[]>  jacobian_coo_cols_;
     std::unique_ptr<RealT[]> jacobian_coo_values_;
 
+    /// The number of non-zero elements currently inserted into the Jacobian. See \ref setJacValues()
     size_t current_jac_size_{0};
 
     std::vector<ScalarT> y_;

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <map>
+#include <memory>
 #include <set>
 
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
@@ -90,6 +90,72 @@ namespace GridKit
     IdxT getNodeConnection(IdxT local_index) const
     {
       return connection_nodes_[local_index];
+    }
+
+    int allocate() override
+    {
+      jacobian_coo_rows_   = std::make_unique<IdxT[]>(nnz_);
+      jacobian_coo_cols_   = std::make_unique<IdxT[]>(nnz_);
+      jacobian_coo_values_ = std::make_unique<RealT[]>(nnz_);
+
+      y_.resize(static_cast<size_t>(size_));
+      yp_.resize(static_cast<size_t>(size_));
+      f_.resize(static_cast<size_t>(size_));
+
+      return 0;
+    }
+
+    IdxT* jacobianCooRows()
+    {
+      return jacobian_coo_rows_.get();
+    }
+
+    const IdxT* jacobianCooRows() const
+    {
+      return jacobian_coo_rows_.get();
+    }
+
+    IdxT* jacobianCooCols()
+    {
+      return jacobian_coo_cols_.get();
+    }
+
+    const IdxT* jacobianCooCols() const
+    {
+      return jacobian_coo_cols_.get();
+    }
+
+    RealT* jacobianCooValues()
+    {
+      return jacobian_coo_values_.get();
+    }
+
+    const RealT* jacobianCooValues() const
+    {
+      return jacobian_coo_values_.get();
+    }
+
+  protected:
+    void zeroJacMatrix()
+    {
+      current_jac_size_ = 0;
+    }
+
+    void setJacValues(const std::vector<IdxT>& rows, const std::vector<IdxT>& cols, const std::vector<RealT>& vals)
+    {
+      assert(rows.size() == cols.size());
+      assert(rows.size() == vals.size());
+      assert(current_jac_size_ + rows.size() <= nnz_);
+
+      for (size_t i = 0; i < rows.size(); i++)
+      {
+
+        jacobian_coo_rows_[current_jac_size_]   = rows[i];
+        jacobian_coo_cols_[current_jac_size_]   = cols[i];
+        jacobian_coo_values_[current_jac_size_] = vals[i];
+
+        current_jac_size_++;
+      }
     }
 
   public:
@@ -292,6 +358,12 @@ namespace GridKit
     IdxT nnz_{0};
     IdxT size_quad_{0};
     IdxT size_opt_{0};
+
+    std::unique_ptr<IdxT[]>  jacobian_coo_rows_;
+    std::unique_ptr<IdxT[]>  jacobian_coo_cols_;
+    std::unique_ptr<RealT[]> jacobian_coo_values_;
+
+    size_t current_jac_size_{0};
 
     std::vector<ScalarT> y_;
     std::vector<ScalarT> yp_;

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -302,12 +302,12 @@ namespace GridKit
 
     MatrixT& getJacobian() final
     {
-      return jac_;
+      throw "Not Implemented";
     }
 
     const MatrixT& getJacobian() const final
     {
-      return jac_;
+      throw "Not Implemented";
     }
 
     std::vector<ScalarT>& getIntegrand() final
@@ -375,8 +375,6 @@ namespace GridKit
     std::vector<ScalarT> ypB_;
     std::vector<ScalarT> fB_;
     std::vector<ScalarT> gB_;
-
-    MatrixT jac_;
 
     std::vector<ScalarT> param_;
     std::vector<ScalarT> param_up_;

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -104,9 +104,9 @@ namespace GridKit
      */
     int allocate() override
     {
-      jacobian_coo_rows_   = std::make_unique<IdxT[]>(nnz_);
-      jacobian_coo_cols_   = std::make_unique<IdxT[]>(nnz_);
-      jacobian_coo_values_ = std::make_unique<RealT[]>(nnz_);
+      jacobian_coo_rows_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
+      jacobian_coo_cols_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
+      jacobian_coo_values_ = std::make_unique<RealT[]>(static_cast<size_t>(nnz_));
 
       y_.resize(static_cast<size_t>(size_));
       yp_.resize(static_cast<size_t>(size_));
@@ -170,7 +170,7 @@ namespace GridKit
     {
       assert(rows.size() == cols.size());
       assert(rows.size() == vals.size());
-      assert(current_jac_size_ + rows.size() <= nnz_);
+      assert(current_jac_size_ + rows.size() <= static_cast<size_t>(nnz_));
 
       for (size_t i = 0; i < rows.size(); i++)
       {

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
@@ -44,24 +44,12 @@ namespace GridKit
     n_extern_       = 3;
     extern_indices_ = {0, 1, 2};
     idc_            = id;
+    nnz_            = refframe_ ? 80 : 78;
   }
 
   template <class ScalarT, typename IdxT>
   DistributedGenerator<ScalarT, IdxT>::~DistributedGenerator()
   {
-  }
-
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int DistributedGenerator<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-
-    return 0;
   }
 
   /**
@@ -180,15 +168,7 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int DistributedGenerator<ScalarT, IdxT>::evaluateJacobian()
   {
-    jac_.zeroMatrix();
-    // Create dF/dy'
-    std::vector<IdxT>  rcordder(13);
-    std::vector<RealT> valsder(13, -1.0);
-    for (int i = 0; i < 13; i++)
-    {
-      rcordder[static_cast<size_t>(i)] = static_cast<IdxT>(i + 3);
-    }
-    MatrixT Jacder = MatrixT(rcordder, rcordder, valsder, 16, 16);
+    this->zeroJacMatrix();
 
     std::vector<IdxT>  ctemp{};
     std::vector<IdxT>  rtemp{};
@@ -204,7 +184,7 @@ namespace GridKit
     valtemp = {-sin(static_cast<RealT>(y_[3])) * static_cast<RealT>(y_[14]) - cos(static_cast<RealT>(y_[3])) * static_cast<RealT>(y_[15]),
                cos(static_cast<RealT>(y_[3])),
                -sin(static_cast<RealT>(y_[3]))};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 2
 
@@ -215,16 +195,16 @@ namespace GridKit
     valtemp = {cos(static_cast<RealT>(y_[3])) * static_cast<RealT>(y_[14]) - sin(static_cast<RealT>(y_[3])) * static_cast<RealT>(y_[15]),
                sin(static_cast<RealT>(y_[3])),
                cos(static_cast<RealT>(y_[3]))};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 3
 
-    ctemp = {0, 4};
+    ctemp = {0, 3, 4};
     rtemp.clear();
     for (size_t i = 0; i < ctemp.size(); i++)
       rtemp.push_back(3);
-    valtemp = {-1.0, -mp_};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    valtemp = {-1.0, -alpha_, -mp_};
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 0
     if (refframe_)
@@ -234,7 +214,7 @@ namespace GridKit
       for (size_t i = 0; i < ctemp.size(); i++)
         rtemp.push_back(0);
       valtemp = {-1.0, -mp_};
-      jac_.setValues(rtemp, ctemp, valtemp);
+      this->setJacValues(rtemp, ctemp, valtemp);
     }
 
     // r = 4
@@ -242,56 +222,56 @@ namespace GridKit
     rtemp.clear();
     for (size_t i = 0; i < ctemp.size(); i++)
       rtemp.push_back(4);
-    valtemp = {-wc_,
+    valtemp = {-wc_ - alpha_,
                wc_ * static_cast<RealT>(y_[14]),
                wc_ * static_cast<RealT>(y_[15]),
                wc_ * static_cast<RealT>(y_[12]),
                wc_ * static_cast<RealT>(y_[13])};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 5
     ctemp = {5, 12, 13, 14, 15};
     rtemp.clear();
     for (size_t i = 0; i < ctemp.size(); i++)
       rtemp.push_back(5);
-    valtemp = {-wc_,
+    valtemp = {-wc_ - alpha_,
                -wc_ * static_cast<RealT>(y_[15]),
                wc_ * static_cast<RealT>(y_[14]),
                wc_ * static_cast<RealT>(y_[13]),
                -wc_ * static_cast<RealT>(y_[12])};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 6
-    ctemp = {5, 12};
+    ctemp = {5, 6, 12};
     rtemp.clear();
     for (size_t i = 0; i < ctemp.size(); i++)
       rtemp.push_back(6);
-    valtemp = {-nq_, -1.0};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    valtemp = {-nq_, -alpha_, -1.0};
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 7
-    ctemp = {13};
+    ctemp = {7, 13};
     rtemp.clear();
     for (size_t i = 0; i < ctemp.size(); i++)
       rtemp.push_back(7);
-    valtemp = {-1.0};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    valtemp = {-alpha_, -1.0};
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 8
-    ctemp = {5, 6, 10, 12, 13, 14};
+    ctemp = {5, 6, 8, 10, 12, 13, 14};
     rtemp.clear();
     for (size_t i = 0; i < ctemp.size(); i++)
       rtemp.push_back(8);
-    valtemp = {-Kpv_ * nq_, Kiv_, -1.0, -Kpv_, -Cf_ * wb_, F_};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    valtemp = {-Kpv_ * nq_, Kiv_, -alpha_, -1.0, -Kpv_, -Cf_ * wb_, F_};
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 9
-    ctemp = {7, 11, 12, 13, 15};
+    ctemp = {7, 9, 11, 12, 13, 15};
     rtemp.clear();
     for (size_t i = 0; i < ctemp.size(); i++)
       rtemp.push_back(9);
-    valtemp = {Kiv_, -1.0, Cf_ * wb_, -Kpv_, F_};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    valtemp = {Kiv_, -alpha_, -1.0, Cf_ * wb_, -Kpv_, F_};
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 10
     ctemp = {4, 5, 6, 8, 10, 11, 12, 13, 14};
@@ -302,12 +282,12 @@ namespace GridKit
                -(Kpc_ * Kpv_ * nq_) / Lf_,
                (Kpc_ * Kiv_) / Lf_,
                Kic_ / Lf_,
-               -(Kpc_ + rLf_) / Lf_,
+               -(Kpc_ + rLf_) / Lf_ - alpha_,
                -mp_ * static_cast<RealT>(y_[4]),
                -(Kpc_ * Kpv_ + 1.0) / Lf_,
                -(Cf_ * Kpc_ * wb_) / Lf_,
                (F_ * Kpc_) / Lf_};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 11
     ctemp = {4, 7, 9, 10, 11, 12, 13, 15};
@@ -318,30 +298,31 @@ namespace GridKit
                (Kiv_ * Kpc_) / Lf_,
                Kic_ / Lf_,
                mp_ * static_cast<RealT>(y_[4]),
-               -(Kpc_ + rLf_) / Lf_,
+               -(Kpc_ + rLf_) / Lf_ - alpha_,
                (Cf_ * Kpc_ * wb_) / Lf_,
                -(Kpc_ * Kpv_ + 1.0) / Lf_,
                (F_ * Kpc_) / Lf_};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 12
-    ctemp = {4, 10, 13, 14};
+    ctemp = {4, 10, 12, 13, 14};
     rtemp.clear();
     for (size_t i = 0; i < ctemp.size(); i++)
       rtemp.push_back(12);
     valtemp = {-mp_ * static_cast<RealT>(y_[13]),
                1.0 / Cf_,
+               -alpha_,
                wb_ - mp_ * static_cast<RealT>(y_[4]),
                -1.0 / Cf_};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 13
-    ctemp = {4, 11, 12, 15};
+    ctemp = {4, 11, 12, 13, 15};
     rtemp.clear();
     for (size_t i = 0; i < ctemp.size(); i++)
       rtemp.push_back(13);
-    valtemp = {mp_ * static_cast<RealT>(y_[12]), 1.0 / Cf_, -wb_ + mp_ * static_cast<RealT>(y_[4]), -1.0 / Cf_};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    valtemp = {mp_ * static_cast<RealT>(y_[12]), 1.0 / Cf_, -wb_ + mp_ * static_cast<RealT>(y_[4]), -alpha_, -1.0 / Cf_};
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 14
     ctemp = {1, 2, 3, 4, 12, 14, 15};
@@ -353,9 +334,9 @@ namespace GridKit
                (1.0 / Lc_) * (sin(static_cast<RealT>(y_[3])) * static_cast<RealT>(y_[1]) - cos(static_cast<RealT>(y_[3])) * static_cast<RealT>(y_[2])),
                -mp_ * static_cast<RealT>(y_[15]),
                1.0 / Lc_,
-               -rLc_ / Lc_,
+               -rLc_ / Lc_ - alpha_,
                wb_ - mp_ * static_cast<RealT>(y_[4])};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     // r = 15
     ctemp = {1, 2, 3, 4, 13, 14, 15};
@@ -368,12 +349,8 @@ namespace GridKit
                mp_ * static_cast<RealT>(y_[14]),
                1.0 / Lc_,
                -wb_ + mp_ * static_cast<RealT>(y_[4]),
-               -rLc_ / Lc_};
-    jac_.setValues(rtemp, ctemp, valtemp);
-
-    // Perform dF/dy + \alpha dF/dy'
-
-    jac_.axpy(alpha_, Jacder);
+               -rLc_ / Lc_ - alpha_};
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
@@ -39,8 +39,7 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   class DistributedGenerator : public CircuitComponent<ScalarT, IdxT>
   {
-    using RealT   = typename CircuitComponent<ScalarT, IdxT>::RealT;
-    using MatrixT = typename CircuitComponent<RealT, IdxT>::MatrixT;
+    using RealT = typename CircuitComponent<ScalarT, IdxT>::RealT;
 
     using CircuitComponent<ScalarT, IdxT>::size_;
     using CircuitComponent<ScalarT, IdxT>::nnz_;
@@ -55,7 +54,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -69,7 +67,6 @@ namespace GridKit
                          bool                                        reference_frame);
     virtual ~DistributedGenerator();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
@@ -45,18 +45,6 @@ namespace GridKit
   {
   }
 
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int InductionMotor<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-    return 0;
-  }
-
   /**
    * Initialization of the grid model
    */

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
@@ -34,7 +34,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -46,7 +45,6 @@ namespace GridKit
     InductionMotor(IdxT id, RealT Lls, RealT Rs, RealT Llr, RealT Rr, RealT Lms, RealT RJ, RealT P);
     virtual ~InductionMotor();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
@@ -24,25 +24,12 @@ namespace GridKit
     n_extern_       = 2;
     extern_indices_ = {0, 1};
     idc_            = id;
+    nnz_            = 5;
   }
 
   template <class ScalarT, typename IdxT>
   Inductor<ScalarT, IdxT>::~Inductor()
   {
-  }
-
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int Inductor<ScalarT, IdxT>::allocate()
-  {
-
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-
-    return 0;
   }
 
   /**
@@ -89,22 +76,13 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int Inductor<ScalarT, IdxT>::evaluateJacobian()
   {
-    jac_.zeroMatrix();
+    this->zeroJacMatrix();
 
     // Create dF/dy
-    std::vector<IdxT>  rcord{0, 1, 2, 2};
-    std::vector<IdxT>  ccord{2, 2, 0, 1};
-    std::vector<RealT> vals{-1.0, 1.0, -1.0, 1.0};
-    jac_.setValues(rcord, ccord, vals);
-
-    // Create dF/dy'
-    std::vector<IdxT>  rcordder{2};
-    std::vector<IdxT>  ccordder{2};
-    std::vector<RealT> valsder{-L_};
-    MatrixT            Jacder = MatrixT(rcordder, ccordder, valsder, 3, 3);
-
-    // Perform dF/dy + \alpha dF/dy'
-    jac_.axpy(alpha_, Jacder);
+    std::vector<IdxT>  rcord{0, 1, 2, 2, 2};
+    std::vector<IdxT>  ccord{2, 2, 0, 1, 2};
+    std::vector<RealT> vals{-1.0, 1.0, -1.0, 1.0, -L_ * alpha_};
+    this->setJacValues(rcord, ccord, vals);
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.hpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.hpp
@@ -19,8 +19,7 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   class Inductor : public CircuitComponent<ScalarT, IdxT>
   {
-    using RealT   = typename CircuitComponent<ScalarT, IdxT>::RealT;
-    using MatrixT = typename CircuitComponent<RealT, IdxT>::MatrixT;
+    using RealT = typename CircuitComponent<ScalarT, IdxT>::RealT;
 
     using CircuitComponent<ScalarT, IdxT>::size_;
     using CircuitComponent<ScalarT, IdxT>::nnz_;
@@ -35,7 +34,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -47,7 +45,6 @@ namespace GridKit
     Inductor(IdxT id, RealT L);
     virtual ~Inductor();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
@@ -47,18 +47,6 @@ namespace GridKit
   {
   }
 
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int LinearTransformer<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-    return 0;
-  }
-
   /**
    * Initialization of the grid model
    */

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
@@ -34,7 +34,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -46,7 +45,6 @@ namespace GridKit
     LinearTransformer(IdxT id, RealT L0, RealT L1, RealT R0, RealT R1, RealT M);
     virtual ~LinearTransformer();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
@@ -29,24 +29,12 @@ namespace GridKit
     n_extern_       = 2;
     extern_indices_ = {0, 1};
     idc_            = id;
+    nnz_            = 2;
   }
 
   template <class ScalarT, typename IdxT>
   MicrogridBusDQ<ScalarT, IdxT>::~MicrogridBusDQ()
   {
-  }
-
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int MicrogridBusDQ<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-
-    return 0;
   }
 
   /**
@@ -95,13 +83,13 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridBusDQ<ScalarT, IdxT>::evaluateJacobian()
   {
-    jac_.zeroMatrix();
+    this->zeroJacMatrix();
 
     // Create dF/dy
     std::vector<IdxT>  rtemp{0, 1};
     std::vector<IdxT>  ctemp{0, 1};
     std::vector<RealT> vals{-1.0 / RN_, -1.0 / RN_};
-    jac_.setValues(rtemp, ctemp, vals);
+    this->setJacValues(rtemp, ctemp, vals);
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
@@ -34,7 +34,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -46,7 +45,6 @@ namespace GridKit
     MicrogridBusDQ(IdxT id, RealT RN);
     virtual ~MicrogridBusDQ();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
@@ -33,24 +33,12 @@ namespace GridKit
     n_extern_       = 5;
     extern_indices_ = {0, 1, 2, 3, 4};
     idc_            = id;
+    nnz_            = 14;
   }
 
   template <class ScalarT, typename IdxT>
   MicrogridLine<ScalarT, IdxT>::~MicrogridLine()
   {
-  }
-
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int MicrogridLine<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-
-    return 0;
   }
 
   /**
@@ -106,34 +94,25 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridLine<ScalarT, IdxT>::evaluateJacobian()
   {
-    jac_.zeroMatrix();
+    this->zeroJacMatrix();
 
     // Create dF/dy
     std::vector<IdxT>  rtemp{1, 2, 3, 4};
     std::vector<IdxT>  ctemp{5, 6, 5, 6};
     std::vector<RealT> valtemp{-1.0, -1.0, 1.0, 1.0};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     std::vector<IdxT> ccord{0, 1, 3, 5, 6};
 
     std::vector<IdxT>  rcord(ccord.size(), 5);
     std::vector<RealT> vals{};
-    vals = {static_cast<RealT>(y_[6]), (1.0 / L_), -(1.0 / L_), -(R_ / L_), static_cast<RealT>(y_[0])};
-    jac_.setValues(rcord, ccord, vals);
+    vals = {static_cast<RealT>(y_[6]), (1.0 / L_), -(1.0 / L_), -(R_ / L_) - alpha_, static_cast<RealT>(y_[0])};
+    this->setJacValues(rcord, ccord, vals);
 
     std::vector<IdxT> ccor2{0, 2, 4, 5, 6};
     std::fill(rcord.begin(), rcord.end(), 6);
-    vals = {-static_cast<RealT>(y_[5]), (1.0 / L_), -(1.0 / L_), -static_cast<RealT>(y_[0]), -(R_ / L_)};
-    jac_.setValues(rcord, ccor2, vals);
-
-    // Create -dF/dy'
-    std::vector<IdxT>  rcordder{5, 6};
-    std::vector<IdxT>  ccordder{5, 6};
-    std::vector<RealT> valsder{-1.0, -1.0};
-    MatrixT            Jacder = MatrixT(rcordder, ccordder, valsder, 7, 7);
-
-    // Perform dF/dy + \alpha dF/dy'
-    jac_.axpy(alpha_, Jacder);
+    vals = {-static_cast<RealT>(y_[5]), (1.0 / L_), -(1.0 / L_), -static_cast<RealT>(y_[0]), -(R_ / L_) - alpha_};
+    this->setJacValues(rcord, ccor2, vals);
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
@@ -19,8 +19,7 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   class MicrogridLine : public CircuitComponent<ScalarT, IdxT>
   {
-    using RealT   = typename CircuitComponent<ScalarT, IdxT>::RealT;
-    using MatrixT = typename CircuitComponent<RealT, IdxT>::MatrixT;
+    using RealT = typename CircuitComponent<ScalarT, IdxT>::RealT;
 
     using CircuitComponent<ScalarT, IdxT>::size_;
     using CircuitComponent<ScalarT, IdxT>::nnz_;
@@ -35,7 +34,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -47,7 +45,6 @@ namespace GridKit
     MicrogridLine(IdxT id, RealT R, RealT L);
     virtual ~MicrogridLine();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
@@ -31,24 +31,12 @@ namespace GridKit
     n_extern_       = 3;
     extern_indices_ = {0, 1, 2};
     idc_            = id;
+    nnz_            = 10;
   }
 
   template <class ScalarT, typename IdxT>
   MicrogridLoad<ScalarT, IdxT>::~MicrogridLoad()
   {
-  }
-
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int MicrogridLoad<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-
-    return 0;
   }
 
   /**
@@ -101,34 +89,25 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridLoad<ScalarT, IdxT>::evaluateJacobian()
   {
-    jac_.zeroMatrix();
+    this->zeroJacMatrix();
 
     // Create dF/dy
     std::vector<IdxT>  rtemp{1, 2};
     std::vector<IdxT>  ctemp{3, 4};
     std::vector<RealT> valtemp{-1.0, -1.0};
-    jac_.setValues(rtemp, ctemp, valtemp);
+    this->setJacValues(rtemp, ctemp, valtemp);
 
     std::vector<IdxT> ccord{0, 1, 3, 4};
 
     std::vector<IdxT>  rcord(ccord.size(), 3);
     std::vector<RealT> vals{};
-    vals = {static_cast<RealT>(y_[4]), (1.0 / L_), -(R_ / L_), static_cast<RealT>(y_[0])};
-    jac_.setValues(rcord, ccord, vals);
+    vals = {static_cast<RealT>(y_[4]), (1.0 / L_), -(R_ / L_) - alpha_, static_cast<RealT>(y_[0])};
+    this->setJacValues(rcord, ccord, vals);
 
     std::vector<IdxT> ccor2{0, 2, 3, 4};
     std::fill(rcord.begin(), rcord.end(), 4);
-    vals = {-static_cast<RealT>(y_[3]), (1.0 / L_), -static_cast<RealT>(y_[0]), -(R_ / L_)};
-    jac_.setValues(rcord, ccor2, vals);
-
-    // Create -dF/dy'
-    std::vector<IdxT>  rcordder{3, 4};
-    std::vector<IdxT>  ccordder{3, 4};
-    std::vector<RealT> valsder{-1.0, -1.0};
-    MatrixT            Jacder = MatrixT(rcordder, ccordder, valsder, 5, 5);
-
-    // Perform dF/dy + \alpha dF/dy'
-    jac_.axpy(alpha_, Jacder);
+    vals = {-static_cast<RealT>(y_[3]), (1.0 / L_), -static_cast<RealT>(y_[0]), -(R_ / L_) - alpha_};
+    this->setJacValues(rcord, ccor2, vals);
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
@@ -19,8 +19,7 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   class MicrogridLoad : public CircuitComponent<ScalarT, IdxT>
   {
-    using RealT   = typename CircuitComponent<ScalarT, IdxT>::RealT;
-    using MatrixT = typename CircuitComponent<RealT, IdxT>::MatrixT;
+    using RealT = typename CircuitComponent<ScalarT, IdxT>::RealT;
 
     using CircuitComponent<ScalarT, IdxT>::size_;
     using CircuitComponent<ScalarT, IdxT>::nnz_;
@@ -35,7 +34,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -47,7 +45,6 @@ namespace GridKit
     MicrogridLoad(IdxT id, RealT R, RealT L);
     virtual ~MicrogridLoad();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
@@ -24,24 +24,12 @@ namespace GridKit
     n_extern_       = 2;
     extern_indices_ = {0, 1};
     idc_            = id;
+    nnz_            = 4;
   }
 
   template <class ScalarT, typename IdxT>
   Resistor<ScalarT, IdxT>::~Resistor()
   {
-  }
-
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int Resistor<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-
-    return 0;
   }
 
   /**
@@ -79,13 +67,14 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int Resistor<ScalarT, IdxT>::evaluateJacobian()
   {
+    this->zeroJacMatrix();
 
     // Create dF/dy
     // does compiler make constant???
     std::vector<IdxT>  rcord{0, 0, 1, 1};
     std::vector<IdxT>  ccord{0, 1, 0, 1};
     std::vector<RealT> vals{1.0 / R_, -1.0 / R_, -1.0 / R_, 1.0 / R_};
-    jac_.setValues(rcord, ccord, vals);
+    this->setJacValues(rcord, ccord, vals);
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.hpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.hpp
@@ -34,7 +34,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -46,7 +45,6 @@ namespace GridKit
     Resistor(IdxT id, RealT R);
     virtual ~Resistor();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
@@ -63,18 +63,6 @@ namespace GridKit
   {
   }
 
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int SynchronousMachine<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-    return 0;
-  }
-
   /**
    * Initialization of the grid model
    */

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
@@ -36,7 +36,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -48,7 +47,6 @@ namespace GridKit
     SynchronousMachine(IdxT id, RealT Lls, std::tuple<RealT, RealT> Llkq, RealT Llfd, RealT Llkd, RealT Lmq, RealT Lmd, RealT Rs, std::tuple<RealT, RealT> Rkq, RealT Rfd, RealT Rkd, RealT RJ, RealT P, RealT mub);
     virtual ~SynchronousMachine();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -61,7 +61,6 @@ namespace GridKit
   class PowerElectronicsModel : public CircuitComponent<ScalarT, IdxT>
   {
     using RealT          = typename CircuitComponent<ScalarT, IdxT>::RealT;
-    using MatrixT        = typename CircuitComponent<ScalarT, IdxT>::MatrixT;
     using CsrMatrixT     = typename CircuitComponent<ScalarT, IdxT>::CsrMatrixT;
     using component_type = CircuitComponent<ScalarT, IdxT>;
     using node_type      = CircuitNode<ScalarT, IdxT>;
@@ -73,7 +72,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::y_;
     using CircuitComponent<ScalarT, IdxT>::yp_;
     using CircuitComponent<ScalarT, IdxT>::f_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::rel_tol_;
     using CircuitComponent<ScalarT, IdxT>::abs_tol_;
 
@@ -196,19 +194,20 @@ namespace GridKit
 
       // Evaluate component Jacobians to get sparsity
       distributeVectors();
-      for (const auto& component : components_)
+      for (component_type* component : components_)
       {
         component->evaluateJacobian();
       }
 
       // Count the number of non-zeros
       IdxT nnz_dup = 0;
-      for (const auto& component : components_)
+      for (const component_type* component : components_)
       {
-        std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> entries = component->getJacobian().getEntries();
-        const auto& [r, c, v]                                                           = entries;
+        const IdxT* r   = component->jacobianCooRows();
+        const IdxT* c   = component->jacobianCooCols();
+        IdxT        nnz = component->nnz();
 
-        for (IdxT i = 0; i < static_cast<IdxT>(r.size()); ++i)
+        for (IdxT i = 0; i < nnz; ++i)
         {
           if (component->getNodeConnection(r[i]) != neg1_ && component->getNodeConnection(c[i]) != neg1_)
           {
@@ -225,10 +224,12 @@ namespace GridKit
       IdxT counter = 0;
       for (const auto& component : components_)
       {
-        std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> entries = component->getJacobian().getEntries();
-        const auto& [r, c, v]                                                           = entries;
+        const IdxT*  r   = component->jacobianCooRows();
+        const IdxT*  c   = component->jacobianCooCols();
+        const RealT* v   = component->jacobianCooValues();
+        IdxT         nnz = component->nnz();
 
-        for (IdxT i = 0; i < static_cast<IdxT>(r.size()); ++i)
+        for (IdxT i = 0; i < nnz; ++i)
         {
           if (component->getNodeConnection(r[i]) != neg1_ && component->getNodeConnection(c[i]) != neg1_)
           {
@@ -390,10 +391,12 @@ namespace GridKit
       {
         component->evaluateJacobian();
 
-        std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> entries = component->getJacobian().getEntries();
-        const auto& [r, c, v]                                                           = entries;
+        const IdxT*  r   = component->jacobianCooRows();
+        const IdxT*  c   = component->jacobianCooCols();
+        const RealT* v   = component->jacobianCooValues();
+        IdxT         nnz = component->nnz();
 
-        for (IdxT i = 0; i < static_cast<IdxT>(r.size()); ++i)
+        for (IdxT i = 0; i < nnz; ++i)
         {
           if (component->getNodeConnection(r[i]) != neg1_ && component->getNodeConnection(c[i]) != neg1_)
           {
@@ -471,17 +474,6 @@ namespace GridKit
     void printResidualMatrixMarket(std::string filename, std::string title)
     {
       writeVectorToMatrixMarket(f_, filename, title);
-    }
-
-    /**
-     * @brief print the system Jacobian in COO format
-     *
-     * @param[in] filename
-     * @param[in] title
-     */
-    void printJacobianMatrixMarket(std::string filename, std::string title)
-    {
-      jac_.printMatrixMarket(filename, title);
     }
 
     CsrMatrixT* getCsrJacobian() const override

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
@@ -32,6 +32,7 @@ namespace GridKit
     n_extern_       = 8;
     extern_indices_ = {0, 1, 2, 3, 4, 5, 6, 7};
     idc_            = id;
+    nnz_            = 44;
 
     RealT magImpendence = 1.0 / (R_ * R_ + X_ * X_);
     YReMat_             = magImpendence * R_;
@@ -42,19 +43,6 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   TransmissionLine<ScalarT, IdxT>::~TransmissionLine()
   {
-  }
-
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int TransmissionLine<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-
-    return 0;
   }
 
   /**
@@ -137,30 +125,31 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int TransmissionLine<ScalarT, IdxT>::evaluateJacobian()
   {
+    this->zeroJacMatrix();
 
     // Create dF/dy
     std::vector<IdxT>  rtemp{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
     std::vector<IdxT>  ctemp{8, 9, 10, 11, 8, 9, 10, 11, 8, 9, 10, 11};
     std::vector<RealT> vals{1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0};
-    jac_.setValues(rtemp, ctemp, vals);
+    this->setJacValues(rtemp, ctemp, vals);
 
     std::vector<IdxT> ccord{0, 1, 2, 3, 4, 5, 6, 7};
 
     std::vector<IdxT> rcord(ccord.size(), 8);
     vals = {YReMat_, -YImMatDi_, -YReMat_, -YImMatOff_, -YReMat_, YImMatDi_, YReMat_, YImMatOff_};
-    jac_.setValues(rtemp, ctemp, vals);
+    this->setJacValues(rtemp, ctemp, vals);
 
     std::fill(rcord.begin(), rcord.end(), 9);
     vals = {YImMatDi_, YReMat_, YImMatOff_, -YReMat_, -YImMatDi_, -YReMat_, -YImMatOff_, YReMat_};
-    jac_.setValues(rtemp, ctemp, vals);
+    this->setJacValues(rtemp, ctemp, vals);
 
     std::fill(rcord.begin(), rcord.end(), 10);
     vals = {-YReMat_, -YImMatDi_, YReMat_, -YImMatOff_, YReMat_, YImMatDi_, -YReMat_, YImMatOff_};
-    jac_.setValues(rtemp, ctemp, vals);
+    this->setJacValues(rtemp, ctemp, vals);
 
     std::fill(rcord.begin(), rcord.end(), 11);
     vals = {YImMatDi_, -YReMat_, YImMatOff_, YReMat_, -YImMatDi_, YReMat_, -YImMatOff_, -YReMat_};
-    jac_.setValues(rtemp, ctemp, vals);
+    this->setJacValues(rtemp, ctemp, vals);
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
@@ -38,7 +38,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -50,7 +49,6 @@ namespace GridKit
     TransmissionLine(IdxT id, RealT R, RealT X, RealT B);
     virtual ~TransmissionLine();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
@@ -24,24 +24,12 @@ namespace GridKit
     n_extern_       = 2;
     extern_indices_ = {0, 1};
     idc_            = id;
+    nnz_            = 4;
   }
 
   template <class ScalarT, typename IdxT>
   VoltageSource<ScalarT, IdxT>::~VoltageSource()
   {
-  }
-
-  /*!
-   * @brief allocate method computes sparsity pattern of the Jacobian.
-   */
-  template <class ScalarT, typename IdxT>
-  int VoltageSource<ScalarT, IdxT>::allocate()
-  {
-    y_.resize(static_cast<size_t>(size_));
-    yp_.resize(static_cast<size_t>(size_));
-    f_.resize(static_cast<size_t>(size_));
-
-    return 0;
   }
 
   /**
@@ -80,11 +68,13 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int VoltageSource<ScalarT, IdxT>::evaluateJacobian()
   {
+    this->zeroJacMatrix();
+
     // Create dF/dy
     std::vector<IdxT>  rcord{0, 1, 2, 2};
     std::vector<IdxT>  ccord{2, 2, 0, 1};
     std::vector<RealT> vals{-1.0, 1.0, -1.0, 1.0};
-    jac_.setValues(rcord, ccord, vals);
+    this->setJacValues(rcord, ccord, vals);
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
@@ -34,7 +34,6 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::ypB_;
     using CircuitComponent<ScalarT, IdxT>::fB_;
     using CircuitComponent<ScalarT, IdxT>::gB_;
-    using CircuitComponent<ScalarT, IdxT>::jac_;
     using CircuitComponent<ScalarT, IdxT>::param_;
     using CircuitComponent<ScalarT, IdxT>::idc_;
 
@@ -46,11 +45,10 @@ namespace GridKit
     VoltageSource(IdxT id, RealT V);
     virtual ~VoltageSource();
 
-    int allocate();
     int initialize();
     int tagDifferentiable();
     int evaluateResidual();
-    int evaluateJacobian();
+    int evaluateJacobian() final;
     int evaluateIntegrand();
 
     int initializeAdjoint();

--- a/examples/Enzyme/PowerElectronics/main.cpp
+++ b/examples/Enzyme/PowerElectronics/main.cpp
@@ -158,12 +158,12 @@ int main()
   // Residual evaluation and reference Jacobian
   dg->evaluateResidual();
   dg->evaluateJacobian();
-  std::vector<double> y       = dg->y();
-  std::vector<double> yp      = dg->yp();
-  std::vector<double> res     = dg->getResidual();
-  SparseMatrix        jac_ref = dg->getJacobian();
-  DenseMatrix         jac_ref_dense(dg->size(), dg->size());
-  jac_ref_dense.setValues(jac_ref);
+  std::vector<double> y   = dg->y();
+  std::vector<double> yp  = dg->yp();
+  std::vector<double> res = dg->getResidual();
+
+  DenseMatrix jac_ref_dense(dg->size(), dg->size());
+  jac_ref_dense.setValues(dg->nnz(), dg->jacobianCooRows(), dg->jacobianCooCols(), dg->jacobianCooValues());
 
   // Enzyme Jacobian
   DenseMatrix jac_autodiff(dg->size(), dg->size());

--- a/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
+++ b/examples/PowerElectronics/ScaleMicrogrid/ScaleMicrogrid.cpp
@@ -322,7 +322,7 @@ int test(index_type Nsize, real_type error_tol, bool debug_output)
 
   sys_model->updateTime(0.0, 1.0e-8);
   sys_model->evaluateJacobian();
-  sys_model->printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + std::to_string(Nsize) + ".mtx", "ScaleMicrogrid Jacobian N" + std::to_string(Nsize));
+  // sys_model->printJacobianMatrixMarket("ScaleMicrogrid_Jacobian_N" + std::to_string(Nsize) + ".mtx", "ScaleMicrogrid Jacobian N" + std::to_string(Nsize));
   // print the jacobian in matrix market format
 
   if (debug_output)


### PR DESCRIPTION
## Description
 
Closes #351
 
 ## Proposed changes
 
COO Jacobian values for components are stored in three new buffers `jacobian_coo_rows_`, `jacobian_coo_cols_`, `jacobian_coo_values_`. To minimize changes to models, a helper function `CircuitComponent::setJacValues` is added with a similar interface as the old `COO_Matrix::setValues()` which fills these new buffers. `nnz_` is also properly added to all of the PowerElectronics models with Jacobians.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments

 
