### PR TITLE
Refactoring phasor dynamics constituent models

### DIFF
--- a/GridKit/Model/PhasorDynamics/BusBase.hpp
+++ b/GridKit/Model/PhasorDynamics/BusBase.hpp
@@ -7,7 +7,7 @@
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/Constants.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/BusData.hpp>
-#include <GridKit/Model/PhasorDynamics/ConstituentModel.hpp>
+#include <GridKit/Model/PhasorDynamics/GridElement.hpp>
 #include <GridKit/Model/VariableMonitor.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
@@ -22,11 +22,11 @@ namespace GridKit
      *
      */
     template <typename ScalarT, typename IdxT>
-    class BusBase : public ConstituentModel<ScalarT, IdxT>
+    class BusBase : public GridElement<ScalarT, IdxT>
     {
     public:
-      using RealT    = typename ConstituentModel<ScalarT, IdxT>::RealT;
-      using MatrixT  = typename ConstituentModel<ScalarT, IdxT>::MatrixT;
+      using RealT    = typename GridElement<ScalarT, IdxT>::RealT;
+      using MatrixT  = typename GridElement<ScalarT, IdxT>::MatrixT;
       using BusTypeT = typename BusData<RealT, IdxT>::BusType;
       using MonitorT = Model::VariableMonitor<BusBase, BusData>;
 

--- a/GridKit/Model/PhasorDynamics/BusBase.hpp
+++ b/GridKit/Model/PhasorDynamics/BusBase.hpp
@@ -6,8 +6,8 @@
 
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/Constants.hpp>
-#include <GridKit/Model/Evaluator.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/BusData.hpp>
+#include <GridKit/Model/PhasorDynamics/ConstituentModel.hpp>
 #include <GridKit/Model/VariableMonitor.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
@@ -22,11 +22,11 @@ namespace GridKit
      *
      */
     template <typename ScalarT, typename IdxT>
-    class BusBase : public Model::Evaluator<ScalarT, IdxT>
+    class BusBase : public ConstituentModel<ScalarT, IdxT>
     {
     public:
-      using RealT    = typename Model::Evaluator<ScalarT, IdxT>::RealT;
-      using MatrixT  = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
+      using RealT    = typename ConstituentModel<ScalarT, IdxT>::RealT;
+      using MatrixT  = typename ConstituentModel<ScalarT, IdxT>::MatrixT;
       using BusTypeT = typename BusData<RealT, IdxT>::BusType;
       using MonitorT = Model::VariableMonitor<BusBase, BusData>;
 
@@ -36,41 +36,25 @@ namespace GridKit
 
       virtual ~BusBase();
 
+      int verify() const override
+      {
+        return 0;
+      }
+
       /// Pure virtual function, returns bus type (DEFAULT or SLACK).
       virtual BusTypeT BusType() const
       {
         return BusTypeT::DEFAULT;
       }
 
-      virtual IdxT size() override
-      {
-        return size_;
-      }
-
-      virtual IdxT nnz() override
-      {
-        return nnz_;
-      }
-
-      virtual bool hasJacobian() override
+      bool hasJacobian() override
       {
         return false;
       }
 
-      virtual void updateTime(RealT /* t */, RealT /* a */) override
+      void updateTime(RealT /* t */, RealT /* a */) override
       {
         // No time to update in bus models
-      }
-
-      virtual void setTolerances(RealT& rtol, RealT& atol) const override
-      {
-        rtol = rtol_;
-        atol = atol_;
-      }
-
-      virtual void setMaxSteps(IdxT& msa) const override
-      {
-        msa = max_steps_;
       }
 
       virtual ScalarT&       Vr()       = 0;
@@ -82,46 +66,6 @@ namespace GridKit
       virtual ScalarT&       Ii()       = 0;
       virtual const ScalarT& Ii() const = 0;
 
-      std::vector<ScalarT>& y() override
-      {
-        return y_;
-      }
-
-      const std::vector<ScalarT>& y() const override
-      {
-        return y_;
-      }
-
-      std::vector<ScalarT>& yp() override
-      {
-        return yp_;
-      }
-
-      const std::vector<ScalarT>& yp() const override
-      {
-        return yp_;
-      }
-
-      std::vector<bool>& tag() override
-      {
-        return tag_;
-      }
-
-      const std::vector<bool>& tag() const override
-      {
-        return tag_;
-      }
-
-      MatrixT& getJacobian() override
-      {
-        return J_;
-      }
-
-      const MatrixT& getJacobian() const override
-      {
-        return J_;
-      }
-
       virtual int setBusID(IdxT) = 0;
 
       virtual const IdxT busID() const
@@ -129,226 +73,13 @@ namespace GridKit
         return bus_id_;
       }
 
-      int setVariableIndex(IdxT local_index, IdxT global_index)
-      {
-        variable_indices_[static_cast<size_t>(local_index)] = global_index;
-        return 0;
-      }
-
-      IdxT getVariableIndex(IdxT local_index) const
-      {
-        return variable_indices_[static_cast<size_t>(local_index)];
-      }
-
-      const std::vector<IdxT>& getVariableIndices() const
-      {
-        return variable_indices_;
-      }
-
-      int setResidualIndex(IdxT local_index, IdxT global_index)
-      {
-        residual_indices_[static_cast<size_t>(local_index)] = global_index;
-        return 0;
-      }
-
-      IdxT getResidualIndex(IdxT local_index) const
-      {
-        return residual_indices_[static_cast<size_t>(local_index)];
-      }
-
-      const std::vector<IdxT>& getResidualIndices() const
-      {
-        return residual_indices_;
-      }
-
       const Model::VariableMonitorBase* getMonitor() const override;
 
     protected:
       IdxT bus_id_{INVALID_INDEX<IdxT>};
 
-      IdxT              size_{0};
-      IdxT              nnz_{0};
-      std::vector<IdxT> variable_indices_; ///< Global (system-level) variable indices
-      std::vector<IdxT> residual_indices_; ///< Global (system-level) residual indices
-
       /// Variable monitor
       std::unique_ptr<MonitorT> monitor_;
-
-      std::vector<ScalarT> y_;
-      std::vector<ScalarT> yp_;
-      std::vector<bool>    tag_;
-      std::vector<ScalarT> f_;
-
-      MatrixT J_;
-      IdxT*   J_rows_buffer_{nullptr};
-      IdxT*   J_cols_buffer_{nullptr};
-      RealT*  J_vals_buffer_{nullptr};
-
-      RealT rtol_;
-      RealT atol_;
-
-      IdxT max_steps_;
-
-      //
-      // Adjoint sensitivity members
-      //
-
-      std::vector<ScalarT> g_{};
-      std::vector<ScalarT> yB_{};
-      std::vector<ScalarT> ypB_{};
-      std::vector<ScalarT> fB_{};
-      std::vector<ScalarT> gB_{};
-
-      std::vector<ScalarT> param_{};
-      std::vector<ScalarT> param_up_{};
-      std::vector<ScalarT> param_lo_{};
-
-      //
-      // Public adjoint sensitivity methods (not yet implemented in components)
-      //
-
-    public:
-      virtual IdxT sizeQuadrature() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 0;
-      }
-
-      virtual IdxT sizeParams() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 0;
-      }
-
-      std::vector<ScalarT>& yB() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return yB_;
-      }
-
-      const std::vector<ScalarT>& yB() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return yB_;
-      }
-
-      std::vector<ScalarT>& ypB() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return ypB_;
-      }
-
-      const std::vector<ScalarT>& ypB() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return ypB_;
-      }
-
-      std::vector<ScalarT>& param() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_;
-      }
-
-      const std::vector<ScalarT>& param() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_;
-      }
-
-      std::vector<ScalarT>& param_up() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_up_;
-      }
-
-      const std::vector<ScalarT>& param_up() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_up_;
-      }
-
-      std::vector<ScalarT>& param_lo() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_lo_;
-      }
-
-      const std::vector<ScalarT>& param_lo() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_lo_;
-      }
-
-      int evaluateIntegrand() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      int initializeAdjoint() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      int evaluateAdjointResidual() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      int evaluateAdjointIntegrand() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      std::vector<ScalarT>& getResidual() override
-      {
-        return f_;
-      }
-
-      const std::vector<ScalarT>& getResidual() const override
-      {
-        return f_;
-      }
-
-      std::vector<ScalarT>& getIntegrand() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return g_;
-      }
-
-      const std::vector<ScalarT>& getIntegrand() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return g_;
-      }
-
-      std::vector<ScalarT>& getAdjointResidual() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return fB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointResidual() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return fB_;
-      }
-
-      std::vector<ScalarT>& getAdjointIntegrand() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return gB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointIntegrand() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return gB_;
-      }
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/BusBaseImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/BusBaseImpl.hpp
@@ -26,15 +26,6 @@ namespace GridKit
     template <typename ScalarT, typename IdxT>
     BusBase<ScalarT, IdxT>::~BusBase()
     {
-      if (J_rows_buffer_ != nullptr)
-      {
-        delete[] J_rows_buffer_;
-        delete[] J_cols_buffer_;
-        delete[] J_vals_buffer_;
-        J_rows_buffer_ = nullptr;
-        J_cols_buffer_ = nullptr;
-        J_vals_buffer_ = nullptr;
-      }
     }
 
     template <typename ScalarT, typename IdxT>

