### PR TITLE
Event Cues + Branch Trips for more Diverse Simulations

### DIFF
--- a/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
@@ -106,6 +106,16 @@ namespace GridKit
         setDerivedParams();
       }
 
+      /// True when the branch is in service (closed). The underlying
+      /// `status_` is a smooth multiplier (1.0 closed / 0.0 open) so that
+      /// `evaluateBusResidualNN` kernels see a constant expression structure
+      bool status() const
+      {
+        return status_ > RealT{0.5};
+      }
+
+      void apply(Action action) override final;
+
       const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
@@ -166,6 +176,7 @@ namespace GridKit
       RealT     X_{0.0};
       RealT     G_{0.0};
       RealT     B_{0.0};
+      RealT     status_{1.0}; ///< Multiplier on residual contributions: 1.0 = closed, 0.0 = open
       IdxT      bus1_id_{0};
       IdxT      bus2_id_{0};
 

--- a/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
@@ -15,10 +15,11 @@ namespace GridKit
     /// Initial parameters for a branch
     enum class BranchParameters
     {
-      R, ///< Line series resistance
-      X, ///< Line series reactance
-      G, ///< Line shunt conductance
-      B, ///< Line shunt charging
+      R,      ///< Line series resistance
+      X,      ///< Line series reactance
+      G,      ///< Line shunt conductance
+      B,      ///< Line shunt charging
+      state0, ///< Initial branch status (true = closed/in-service, default true)
     };
 
     /// Ports for a branch

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -97,6 +97,20 @@ namespace GridKit
       // std::cout << "Destroy Branch..." << std::endl;
     }
 
+    template <class ScalarT, typename IdxT>
+    void Branch<ScalarT, IdxT>::apply(Action action)
+    {
+      switch (action)
+      {
+      case Action::On:
+        status_ = RealT{1.0};
+        break;
+      case Action::Off:
+        status_ = RealT{0.0};
+        break;
+      }
+    }
+
     /**
      * @brief Set the component ID
      */
@@ -155,8 +169,8 @@ namespace GridKit
       ScalarT Vi1 = wb[1];
       ScalarT Ir1 = -(g_ + 0.5 * G_) * Vr1 + (b_ + 0.5 * B_) * Vi1;
       ScalarT Ii1 = -(b_ + 0.5 * B_) * Vr1 - (g_ + 0.5 * G_) * Vi1;
-      h[0]        = Ir1;
-      h[1]        = Ii1;
+      h[0]        = status_ * Ir1;
+      h[1]        = status_ * Ii1;
 
       return 0;
     }
@@ -176,8 +190,8 @@ namespace GridKit
       ScalarT Vi2 = wb[1];
       ScalarT Ir1 = g_ * Vr2 - b_ * Vi2;
       ScalarT Ii1 = b_ * Vr2 + g_ * Vi2;
-      h[0]        = Ir1;
-      h[1]        = Ii1;
+      h[0]        = status_ * Ir1;
+      h[1]        = status_ * Ii1;
 
       return 0;
     }
@@ -197,8 +211,8 @@ namespace GridKit
       ScalarT Vi1 = wb[1];
       ScalarT Ir2 = g_ * Vr1 - b_ * Vi1;
       ScalarT Ii2 = b_ * Vr1 + g_ * Vi1;
-      h[0]        = Ir2;
-      h[1]        = Ii2;
+      h[0]        = status_ * Ir2;
+      h[1]        = status_ * Ii2;
 
       return 0;
     }
@@ -218,8 +232,8 @@ namespace GridKit
       ScalarT Vi2 = wb[1];
       ScalarT Ir2 = -(g_ + 0.5 * G_) * Vr2 + (b_ + 0.5 * B_) * Vi2;
       ScalarT Ii2 = -(b_ + 0.5 * B_) * Vr2 - (g_ + 0.5 * G_) * Vi2;
-      h[0]        = Ir2;
-      h[1]        = Ii2;
+      h[0]        = status_ * Ir2;
+      h[1]        = status_ * Ii2;
 
       return 0;
     }
@@ -273,6 +287,13 @@ namespace GridKit
       if (data.parameters.contains(model_data_type::Parameters::B))
       {
         B_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::B));
+      }
+
+      if (data.parameters.contains(model_data_type::Parameters::state0))
+      {
+        status_ = std::get<bool>(data.parameters.at(model_data_type::Parameters::state0))
+                      ? RealT{1.0}
+                      : RealT{0.0};
       }
 
       if (data.ports.contains(model_data_type::Ports::bus1))

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -64,6 +64,8 @@ namespace GridKit
       {
       }
 
+      void apply(Action action) override final;
+
     public:
       void setR(RealT R)
       {
@@ -75,11 +77,6 @@ namespace GridKit
       {
         X_ = X;
         setDerivedParams();
-      }
-
-      void setStatus(bool status)
-      {
-        status_ = status;
       }
 
       const Model::VariableMonitorBase* getMonitor() const override;

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
@@ -184,6 +184,20 @@ namespace GridKit
       return monitor_.get();
     }
 
