### PR TITLE
State Sync + Simulation Performance

### DIFF
--- a/GridKit/Model/PhasorDynamics/SystemModel.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModel.hpp
@@ -571,26 +571,15 @@ namespace GridKit
        */
       int evaluateResidual() override
       {
-        // Update variables and evaluate component residuals
+        updateVariables();
+
         for (const auto& bus : buses_)
         {
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            bus->y()[j]  = y_[bus->getVariableIndex(j)];
-            bus->yp()[j] = yp_[bus->getVariableIndex(j)];
-          }
-
           bus->evaluateResidual();
         }
 
         for (const auto& component : components_)
         {
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            component->y()[j]  = y_[component->getVariableIndex(j)];
-            component->yp()[j] = yp_[component->getVariableIndex(j)];
-          }
-
           component->evaluateResidual();
         }
 

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -752,9 +752,9 @@ namespace AnalysisManager
     {
       GridKit::Model::Evaluator<ScalarT, IdxT>* model = static_cast<GridKit::Model::Evaluator<ScalarT, IdxT>*>(user_data);
 
-      model->updateTime(tres, 0.0);
       copyVec(yy, model->y());
       copyVec(yp, model->yp());
+      model->updateTime(tres, 0.0);
 
       model->evaluateResidual();
       const std::vector<ScalarT>& f = model->getResidual();
@@ -776,9 +776,9 @@ namespace AnalysisManager
     {
       GridKit::Model::Evaluator<ScalarT, IdxT>* model = static_cast<GridKit::Model::Evaluator<ScalarT, IdxT>*>(user_data);
 
-      model->updateTime(t, cj);
       copyVec(yy, model->y());
       copyVec(yp, model->yp());
+      model->updateTime(t, cj);
 
       model->evaluateJacobian();
 

--- a/application/PhasorDynamics/PDSim.cpp
+++ b/application/PhasorDynamics/PDSim.cpp
@@ -70,7 +70,7 @@ int main(int argc, const char* argv[])
     }
 
     // Re-initialize simulation at event time
-    ida.initializeSimulation(event.time, false);
+    ida.initializeSimulation(event.time, true);
     curr_time = event.time;
   }
 


### PR DESCRIPTION
## Description
 
In my feature branch, where I have larger models with more signals, I was running into some strange state synchronization issues between the machine, exciter, and bus. I noticed that `Ida.cpp`and `SystemModel.hpp` seem to pass state in a different order, fixing the inter-model issues I had. Ida stopped failing during fault events in a 240-Bus case I am constructing, and it reduced the solve time by ~3x across all examples.

I'm not sure why this has such a big impact on performance, or whether it's related to my build configuration. Worth looking at because GK now simulates faster than PowerWorld for my machine on this branch, but not on the `develop` branch.

Example of change

*Before*
```
  model->updateTime(tres, 0.0);
  copyVec(yy, model->y());
  copyVec(yp, model->yp());
```

*After* (i.e., share state before invoking so it's not stale)
```
  copyVec(yy, model->y());
  copyVec(yp, model->yp());
  model->updateTime(tres, 0.0);
```
 
 _Closes #(issue)_
 
 _Mentions @(user)_
 
 ## Proposed changes
 
 _Describe how your changes here address the issue and why the proposed changes
 should be accepted._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [ ] All tests pass.
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [ ] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
- [ ] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc..._
 