--- a/GridKit/Model/PhasorDynamics/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/CMakeLists.txt
@@ -16,7 +16,7 @@ gridkit_add_library(phasor_dynamics_core
     ComponentData.hpp
     ComponentLibrary.hpp
     ComponentSignals.hpp
-    ConstituentModel.hpp
+    GridElement.hpp
     SystemModel.hpp
     SystemModelData.hpp
   LINK_LIBRARIES

--- a/GridKit/Model/PhasorDynamics/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/CMakeLists.txt
@@ -11,10 +11,12 @@ gridkit_add_library(phasor_dynamics_core
     SystemModelData.cpp
   HEADERS
     BusBase.hpp
+    BusBaseImpl.hpp
     Component.hpp
     ComponentData.hpp
     ComponentLibrary.hpp
     ComponentSignals.hpp
+    ConstituentModel.hpp
     SystemModel.hpp
     SystemModelData.hpp
   LINK_LIBRARIES

--- a/GridKit/Model/PhasorDynamics/Component.hpp
+++ b/GridKit/Model/PhasorDynamics/Component.hpp
@@ -4,7 +4,7 @@
 
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/CommonMath.hpp>
-#include <GridKit/Model/PhasorDynamics/ConstituentModel.hpp>
+#include <GridKit/Model/PhasorDynamics/GridElement.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
 namespace GridKit
@@ -17,11 +17,11 @@ namespace GridKit
      * @brief Component model implementation base class.
      */
     template <class ScalarT, typename IdxT>
-    class Component : public ConstituentModel<ScalarT, IdxT>
+    class Component : public GridElement<ScalarT, IdxT>
     {
     public:
-      using RealT   = typename ConstituentModel<ScalarT, IdxT>::RealT;
-      using MatrixT = typename ConstituentModel<ScalarT, IdxT>::MatrixT;
+      using RealT   = typename GridElement<ScalarT, IdxT>::RealT;
+      using MatrixT = typename GridElement<ScalarT, IdxT>::MatrixT;
 
       Component() = default;
 

--- a/GridKit/Model/PhasorDynamics/Component.hpp
+++ b/GridKit/Model/PhasorDynamics/Component.hpp
@@ -4,7 +4,7 @@
 
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/CommonMath.hpp>
-#include <GridKit/Model/Evaluator.hpp>
+#include <GridKit/Model/PhasorDynamics/ConstituentModel.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
 namespace GridKit
@@ -17,114 +17,28 @@ namespace GridKit
      * @brief Component model implementation base class.
      */
     template <class ScalarT, typename IdxT>
-    class Component : public Model::Evaluator<ScalarT, IdxT>
+    class Component : public ConstituentModel<ScalarT, IdxT>
     {
     public:
-      using RealT   = typename Model::Evaluator<ScalarT, IdxT>::RealT;
-      using MatrixT = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
+      using RealT   = typename ConstituentModel<ScalarT, IdxT>::RealT;
+      using MatrixT = typename ConstituentModel<ScalarT, IdxT>::MatrixT;
 
-      Component()
-        : size_(0)
-      {
-      }
+      Component() = default;
 
       virtual ~Component()
       {
-        if (J_rows_buffer_ != nullptr)
-        {
-          delete[] J_rows_buffer_;
-          delete[] J_cols_buffer_;
-          delete[] J_vals_buffer_;
-          J_rows_buffer_ = nullptr;
-          J_cols_buffer_ = nullptr;
-          J_vals_buffer_ = nullptr;
-        }
-      }
-
-      virtual int verify() const = 0;
-
-      virtual IdxT size() override
-      {
-        return size_;
-      }
-
-      virtual IdxT nnz() override
-      {
-        return nnz_;
       }
 
       /// @todo Remove this method. It should be part of DynamicSolver class.
-      virtual bool hasJacobian() override
+      bool hasJacobian() override
       {
         return true;
       }
 
-      virtual void updateTime(RealT t, RealT a) override
+      void updateTime(RealT t, RealT a) override
       {
         time_  = t;
         alpha_ = a;
-        // std::cout << "updateTime: t = " << time_ << ", alpha = " << alpha_ << "\n";
-      }
-
-      virtual void setTolerances(RealT& rtol, RealT& atol) const override
-      {
-        rtol = rel_tol_;
-        atol = abs_tol_;
-      }
-
-      virtual void setMaxSteps(IdxT& msa) const override
-      {
-        msa = max_steps_;
-      }
-
-      std::vector<ScalarT>& y() override
-      {
-        return y_;
-      }
-
-      const std::vector<ScalarT>& y() const override
-      {
-        return y_;
-      }
-
-      std::vector<ScalarT>& yp() override
-      {
-        return yp_;
-      }
-
-      const std::vector<ScalarT>& yp() const override
-      {
-        return yp_;
-      }
-
-      std::vector<bool>& tag() override
-      {
-        return tag_;
-      }
-
-      const std::vector<bool>& tag() const override
-      {
-        return tag_;
-      }
-
-      std::vector<ScalarT>& getResidual() override
-      {
-        return f_;
-      }
-
-      const std::vector<ScalarT>& getResidual() const override
-      {
-        return f_;
-      }
-
-      MatrixT& getJacobian() override
-      {
-        return J_;
-      }
-
-      const MatrixT& getJacobian() const override
-      {
-        return J_;
       }
 
       virtual int setGridKitComponentID(IdxT) = 0;
@@ -134,65 +48,14 @@ namespace GridKit
         return gridkit_component_id_;
       }
 
-      int setVariableIndex(IdxT local_index, IdxT global_index)
-      {
-        variable_indices_[static_cast<size_t>(local_index)] = global_index;
-        return 0;
-      }
-
-      IdxT& getVariableIndex(IdxT local_index)
-      {
-        return variable_indices_[static_cast<size_t>(local_index)];
-      }
-
-      const std::vector<IdxT>& getVariableIndices() const
-      {
-        return variable_indices_;
-      }
-
-      int setResidualIndex(IdxT local_index, IdxT global_index)
-      {
-        residual_indices_[static_cast<size_t>(local_index)] = global_index;
-        return 0;
-      }
-
-      IdxT& getResidualIndex(IdxT local_index)
-      {
-        return residual_indices_[static_cast<size_t>(local_index)];
-      }
-
-      const std::vector<IdxT>& getResidualIndices() const
-      {
-        return residual_indices_;
-      }
-
     protected:
-      IdxT              gridkit_component_id_{0};
-      IdxT              size_{0};
-      IdxT              nnz_{0};
-      std::vector<IdxT> variable_indices_; ///< Global (system-level) variable indices
-      std::vector<IdxT> residual_indices_; ///< Global (system-level) residual indices
+      IdxT gridkit_component_id_{0};
 
-      std::vector<ScalarT> y_;
-      std::vector<ScalarT> yp_;
-      std::vector<bool>    tag_;
-      std::vector<ScalarT> f_;
-      std::vector<ScalarT> g_;
       std::vector<ScalarT> wb_;
       std::vector<ScalarT> h_;
 
-      MatrixT J_;
-      IdxT*   J_rows_buffer_{nullptr};
-      IdxT*   J_cols_buffer_{nullptr};
-      RealT*  J_vals_buffer_{nullptr};
-
       RealT time_;
       RealT alpha_;
-
-      RealT rel_tol_;
-      RealT abs_tol_;
-
-      IdxT max_steps_;
 
       /*
 
@@ -205,156 +68,6 @@ namespace GridKit
       */
 
       RealT mva_system_base_{100.0};
-
-      //
-      // Adjoint sensitivity members
-      //
-
-      std::vector<ScalarT> yB_{};
-      std::vector<ScalarT> ypB_{};
-      std::vector<ScalarT> fB_{};
-      std::vector<ScalarT> gB_{};
-
-      std::vector<ScalarT> param_{};
-      std::vector<ScalarT> param_up_{};
-      std::vector<ScalarT> param_lo_{};
-
-      //
-      // Public adjoint sensitivity methods (not yet implemented in components)
-      //
-
-    public:
-      virtual IdxT sizeQuadrature() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 0;
-      }
-
-      virtual IdxT sizeParams() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 0;
-      }
-
-      std::vector<ScalarT>& yB() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return yB_;
-      }
-
-      const std::vector<ScalarT>& yB() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return yB_;
-      }
-
-      std::vector<ScalarT>& ypB() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return ypB_;
-      }
-
-      const std::vector<ScalarT>& ypB() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return ypB_;
-      }
-
-      std::vector<ScalarT>& param() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_;
-      }
-
-      const std::vector<ScalarT>& param() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_;
-      }
-
-      std::vector<ScalarT>& param_up() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_up_;
-      }
-
-      const std::vector<ScalarT>& param_up() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_up_;
-      }
-
-      std::vector<ScalarT>& param_lo() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_lo_;
-      }
-
-      const std::vector<ScalarT>& param_lo() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_lo_;
-      }
-
-      int evaluateIntegrand() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      int initializeAdjoint() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      int evaluateAdjointResidual() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      int evaluateAdjointIntegrand() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      std::vector<ScalarT>& getIntegrand() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return g_;
-      }
-
-      const std::vector<ScalarT>& getIntegrand() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return g_;
-      }
-
-      std::vector<ScalarT>& getAdjointResidual() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return fB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointResidual() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return fB_;
-      }
-
-      std::vector<ScalarT>& getAdjointIntegrand() override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return gB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointIntegrand() const override
-      {
-        throw "ERROR: Method not implemented!\n";
-        return gB_;
-      }
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/ConstituentModel.hpp
+++ b/GridKit/Model/PhasorDynamics/ConstituentModel.hpp
@@ -1,0 +1,302 @@
+#pragma once
+
+#include <vector>
+
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+#include <GridKit/CommonMath.hpp>
+#include <GridKit/Model/Evaluator.hpp>
+#include <GridKit/Utilities/Errors.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    using Log = ::GridKit::Utilities::Logger;
+
+    /**
+     * @brief Model base class for all system constituents
+     */
+    template <class ScalarT, typename IdxT>
+    class ConstituentModel : public Model::Evaluator<ScalarT, IdxT>
+    {
+    public:
+      using RealT   = typename Model::Evaluator<ScalarT, IdxT>::RealT;
+      using MatrixT = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
+
+      ConstituentModel()
+        : size_{0}
+      {
+      }
+
+      virtual ~ConstituentModel()
+      {
+        if (J_rows_buffer_ != nullptr)
+        {
+          delete[] J_rows_buffer_;
+          delete[] J_cols_buffer_;
+          delete[] J_vals_buffer_;
+          J_rows_buffer_ = nullptr;
+          J_cols_buffer_ = nullptr;
+          J_vals_buffer_ = nullptr;
+        }
+      }
+
+      virtual int verify() const = 0;
+
+      IdxT size() override final
+      {
+        return size_;
+      }
+
+      IdxT nnz() override final
+      {
+        return nnz_;
+      }
+
+      void setTolerances(RealT& rtol, RealT& atol) const override
+      {
+        rtol = rel_tol_;
+        atol = abs_tol_;
+      }
+
+      void setMaxSteps(IdxT& msa) const override
+      {
+        msa = max_steps_;
+      }
+
+      std::vector<ScalarT>& y() override
+      {
+        return y_;
+      }
+
+      const std::vector<ScalarT>& y() const override
+      {
+        return y_;
+      }
+
+      std::vector<ScalarT>& yp() override
+      {
+        return yp_;
+      }
+
+      const std::vector<ScalarT>& yp() const override
+      {
+        return yp_;
+      }
+
+      std::vector<bool>& tag() override
+      {
+        return tag_;
+      }
+
+      const std::vector<bool>& tag() const override
+      {
+        return tag_;
+      }
+
+      std::vector<ScalarT>& getResidual() override
+      {
+        return f_;
+      }
+
+      const std::vector<ScalarT>& getResidual() const override
+      {
+        return f_;
+      }
+
+      MatrixT& getJacobian() override
+      {
+        return J_;
+      }
+
+      const MatrixT& getJacobian() const override
+      {
+        return J_;
+      }
+
+      int setVariableIndex(IdxT local_index, IdxT global_index)
+      {
+        variable_indices_[static_cast<size_t>(local_index)] = global_index;
+        return 0;
+      }
+
+      IdxT& getVariableIndex(IdxT local_index)
+      {
+        return variable_indices_[static_cast<size_t>(local_index)];
+      }
+
+      const std::vector<IdxT>& getVariableIndices() const
+      {
+        return variable_indices_;
+      }
+
+      int setResidualIndex(IdxT local_index, IdxT global_index)
+      {
+        residual_indices_[static_cast<size_t>(local_index)] = global_index;
+        return 0;
+      }
+
+      IdxT& getResidualIndex(IdxT local_index)
+      {
+        return residual_indices_[static_cast<size_t>(local_index)];
+      }
+
+      const std::vector<IdxT>& getResidualIndices() const
+      {
+        return residual_indices_;
+      }
+
+    protected:
+      IdxT              size_{0};
+      IdxT              nnz_{0};
+      /// Global (system-level) variable indices
+      std::vector<IdxT> variable_indices_;
+      /// Global (system-level) residual indices
+      std::vector<IdxT> residual_indices_;
+
+      std::vector<ScalarT> y_;
+      std::vector<ScalarT> yp_;
+      std::vector<bool>    tag_;
+      std::vector<ScalarT> f_;
+      std::vector<ScalarT> g_;
+
+      MatrixT J_;
+      IdxT*   J_rows_buffer_{nullptr};
+      IdxT*   J_cols_buffer_{nullptr};
+      RealT*  J_vals_buffer_{nullptr};
+
+      RealT rel_tol_;
+      RealT abs_tol_;
+
+      IdxT max_steps_;
+
+      //
+      // Adjoint sensitivity members
+      //
+
+      std::vector<ScalarT> yB_{};
+      std::vector<ScalarT> ypB_{};
+      std::vector<ScalarT> fB_{};
+      std::vector<ScalarT> gB_{};
+
+      std::vector<ScalarT> param_{};
+      std::vector<ScalarT> param_up_{};
+      std::vector<ScalarT> param_lo_{};
+
+      using NotImplementedError = GridKit::Utilities::NotImplementedError;
+
+    public:
+      [[noreturn]] IdxT sizeQuadrature() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] IdxT sizeParams() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& yB() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& yB() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& ypB() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& ypB() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& param() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& param() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& param_up() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& param_up() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& param_lo() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& param_lo() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] int evaluateIntegrand() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] int initializeAdjoint() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] int evaluateAdjointResidual() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] int evaluateAdjointIntegrand() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& getIntegrand() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& getIntegrand() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& getAdjointResidual() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& getAdjointResidual() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& getAdjointIntegrand() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& getAdjointIntegrand() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+    };
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/GridElement.hpp
+++ b/GridKit/Model/PhasorDynamics/GridElement.hpp
@@ -18,18 +18,18 @@ namespace GridKit
      * @brief Model base class for all system constituents
      */
     template <class ScalarT, typename IdxT>