+    template <class ScalarT, typename IdxT>
+    void BusFault<ScalarT, IdxT>::apply(Action action)
+    {
+      switch (action)
+      {
+      case Action::On:
+        status_ = true;
+        break;
+      case Action::Off:
+        status_ = false;
+        break;
+      }
+    }
+
     /**
      * @brief Derived parameters
      *

--- a/GridKit/Model/PhasorDynamics/Component.hpp
+++ b/GridKit/Model/PhasorDynamics/Component.hpp
@@ -15,10 +15,9 @@ namespace GridKit
   {
     using Log = ::GridKit::Utilities::Logger;
 
-    /// Project-wide control actions. Today only BusFault uses cues, so this
-    /// vocabulary is small. When a second action-bearing component arrives,
-    /// either add its actions here (if they read naturally as shared verbs)
-    /// or switch to per-component action enums + typed dispatch.
+    /// Project-wide control actions shared by cue-targetable components such
+    /// as BusFault and Branch. If future runtime controls stop fitting these
+    /// verbs naturally, switch to per-component action enums + typed dispatch.
     enum class Action
     {
       On,

--- a/GridKit/Model/PhasorDynamics/Component.hpp
+++ b/GridKit/Model/PhasorDynamics/Component.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
@@ -12,6 +14,16 @@ namespace GridKit
   namespace PhasorDynamics
   {
     using Log = ::GridKit::Utilities::Logger;
+
+    /// Project-wide control actions. Today only BusFault uses cues, so this
+    /// vocabulary is small. When a second action-bearing component arrives,
+    /// either add its actions here (if they read naturally as shared verbs)
+    /// or switch to per-component action enums + typed dispatch.
+    enum class Action
+    {
+      On,
+      Off,
+    };
 
     /**
      * @brief Component model implementation base class.
@@ -42,6 +54,15 @@ namespace GridKit
       }
 
       virtual int verify() const = 0;
+
+      /// Cue dispatch. Called by PDSim only at IDA re-init points; never
+      /// during integration. Default throws — Components without a runtime
+      /// control surface inherit the default and ignore cues.
+      /// SystemModel's routing layer wraps the throw with the target id.
+      virtual void apply(Action)
+      {
+        throw std::runtime_error("Component does not accept cues");
+      }
 
       virtual IdxT size() override
       {

--- a/GridKit/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/GridKit/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -141,7 +141,7 @@ are specified:
 
   Device class  | Description                                          | Ports                            | Initialization parameters   | Variables available to monitor
   --------------|------------------------------------------------------|----------------------------------|---------------------------- | -------------------------
-  `Branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`           | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
+  `Branch`      | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`, `state0` | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
   `Load`        | a basic static impedence load model                  | `bus`                            | `R`, `X` | `p`, `q`
   `Genrou`      | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Tqop`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12`, `mva_base`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`, `speed`
   `GenClassical`| the classical machine model                          | `bus`, `pmech`\*, `speed`\*, `efd`\*  | `p0`, `q0`, `H`, `D`, `Ra`, `Xdp`, `mva_base` | `ir`, `ii`, `p`, `q`, `delta`, `omega`

--- a/GridKit/Model/PhasorDynamics/SystemModel.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModel.hpp
@@ -125,7 +125,7 @@ namespace GridKit
           }
 
           auto* branch = new Branch<ScalarT, IdxT>(getBus(bus1_index), getBus(bus2_index), branchdata);
-          addComponent(branch);
+          addComponent(branch, branchdata.disambiguation_string);
         }
 
         // Add loads

--- a/GridKit/Model/PhasorDynamics/SystemModel.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModel.hpp
@@ -2,6 +2,10 @@
 
 #include <cassert>
 #include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <GridKit/Definitions.hpp>
@@ -308,7 +312,7 @@ namespace GridKit
             bus_index = faultdata.ports.at(BusFaultData<ScalarT, IdxT>::Ports::bus);
           }
           auto* fault = new BusFault<ScalarT, IdxT>(getBus(bus_index), faultdata);
-          addFault(fault);
+          addComponent(fault, faultdata.disambiguation_string);
         }
 
         for (const auto& sink : data.monitor_sink)
@@ -905,11 +909,8 @@ namespace GridKit
       /**
        * @brief Add component
        *
-       * Add component at the end of the components array and set GridKit's component ID
-       *
-       * @todo: No integer user-facing component_id for now, but we could map GridKit's
-       * component ID to the disambiguation_string
-       *
+       * Add component at the end of the components array and set GridKit's component ID.
+       * This overload does not register the component for cue routing.
        */
       void addComponent(component_type* component)
       {
@@ -919,18 +920,17 @@ namespace GridKit
       }
 
       /**
-       * @brief Add fault
+       * @brief Add component and register it as a cue target under `id`.
        *
-       * The fault is added to the components array, and we keep a map to its
-       * location, so it can easily be accessed.
-       *
+       * The id originates from the case JSON (`"id"` field, parsed into
+       * `data.disambiguation_string`). It is stored only here, in the system's
+       * routing map — the component itself does not carry it.
        */
-      void addFault(component_type* component)
+      void addComponent(component_type* component, const std::string& id)
       {
-        IdxT gridkit_component_id                = static_cast<IdxT>(components_.size());
-        IdxT gridkit_fault_id                    = static_cast<IdxT>(gridkit_fault_indices_.size());
-        gridkit_fault_indices_[gridkit_fault_id] = gridkit_component_id;
         addComponent(component);
+        if (!id.empty())
+          by_id_[id] = component;
       }
 
       /**
@@ -967,27 +967,20 @@ namespace GridKit
         return components_[gridkit_component_id];
       }
 
-      /**
-       * @brief Return pointer to a bus fault model
-       *
-       * This function is used to provide easier access to setting and
-       * clearing faults from the SystemModel interface.
-       *
-       */
-      BusFault<ScalarT, IdxT>* getBusFault(IdxT fault_id)
+      /// Route a cue to the component registered under `target`.
+      void cue(const std::string& target, Action action)
       {
-        IdxT component_id = gridkit_fault_indices_.at(fault_id);
-        return dynamic_cast<BusFault<ScalarT, IdxT>*>(components_[component_id]);
+        by_id_.at(target)->apply(action);
       }
 
     private:
-      std::vector<bus_type*>       buses_;
-      std::vector<signal_type*>    signals_;
-      std::vector<component_type*> components_;
+      std::vector<bus_type*>                           buses_;
+      std::vector<signal_type*>                        signals_;
+      std::vector<component_type*>                     components_;
+      std::unordered_map<std::string, component_type*> by_id_; ///< Routing map for cues
 
       std::map<IdxT, IdxT> gridkit_bus_indices_;    ///< Map between gridkit_bus_id and bus_id
       std::map<IdxT, IdxT> gridkit_signal_indices_; ///< Map between gridkit_signal_id and signal_id
-      std::map<IdxT, IdxT> gridkit_fault_indices_;  ///< Map between fault_id and component_id
 
       bool owns_components_{false};
 

--- a/application/PhasorDynamics/PDSim.cpp
+++ b/application/PhasorDynamics/PDSim.cpp
@@ -26,9 +26,9 @@ int main(int argc, const char* argv[])
     Log::error() << "No input file provided" << std::endl;
     std::cout << "\n"
                  "Usage:\n"
-                 "       pdsim <json-input-file>\n"
+                 "       pdsim <solver-file.solver.json>\n"
                  "\n"
-                 "Please provide a json input file for the study to run.\n"
+                 "Please provide a JSON solver file for the study to run.\n"
                  "\n";
     exit(1);
   }
@@ -48,30 +48,30 @@ int main(int argc, const char* argv[])
   // Start timer
   real_type start = static_cast<real_type>(clock());
 
-  using EventType = SystemEvent::Type;
-
   // Initilize simultation for first run
   ida.initializeSimulation(0.0, false);
   real_type curr_time = 0.0;
