### PR TITLE
Separate internal and external residuals in PowerElectronics models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Added SEXS-PTI Exciter Model
 - Added 200 Bus Synthetic Illinois Case
 - Added node objects to `PowerElectronics` module & updated all examples to make use of them.
+- Separated internal and external residuals of `PowerElectronics` models.
 
 ## v0.1
 

--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
@@ -57,15 +57,19 @@ namespace GridKit
    *
    */
   template <class ScalarT, typename IdxT>
-  int Capacitor<ScalarT, IdxT>::evaluateResidual()
+  int Capacitor<ScalarT, IdxT>::evaluateInternalResidual()
+  {
+    f_[2] = -C_ * yp_[2] + y_[0] - y_[1] - y_[2];
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int Capacitor<ScalarT, IdxT>::evaluateExternalResidual()
   {
     // input
     f_[0] = C_ * yp_[2];
     // output
     f_[1] = -C_ * yp_[2];
-
-    // internal
-    f_[2] = -C_ * yp_[2] + y_[0] - y_[1] - y_[2];
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.hpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.hpp
@@ -47,7 +47,8 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -24,14 +24,6 @@ namespace GridKit
 
     CircuitComponent() = default;
 
-    ~CircuitComponent()
-    {
-      if (connection_nodes_ != nullptr)
-      {
-        delete[] connection_nodes_;
-      }
-    };
-
     /**
      * @note Cannot be marked final, since it is overriden to recurse in the system model.
      */
@@ -70,12 +62,7 @@ namespace GridKit
      */
     int setExternalConnectionNodes(IdxT local_index, IdxT global_index)
     {
-      if (connection_nodes_ == nullptr)
-      {
-        connection_nodes_ = new IdxT[static_cast<size_t>(size_)];
-      }
-
-      connection_nodes_[local_index] = global_index;
+      connection_nodes_[static_cast<size_t>(local_index)] = global_index;
       return 0;
     }
 
@@ -107,6 +94,8 @@ namespace GridKit
       jacobian_coo_rows_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
       jacobian_coo_cols_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
       jacobian_coo_values_ = std::make_unique<RealT[]>(static_cast<size_t>(nnz_));
+
+      connection_nodes_ = std::make_unique<IdxT[]>(static_cast<size_t>(size_));
 
       y_.resize(static_cast<size_t>(size_));
       yp_.resize(static_cast<size_t>(size_));
@@ -403,11 +392,11 @@ namespace GridKit
     }
 
   protected:
-    size_t         n_extern_;
-    size_t         n_intern_;
-    std::set<IdxT> extern_indices_;
+    size_t                  n_extern_;
+    size_t                  n_intern_;
+    std::set<IdxT>          extern_indices_;
     ///@todo may want to replace the mapping of connection_nodes to Node objects instead of IdxT. Allows for container free setup
-    IdxT*          connection_nodes_ = nullptr;
+    std::unique_ptr<IdxT[]> connection_nodes_;
 
   protected:
     IdxT size_{0};

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -145,6 +145,14 @@ namespace GridKit
       return jacobian_coo_values_.get();
     }
 
+    /**
+     * @brief Evaluating the residual of a CircuitComponent should be done by evaluating the
+     * internal residuals and external residuals. CircuitComponents should overload those
+     * functions for their residuals (and the system will call those function instead of this one),
+     * so there is no reason to overload this functionality.
+     *
+     * @return An error code, or 0 is successful.
+     */
     int evaluateResidual() final
     {
       if (int err_code = evaluateInternalResidual())
@@ -153,8 +161,20 @@ namespace GridKit
       return evaluateExternalResidual();
     }
 
+    /**
+     * @brief Evaluate all of the residuals of internal variables of the component,
+     * modifying \ref f_.
+     *
+     * @return An error code, or 0 if successful.
+     */
     virtual int evaluateInternalResidual() = 0;
 
+    /**
+     * @brief Evaluate all of the residuals of external variables of the component,
+     * modifying \ref f_
+     *
+     * @return An error code, or 0 if successful.
+     */
     virtual int evaluateExternalResidual() = 0;
 
   protected:

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -145,6 +145,18 @@ namespace GridKit
       return jacobian_coo_values_.get();
     }
 