-    class ConstituentModel : public Model::Evaluator<ScalarT, IdxT>
+    class GridElement : public Model::Evaluator<ScalarT, IdxT>
     {
     public:
       using RealT   = typename Model::Evaluator<ScalarT, IdxT>::RealT;
       using MatrixT = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
 
-      ConstituentModel()
+      GridElement()
         : size_{0}
       {
       }
 
-      virtual ~ConstituentModel()
+      virtual ~GridElement()
       {
         if (J_rows_buffer_ != nullptr)
         {
@@ -187,6 +187,8 @@ namespace GridKit
       using NotImplementedError = GridKit::Utilities::NotImplementedError;
 
     public:
+      // TODO: evaluate how this complies with xSDK guidelines
+
       [[noreturn]] IdxT sizeQuadrature() override
       {
         throw NotImplementedError(__func__);

--- a/GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <vector>
-
-#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
-#include <GridKit/Model/Evaluator.hpp>
+#include <GridKit/Constants.hpp>
+#include <GridKit/ScalarTraits.hpp>
 
 namespace GridKit
 {
@@ -23,22 +21,15 @@ namespace GridKit
      *
      */
     template <class ScalarT, typename IdxT>
-    class SignalNode : public Model::Evaluator<ScalarT, IdxT>
+    class SignalNode
     {
     public:
-      using RealT   = typename Model::Evaluator<ScalarT, IdxT>::RealT;
-      using MatrixT = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
+      using RealT = typename GridKit::ScalarTraits<ScalarT>::RealT;
 
       SignalNode();
       SignalNode(const SignalNodeData<RealT, IdxT>& data);
 
       virtual ~SignalNode() = default;
-
-      virtual int allocate() override final;
-      virtual int initialize() override final;
-      virtual int tagDifferentiable() override final;
-      virtual int evaluateResidual() override final;
-      virtual int evaluateJacobian() override final;
 
       void    set(ScalarT* signal_in, IdxT* global_index);
       bool    linked() const;
@@ -50,80 +41,14 @@ namespace GridKit
         return signal_id_;
       }
 
-      virtual IdxT size() override final
-      {
-        return size_;
-      }
-
-      virtual IdxT nnz() override final
-      {
-        return nnz_;
-      }
-
-      virtual bool hasJacobian() override final
-      {
-        return false;
-      }
-
-      virtual void updateTime(RealT /* t */, RealT /* a */) override final
-      {
-        // No time to update in signal nodes
-      }
-
-      virtual void setTolerances(RealT& rtol, RealT& atol) const override final
-      {
-        rtol = rtol_;
-        atol = atol_;
-      }
-
-      virtual void setMaxSteps(IdxT& msa) const override final
-      {
-        msa = max_steps_;
-      }
-
-      std::vector<ScalarT>& y() override final
-      {
-        return y_;
-      }
-
-      const std::vector<ScalarT>& y() const override final
-      {
-        return y_;
-      }
-
-      std::vector<ScalarT>& yp() override final
-      {
-        return yp_;
-      }
-
-      const std::vector<ScalarT>& yp() const override final
-      {
-        return yp_;
-      }
-
-      std::vector<bool>& tag() override final
-      {
-        return tag_;
-      }
-
-      const std::vector<bool>& tag() const override final
-      {
-        return tag_;
-      }
-
-      MatrixT& getJacobian() override final
-      {
-        return J_;
-      }
-
-      const MatrixT& getJacobian() const override final
-      {
-        return J_;
-      }
-
       IdxT getVariableIndex() const
       {
         return *variable_index_;
+      }
+
+      virtual const IdxT busID() const
+      {
+        return bus_id_;
       }
 
     private:
@@ -133,187 +58,7 @@ namespace GridKit
     protected:
       const IdxT bus_id_{INVALID_INDEX<IdxT>};
 
-      IdxT  size_{0};
-      IdxT  nnz_{0};
       IdxT* variable_index_{nullptr};
-
-      std::vector<ScalarT> y_;
-      std::vector<ScalarT> yp_;
-      std::vector<bool>    tag_;
-      std::vector<ScalarT> f_;
-
-      MatrixT J_;
-
-      RealT rtol_;
-      RealT atol_;
-
-      IdxT max_steps_;
-
-      //
-      // Adjoint sensitivity members
-      //
-
-      std::vector<ScalarT> g_{};
-      std::vector<ScalarT> yB_{};
-      std::vector<ScalarT> ypB_{};
-      std::vector<ScalarT> fB_{};
-      std::vector<ScalarT> gB_{};
-
-      std::vector<ScalarT> param_{};
-      std::vector<ScalarT> param_up_{};
-      std::vector<ScalarT> param_lo_{};
-
-      //
-      // Public adjoint sensitivity methods (not yet implemented in components)
-      //
-
-    public:
-      virtual IdxT sizeQuadrature() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 0;
-      }
-
-      virtual IdxT sizeParams() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 0;
-      }
-
-      std::vector<ScalarT>& yB() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return yB_;
-      }
-
-      const std::vector<ScalarT>& yB() const override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return yB_;
-      }
-
-      std::vector<ScalarT>& ypB() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return ypB_;
-      }
-
-      const std::vector<ScalarT>& ypB() const override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return ypB_;
-      }
-
-      std::vector<ScalarT>& param() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_;
-      }
-
-      const std::vector<ScalarT>& param() const override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_;
-      }
-
-      std::vector<ScalarT>& param_up() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_up_;
-      }
-
-      const std::vector<ScalarT>& param_up() const override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_up_;
-      }
-
-      std::vector<ScalarT>& param_lo() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_lo_;
-      }
-
-      const std::vector<ScalarT>& param_lo() const override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return param_lo_;
-      }
-
-      int evaluateIntegrand() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      int initializeAdjoint() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      int evaluateAdjointResidual() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      int evaluateAdjointIntegrand() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return 1;
-      }
-
-      std::vector<ScalarT>& getResidual() override final
-      {
-        return f_;
-      }
-
-      const std::vector<ScalarT>& getResidual() const override final
-      {
-        return f_;
-      }
-
-      std::vector<ScalarT>& getIntegrand() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return g_;
-      }
-
-      const std::vector<ScalarT>& getIntegrand() const override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return g_;
-      }
-
-      std::vector<ScalarT>& getAdjointResidual() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return fB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointResidual() const override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return fB_;
-      }
-
-      std::vector<ScalarT>& getAdjointIntegrand() override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return gB_;
-      }
-
-      const std::vector<ScalarT>& getAdjointIntegrand() const override final
-      {
-        throw "ERROR: Method not implemented!\n";
-        return gB_;
-      }
-
-      virtual const IdxT busID() const
-      {
-        return bus_id_;
-      }
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeDependencyTracking.cpp
@@ -1,6 +1,8 @@
 /**
  * @file SignalNode model implementation.
  */
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+
 #include "SignalNodeImpl.hpp"
 
 namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