-  for (const auto& event : study.events)
+
+  size_t i = 0;
+  while (i < study.schedule.size())
   {
-    // Run to event time
-    int nout = static_cast<int>(std::round((event.time - curr_time) / dt));
-    ida.runSimulation(event.time, nout);
+    real_type t_cue = study.schedule[i].time;
 
-    // Set up run for event (to start at event time)
-    if (event.type == EventType::FAULT_ON)
+    // Run to cue time
+    int nout = static_cast<int>(std::round((t_cue - curr_time) / dt));
+    ida.runSimulation(t_cue, nout);
+
+    // Batch simultaneous cues into one re-init so IDA never sees a
+    // zero-length segment between back-to-back applies at the same time.
+    while (i < study.schedule.size() && study.schedule[i].time == t_cue)
     {
-      sys.getBusFault(event.element_id)->setStatus(true);
-    }
-    else if (event.type == EventType::FAULT_OFF)
-    {
-      sys.getBusFault(event.element_id)->setStatus(false);
+      sys.cue(study.schedule[i].target, study.schedule[i].action);
+      ++i;
     }
 
-    // Re-initialize simulation at event time
-    ida.initializeSimulation(event.time, true);
-    curr_time = event.time;
+    // Re-initialize simulation at cue time
+    ida.initializeSimulation(t_cue, true);
+    curr_time = t_cue;
   }
 
   // Run to final time

--- a/application/PhasorDynamics/PDSim.hpp
+++ b/application/PhasorDynamics/PDSim.hpp
@@ -1,12 +1,16 @@
 #pragma once
 
+#include <cassert>
 #include <filesystem>
 #include <fstream>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
-#include <magic_enum/magic_enum.hpp>
 #include <nlohmann/json.hpp>
 
+#include <GridKit/Model/PhasorDynamics/Component.hpp>
+#include <GridKit/Model/PhasorDynamics/ComponentDataJSONParser.hpp>
 #include <GridKit/Model/PhasorDynamics/SystemModelData.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
@@ -16,135 +20,120 @@ namespace GridKit
   {
     namespace fs = ::std::filesystem;
 
-    /**
-     * @brief Describes an event that is used to modify the simulation at the
-     * given time point
-     */
-    struct SystemEvent
-    {
-      /// Type of event determines action performed
-      enum class Type
-      {
-        FAULT_ON,
-        FAULT_OFF
-      };
-
-      /// Time event takes place
-      double      time;
-      /// Event type
-      Type        type;
-      /// ID of element used in event (e.g., bus fault id)
-      std::size_t element_id;
-    };
-
-    /**
-     * @brief Data defined in JSON file for parameterized study
-     */
-    struct StudyData
-    {
-      /// path to system model JSON file
-      fs::path                 system_model_file;
-      /// time step size
-      double                   dt;
-      /// max time
-      double                   tmax;
-      /// set of system events
-      std::vector<SystemEvent> events;
-      /// path to output file
-      fs::path                 output_file;
-      /// path to reference file for validation
-      fs::path                 reference_file;
-      /// Error tolerance (between output file and reference file)
-      double                   error_tol;
-      /// Instance of model data
-      SystemModelData<>        model_data;
-    };
-
     using json = ::nlohmann::json;
     using Log  = ::GridKit::Utilities::Logger;
 
-    /**
-     * @brief JSON parser implemntation for `StudyData`
-     */
-    void from_json(const json& j, StudyData& c)
+    /// One scheduled cue: at `time`, deliver `action` to `target`.
+    /// Consumed by PDSim — `time` drives integration, `target`+`action` are
+    /// forwarded to `SystemModel::cue`. Components themselves never see this.
+    struct Cue
     {
-      using namespace magic_enum;
+      double      time{0.0};
+      std::string target;
+      Action      action{Action::Off};
+    };
 
-      j.at("system_model_file").get_to(c.system_model_file);
-      j.at("dt").get_to(c.dt);
-      j.at("tmax").get_to(c.tmax);
+    struct StudyData
+    {
+      int               format_version{1};
+      fs::path          case_file;
+      double            dt{0.0};
+      double            tmax{0.0};
+      std::vector<Cue>  schedule;
+      fs::path          output_file;
+      fs::path          reference_file;
+      double            error_tol{1.0e-4};
+      SystemModelData<> model_data;
+    };
 
-      for (auto& raw_event : j.at("events"))
-      {
-        auto& event = c.events.emplace_back();
-        raw_event.at("time").get_to(event.time);
-        raw_event.at("element_id").get_to(event.element_id);
-
-        auto type_str   = raw_event.at("type").get<std::string>();
-        using EventType = SystemEvent::Type;
-        auto type_wrap  = enum_cast<EventType>(type_str, case_insensitive);
-        if (!type_wrap.has_value())
-        {
-          Log::error() << "Unable to parse event type \"" << type_str << "\"\n";
-        }
-        event.type = type_wrap.value();
-      }
-
-      if (j.contains("output_file"))
-      {
-        j.at("output_file").get_to(c.output_file);
-      }
-
-      if (j.contains("reference_file"))
-      {
-        j.at("reference_file").get_to(c.reference_file);
-      }
-
-      c.error_tol = j.value("error_tolerance", 1.0e-4);
-    }
-
-    /**
-     * @brief Check for existence and successful input file open
-     */
-    std::ifstream openFile(const fs::path& file_path)
+    inline std::ifstream openFile(const fs::path& file_path)
     {
       if (!exists(file_path))
       {
         Log::error() << "File not found: " << file_path << std::endl;
+        throw std::runtime_error("File not found: " + file_path.string());
       }
       auto fs = std::ifstream(file_path);
       if (!fs)
       {
         Log::error() << "Failed to open file: " << file_path << std::endl;
+        throw std::runtime_error("Failed to open file: " + file_path.string());
       }
       return fs;
     }
 