+    int evaluateResidual() final
+    {
+      if (int err_code = evaluateInternalResidual())
+        return err_code;
+
+      return evaluateExternalResidual();
+    }
+
+    virtual int evaluateInternalResidual() = 0;
+
+    virtual int evaluateExternalResidual() = 0;
+
   protected:
     /**
      * @brief Reset the Jacobian so it can be constructed. Helper method for \ref setJacValues().

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
@@ -140,7 +140,6 @@ namespace GridKit
   {
     ScalarT omega = wb_ - mp_ * y_[4];
     // ref common ref motor angle
-    /// @todo fix boolian conditional, unclear result
     if (refframe_)
     {
       f_[0] = omega - y_[0];

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
@@ -89,26 +89,9 @@ namespace GridKit
    *
    */
   template <class ScalarT, typename IdxT>
-  int DistributedGenerator<ScalarT, IdxT>::evaluateResidual()
+  int DistributedGenerator<ScalarT, IdxT>::evaluateInternalResidual()
   {
-    //   ### Externals Componenets ###
-
     ScalarT omega = wb_ - mp_ * y_[4];
-    // ref common ref motor angle
-    /// @todo fix boolian conditional, unclear result
-    if (refframe_)
-    {
-      f_[0] = omega - y_[0];
-    }
-    else
-    {
-      f_[0] = 0.0;
-    }
-
-    // output
-    // current transformed to common frame
-    f_[1] = std::cos(y_[3]) * y_[14] - std::sin(y_[3]) * y_[15];
-    f_[2] = std::sin(y_[3]) * y_[14] + std::cos(y_[3]) * y_[15];
 
     // Take incoming voltages to current rotator reference frame
     ScalarT vbd_in = std::cos(y_[3]) * y_[1] + std::sin(y_[3]) * y_[2];
@@ -149,6 +132,28 @@ namespace GridKit
     // Output Connector
     f_[14] = -yp_[14] - (rLc_ / Lc_) * y_[14] + omega * y_[15] + (y_[12] - vbd_in) / Lc_;
     f_[15] = -yp_[15] - (rLc_ / Lc_) * y_[15] - omega * y_[14] + (y_[13] - vbq_in) / Lc_;
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int DistributedGenerator<ScalarT, IdxT>::evaluateExternalResidual()
+  {
+    ScalarT omega = wb_ - mp_ * y_[4];
+    // ref common ref motor angle
+    /// @todo fix boolian conditional, unclear result
+    if (refframe_)
+    {
+      f_[0] = omega - y_[0];
+    }
+    else
+    {
+      f_[0] = 0.0;
+    }
+
+    // output
+    // current transformed to common frame
+    f_[1] = std::cos(y_[3]) * y_[14] - std::sin(y_[3]) * y_[15];
+    f_[2] = std::sin(y_[3]) * y_[14] + std::cos(y_[3]) * y_[15];
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
@@ -74,7 +74,8 @@ namespace GridKit
     int initialize();
     int allocate() final;
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
     int initializeAdjoint();

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
@@ -68,19 +68,24 @@ namespace GridKit
    *
    */
   template <class ScalarT, typename IdxT>
-  int InductionMotor<ScalarT, IdxT>::evaluateResidual()
+  int InductionMotor<ScalarT, IdxT>::evaluateInternalResidual()
   {
-
-    f_[0] = y_[5] + y_[7];
-    f_[1] = (-1.0 / 2.0) * y_[5] - (std::sqrt(3.0) / 2.0) * y_[6] + y_[7];
-    f_[2] = (-1.0 / 2.0) * y_[5] + (std::sqrt(3.0) / 2.0) * y_[6] + y_[7];
-    f_[3] = RJ_ * yp_[3] - (3.0 / 4.0) * P_ * Lms_ * (y_[5] * y_[9] - y_[6] * y_[8]);
-    f_[4] = yp_[4] - y_[3];
     f_[5] = (1.0 / 3.0) * (2.0 * y_[0] - y_[1] - y_[2]) - Rs_ * y_[5] - (Lls_ + Lms_) * yp_[5] - Lms_ * yp_[6];
     f_[6] = (1.0 / std::sqrt(3.0)) * (-y_[1] + y_[2]) - Rs_ * y_[6] - (Lls_ + Lms_) * yp_[6] - Lms_ * yp_[5];
     f_[7] = (y_[0] + y_[1] + y_[2]) / 3.0 - Rs_ * y_[7] - Lls_ * yp_[7];
     f_[8] = Rr_ * y_[8] + (Llr_ + Lms_) * yp_[8] + Lms_ * yp_[5] - (P_ / 2.0) * y_[3] * ((Llr_ + Lms_) * y_[9] + Lms_ * y_[6]);
     f_[9] = Rr_ * y_[9] + (Llr_ + Lms_) * yp_[9] + Lms_ * yp_[6] + (P_ / 2.0) * y_[3] * ((Llr_ + Lms_) * y_[8] + Lms_ * y_[5]);
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int InductionMotor<ScalarT, IdxT>::evaluateExternalResidual()
+  {
+    f_[0] = y_[5] + y_[7];
+    f_[1] = (-1.0 / 2.0) * y_[5] - (std::sqrt(3.0) / 2.0) * y_[6] + y_[7];
+    f_[2] = (-1.0 / 2.0) * y_[5] + (std::sqrt(3.0) / 2.0) * y_[6] + y_[7];
+    f_[3] = RJ_ * yp_[3] - (3.0 / 4.0) * P_ * Lms_ * (y_[5] * y_[9] - y_[6] * y_[8]);
+    f_[4] = yp_[4] - y_[3];
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
@@ -47,7 +47,8 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
@@ -56,14 +56,19 @@ namespace GridKit
    *
    */
   template <class ScalarT, typename IdxT>
-  int Inductor<ScalarT, IdxT>::evaluateResidual()
+  int Inductor<ScalarT, IdxT>::evaluateInternalResidual()
+  {
+    f_[2] = -L_ * yp_[2] + y_[1] - y_[0];
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int Inductor<ScalarT, IdxT>::evaluateExternalResidual()
   {
     // input
     f_[0] = -y_[2];
     // output
     f_[1] = y_[2];
-    // internal
-    f_[2] = -L_ * yp_[2] + y_[1] - y_[0];
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.hpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.hpp
@@ -50,7 +50,8 @@ namespace GridKit
     int initialize();
     int allocate() final;
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
@@ -67,15 +67,12 @@ namespace GridKit
 
   /**
    * @brief Computes the component resisdual
-   * @todo Check if there is a bug here
    */
   template <class ScalarT, typename IdxT>
   int LinearTransformer<ScalarT, IdxT>::evaluateInternalResidual()
   {
-    // HMMMMM... This looks like a bug
-    // TODO
     f_[2] = y_[0] - R0_ * y_[2] - L0_ * yp_[2] - M_ * yp_[3];
-    f_[2] = y_[1] - R1_ * y_[3] - M_ * yp_[2] - L1_ * yp_[3];
+    f_[3] = y_[1] - R1_ * y_[3] - M_ * yp_[2] - L1_ * yp_[3];
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
@@ -67,15 +67,23 @@ namespace GridKit
 
   /**
    * @brief Computes the component resisdual
-   *
+   * @todo Check if there is a bug here
    */
   template <class ScalarT, typename IdxT>
-  int LinearTransformer<ScalarT, IdxT>::evaluateResidual()
+  int LinearTransformer<ScalarT, IdxT>::evaluateInternalResidual()
+  {
+    // HMMMMM... This looks like a bug
+    // TODO
+    f_[2] = y_[0] - R0_ * y_[2] - L0_ * yp_[2] - M_ * yp_[3];
+    f_[2] = y_[1] - R1_ * y_[3] - M_ * yp_[2] - L1_ * yp_[3];
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int LinearTransformer<ScalarT, IdxT>::evaluateExternalResidual()
   {
     f_[0] = y_[2];
     f_[1] = y_[3];
-    f_[2] = y_[0] - R0_ * y_[2] - L0_ * yp_[2] - M_ * yp_[3];
-    f_[2] = y_[1] - R1_ * y_[3] - M_ * yp_[2] - L1_ * yp_[3];
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
@@ -47,7 +47,8 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
@@ -56,8 +56,14 @@ namespace GridKit
     return 0;
   }
 
+  template <class ScalarT, typename IdxT>
+  int MicrogridBusDQ<ScalarT, IdxT>::evaluateInternalResidual()
+  {
+    return 0;
+  }
+
   /**
-   * @brief Evaluate residual of microgrid line
+   * @brief Evaluate residual
    * This model has "Virtual resistors". The voltage of the bus divided by its virtual resistance.
    * The components are external to allow for outside components to add inductances to the terms.
    *
@@ -65,7 +71,7 @@ namespace GridKit
    *
    */
   template <class ScalarT, typename IdxT>
-  int MicrogridBusDQ<ScalarT, IdxT>::evaluateResidual()
+  int MicrogridBusDQ<ScalarT, IdxT>::evaluateExternalResidual()
   {
     // bus voltage
     f_[0] = -y_[0] / RN_;

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
@@ -50,7 +50,8 @@ namespace GridKit
     int initialize();
     int allocate() final;
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
@@ -70,7 +70,16 @@ namespace GridKit
    *
    */
   template <class ScalarT, typename IdxT>
-  int MicrogridLine<ScalarT, IdxT>::evaluateResidual()
+  int MicrogridLine<ScalarT, IdxT>::evaluateInternalResidual()
+  {
+    f_[5] = -yp_[5] - (R_ / L_) * y_[5] + y_[0] * y_[6] + (y_[1] - y_[3]) / L_;
+    f_[6] = -yp_[6] - (R_ / L_) * y_[6] - y_[0] * y_[5] + (y_[2] - y_[4]) / L_;
+
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int MicrogridLine<ScalarT, IdxT>::evaluateExternalResidual()
   {
     // ref motor
     f_[0] = 0.0;
@@ -82,10 +91,6 @@ namespace GridKit
     // output
     f_[3] = y_[5];
     f_[4] = y_[6];
-
-    // Internal variables
-    f_[5] = -yp_[5] - (R_ / L_) * y_[5] + y_[0] * y_[6] + (y_[1] - y_[3]) / L_;
-    f_[6] = -yp_[6] - (R_ / L_) * y_[6] - y_[0] * y_[5] + (y_[2] - y_[4]) / L_;
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
@@ -84,11 +84,11 @@ namespace GridKit
     // ref motor
     f_[0] = 0.0;
 
-    // input
+    // Port 1
     f_[1] = -y_[5];
     f_[2] = -y_[6];
 
-    // output
+    // Port 2
     f_[3] = y_[5];
     f_[4] = y_[6];
 

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
@@ -50,7 +50,8 @@ namespace GridKit
     int initialize();
     int allocate() final;
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
@@ -65,7 +65,16 @@ namespace GridKit
    * @brief Eval Micro Load
    */
   template <class ScalarT, typename IdxT>
-  int MicrogridLoad<ScalarT, IdxT>::evaluateResidual()
+  int MicrogridLoad<ScalarT, IdxT>::evaluateInternalResidual()
+  {
+    f_[3] = -yp_[3] - (R_ / L_) * y_[3] + y_[0] * y_[4] + y_[1] / L_;
+    f_[4] = -yp_[4] - (R_ / L_) * y_[4] - y_[0] * y_[3] + y_[2] / L_;
+
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int MicrogridLoad<ScalarT, IdxT>::evaluateExternalResidual()
   {
     // ref motor
     f_[0] = 0.0;
@@ -75,10 +84,6 @@ namespace GridKit
     // input
     f_[1] = -y_[3];
     f_[2] = -y_[4];
-
-    // Internal variables
-    f_[3] = -yp_[3] - (R_ / L_) * y_[3] + y_[0] * y_[4] + y_[1] / L_;
-    f_[4] = -yp_[4] - (R_ / L_) * y_[4] - y_[0] * y_[3] + y_[2] / L_;
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
@@ -50,7 +50,8 @@ namespace GridKit
     int initialize();
     int allocate() final;
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
@@ -57,7 +57,13 @@ namespace GridKit
    *
    */
   template <class ScalarT, typename IdxT>
-  int Resistor<ScalarT, IdxT>::evaluateResidual()
+  int Resistor<ScalarT, IdxT>::evaluateInternalResidual()
+  {
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int Resistor<ScalarT, IdxT>::evaluateExternalResidual()
   {
     // input
     f_[0] = (y_[0] - y_[1]) / R_;

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.hpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.hpp
@@ -50,7 +50,8 @@ namespace GridKit
     int initialize();
     int allocate() final;
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
@@ -87,11 +87,32 @@ namespace GridKit
    * @todo not finished
    */
   template <class ScalarT, typename IdxT>
-  int SynchronousMachine<ScalarT, IdxT>::evaluateResidual()
+  int SynchronousMachine<ScalarT, IdxT>::evaluateInternalResidual()
   {
     ScalarT                  rkq1  = static_cast<ScalarT>(std::get<0>(Rkq_));
     [[maybe_unused]] ScalarT rkq2  = static_cast<ScalarT>(std::get<1>(Rkq_));
     ScalarT                  llkq1 = static_cast<ScalarT>(std::get<0>(Llkq_));
+    [[maybe_unused]] ScalarT llkq2 = static_cast<ScalarT>(std::get<1>(Llkq_));
+
+    ScalarT cos1   = std::cos((P_ / 2.0) * y_[5]);
+    ScalarT sin1   = std::sin((P_ / 2.0) * y_[5]);
+    ScalarT cos23m = std::cos((P_ / 2.0) * y_[5] - (2.0 / 3.0) * M_PI);
+    ScalarT sin23m = std::sin((P_ / 2.0) * y_[5] - (2.0 / 3.0) * M_PI);
+    ScalarT cos23p = std::cos((P_ / 2.0) * y_[5] + (2.0 / 3.0) * M_PI);
+    ScalarT sin23p = std::sin((P_ / 2.0) * y_[5] + (2.0 / 3.0) * M_PI);
+
+    f_[5] = (-2.0 / 3.0) * (y_[0] * cos1 + y_[1] * cos23m + y_[2] * cos23p) + Rs_ * y_[6] + (Lls_ + Lmq_) * yp_[6] + Lmq_ * yp_[9] + Lmq_ * yp_[10] + y_[4] * (P_ / 2.0) * ((Lls_ + Lmd_) * y_[7] + Lmd_ * y_[11] + Lmd_ * y_[12]);
+    f_[6] = (-2.0 / 3.0) * (y_[0] * sin1 - y_[1] * sin23m - y_[2] * sin23p) + Rs_ * y_[7] + (Lls_ + Lmd_) * yp_[7] + Lmd_ * yp_[11] + Lmd_ * yp_[12] - y_[4] * (P_ / 2.0) * ((Lls_ + Lmq_) * y_[6] + Lmq_ * y_[9] + Lmq_ * y_[10]);
+    f_[7] = (-1.0 / 3.0) * (y_[0] + y_[1] + y_[2]) + Rs_ * y_[8] + Lls_ * yp_[8];
+    f_[8] = rkq1 * y_[9] + (llkq1 + Lmq_) * yp_[9] + Lmq_ * yp_[6] + Lmq_ * yp_[10];
+    f_[9] = rkq1 * y_[9] + (llkq1 + Lmq_) * yp_[9] + Lmq_ * yp_[6] + Lmq_ * yp_[10];
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int SynchronousMachine<ScalarT, IdxT>::evaluateExternalResidual()
+  {
+    [[maybe_unused]] ScalarT rkq2  = static_cast<ScalarT>(std::get<1>(Rkq_));
     [[maybe_unused]] ScalarT llkq2 = static_cast<ScalarT>(std::get<1>(Llkq_));
 
     ScalarT cos1   = std::cos((P_ / 2.0) * y_[5]);
@@ -106,11 +127,6 @@ namespace GridKit
     f_[2] = y_[6] * cos23p + y_[7] * sin23p + y_[8];
     f_[3] = RJ_ * yp_[4] - (3.0 / 4.0) * P_ * (Lmd_ * y_[6] * (y_[7] + y_[11] + y_[12]) - Lmq_ * y_[7] * (y_[6] + y_[9] + y_[0]));
     f_[4] = yp_[5] - y_[4];
-    f_[5] = (-2.0 / 3.0) * (y_[0] * cos1 + y_[1] * cos23m + y_[2] * cos23p) + Rs_ * y_[6] + (Lls_ + Lmq_) * yp_[6] + Lmq_ * yp_[9] + Lmq_ * yp_[10] + y_[4] * (P_ / 2.0) * ((Lls_ + Lmd_) * y_[7] + Lmd_ * y_[11] + Lmd_ * y_[12]);
-    f_[6] = (-2.0 / 3.0) * (y_[0] * sin1 - y_[1] * sin23m - y_[2] * sin23p) + Rs_ * y_[7] + (Lls_ + Lmd_) * yp_[7] + Lmd_ * yp_[11] + Lmd_ * yp_[12] - y_[4] * (P_ / 2.0) * ((Lls_ + Lmq_) * y_[6] + Lmq_ * y_[9] + Lmq_ * y_[10]);
-    f_[7] = (-1.0 / 3.0) * (y_[0] + y_[1] + y_[2]) + Rs_ * y_[8] + Lls_ * yp_[8];
-    f_[8] = rkq1 * y_[9] + (llkq1 + Lmq_) * yp_[9] + Lmq_ * yp_[6] + Lmq_ * yp_[10];
-    f_[9] = rkq1 * y_[9] + (llkq1 + Lmq_) * yp_[9] + Lmq_ * yp_[6] + Lmq_ * yp_[10];
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
@@ -49,7 +49,8 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -363,7 +363,7 @@ namespace GridKit
      *
      * @return int 0 if successful, positive if there's a recoverable error, negative if unrecoverable
      */
-    int evaluateResidual() final
+    int evaluateInternalResidual() final
     {
       for (IdxT i = 0; i < this->f_.size(); i++)
       {
@@ -374,10 +374,17 @@ namespace GridKit
 
       // Update system residual vector
 
+      // Evaluate component internal residuals - this is embarassingly parallel
+      for (component_type* component : components_)
+      {
+        if (int err_code = component->evaluateInternalResidual())
+          return err_code;
+      }
+
       for (const auto& component : components_)
       {
-        // TODO:check return type
-        component->evaluateResidual();
+        if (int err_code = component->evaluateExternalResidual())
+          return err_code;
 
         IdxT                        size     = component->size();
         const std::vector<ScalarT>& residual = component->getResidual();
@@ -391,9 +398,14 @@ namespace GridKit
         }
       }
 
-      // Uncomment to print the residual in matrix market format
-      // writeVectorToMatrixMarket(f_, "ScaleMicrogrid_Residual_N2_number" + std::to_string(jac_call_count_) + ".mtx", "Residual N2 number " + std::to_string(jac_call_count_));
+      return 0;
+    }
 
+    /**
+     * @todo implement this for nested systems
+     */
+    int evaluateExternalResidual() final
+    {
       return 0;
     }
 

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
@@ -82,21 +82,8 @@ namespace GridKit
    * To express this for Modified Nodal Analysis the Voltages of the admittance matrix are put into voltage drops
    */
   template <class ScalarT, typename IdxT>
-  int TransmissionLine<ScalarT, IdxT>::evaluateResidual()
+  int TransmissionLine<ScalarT, IdxT>::evaluateInternalResidual()
   {
-    // input
-    f_[0] = y_[8];
-    f_[1] = y_[9];
-
-    f_[2] = y_[10];
-    f_[3] = y_[11];
-    // ouput
-    f_[4] = -y_[8];
-    f_[5] = -y_[9];
-
-    f_[6] = -y_[10];
-    f_[7] = -y_[11];
-
     // Voltage drop accross terminals
     ScalarT V1re = y_[0] - y_[4];
     ScalarT V1im = y_[1] - y_[5];
@@ -111,6 +98,25 @@ namespace GridKit
     // row2
     f_[10] = YReMat_ * (V2re - V1re) - (YImMatOff_ * V1im + YImMatDi_ * V2im) - y_[10];
     f_[11] = YReMat_ * (V2im - V1im) + (YImMatOff_ * V1re + YImMatDi_ * V2re) - y_[11];
+
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int TransmissionLine<ScalarT, IdxT>::evaluateExternalResidual()
+  {
+    // input
+    f_[0] = y_[8];
+    f_[1] = y_[9];
+
+    f_[2] = y_[10];
+    f_[3] = y_[11];
+    // ouput
+    f_[4] = -y_[8];
+    f_[5] = -y_[9];
+
+    f_[6] = -y_[10];
+    f_[7] = -y_[11];
 
     return 0;
   }

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
@@ -51,7 +51,8 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
@@ -56,14 +56,20 @@ namespace GridKit
    * @brief Evaluate resisdual of component
    */
   template <class ScalarT, typename IdxT>
-  int VoltageSource<ScalarT, IdxT>::evaluateResidual()
+  int VoltageSource<ScalarT, IdxT>::evaluateInternalResidual()
+  {
+    // internal
+    f_[2] = y_[1] - y_[0] - V_;
+    return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  int VoltageSource<ScalarT, IdxT>::evaluateExternalResidual()
   {
     // input
     f_[0] = -y_[2];
     // ouput
     f_[1] = y_[2];
-    // internal
-    f_[2] = y_[1] - y_[0] - V_;
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
@@ -50,7 +50,8 @@ namespace GridKit
     int initialize();
     int allocate() final;
     int tagDifferentiable();
-    int evaluateResidual();
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
     int evaluateJacobian() final;
     int evaluateIntegrand();
 


### PR DESCRIPTION
## Description
 
Partially addresses #353. Separates the internal and external residual evaluations of all `PowerElectronics` models so that the internal residuals of all components can be easily evaluated in parallel.
 
 ## Proposed changes
 
Two new pure virtual functions have been added to `CircuitComponent`: `evaluateInternalResidual()` and `evaluateExternalResidual()`. There is now a final implementation for `CircuitComponent::evaluateResidual()` which just calls these two new functions.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