@@ -10,45 +10,13 @@ namespace GridKit
   {
     template <class ScalarT, typename IdxT>
     SignalNode<ScalarT, IdxT>::SignalNode()
-      : size_(0)
     {
     }
 
     template <class ScalarT, typename IdxT>
     SignalNode<ScalarT, IdxT>::SignalNode(const SignalNodeData<RealT, IdxT>& data)
-      : signal_id_(data.signal_id),
-        size_(0)
+      : signal_id_(data.signal_id)
     {
-    }
-
-    template <class ScalarT, typename IdxT>
-    int SignalNode<ScalarT, IdxT>::allocate()
-    {
-      return 0;
-    }
-
-    template <class ScalarT, typename IdxT>
-    int SignalNode<ScalarT, IdxT>::initialize()
-    {
-      return 0;
-    }
-
-    template <class ScalarT, typename IdxT>
-    int SignalNode<ScalarT, IdxT>::tagDifferentiable()
-    {
-      return 0;
-    }
-
-    template <class ScalarT, typename IdxT>
-    int SignalNode<ScalarT, IdxT>::evaluateResidual()
-    {
-      return 0;
-    }
-
-    template <class ScalarT, typename IdxT>
-    int SignalNode<ScalarT, IdxT>::evaluateJacobian()
-    {
-      return 0;
     }
 
     template <class ScalarT, typename IdxT>

--- a/GridKit/Utilities/CMakeLists.txt
+++ b/GridKit/Utilities/CMakeLists.txt
@@ -12,6 +12,7 @@ install(TARGETS Utilities EXPORT gridkit-targets)
 install(
   FILES
     Colors.hpp
+    Errors.hpp
     FileIO.hpp
     MapFromCOO.hpp
   DESTINATION

--- a/GridKit/Utilities/Errors.hpp
+++ b/GridKit/Utilities/Errors.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace GridKit
+{
+  namespace Utilities
+  {
+    class NotImplementedError : public std::runtime_error
+    {
+    public:
+      NotImplementedError(const std::string& funcname)
+        : std::runtime_error("ERROR: Function not implemented: " + funcname)
+      {
+      }
+    };
+  } // namespace Utilities
+} // namespace GridKit


### PR DESCRIPTION
## Description
 
This PR removes some duplicate code and makes a small improvement to 
 
 ## Proposed changes

- Add `GridElement` as common base for components and buses.
- Remove `SignalNode` from evaluator tree (since it doesn't do anything related)
 
 ## Checklist

- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [ ] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.