-    /**
-     * @brief Wrapper function to parse `StudyData` from JSON and perform
-     * follow-up configuration
-     */
-    StudyData parseStudyData(const fs::path& file_path)
+    inline StudyData parseStudyData(const fs::path& file_path)
     {
-      auto data = StudyData(json::parse(openFile(file_path)));
+      auto raw = json::parse(openFile(file_path));
 
-      auto loc = file_path.parent_path();
-      if (!data.system_model_file.is_absolute())
+      StudyData data;
+
+      data.format_version = raw.value("format_version", 1);
+      if (data.format_version != 1)
       {
-        data.system_model_file = loc / data.system_model_file;
+        throw std::runtime_error(
+            "Unsupported solver file format_version: "
+            + std::to_string(data.format_version));
       }
-      if (!data.reference_file.empty())
+
+      raw.at("case_file").get_to(data.case_file);
+      auto loc = file_path.parent_path();
+      if (!data.case_file.is_absolute())
       {
+        data.case_file = loc / data.case_file;
+      }
+
+      raw.at("dt").get_to(data.dt);
+      raw.at("tmax").get_to(data.tmax);
+
+      if (raw.contains("output_file"))
+      {
+        raw.at("output_file").get_to(data.output_file);
+      }
+      if (raw.contains("reference_file"))
+      {
+        raw.at("reference_file").get_to(data.reference_file);
         if (!data.reference_file.is_absolute())
         {
           data.reference_file = loc / data.reference_file;
         }
       }
+      data.error_tol = raw.value("error_tolerance", 1.0e-4);
 
-      auto csv        = ::GridKit::Model::VariableMonitorFormat::CSV;
-      data.model_data = parseSystemModelData(data.system_model_file);
+      data.model_data = parseSystemModelData(data.case_file);
+
+      if (raw.contains("schedule"))
+      {
+        double last_time = -std::numeric_limits<double>::infinity();
+        for (const auto& raw_cue : raw.at("schedule"))
+        {
+          Cue cue;
+          raw_cue.at("time").get_to(cue.time);
+          raw_cue.at("target").get_to(cue.target);
+
+          std::string action_str;
+          raw_cue.at("action").get_to(action_str);
+          if (action_str == "on")
+            cue.action = Action::On;
+          else if (action_str == "off")
+            cue.action = Action::Off;
+          else
+            throw std::runtime_error(
+                "Solver file: unknown action '" + action_str + "' (valid: on, off)");
+
+          assert(cue.time <= data.tmax);
+          if (cue.time < last_time)
+          {
+            throw std::runtime_error(
+                "Solver file: schedule is not monotone non-decreasing in time");
+          }
+          last_time = cue.time;
+          data.schedule.push_back(std::move(cue));
+        }
+      }
+
+      auto        csv = ::GridKit::Model::VariableMonitorFormat::CSV;
       std::string model_output_file;
-      // Find output file (CSV) specified in model input file
       for (const auto& sink : data.model_data.monitor_sink)
       {
         if (sink.format == csv && sink.delim == ",")
@@ -155,8 +144,10 @@ namespace GridKit
 
       if (model_output_file.empty())
       {
-        // Add study output file to model if one did not already exist
-        data.model_data.monitor_sink.emplace_back(data.output_file, csv);
+        if (!data.output_file.empty())
+        {
+          data.model_data.monitor_sink.emplace_back(data.output_file.string(), csv);
+        }
       }
       else
       {
@@ -164,13 +155,12 @@ namespace GridKit
         {
           data.output_file = model_output_file;
         }
-        else
+        else if (data.output_file.string() != model_output_file)
         {
-          // If model file already specifies a CSV output file, then the study
-          // output file must be a symlink to the model output file
           if (exists(data.output_file))
           {
-            if ((!is_symlink(data.output_file)) || (read_symlink(data.output_file) != model_output_file))
+            if ((!is_symlink(data.output_file))
+                || (read_symlink(data.output_file) != model_output_file))
             {
               Log::error() << "Study output file not usable" << std::endl;
             }

--- a/application/PhasorDynamics/README.md
+++ b/application/PhasorDynamics/README.md
@@ -7,7 +7,7 @@ simulations. It reads a JSON solver file that specifies the case (system
 model) to load, the simulation parameters, an optional schedule of runtime
 cues, and output configuration.
 
-Components that respond to runtime control (e.g. `BusFault`) are declared in
+Components that respond to runtime control (e.g. `BusFault`, `Branch`) are declared in
 the case file as ordinary devices. The solver file's `schedule` then drives
 their state changes by referencing each component's `id` from the case file.
 
@@ -66,6 +66,7 @@ last cue, it runs to `tmax`.
   Class       | Action vocabulary | Effect
   ------------|-------------------|----------------------------------------------
   `BusFault`  | `on`, `off`       | Engage or clear the fault impedance at the bus
+  `Branch`    | `on`, `off`       | Close or open the branch (in service / tripped)
 
 A device is cue-targetable only if its `id` is referenced by the schedule.
 Devices whose class does not accept cues (or unknown actions) cause

--- a/application/PhasorDynamics/README.md
+++ b/application/PhasorDynamics/README.md
@@ -1,25 +1,115 @@
-# Input file for GridKit phasor dynamics application
+# PDSim — Phasor Dynamics Study Runner
 
-## Root elements
+## Overview
 
-   Name               | Value
- ---------------------|-------------------------------------------------------
-  `system_model_file` | Path to the system model file[^1]
-  `dt`                | A floating point value for time step size
-  `tmax`              | A floating point value for max time
-  `events`            | An array of event groups (see [Events](#events) below)
-  `output_file`       | Path to output (CSV) file
-  `reference_file`    | A string containing the name of the case
-  `error_tolerance`   | A string containing the name of the case
+PDSim is a command-line application for running parameterized phasor dynamics
+simulations. It reads a JSON solver file that specifies the case (system
+model) to load, the simulation parameters, an optional schedule of runtime
+cues, and output configuration.
 
-[^1]: See system model [case format](../../Model/PhasorDynamics/INPUT_FORMAT.md)
+Components that respond to runtime control (e.g. `BusFault`) are declared in
+the case file as ordinary devices. The solver file's `schedule` then drives
+their state changes by referencing each component's `id` from the case file.
 
-## Events
+### Usage
 
-Each event group describes a system event that occurs at a given time point
+```
+PDSim <study-file.solver.json>
+```
 
-   Name              | Value
- --------------------|-------------------------------------------------------
-  `time`             | A floating point value for time event occurs
-  `type`             | Event type (one of { "fault_on", "fault_off" })
-  `element_id`       | An integer value referencing the element associated with the event (e.g., bus fault id)
+## Solver file format
+
+The solver file configures a simulation run. All paths are resolved relative
+to the solver file's directory.
+
+### Top-level fields
+
+  Name               | Required | Description
+  -------------------|----------|------------------------------------------------------
+  `format_version`   | No       | Format version integer (default: `1`)
+  `case_file`        | Yes      | Path to the case (system model) JSON file
+  `dt`               | Yes      | Simulation time step in seconds
+  `tmax`             | Yes      | Simulation end time in seconds
+  `schedule`         | No       | Ordered array of timed cues (see below)
+  `output_file`      | No       | Path to monitor output file (CSV). If omitted, writes to a default sink declared in the case file
+  `reference_file`   | No       | Path to reference CSV for validation
+  `error_tolerance`  | No       | Maximum allowed error vs reference (default: `1e-4`)
+
+### Output
+
+Which variables are monitored — and in what format — is configured by the
+case file (the `mon` fields on buses and devices, and the monitor sink
+declarations). The solver file's `output_file` only chooses the destination
+path for the study's CSV sink; everything else about the output (format,
+delimiter, monitored variables) is a model property.
+
+### Schedule
+
+The schedule is an ordered list of timed **cues**. Each cue addresses a
+device declared in the case file by its `id` and asks it to perform an
+action at the given simulation time.
+
+  Name     | Description
+  ---------|------------------------------------------------------
+  `time`   | Simulation time to fire the cue, in seconds (must be ≤ `tmax`)
+  `target` | Device `id` from the case file (e.g. a `BusFault` device's `id`)
+  `action` | Action verb interpreted by the target device's class
+
+The schedule must be non-decreasing in time; ties are allowed for
+simultaneous cues (e.g. trip line A and B at the same instant). PDSim
+runs to each distinct cue time, applies every cue scheduled at that
+instant, re-initializes for a consistent IC, and continues. After the
+last cue, it runs to `tmax`.
+
+#### Devices that accept cues
+
+  Class       | Action vocabulary | Effect
+  ------------|-------------------|----------------------------------------------
+  `BusFault`  | `on`, `off`       | Engage or clear the fault impedance at the bus
+
+A device is cue-targetable only if its `id` is referenced by the schedule.
+Devices whose class does not accept cues (or unknown actions) cause
+PDSim to fail with a clear error.
+
+### Validation
+
+When both `output_file` and `reference_file` are provided, PDSim compares
+the simulation output against the reference and reports whether the
+maximum error is within `error_tolerance`. The process exit code is `0`
+on pass, `1` on failure.
+
+## Example
+
+Solver file:
+
+```json
+{
+    "format_version":  1,
+    "case_file":       "ThreeBusBasic.case.json",
+    "dt":              0.00416666666666,
+    "tmax":            10,
+    "schedule": [
+        { "time": 1.0, "target": "fault_1", "action": "on"  },
+        { "time": 1.1, "target": "fault_1", "action": "off" }
+    ],
+    "output_file":     "ThreeBus_six_cycle_fault_bus1.csv",
+    "reference_file":  "ThreeBusBasic.ref.csv",
+    "error_tolerance": 1e-4
+}
+```
+
+The corresponding case file declares the `BusFault` device whose `id` is
+referenced as `target`:
+
+```json
+{
+    "devices": [
+        {
+            "class":  "BusFault",
+            "id":     "fault_1",
+            "ports":  { "bus": 2 },
+            "params": { "R": 0.0, "X": 1e-5, "state0": false }
+        }
+    ]
+}
+```

--- a/examples/PhasorDynamics/Large/Texas/texas.cpp
+++ b/examples/PhasorDynamics/Large/Texas/texas.cpp
@@ -79,15 +79,6 @@ int main(int argc, const char* argv[])
   real_type   start = static_cast<real_type>(clock());
   std::string phase = "setup";
 
-  // Get access to fault 0.
-  auto* fault = sys.getBusFault(0);
-  if (fault == nullptr)
-  {
-    std::cerr << "ERROR: Texas input is missing BusFault component at index 0.\n";
-    sys.stopMonitor();
-    return 2;
-  }
-
   try
   {
     phase = "pre-fault";
@@ -98,14 +89,14 @@ int main(int argc, const char* argv[])
 
     phase = "fault";
     std::cout << "[fault] t = 10.0 -> 10.15\n";
-    fault->setStatus(true);
+    sys.cue("fault_1", Action::On);
     ida.initializeSimulation(10.0, false);
     nout = static_cast<int>(std::round((10.15 - 10.0) / dt));
     ida.runSimulation(10.15, nout);
 
     phase = "post-fault";
     std::cout << "[post-fault] t = 10.15 -> 20.0\n";
-    fault->setStatus(false);
+    sys.cue("fault_1", Action::Off);
     ida.initializeSimulation(10.15, false);
     nout = static_cast<int>(std::round((20.0 - 10.15) / dt));
     ida.runSimulation(20.0, nout);

--- a/examples/PhasorDynamics/Medium/Hawaii/hawaiiJson.cpp
+++ b/examples/PhasorDynamics/Medium/Hawaii/hawaiiJson.cpp
@@ -70,9 +70,6 @@ int main(int argc, const char* argv[])
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
 
-  // Get access to fault 0
-  auto* fault = sys.getBusFault(0);
-
   // NOTE Now we try and run the case.
   // Fails for now but left here for future
 
@@ -92,13 +89,13 @@ int main(int argc, const char* argv[])
   ida.runSimulation(1.0, nout);
 
   // Introduce fault to ground and run for 0.1s
-  fault->setStatus(true);
+  sys.cue("fault_1", Action::On);
   ida.initializeSimulation(1.0, true);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout);
 
   // Clear fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("fault_1", Action::Off);
   ida.initializeSimulation(1.1, true);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout);

--- a/examples/PhasorDynamics/Medium/NewEngland/newengland.cpp
+++ b/examples/PhasorDynamics/Medium/NewEngland/newengland.cpp
@@ -71,9 +71,6 @@ int main(int argc, const char* argv[])
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
 
-  // Get access to fault 0
-  auto* fault = sys.getBusFault(0);
-
   // Set time step to 1/4 of a 60Hz cycle.
   real_type dt = 1.0 / 4.0 / 60.0;
 
@@ -89,13 +86,13 @@ int main(int argc, const char* argv[])
   ida.runSimulation(1.0, nout);
 
   // Introduce fault to ground and run for 0.1s
-  fault->setStatus(true);
+  sys.cue("fault_1", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout);
 
   // Clear fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("fault_1", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout);

--- a/examples/PhasorDynamics/Small/TenGen/Classical/TenGenClassical.cpp
+++ b/examples/PhasorDynamics/Small/TenGen/Classical/TenGenClassical.cpp
@@ -169,13 +169,13 @@ int main()
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault to ground and run for 0.1s
-  fault.setStatus(1);
+  fault.apply(Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear fault and run until t = 10s.
-  fault.setStatus(0);
+  fault.apply(Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Small/TenGen/Genrou/TenGenGenrou.cpp
+++ b/examples/PhasorDynamics/Small/TenGen/Genrou/TenGenGenrou.cpp
@@ -155,13 +155,13 @@ int main()
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault to ground and run for 0.1s
-  fault.setStatus(1);
+  fault.apply(Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear fault and run until t = 10s.
-  fault.setStatus(0);
+  fault.apply(Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(ThreeBusBasicJson
 install(TARGETS ThreeBusBasicJson RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(ThreeBusBasic.case.json)
 gridkit_example_add_file(ThreeBusBasic.ref.csv)
+gridkit_example_add_file(ThreeBusBasicBranchTrip.ref.csv)
 
 add_test(NAME ThreeBusBasic COMMAND ThreeBusBasic)
 add_test(NAME ThreeBusBasicJson
@@ -23,6 +24,10 @@ add_test(NAME ThreeBusBasicJson_no_arg
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 gridkit_example_add_file(ThreeBusBasic.solver.json)
+gridkit_example_add_file(ThreeBusBasicBranchTrip.solver.json)
 add_test(NAME ThreeBusBasic_using_app
     COMMAND PDSim ThreeBusBasic.solver.json
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME ThreeBusBasicBranchTrip_using_app
+    COMMAND PDSim ThreeBusBasicBranchTrip.solver.json
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(ThreeBusBasicJson
 install(TARGETS ThreeBusBasicJson RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(ThreeBusBasic.case.json)
 gridkit_example_add_file(ThreeBusBasic.ref.csv)
-gridkit_example_add_file(ThreeBusBasicBranchTrip.ref.csv)
 
 add_test(NAME ThreeBusBasic COMMAND ThreeBusBasic)
 add_test(NAME ThreeBusBasicJson

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.cpp
@@ -193,6 +193,7 @@ int main()
   data.bus_fault[0].parameters[BusFaultParameters::R]      = 0.0;
   data.bus_fault[0].parameters[BusFaultParameters::X]      = 1e-5;
   data.bus_fault[0].parameters[BusFaultParameters::state0] = false;
+  data.bus_fault[0].disambiguation_string                  = "fault_0";
 
   //
   // Instantiate system
@@ -200,9 +201,6 @@ int main()
 
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
-
-  // Get access to fault 0
-  auto* fault = sys.getBusFault(0);
 
   real_type dt = 1.0 / 4.0 / 60.0;
 
@@ -238,13 +236,13 @@ int main()
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault to ground and run for 0.1s
-  fault->setStatus(true);
+  sys.cue("fault_0", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("fault_0", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.solver.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.solver.json
@@ -1,12 +1,15 @@
 {
-    "system_model_file": "ThreeBusBasic.case.json",
-    "dt":   0.00416666666666,
-    "tmax":  10,
-    "events": [
-        {"time": 1, "type": "fault_on", "element_id": 0},
-        {"time": 1.1, "type": "fault_off", "element_id": 0}
+    "format_version": 1,
+    "case_file":      "ThreeBusBasic.case.json",
+    "dt":             0.00416666666666,
+    "tmax":           10,
+
+    "schedule": [
+        { "time": 1.0,  "target": "bus_fault_2", "action": "on"  },
+        { "time": 1.1,  "target": "bus_fault_2", "action": "off" }
     ],
-    "output_file": "ThreeBus_six_cycle_fault_bus1.csv",
-    "reference_file": "ThreeBusBasic.ref.csv",
-    "error_tolerance":  1e-4
+
+    "output_file":     "ThreeBus_six_cycle_fault_bus1.csv",
+    "reference_file":  "ThreeBusBasic.ref.csv",
+    "error_tolerance": 1e-4
 }

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicBranchTrip.solver.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicBranchTrip.solver.json
@@ -1,0 +1,12 @@
+{
+    "format_version":  1,
+    "case_file":       "ThreeBusBasic.case.json",
+    "dt":              0.00416666666666,
+    "tmax":            10,
+    "schedule": [
+        { "time": 1.0, "target": "BR_1_2", "action": "off" }
+    ],
+    "output_file":     "ThreeBusBasicBranchTrip.csv",
+    "reference_file":  "ThreeBusBasicBranchTrip.ref.csv",
+    "error_tolerance": 1e-4
+}

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicBranchTrip.solver.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicBranchTrip.solver.json
@@ -6,7 +6,5 @@
     "schedule": [
         { "time": 1.0, "target": "BR_1_2", "action": "off" }
     ],
-    "output_file":     "ThreeBusBasicBranchTrip.csv",
-    "reference_file":  "ThreeBusBasicBranchTrip.ref.csv",
-    "error_tolerance": 1e-4
+    "output_file":     "ThreeBusBasicBranchTrip.csv"
 }

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
@@ -89,9 +89,6 @@ int main(int argc, const char* argv[])
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
 
-  // Get access to fault 0
-  auto* fault = sys.getBusFault(0);
-
   real_type dt = 1.0 / 4.0 / 60.0;
 
   // Set up simulation
@@ -107,13 +104,13 @@ int main(int argc, const char* argv[])
   ida.runSimulation(1.0, nout);
 
   // Introduce fault to ground and run for 0.1s
-  fault->setStatus(true);
+  sys.cue("bus_fault_2", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout);
 
   // Clear fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("bus_fault_2", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout);

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
@@ -170,6 +170,7 @@ int main()
   data.bus_fault[0].parameters[BusFaultParameters::R]      = 0.0;
   data.bus_fault[0].parameters[BusFaultParameters::X]      = 1e-5;
   data.bus_fault[0].parameters[BusFaultParameters::state0] = false;
+  data.bus_fault[0].disambiguation_string                  = "fault_0";
 
   //
   // Instantiate system
@@ -177,9 +178,6 @@ int main()
 
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
-
-  // Get access to fault 0
-  auto* fault = sys.getBusFault(0);
 
   real_type dt = 1.0 / 4.0 / 60.0;
 
@@ -209,13 +207,13 @@ int main()
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault to ground and run for 0.1s
-  fault->setStatus(true);
+  sys.cue("fault_0", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("fault_0", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassicalJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassicalJson.cpp
@@ -125,9 +125,6 @@ int main(int argc, const char* argv[])
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
 
-  // Get access to fault 0
-  auto* fault = sys.getBusFault(0);
-
   real_type dt = 1.0 / 4.0 / 60.0;
 
   std::vector<OutputData> output;
@@ -156,13 +153,13 @@ int main(int argc, const char* argv[])
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault to ground and run for 0.1s
-  fault->setStatus(true);
+  sys.cue("bus_fault_2", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("bus_fault_2", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ZipLoad/ThreeBusZipLoadJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ZipLoad/ThreeBusZipLoadJson.cpp
@@ -123,9 +123,6 @@ int main(int argc, const char* argv[])
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
 
-  // Get access to fault 0
-  auto* fault = sys.getBusFault(0);
-
   real_type dt = 1.0 / 4.0 / 60.0;
 
   std::vector<OutputData> output;
@@ -154,13 +151,13 @@ int main(int argc, const char* argv[])
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault to ground and run for 0.1s
-  fault->setStatus(true);
+  sys.cue("bus_fault_2", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("bus_fault_2", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.cpp
@@ -89,6 +89,7 @@ int main()
   data.bus_fault[0].parameters[BusFaultParameters::R]      = 0.0;
   data.bus_fault[0].parameters[BusFaultParameters::X]      = 1e-3;
   data.bus_fault[0].parameters[BusFaultParameters::state0] = false;
+  data.bus_fault[0].disambiguation_string                  = "fault_0";
 
   //
   // Instantiate system model
@@ -96,9 +97,6 @@ int main()
 
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
-
-  // Get access to the fault
-  auto* fault = sys.getBusFault(0);
 
   // Set time step to 1/4 of a 60Hz cycle
   real_type dt = 1.0 / 4.0 / 60.0;
@@ -154,13 +152,13 @@ int main()
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault and run for the next 0.1s
-  fault->setStatus(true);
+  sys.cue("fault_0", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear the fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("fault_0", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.solver.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.solver.json
@@ -1,11 +1,14 @@
 {
-    "system_model_file": "TwoBusBasic.case.json",
-    "dt":   0.00416666666666,
-    "tmax":  10,
-    "events": [
-        {"time": 1, "type": "fault_on", "element_id": 0},
-        {"time": 1.1, "type": "fault_off", "element_id": 0}
+    "format_version": 1,
+    "case_file":      "TwoBusBasic.case.json",
+    "dt":             0.00416666666666,
+    "tmax":           10,
+
+    "schedule": [
+        { "time": 1.0,  "target": "0", "action": "on"  },
+        { "time": 1.1,  "target": "0", "action": "off" }
     ],
-    "reference_file": "TwoBusBasic.ref.csv",
-    "error_tolerance":  2.01e-4
+
+    "reference_file":  "TwoBusBasic.ref.csv",
+    "error_tolerance": 2.01e-4
 }

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
@@ -77,9 +77,6 @@ int main(int argc, const char* argv[])
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
 
-  // Get access to the fault
-  auto* fault = sys.getBusFault(0);
-
   // Set time step to 1/4 of a 60Hz cycle
   real_type dt = 1.0 / 4.0 / 60.0;
 
@@ -134,13 +131,13 @@ int main(int argc, const char* argv[])
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault and run for the next 0.1s
-  fault->setStatus(true);
+  sys.cue("0", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear the fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("0", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.cpp
@@ -78,6 +78,7 @@ int main()
   data.bus_fault[0].parameters[BusFaultParameters::R]      = 0.0;
   data.bus_fault[0].parameters[BusFaultParameters::X]      = 1e-3;
   data.bus_fault[0].parameters[BusFaultParameters::state0] = false;
+  data.bus_fault[0].disambiguation_string                  = "fault_0";
 
   // Set generator data
   data.genrou.resize(1);
@@ -144,9 +145,6 @@ int main()
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
 
-  // Get access to the fault
-  auto* fault = sys.getBusFault(0);
-
   // Set time step to 1/4 of a 60Hz cycle
   real_type dt = 1.0 / 4.0 / 60.0;
 
@@ -210,13 +208,13 @@ int main()
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault and run for the next 0.1s
-  fault->setStatus(true);
+  sys.cue("fault_0", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear the fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("fault_0", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
@@ -77,9 +77,6 @@ int main(int argc, const char* argv[])
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
 
-  // Get access to the fault
-  auto* fault = sys.getBusFault(0);
-
   // Set time step to 1/4 of a 60Hz cycle
   real_type dt = 1.0 / 4.0 / 60.0;
 
@@ -143,15 +140,13 @@ int main(int argc, const char* argv[])
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault and run for the next 0.1s
-  // fault.setStatus(true);
-  fault->setStatus(true);
+  sys.cue("0", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear the fault and run until t = 10s.
-  // fault.setStatus(false);
-  fault->setStatus(false);
+  sys.cue("0", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
@@ -77,6 +77,7 @@ int main()
   data.bus_fault[0].parameters[BusFaultParameters::R]      = 0.0;
   data.bus_fault[0].parameters[BusFaultParameters::X]      = 1e-3;
   data.bus_fault[0].parameters[BusFaultParameters::state0] = false;
+  data.bus_fault[0].disambiguation_string                  = "fault_0";
 
   // Set generator data
   data.genrou.resize(1);
@@ -117,9 +118,6 @@ int main()
 
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
-
-  // Get access to the fault
-  auto* fault = sys.getBusFault(0);
 
   // Set time step to 1/4 of a 60Hz cycle
   real_type dt = 1.0 / 4.0 / 60.0;
@@ -175,13 +173,13 @@ int main()
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault and run for the next 0.1s
-  fault->setStatus(true);
+  sys.cue("fault_0", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear the fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("fault_0", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
@@ -81,9 +81,6 @@ int main(int argc, const char* argv[])
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();
 
-  // Get access to the fault
-  auto* fault = sys.getBusFault(0);
-
   // Set time step to 1/4 of a 60Hz cycle
   real_type dt = 1.0 / 4.0 / 60.0;
 
@@ -138,13 +135,13 @@ int main(int argc, const char* argv[])
   ida.runSimulation(1.0, nout, output_cb);
 
   // Introduce fault and run for the next 0.1s
-  fault->setStatus(true);
+  sys.cue("0", Action::On);
   ida.initializeSimulation(1.0, false);
   nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
   ida.runSimulation(1.1, nout, output_cb);
 
   // Clear the fault and run until t = 10s.
-  fault->setStatus(false);
+  sys.cue("0", Action::Off);
   ida.initializeSimulation(1.1, false);
   nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
   ida.runSimulation(10.0, nout, output_cb);

--- a/tests/UnitTests/PhasorDynamics/SystemSingleComponentTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/SystemSingleComponentTests.hpp
@@ -49,6 +49,69 @@ namespace GridKit
         return success.report(__func__);
       }
 
+      TestOutcome branchTrip()
+      {
+        TestStatus success = true;
+
+        PhasorDynamics::SystemModel<ScalarT, IdxT>* system = new PhasorDynamics::SystemModel<ScalarT, IdxT>();
+
+        PhasorDynamics::BusInfinite<ScalarT, IdxT> bus1, bus2;
+        system->addBus(&bus1);
+        system->addBus(&bus2);
+
+        // Branch data with realistic R/X/G/B so setDerivedParams stays finite.
+        PhasorDynamics::BranchData<RealT, IdxT> branch_data;
+        branch_data.disambiguation_string                           = "br_0";
+        branch_data.parameters[PhasorDynamics::BranchParameters::R] = 0.05;
+        branch_data.parameters[PhasorDynamics::BranchParameters::X] = 0.21;
+        branch_data.parameters[PhasorDynamics::BranchParameters::G] = 0.0;
+        branch_data.parameters[PhasorDynamics::BranchParameters::B] = 0.1;
+
+        PhasorDynamics::Branch<ScalarT, IdxT> branch(&bus1, &bus2, branch_data);
+        system->addComponent(&branch, branch_data.disambiguation_string);
+
+        success *= system->allocate() == 0;
+        success *= system->initialize() == 0;
+
+        // Default: branch is closed (in service)
+        success *= branch.status() == true;
+
+        // Open via cue
+        try
+        {
+          system->cue("br_0", PhasorDynamics::Action::Off);
+        }
+        catch (...)
+        {
+          success *= false;
+        }
+        success *= branch.status() == false;
+
+        // Close via cue
+        try
+        {
+          system->cue("br_0", PhasorDynamics::Action::On);
+        }
+        catch (...)
+        {
+          success *= false;
+        }
+        success *= branch.status() == true;
+
+        // state0 = false -> branch starts open without a cue.
+        PhasorDynamics::BranchData<RealT, IdxT> open_data;
+        open_data.parameters[PhasorDynamics::BranchParameters::R]      = 0.05;
+        open_data.parameters[PhasorDynamics::BranchParameters::X]      = 0.21;
+        open_data.parameters[PhasorDynamics::BranchParameters::state0] = false;
+        PhasorDynamics::Branch<ScalarT, IdxT> open_branch(&bus1, &bus2, open_data);
+        success *= open_branch.status() == false;
+
+        delete system;
+        system = nullptr;
+
+        return success.report(__func__);
+      }
+
       TestOutcome bus()
       {
         TestStatus success = true;

--- a/tests/UnitTests/PhasorDynamics/SystemSingleComponentTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/SystemSingleComponentTests.hpp
@@ -1,6 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
+#include <GridKit/Model/PhasorDynamics/BusFault/BusFaultData.hpp>
 #include <GridKit/Model/PhasorDynamics/ComponentLibrary.hpp>
 #include <GridKit/Model/PhasorDynamics/SystemModel.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
@@ -78,8 +79,10 @@ namespace GridKit
         PhasorDynamics::BusInfinite<ScalarT, IdxT> bus;
         system->addBus(&bus);
 
-        PhasorDynamics::BusFault<ScalarT, IdxT> fault(&bus);
-        system->addFault(&fault);
+        PhasorDynamics::BusFaultData<RealT, IdxT> fault_data;
+        fault_data.disambiguation_string = "fault_0";
+        PhasorDynamics::BusFault<ScalarT, IdxT> fault(&bus, fault_data);
+        system->addComponent(&fault, fault_data.disambiguation_string);
 
         success *= system->allocate() == 0;
         success *= system->initialize() == 0;
@@ -87,6 +90,28 @@ namespace GridKit
         success *= system->evaluateJacobian() == 0;
         success *= system->size() == 0;
         success *= system->size() == fault.size();
+
+        // Cue routes to the matching child via SystemModel::cue.
+        try
+        {
+          system->cue("fault_0", PhasorDynamics::Action::On);
+        }
+        catch (...)
+        {
+          success *= false;
+        }
+
+        // Unknown target throws.
+        bool threw = false;
+        try
+        {
+          system->cue("no_such", PhasorDynamics::Action::On);
+        }
+        catch (const std::exception&)
+        {
+          threw = true;
+        }
+        success *= threw;
 
         delete system;
         system = nullptr;

--- a/tests/UnitTests/PhasorDynamics/runSystemSingleComponentTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runSystemSingleComponentTests.cpp
@@ -9,6 +9,7 @@ int main()
   GridKit::Testing::SystemSingleComponentTests<double, size_t> test;
 
   result += test.branch();
+  result += test.branchTrip();
   result += test.bus();
   result += test.busFault();
   result += test.ieeet1();


### PR DESCRIPTION
## Description

 After some reflection, I think it is wise to model events as a typed `Action` performed on a `Component`, much like `BusFault` is implemented now.  

- A model of the `Component` class can perform an  `Action`, which is expressed by the implementation of the interface `apply(Action)` .
- The `SystemModel` cues a target `Component` to perform said  `Action`  by invoking  `sys->cue(target, action)`
- Alternatively, a component can be directly invoked via `target->apply(Action)`.
- A `Study` is a timed sequence of `Cue`s and `Component` targets.

For every event I can consider, this is very intuitive (i.e., `Fault` a `Bus`, `Fault` a `Branch`, `Close`/`Open` a `Branch`, `Oscillate` a machine (forced oscillation), `Ramp` a `Signal`, etc.). 
 
 ## Proposed changes
 
- Using this representation, I have implemented a Branch trip action that opens a broad class of studies in Power Systems. 
- `SystemModel` no longer treats `BusFaults` as a special set of components. In the future, we should probably make `Fault` or `Faultable` and interface so that `Bus` and `Branch` can implement, so there is no need for a dedicated `BusFault` component.
- A `README` for `PDSim` which details the proposed `*.study.json` schema. 
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [ ] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
Nice to have before we merge #374 so that we can do more diverse studies and non-fault events!

A stepping stone toward a more general solution to #377. 
