### PR TITLE
Refactor `PhasorDynamics` hierarchy to consolidate duplicate code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,13 +240,22 @@ Always declare type aliases with the `using` keyword rather than `typedef typena
   typedef typename GridKit::ScalarTraits<ScalarT>::RealT RealT; // No
 ```
 
-Types that are used as template parameters should use uppercase camel name format, 
-similar to classes, with the `T` suffix to indicate that it is a type. 
-For consistency, use the same name everywhere the same type is used.
+Types that are used as template parameters should use uppercase camel name
+format, similar to classes, with the `P` suffix to indicate that it is a
+template type "parameter". Inside classes define all interface type aliases
+using upper camel case with the `T` suffix for "type".  For consistency, use the
+same name everywhere the same type is used.
 
 ```c++
-  template <typename RealT> ...; // Yes
+  template <typename RealP> ...; // Yes
+  template <typename RealT> ...; // No, `T` used for template parameter
   template <typename real_type>; // No, `_type` used in a template parameter name
+
+  template <typename RealP>
+  struct MyGenericStruct
+  {
+    using RealT = RealP; // Use RealT throughout the code
+  };
 ```
 
 

--- a/GridKit/Model/Evaluator.hpp
+++ b/GridKit/Model/Evaluator.hpp
@@ -17,10 +17,12 @@ namespace GridKit
      * @brief Abstract class describing a model.
      *
      */
-    template <class ScalarT, typename IdxT>
+    template <class ScalarP, typename IdxP>
     class Evaluator
     {
     public:
+      using ScalarT    = ScalarP;
+      using IdxT       = IdxP;
       using RealT      = typename GridKit::ScalarTraits<ScalarT>::RealT;
       using MatrixT    = GridKit::LinearAlgebra::COO_Matrix<RealT, IdxT>; //\todo Use CsrMatrix
       using CsrMatrixT = GridKit::LinearAlgebra::CsrMatrix<RealT, IdxT>;

--- a/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
@@ -10,18 +10,17 @@
 
 #include <GridKit/Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 
 // Forward declarations.
 namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class BusBase;
 
-    template <typename RealT, typename IdxT>
+    template <typename RealP, typename IdxP>
     struct BranchData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -30,6 +29,34 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    template <typename, typename>
+    class Branch;
+
+    enum class BranchInternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    enum class BranchExternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<Branch<ScalarP, IdxP>>
+    {
+      using BranchT = Branch<ScalarP, IdxP>;
+
+      using ElementT           = BranchT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = BranchData<RealT, IdxT>;
+      using InternalVariablesT = BranchInternalVariables;
+      using ExternalVariablesT = BranchExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
     /**
      * @brief Implementation of a pi-model branch between two buses.
      *
@@ -37,36 +64,39 @@ namespace GridKit
      * direction is into the busses.
      *
      */
-    template <class ScalarT, typename IdxT>
-    class Branch : public Component<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    class Branch : public ConnectedElement<Branch<ScalarP, IdxP>>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using ConnectedElement<Branch>::gridkit_component_id_;
+      using ConnectedElement<Branch>::size_;
+      using ConnectedElement<Branch>::nnz_;
+      using ConnectedElement<Branch>::time_;
+      using ConnectedElement<Branch>::alpha_;
+      using ConnectedElement<Branch>::y_;
+      using ConnectedElement<Branch>::yp_;
+      using ConnectedElement<Branch>::tag_;
+      using ConnectedElement<Branch>::f_;
+      using ConnectedElement<Branch>::wb_;
+      using ConnectedElement<Branch>::h_;
+      using ConnectedElement<Branch>::J_;
+      using ConnectedElement<Branch>::J_rows_buffer_;
+      using ConnectedElement<Branch>::J_cols_buffer_;
+      using ConnectedElement<Branch>::J_vals_buffer_;
+      using ConnectedElement<Branch>::variable_indices_;
+      using ConnectedElement<Branch>::residual_indices_;
+      using ConnectedElement<Branch>::monitor_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using bus_type        = BusBase<ScalarT, IdxT>;
-      using model_data_type = BranchData<RealT, IdxT>;
-      using MonitorT        = Model::VariableMonitor<Branch, BranchData>;
+      using ScalarT    = typename ConnectedElement<Branch>::ScalarT;
+      using IdxT       = typename ConnectedElement<Branch>::IdxT;
+      using RealT      = typename ConnectedElement<Branch>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = BranchData<RealT, IdxT>;
+      using MonitorT   = typename ConnectedElement<Branch>::MonitorT;
 
-      Branch(bus_type* bus1, bus_type* bus2);
-      Branch(bus_type* bus1, bus_type* bus2, RealT R, RealT X, RealT G, RealT B);
-      Branch(bus_type* bus1, bus_type* bus2, const model_data_type& data);
+      Branch(BusT* bus1, BusT* bus2);
+      Branch(BusT* bus1, BusT* bus2, RealT R, RealT X, RealT G, RealT B);
+      Branch(BusT* bus1, BusT* bus2, const ModelDataT& data);
       virtual ~Branch();
 
       virtual int setGridKitComponentID(IdxT) override final;
@@ -109,7 +139,7 @@ namespace GridKit
       const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
-      void initializeParameters(const model_data_type& data);
+      void initializeParameters(const ModelDataT& data);
       void initializeMonitor();
       void setDerivedParams();
 
@@ -160,21 +190,18 @@ namespace GridKit
       __attribute__((always_inline)) inline int evaluateBusResidual22(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
-      bus_type* bus1_;
-      bus_type* bus2_;
-      RealT     R_{0.0};
-      RealT     X_{0.0};
-      RealT     G_{0.0};
-      RealT     B_{0.0};
-      IdxT      bus1_id_{0};
-      IdxT      bus2_id_{0};
+      BusT* bus1_;
+      BusT* bus2_;
+      RealT R_{0.0};
+      RealT X_{0.0};
+      RealT G_{0.0};
+      RealT B_{0.0};
+      IdxT  bus1_id_{0};
+      IdxT  bus2_id_{0};
 
       /* Derived parameters */
       RealT b_;
       RealT g_;
-
-      /// Variable monitor
-      std::unique_ptr<MonitorT> monitor_;
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Branch/BranchDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchDependencyTracking.cpp
@@ -4,6 +4,8 @@
  *
  */
 
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+
 #include "BranchImpl.hpp"
 
 namespace GridKit

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -13,7 +13,7 @@
 #include <GridKit/Model/PhasorDynamics/Branch/Branch.hpp>
 #include <GridKit/Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 
 namespace GridKit
 {
@@ -26,8 +26,8 @@ namespace GridKit
      * - Number of equations = 0
      * - Number of internal variables = 0
      */
-    template <class ScalarT, typename IdxT>
-    Branch<ScalarT, IdxT>::Branch(bus_type* bus1, bus_type* bus2)
+    template <typename ScalarP, typename IdxP>
+    Branch<ScalarP, IdxP>::Branch(BusT* bus1, BusT* bus2)
       : bus1_(bus1),
         bus2_(bus2),
         R_(0.0),
@@ -44,8 +44,6 @@ namespace GridKit
     /**
      * @brief Construct a new Branch
      *
-     * @tparam ScalarT - scalar type
-     * @tparam IdxT    - matrix/vector index type
      * @param bus1 - pointer to bus-1
      * @param bus2 - pointer to bus-2
      * @param R - line series resistance
@@ -53,13 +51,13 @@ namespace GridKit
      * @param G - line shunt conductance
      * @param B - line shunt charging
      */
-    template <class ScalarT, typename IdxT>
-    Branch<ScalarT, IdxT>::Branch(bus_type* bus1,
-                                  bus_type* bus2,
-                                  RealT     R,
-                                  RealT     X,
-                                  RealT     G,
-                                  RealT     B)
+    template <typename ScalarP, typename IdxP>
+    Branch<ScalarP, IdxP>::Branch(BusT* bus1,
+                                  BusT* bus2,
+                                  RealT R,
+                                  RealT X,
+                                  RealT G,
+                                  RealT B)
       : bus1_(bus1),
         bus2_(bus2),
         R_(R),
@@ -72,11 +70,11 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    Branch<ScalarT, IdxT>::Branch(bus_type* bus1, bus_type* bus2, const model_data_type& data)
-      : bus1_(bus1),
-        bus2_(bus2),
-        monitor_(std::make_unique<MonitorT>(data))
+    template <typename ScalarP, typename IdxP>
+    Branch<ScalarP, IdxP>::Branch(BusT* bus1, BusT* bus2, const ModelDataT& data)
+      : ConnectedElement<Branch>(data),
+        bus1_(bus1),
+        bus2_(bus2)
     {
       initializeParameters(data);
       initializeMonitor();
@@ -88,11 +86,9 @@ namespace GridKit
     /**
      * @brief Destroy the Branch
      *
-     * @tparam ScalarT
-     * @tparam IdxT
      */
-    template <class ScalarT, typename IdxT>
-    Branch<ScalarT, IdxT>::~Branch()
+    template <typename ScalarP, typename IdxP>
+    Branch<ScalarP, IdxP>::~Branch()
     {
       // std::cout << "Destroy Branch..." << std::endl;
     }
@@ -100,8 +96,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename ScalarP, typename IdxP>
+    int Branch<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -110,8 +106,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::allocate()
+    template <typename ScalarP, typename IdxP>
+    int Branch<ScalarP, IdxP>::allocate()
     {
       // std::cout << "Allocate Branch..." << std::endl;
 
@@ -125,8 +121,8 @@ namespace GridKit
      * Initialization of the branch model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::initialize()
+    template <typename ScalarP, typename IdxP>
+    int Branch<ScalarP, IdxP>::initialize()
     {
       return 0;
     }
@@ -134,8 +130,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::tagDifferentiable()
+    template <typename ScalarP, typename IdxP>
+    int Branch<ScalarP, IdxP>::tagDifferentiable()
     {
       return 0;
     }
@@ -144,8 +140,8 @@ namespace GridKit
      * @brief Bus 1 residual contribution from bus 1 variables
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Branch<ScalarT, IdxT>::evaluateBusResidual11(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) inline int Branch<ScalarP, IdxP>::evaluateBusResidual11(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -165,8 +161,8 @@ namespace GridKit
      * @brief Bus 1 residual contribution from bus 2 variables
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Branch<ScalarT, IdxT>::evaluateBusResidual12(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) inline int Branch<ScalarP, IdxP>::evaluateBusResidual12(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -186,8 +182,8 @@ namespace GridKit
      * @brief Bus 2 residual contribution from bus 1 variables
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual21(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) int Branch<ScalarP, IdxP>::evaluateBusResidual21(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -207,8 +203,8 @@ namespace GridKit
      * @brief Bus 2 residual contribution from bus 2 variables
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual22(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) int Branch<ScalarP, IdxP>::evaluateBusResidual22(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -228,8 +224,8 @@ namespace GridKit
      * @brief Residual contribution of the branch is computed and pushed to the terminal buses.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateResidual()
+    template <typename ScalarP, typename IdxP>
+    int Branch<ScalarP, IdxP>::evaluateResidual()
     {
       wb_[0] = Vr1();
       wb_[1] = Vi1();
@@ -252,50 +248,50 @@ namespace GridKit
       return 0;
     }
 
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
+    template <typename ScalarP, typename IdxP>
+    void Branch<ScalarP, IdxP>::initializeParameters(const ModelDataT& data)
     {
-      if (data.parameters.contains(model_data_type::Parameters::R))
+      if (data.parameters.contains(ModelDataT::Parameters::R))
       {
-        R_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::R));
+        R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::X))
+      if (data.parameters.contains(ModelDataT::Parameters::X))
       {
-        X_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::X));
+        X_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::X));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::G))
+      if (data.parameters.contains(ModelDataT::Parameters::G))
       {
-        G_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::G));
+        G_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::G));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::B))
+      if (data.parameters.contains(ModelDataT::Parameters::B))
       {
-        B_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::B));
+        B_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::B));
       }
 
-      if (data.ports.contains(model_data_type::Ports::bus1))
+      if (data.ports.contains(ModelDataT::Ports::bus1))
       {
-        bus1_id_ = data.ports.at(model_data_type::Ports::bus1);
+        bus1_id_ = data.ports.at(ModelDataT::Ports::bus1);
       }
 
-      if (data.ports.contains(model_data_type::Ports::bus2))
+      if (data.ports.contains(ModelDataT::Ports::bus2))
       {
-        bus2_id_ = data.ports.at(model_data_type::Ports::bus2);
+        bus2_id_ = data.ports.at(ModelDataT::Ports::bus2);
       }
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* Branch<ScalarT, IdxT>::getMonitor() const
+    template <typename ScalarP, typename IdxP>
+    const Model::VariableMonitorBase* Branch<ScalarP, IdxP>::getMonitor() const
     {
       return monitor_.get();
     }
 
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::initializeMonitor()
+    template <typename ScalarP, typename IdxP>
+    void Branch<ScalarP, IdxP>::initializeMonitor()
     {
-      using Variable = typename model_data_type::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::ir1, [this]
                     { return Ir1(); });
       monitor_->set(Variable::ii1, [this]
@@ -322,8 +318,8 @@ namespace GridKit
      * @brief Derived parameters
      *
      */
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::setDerivedParams()
+    template <typename ScalarP, typename IdxP>
+    void Branch<ScalarP, IdxP>::setDerivedParams()
     {
       b_ = -X_ / (R_ * R_ + X_ * X_);
       g_ = R_ / (R_ * R_ + X_ * X_);

--- a/GridKit/Model/PhasorDynamics/Branch/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/Branch/CMakeLists.txt
@@ -15,11 +15,10 @@ if(GRIDKIT_ENABLE_ENZYME)
       BranchEnzyme.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PRIVATE ClangEnzymeFlags
       PUBLIC GridKit::phasor_dynamics_core
+      PRIVATE GridKit::phasor_dynamics_utils
     COMPILE_OPTIONS
       PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
@@ -30,8 +29,7 @@ else()
       ${_install_headers}
     LINK_LIBRARIES
       PUBLIC GridKit::phasor_dynamics_core
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+      PRIVATE GridKit::phasor_dynamics_utils)
 endif()
 
 gridkit_add_library(phasor_dynamics_branch_dependency_tracking
@@ -39,8 +37,7 @@ gridkit_add_library(phasor_dynamics_branch_dependency_tracking
     BranchDependencyTracking.cpp
   LINK_LIBRARIES
     PUBLIC GridKit::phasor_dynamics_core
-  INCLUDE_DIRECTORIES 
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+    PRIVATE GridKit::phasor_dynamics_utils)
 
 # Link to interface target for all components
 target_link_libraries(phasor_dynamics_components

--- a/GridKit/Model/PhasorDynamics/Bus/Bus.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/Bus.hpp
@@ -2,11 +2,30 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/BusBase.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 
 namespace GridKit
 {
   namespace PhasorDynamics
   {
+    template <typename, typename>
+    class Bus;
+
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<Bus<ScalarP, IdxP>>
+    {
+      using BusT = Bus<ScalarP, IdxP>;
+
+      using ElementT           = BusT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = BusData<RealT, IdxT>;
+      using InternalVariablesT = BusInternalVariables;
+      using ExternalVariablesT = BusExternalVariables;
+      using InterfaceT         = BusBase<ScalarT, IdxT>;
+    };
+
     /*!
      * @brief Implementation of a PQ bus.
      *
@@ -15,30 +34,33 @@ namespace GridKit
      *
      *
      */
-    template <class ScalarT, typename IdxT>
-    class Bus : public BusBase<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    class Bus : public ConnectedElement<Bus<ScalarP, IdxP>>
     {
-      using BusBase<ScalarT, IdxT>::bus_id_;
-      using BusBase<ScalarT, IdxT>::size_;
-      using BusBase<ScalarT, IdxT>::y_;
-      using BusBase<ScalarT, IdxT>::yp_;
-      using BusBase<ScalarT, IdxT>::f_;
-      using BusBase<ScalarT, IdxT>::J_;
-      using BusBase<ScalarT, IdxT>::J_rows_buffer_;
-      using BusBase<ScalarT, IdxT>::J_cols_buffer_;
-      using BusBase<ScalarT, IdxT>::J_vals_buffer_;
-      using BusBase<ScalarT, IdxT>::tag_;
-      using BusBase<ScalarT, IdxT>::variable_indices_;
-      using BusBase<ScalarT, IdxT>::residual_indices_;
+      using ConnectedElement<Bus>::bus_id_;
+      using ConnectedElement<Bus>::size_;
+      using ConnectedElement<Bus>::y_;
+      using ConnectedElement<Bus>::yp_;
+      using ConnectedElement<Bus>::f_;
+      using ConnectedElement<Bus>::J_;
+      using ConnectedElement<Bus>::J_rows_buffer_;
+      using ConnectedElement<Bus>::J_cols_buffer_;
+      using ConnectedElement<Bus>::J_vals_buffer_;
+      using ConnectedElement<Bus>::tag_;
+      using ConnectedElement<Bus>::variable_indices_;
+      using ConnectedElement<Bus>::residual_indices_;
+      using ConnectedElement<Bus>::monitor_;
 
     public:
-      using RealT    = typename BusBase<ScalarT, IdxT>::RealT;
-      using DataT    = BusData<RealT, IdxT>;
-      using BusTypeT = typename BusData<RealT, IdxT>::BusType;
+      using ScalarT    = typename ConnectedElement<Bus>::ScalarT;
+      using IdxT       = typename ConnectedElement<Bus>::IdxT;
+      using RealT      = typename ConnectedElement<Bus>::RealT;
+      using ModelDataT = BusData<RealT, IdxT>;
+      using BusTypeT   = typename ConnectedElement<Bus>::BusTypeT;
 
       Bus();
       Bus(ScalarT Vr, ScalarT Vi);
-      Bus(const DataT& data);
+      Bus(const ModelDataT& data);
       virtual ~Bus();
 
       virtual int setBusID(IdxT) override final;

--- a/GridKit/Model/PhasorDynamics/Bus/BusData.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusData.hpp
@@ -37,7 +37,11 @@ namespace GridKit
     template <typename RealT, typename IdxT>
     struct BusData
     {
+      std::string device_class{"Bus"}; ///< Classification
+
       std::string name; ///< A name given to this bus
+
+      std::string disambiguation_string; ///< Same as name
 
       RealT Vr0{1.0}; ///< Initial value for the real bus voltage
       RealT Vi0{0.0}; ///< Initial value for the imaginary bus voltage

--- a/GridKit/Model/PhasorDynamics/Bus/BusDataJSONParser.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusDataJSONParser.hpp
@@ -23,6 +23,7 @@ namespace GridKit
     void from_json(const json& j, BusData<RealT, IdxT>& bd)
     {
       j.at("name").get_to(bd.name);
+      bd.disambiguation_string = bd.name;
 
       std::stringstream error_context;
       error_context << "\n\tSee bus number " << bd.bus_id

--- a/GridKit/Model/PhasorDynamics/Bus/BusDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusDependencyTracking.cpp
@@ -1,4 +1,6 @@
 
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+
 #include "BusImpl.hpp"
 
 namespace GridKit

--- a/GridKit/Model/PhasorDynamics/Bus/BusImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusImpl.hpp
@@ -22,8 +22,8 @@ namespace GridKit
      * - Number of quadratures = 0
      * - Number of optimization parameters = 0
      */
-    template <class ScalarT, typename IdxT>
-    Bus<ScalarT, IdxT>::Bus()
+    template <typename ScalarP, typename IdxP>
+    Bus<ScalarP, IdxP>::Bus()
       : Vr0_(0.0), Vi0_(0.0)
     {
       size_ = 2;
@@ -40,8 +40,8 @@ namespace GridKit
      * - Number of quadratures = 0
      * - Number of optimization parameters = 0
      */
-    template <class ScalarT, typename IdxT>
-    Bus<ScalarT, IdxT>::Bus(ScalarT Vr, ScalarT Vi)
+    template <typename ScalarP, typename IdxP>
+    Bus<ScalarP, IdxP>::Bus(ScalarT Vr, ScalarT Vi)
       : Vr0_(Vr), Vi0_(Vi)
     {
       size_ = 2;
@@ -50,24 +50,30 @@ namespace GridKit
     /**
      * @brief Construct a new Bus
      *
-     * @tparam ScalarT - type of scalar variables
-     * @tparam IdxT    - type for vector/matrix indices
      * @param[in] data - structure with bus data
      */
-    template <class ScalarT, typename IdxT>
-    Bus<ScalarT, IdxT>::Bus(const DataT& data)
-      : BusBase<ScalarT, IdxT>(data),
+    template <typename ScalarP, typename IdxP>
+    Bus<ScalarP, IdxP>::Bus(const ModelDataT& data)
+      : ConnectedElement<Bus>(data),
         Vr0_(data.Vr0),
         Vi0_(data.Vi0)
     {
-      // std::cout << "Create Bus..." << std::endl;
-      // std::cout << "Number of equations is " << size_ << std::endl;
-
       size_ = 2;
+
+      using Variable = typename BusData<RealT, IdxT>::MonitorableVariables;
+
+      monitor_->set(Variable::Vr, [this]
+                    { return Vr(); });
+      monitor_->set(Variable::Vi, [this]
+                    { return Vi(); });
+      monitor_->set(Variable::Vm, [this]
+                    { return std::sqrt(Vr() * Vr() + Vi() * Vi()); });
+      monitor_->set(Variable::Va, [this]
+                    { return std::atan2(Vi(), Vr()); });
     }
 
-    template <class ScalarT, typename IdxT>
-    Bus<ScalarT, IdxT>::~Bus()
+    template <typename ScalarP, typename IdxP>
+    Bus<ScalarP, IdxP>::~Bus()
     {
       // std::cout << "Destroy PQ bus ..." << std::endl;
     }
@@ -75,8 +81,8 @@ namespace GridKit
     /*!
      * @brief allocate method resizes local solution and residual vectors.
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::allocate()
+    template <typename ScalarP, typename IdxP>
+    int Bus<ScalarP, IdxP>::allocate()
     {
       // Temporary while we use std::vector in the code
       size_t size = static_cast<size_t>(size_);
@@ -102,8 +108,8 @@ namespace GridKit
     /**
      * @brief Set the bus ID
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::setBusID(IdxT bus_id)
+    template <typename ScalarP, typename IdxP>
+    int Bus<ScalarP, IdxP>::setBusID(IdxT bus_id)
     {
       bus_id_ = bus_id;
       return 0;
@@ -112,8 +118,8 @@ namespace GridKit
     /*!
      * @brief Bus variables are algebraic.
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::tagDifferentiable()
+    template <typename ScalarP, typename IdxP>
+    int Bus<ScalarP, IdxP>::tagDifferentiable()
     {
       tag_[0] = false;
       tag_[1] = false;
@@ -123,8 +129,8 @@ namespace GridKit
     /*!
      * @brief initialize method sets bus variables to stored initial values.
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::initialize()
+    template <typename ScalarP, typename IdxP>
+    int Bus<ScalarP, IdxP>::initialize()
     {
       // std::cout << "Initialize Bus..." << std::endl;
       y_[0]  = Vr0_;
@@ -142,8 +148,8 @@ namespace GridKit
      * _before_ component model residuals.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::evaluateResidual()
+    template <typename ScalarP, typename IdxP>
+    int Bus<ScalarP, IdxP>::evaluateResidual()
     {
       // std::cout << "Evaluating residual of a PQ bus ...\n";
       f_[0] = 0.0;

--- a/GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp
@@ -2,37 +2,59 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/BusBase.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 
 namespace GridKit
 {
   namespace PhasorDynamics
   {
+    template <typename, typename>
+    class BusInfinite;
+
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<BusInfinite<ScalarP, IdxP>>
+    {
+      using BusT = BusInfinite<ScalarP, IdxP>;
+
+      using ElementT           = BusT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = BusData<RealT, IdxT>;
+      using InternalVariablesT = BusInternalVariables;
+      using ExternalVariablesT = BusExternalVariables;
+      using InterfaceT         = BusBase<ScalarT, IdxT>;
+    };
+
     /*!
      * @brief Implementation of an "infinite" bus.
      *
      *
      *
      */
-    template <class ScalarT, typename IdxT>
-    class BusInfinite : public BusBase<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    class BusInfinite : public ConnectedElement<BusInfinite<ScalarP, IdxP>>
     {
-      using BusBase<ScalarT, IdxT>::bus_id_;
-      using BusBase<ScalarT, IdxT>::size_;
-      using BusBase<ScalarT, IdxT>::y_;
-      using BusBase<ScalarT, IdxT>::yp_;
-      using BusBase<ScalarT, IdxT>::f_;
-      using BusBase<ScalarT, IdxT>::J_;
-      using BusBase<ScalarT, IdxT>::variable_indices_;
-      using BusBase<ScalarT, IdxT>::residual_indices_;
+      using ConnectedElement<BusInfinite>::bus_id_;
+      using ConnectedElement<BusInfinite>::size_;
+      using ConnectedElement<BusInfinite>::y_;
+      using ConnectedElement<BusInfinite>::yp_;
+      using ConnectedElement<BusInfinite>::f_;
+      using ConnectedElement<BusInfinite>::J_;
+      using ConnectedElement<BusInfinite>::variable_indices_;
+      using ConnectedElement<BusInfinite>::residual_indices_;
+      using ConnectedElement<BusInfinite>::monitor_;
 
     public:
-      using RealT    = typename BusBase<ScalarT, IdxT>::RealT;
-      using DataT    = BusData<RealT, IdxT>;
-      using BusTypeT = typename BusData<RealT, IdxT>::BusType;
+      using ScalarT    = typename ConnectedElement<BusInfinite>::ScalarT;
+      using IdxT       = typename ConnectedElement<BusInfinite>::IdxT;
+      using RealT      = typename ConnectedElement<BusInfinite>::RealT;
+      using ModelDataT = BusData<RealT, IdxT>;
+      using BusTypeT   = typename ConnectedElement<BusInfinite>::BusTypeT;
 
       BusInfinite();
       BusInfinite(ScalarT Vr, ScalarT Vi);
-      BusInfinite(const DataT& data);
+      BusInfinite(const ModelDataT& data);
       virtual ~BusInfinite();
 
       virtual int setBusID(IdxT) override final;

--- a/GridKit/Model/PhasorDynamics/Bus/BusInfiniteImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusInfiniteImpl.hpp
@@ -5,6 +5,7 @@
 #include <GridKit/Model/PhasorDynamics/Bus/BusData.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <GridKit/Model/PhasorDynamics/BusBaseImpl.hpp>
+#include <GridKit/Model/PhasorDynamics/GridElementImpl.hpp>
 
 namespace GridKit
 {
@@ -20,10 +21,9 @@ namespace GridKit
      * - Number of equations = 0 (size_)
      * - Number of variables = 0 (size_)
      */
-    template <class ScalarT, typename IdxT>
-    BusInfinite<ScalarT, IdxT>::BusInfinite()
+    template <typename ScalarP, typename IdxP>
+    BusInfinite<ScalarP, IdxP>::BusInfinite()
     {
-      size_ = 0;
     }
 
     /*!
@@ -35,11 +35,10 @@ namespace GridKit
      * - Number of equations = 0 (size_)
      * - Number of variables = 0 (size_)
      */
-    template <class ScalarT, typename IdxT>
-    BusInfinite<ScalarT, IdxT>::BusInfinite(ScalarT Vr, ScalarT Vi)
+    template <typename ScalarP, typename IdxP>
+    BusInfinite<ScalarP, IdxP>::BusInfinite(ScalarT Vr, ScalarT Vi)
       : Vr_(Vr), Vi_(Vi)
     {
-      size_ = 0;
     }
 
     /**
@@ -49,29 +48,36 @@ namespace GridKit
      * - Number of equations = 0 (size_)
      * - Number of variables = 0 (size_)
 
-     * @tparam ScalarT - type of scalar variables
-     * @tparam IdxT    - type for vector/matrix indices
      * @param[in] data - structure with bus data
      */
-    template <class ScalarT, typename IdxT>
-    BusInfinite<ScalarT, IdxT>::BusInfinite(const DataT& data)
-      : BusBase<ScalarT, IdxT>(data),
+    template <typename ScalarP, typename IdxP>
+    BusInfinite<ScalarP, IdxP>::BusInfinite(const ModelDataT& data)
+      : ConnectedElement<BusInfinite>(data),
         Vr_(data.Vr0),
         Vi_(data.Vi0)
     {
-      size_ = 0;
+      using Variable = typename BusData<RealT, IdxT>::MonitorableVariables;
+
+      monitor_->set(Variable::Vr, [this]
+                    { return Vr(); });
+      monitor_->set(Variable::Vi, [this]
+                    { return Vi(); });
+      monitor_->set(Variable::Vm, [this]
+                    { return std::sqrt(Vr() * Vr() + Vi() * Vi()); });
+      monitor_->set(Variable::Va, [this]
+                    { return std::atan2(Vi(), Vr()); });
     }
 
-    template <class ScalarT, typename IdxT>
-    BusInfinite<ScalarT, IdxT>::~BusInfinite()
+    template <typename ScalarP, typename IdxP>
+    BusInfinite<ScalarP, IdxP>::~BusInfinite()
     {
     }
 
     /**
      * @brief Set the bus ID
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::setBusID(IdxT bus_id)
+    template <typename ScalarP, typename IdxP>
+    int BusInfinite<ScalarP, IdxP>::setBusID(IdxT bus_id)
     {
       bus_id_ = bus_id;
       return 0;
@@ -80,8 +86,8 @@ namespace GridKit
     /*!
      * @brief allocate method resizes local solution and residual vectors.
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::allocate()
+    template <typename ScalarP, typename IdxP>
+    int BusInfinite<ScalarP, IdxP>::allocate()
     {
       return 0;
     }
@@ -89,8 +95,8 @@ namespace GridKit
     /**
      * @brief Tag differentiable variables
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::tagDifferentiable()
+    template <typename ScalarP, typename IdxP>
+    int BusInfinite<ScalarP, IdxP>::tagDifferentiable()
     {
       return 0;
     }
@@ -98,8 +104,8 @@ namespace GridKit
     /*!
      * @brief initialize method sets bus variables to stored initial values.
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::initialize()
+    template <typename ScalarP, typename IdxP>
+    int BusInfinite<ScalarP, IdxP>::initialize()
     {
       return 0;
     }
@@ -116,8 +122,8 @@ namespace GridKit
      * _before_ component model residuals.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::evaluateResidual()
+    template <typename ScalarP, typename IdxP>
+    int BusInfinite<ScalarP, IdxP>::evaluateResidual()
     {
       Ir_ = 0.0;
       Ii_ = 0.0;
@@ -127,12 +133,10 @@ namespace GridKit
     /**
      * @brief There is no Jacobian for slack variables
      *
-     * @tparam ScalarT - data type for Jacobian elements
-     * @tparam IdxT    - data type for matrix indices
      * @return int - error code
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::evaluateJacobian()
+    template <typename ScalarP, typename IdxP>
+    int BusInfinite<ScalarP, IdxP>::evaluateJacobian()
     {
       return 0;
     }

--- a/GridKit/Model/PhasorDynamics/Bus/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/Bus/CMakeLists.txt
@@ -17,9 +17,8 @@ if(GRIDKIT_ENABLE_ENZYME)
       BusInfinite.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
+      PRIVATE GridKit::phasor_dynamics_utils
       PUBLIC GridKit::phasor_dynamics_core)
 else()
   gridkit_add_library(phasor_dynamics_bus
@@ -28,9 +27,8 @@ else()
       BusInfinite.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
+      PRIVATE GridKit::phasor_dynamics_utils
       PUBLIC GridKit::phasor_dynamics_core)
 endif()
 
@@ -38,9 +36,8 @@ gridkit_add_library(phasor_dynamics_bus_dependency_tracking
   SOURCES
     BusDependencyTracking.cpp
     BusInfiniteDependencyTracking.cpp
-  INCLUDE_DIRECTORIES
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
   LINK_LIBRARIES
+    PRIVATE GridKit::phasor_dynamics_utils
     PUBLIC GridKit::phasor_dynamics_core)
 
 # Link to interface target for all components

--- a/GridKit/Model/PhasorDynamics/BusBase.hpp
+++ b/GridKit/Model/PhasorDynamics/BusBase.hpp
@@ -4,31 +4,42 @@
 #include <set>
 #include <vector>
 
-#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/Constants.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/BusData.hpp>
 #include <GridKit/Model/PhasorDynamics/GridElement.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
 namespace GridKit
 {
   namespace PhasorDynamics
   {
-    using Log = ::GridKit::Utilities::Logger;
+    template <typename, typename>
+    class BusBase;
+
+    enum class BusInternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    enum class BusExternalVariables : size_t
+    {
+      MAXIMUM
+    };
 
     /*!
      * @brief BusBase model implementation base class.
      *
      */
-    template <typename ScalarT, typename IdxT>
-    class BusBase : public GridElement<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    class BusBase : public GridElement<ScalarP, IdxP>
     {
     public:
-      using RealT    = typename GridElement<ScalarT, IdxT>::RealT;
-      using MatrixT  = typename GridElement<ScalarT, IdxT>::MatrixT;
-      using BusTypeT = typename BusData<RealT, IdxT>::BusType;
-      using MonitorT = Model::VariableMonitor<BusBase, BusData>;
+      using ScalarT    = typename GridElement<ScalarP, IdxP>::ScalarT;
+      using IdxT       = typename GridElement<ScalarP, IdxP>::IdxT;
+      using RealT      = typename GridElement<ScalarP, IdxP>::RealT;
+      using MatrixT    = typename GridElement<ScalarP, IdxP>::MatrixT;
+      using ModelDataT = BusData<RealT, IdxT>;
+      using BusTypeT   = typename BusData<RealT, IdxT>::BusType;
 
       BusBase() = default;
 
@@ -73,13 +84,8 @@ namespace GridKit
         return bus_id_;
       }
 
-      const Model::VariableMonitorBase* getMonitor() const override;
-
     protected:
       IdxT bus_id_{INVALID_INDEX<IdxT>};
-
-      /// Variable monitor
-      std::unique_ptr<MonitorT> monitor_;
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/BusBaseImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/BusBaseImpl.hpp
@@ -1,37 +1,23 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/BusBase.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 
 namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename ScalarT, typename IdxT>
-    BusBase<ScalarT, IdxT>::BusBase(const BusData<RealT, IdxT>& data)
-      : bus_id_(data.bus_id),
-        monitor_(std::make_unique<MonitorT>("Bus_" + data.name, data.monitored_variables))
-    {
-      using Variable = typename BusData<RealT, IdxT>::MonitorableVariables;
-      monitor_->set(Variable::Vr, [this]
-                    { return Vr(); });
-      monitor_->set(Variable::Vi, [this]
-                    { return Vi(); });
-      monitor_->set(Variable::Vm, [this]
-                    { return std::sqrt(Vr() * Vr() + Vi() * Vi()); });
-      monitor_->set(Variable::Va, [this]
-                    { return std::atan2(Vi(), Vr()); });
-    }
+    using Log = ::GridKit::Utilities::Logger;
 
-    template <typename ScalarT, typename IdxT>
-    BusBase<ScalarT, IdxT>::~BusBase()
+    template <typename ScalarP, typename IdxP>
+    BusBase<ScalarP, IdxP>::BusBase(const BusData<RealT, IdxT>& data)
+      : bus_id_(data.bus_id)
     {
     }
 
-    template <typename ScalarT, typename IdxT>
-    inline const Model::VariableMonitorBase* BusBase<ScalarT, IdxT>::getMonitor() const
+    template <typename ScalarP, typename IdxP>
+    BusBase<ScalarP, IdxP>::~BusBase()
     {
-      return monitor_.get();
     }
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -3,15 +3,14 @@
 
 #include <GridKit/Model/PhasorDynamics/BusBase.hpp>
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 
 // Forward declaration of BusData structure
 namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename RealT, typename IdxT>
+    template <typename RealP, typename IdxP>
     struct BusFaultData;
   }
 } // namespace GridKit
@@ -20,32 +19,63 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
-    class BusFault : public Component<ScalarT, IdxT>
+    template <typename, typename>
+    class BusFault;
+
+    enum class BusFaultInternalVariables : size_t
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
+      MAXIMUM
+    };
+
+    enum class BusFaultExternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<BusFault<ScalarP, IdxP>>
+    {
+      using BusFaultT = BusFault<ScalarP, IdxP>;
+
+      using ElementT           = BusFaultT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = BusFaultData<RealT, IdxT>;
+      using InternalVariablesT = BusFaultInternalVariables;
+      using ExternalVariablesT = BusFaultExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
+    template <typename ScalarP, typename IdxP>
+    class BusFault : public ConnectedElement<BusFault<ScalarP, IdxP>>
+    {
+      using ConnectedElement<BusFault>::gridkit_component_id_;
+      using ConnectedElement<BusFault>::alpha_;
+      using ConnectedElement<BusFault>::nnz_;
+      using ConnectedElement<BusFault>::size_;
+      using ConnectedElement<BusFault>::tag_;
+      using ConnectedElement<BusFault>::time_;
+      using ConnectedElement<BusFault>::y_;
+      using ConnectedElement<BusFault>::yp_;
+      using ConnectedElement<BusFault>::wb_;
+      using ConnectedElement<BusFault>::h_;
+      using ConnectedElement<BusFault>::J_rows_buffer_;
+      using ConnectedElement<BusFault>::J_cols_buffer_;
+      using ConnectedElement<BusFault>::J_vals_buffer_;
+      using ConnectedElement<BusFault>::monitor_;
 
     public:
-      using bus_type = BusBase<ScalarT, IdxT>;
-      using RealT    = typename Component<ScalarT, IdxT>::RealT;
-      using DataT    = BusFaultData<RealT, IdxT>;
-      using MonitorT = Model::VariableMonitor<BusFault, BusFaultData>;
+      using ScalarT    = typename ConnectedElement<BusFault>::ScalarT;
+      using IdxT       = typename ConnectedElement<BusFault>::IdxT;
+      using RealT      = typename ConnectedElement<BusFault>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = BusFaultData<RealT, IdxT>;
+      using MonitorT   = typename ConnectedElement<BusFault>::MonitorT;
 
-      BusFault(bus_type* bus);
-      BusFault(bus_type* bus, RealT R, RealT X, int status);
-      BusFault(bus_type* bus, const DataT& data);
+      BusFault(BusT* bus);
+      BusFault(BusT* bus, RealT R, RealT X, int status);
+      BusFault(BusT* bus, const ModelDataT& data);
       ~BusFault();
 
       int setGridKitComponentID(IdxT) override final;
@@ -82,8 +112,6 @@ namespace GridKit
         status_ = status;
       }
 
-      const Model::VariableMonitorBase* getMonitor() const override;
-
     private:
       void setDerivedParams();
 
@@ -111,18 +139,15 @@ namespace GridKit
       __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
-      bus_type* bus_;
-      RealT     R_{0.0};
-      RealT     X_{0.0};
-      bool      status_{false};
-      IdxT      bus_id_{0};
+      BusT* bus_;
+      RealT R_{0.0};
+      RealT X_{0.0};
+      bool  status_{false};
+      IdxT  bus_id_{0};
 
       /* Derivied parameters */
       RealT B_;
       RealT G_;
-
-      /// Variable monitor
-      std::unique_ptr<MonitorT> monitor_;
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultDependencyTracking.cpp
@@ -1,3 +1,5 @@
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+
 #include "BusFaultImpl.hpp"
 
 namespace GridKit

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
@@ -6,7 +6,7 @@
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
 #include <GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp>
 #include <GridKit/Model/PhasorDynamics/BusFault/BusFaultData.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 
 namespace GridKit
 {
@@ -19,8 +19,8 @@ namespace GridKit
      * - Number of equations = 0
      * - Number of independent variables = 0
      */
-    template <class ScalarT, typename IdxT>
-    BusFault<ScalarT, IdxT>::BusFault(bus_type* bus)
+    template <typename ScalarP, typename IdxP>
+    BusFault<ScalarP, IdxP>::BusFault(BusT* bus)
       : bus_(bus), R_(0), X_(0.01), status_(0), bus_id_(0)
     {
       (void) bus_id_;
@@ -31,8 +31,6 @@ namespace GridKit
     /**
      * @brief Construct a new BusFault
      *
-     * @tparam ScalarT - scalar type
-     * @tparam IdxT    - matrix/vector index type
      * @param bus1 - pointer to bus-1
      * @param bus2 - pointer to bus-2
      * @param R - line series resistance
@@ -40,8 +38,8 @@ namespace GridKit
      * @param G - line shunt conductance
      * @param B - line shunt charging
      */
-    template <class ScalarT, typename IdxT>
-    BusFault<ScalarT, IdxT>::BusFault(bus_type* bus, RealT R, RealT X, int status)
+    template <typename ScalarP, typename IdxP>
+    BusFault<ScalarP, IdxP>::BusFault(BusT* bus, RealT R, RealT X, int status)
       : bus_(bus), R_(R), X_(X), status_(status), bus_id_(0)
     {
       size_ = 0;
@@ -51,37 +49,35 @@ namespace GridKit
     /**
      * @brief Construct a new BusFault
      *
-     * @tparam ScalarT - scalar type
-     * @tparam IdxT    - matrix/vector index type
      * @param bus1 - pointer to bus-1
      * @param bus2 - pointer to bus-2
      */
-    template <class ScalarT, typename IdxT>
-    BusFault<ScalarT, IdxT>::BusFault(bus_type* bus, const DataT& data)
-      : bus_(bus),
-        monitor_(std::make_unique<MonitorT>(data))
+    template <typename ScalarP, typename IdxP>
+    BusFault<ScalarP, IdxP>::BusFault(BusT* bus, const ModelDataT& data)
+      : ConnectedElement<BusFault>(data),
+        bus_(bus)
     {
-      if (data.parameters.contains(DataT::Parameters::R))
+      if (data.parameters.contains(ModelDataT::Parameters::R))
       {
-        R_ = std::get<RealT>(data.parameters.at(DataT::Parameters::R));
+        R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
       }
 
-      if (data.parameters.contains(DataT::Parameters::X))
+      if (data.parameters.contains(ModelDataT::Parameters::X))
       {
-        X_ = std::get<RealT>(data.parameters.at(DataT::Parameters::X));
+        X_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::X));
       }
 
-      if (data.parameters.contains(DataT::Parameters::state0))
+      if (data.parameters.contains(ModelDataT::Parameters::state0))
       {
-        status_ = std::get<bool>(data.parameters.at(DataT::Parameters::state0));
+        status_ = std::get<bool>(data.parameters.at(ModelDataT::Parameters::state0));
       }
 
-      if (data.ports.contains(DataT::Ports::bus))
+      if (data.ports.contains(ModelDataT::Ports::bus))
       {
-        bus_id_ = data.ports.at(DataT::Ports::bus);
+        bus_id_ = data.ports.at(ModelDataT::Ports::bus);
       }
 
-      using Variable = typename DataT::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::state, [this]
                     { return status_; });
       monitor_->set(Variable::ir, [this]
@@ -93,16 +89,16 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    BusFault<ScalarT, IdxT>::~BusFault()
+    template <typename ScalarP, typename IdxP>
+    BusFault<ScalarP, IdxP>::~BusFault()
     {
     }
 
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename ScalarP, typename IdxP>
+    int BusFault<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -111,8 +107,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::allocate()
+    template <typename ScalarP, typename IdxP>
+    int BusFault<ScalarP, IdxP>::allocate()
     {
       // std::cout << "Allocate BusFault..." << std::endl;
 
@@ -126,8 +122,8 @@ namespace GridKit
      * Initialization of the branch model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::initialize()
+    template <typename ScalarP, typename IdxP>
+    int BusFault<ScalarP, IdxP>::initialize()
     {
       return 0;
     }
@@ -135,8 +131,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::tagDifferentiable()
+    template <typename ScalarP, typename IdxP>
+    int BusFault<ScalarP, IdxP>::tagDifferentiable()
     {
       return 0;
     }
@@ -145,8 +141,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int BusFault<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) int BusFault<ScalarP, IdxP>::evaluateBusResidual(
         [[maybe_unused]] ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* wb, ScalarT* h)
     {
       ScalarT Vr = wb[0];
@@ -164,8 +160,8 @@ namespace GridKit
      * two terminal buses.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::evaluateResidual()
+    template <typename ScalarP, typename IdxP>
+    int BusFault<ScalarP, IdxP>::evaluateResidual()
     {
       if (status_)
       {
@@ -178,18 +174,12 @@ namespace GridKit
       return 0;
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* BusFault<ScalarT, IdxT>::getMonitor() const
-    {
-      return monitor_.get();
-    }
-
     /**
      * @brief Derived parameters
      *
      */
-    template <class ScalarT, typename IdxT>
-    void BusFault<ScalarT, IdxT>::setDerivedParams()
+    template <typename ScalarP, typename IdxP>
+    void BusFault<ScalarP, IdxP>::setDerivedParams()
     {
       B_ = -X_ / (X_ * X_ + R_ * R_);
       G_ = R_ / (X_ * X_ + R_ * R_);

--- a/GridKit/Model/PhasorDynamics/BusFault/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/BusFault/CMakeLists.txt
@@ -9,11 +9,10 @@ if(GRIDKIT_ENABLE_ENZYME)
       BusFaultEnzyme.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PRIVATE ClangEnzymeFlags
       PUBLIC GridKit::phasor_dynamics_core
+      PRIVATE GridKit::phasor_dynamics_utils
     COMPILE_OPTIONS
       PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
@@ -22,18 +21,16 @@ else()
       BusFault.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
+      PRIVATE GridKit::phasor_dynamics_utils
       PUBLIC GridKit::phasor_dynamics_core)
 endif()
 
 gridkit_add_library(phasor_dynamics_bus_fault_dependency_tracking
   SOURCES 
     BusFaultDependencyTracking.cpp
-  INCLUDE_DIRECTORIES 
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
   LINK_LIBRARIES
+    PRIVATE GridKit::phasor_dynamics_utils
     PUBLIC GridKit::phasor_dynamics_core)
 
 # Link to interface target for all components

--- a/GridKit/Model/PhasorDynamics/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/CMakeLists.txt
@@ -6,31 +6,55 @@
 add_library(phasor_dynamics_components INTERFACE)
 add_library(phasor_dynamics_components_dependency_tracking INTERFACE)
 
+add_library(phasor_dynamics_utils INTERFACE)
+target_include_directories(phasor_dynamics_utils INTERFACE
+    ${GRIDKIT_THIRD_PARTY_DIR}/nlohmann-json/include
+    ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+add_library(GridKit::phasor_dynamics_utils ALIAS phasor_dynamics_utils)
+
 gridkit_add_library(phasor_dynamics_core
   SOURCES
     SystemModelData.cpp
   HEADERS
     BusBase.hpp
-    BusBaseImpl.hpp
     Component.hpp
     ComponentData.hpp
     ComponentLibrary.hpp
     ComponentSignals.hpp
+    ConnectedElement.hpp
     GridElement.hpp
-    SystemModel.hpp
     SystemModelData.hpp
   LINK_LIBRARIES
     PUBLIC GridKit::definitions
     PUBLIC GridKit::utilities_logger
     PUBLIC GridKit::sparse_matrix
-  INCLUDE_DIRECTORIES
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/nlohmann-json/include
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+    PRIVATE GridKit::phasor_dynamics_utils)
 
 target_link_libraries(phasor_dynamics_components
   INTERFACE GridKit::phasor_dynamics_core)
 target_link_libraries(phasor_dynamics_components_dependency_tracking
   INTERFACE GridKit::phasor_dynamics_core)
+
+gridkit_add_library(phasor_dynamics_system_model
+  SOURCES
+    SystemModel.cpp
+  HEADERS
+    SystemModel.hpp
+  LINK_LIBRARIES
+    PUBLIC GridKit::phasor_dynamics_core
+    PRIVATE GridKit::phasor_dynamics_utils)
+
+gridkit_add_library(phasor_dynamics_system_model_dependency_tracking
+  SOURCES
+    SystemModelDependencyTracking.cpp
+  LINK_LIBRARIES
+    PUBLIC GridKit::phasor_dynamics_core
+  PRIVATE GridKit::phasor_dynamics_utils)
+
+target_link_libraries(phasor_dynamics_components
+  INTERFACE GridKit::phasor_dynamics_system_model)
+target_link_libraries(phasor_dynamics_components_dependency_tracking
+  INTERFACE GridKit::phasor_dynamics_system_model_dependency_tracking)
 
 add_subdirectory(Branch)
 add_subdirectory(Bus)

--- a/GridKit/Model/PhasorDynamics/Component.hpp
+++ b/GridKit/Model/PhasorDynamics/Component.hpp
@@ -2,7 +2,6 @@
 
 #include <vector>
 
-#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/CommonMath.hpp>
 #include <GridKit/Model/PhasorDynamics/GridElement.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
@@ -11,19 +10,24 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    using Log = ::GridKit::Utilities::Logger;
-
     /**
      * @brief Component model implementation base class.
      */
-    template <class ScalarT, typename IdxT>
-    class Component : public GridElement<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    class Component : public GridElement<ScalarP, IdxP>
     {
     public:
-      using RealT   = typename GridElement<ScalarT, IdxT>::RealT;
-      using MatrixT = typename GridElement<ScalarT, IdxT>::MatrixT;
+      using ScalarT = ScalarP;
+      using IdxT    = IdxP;
+      using RealT   = typename Model::Evaluator<ScalarT, IdxT>::RealT;
+      using MatrixT = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
 
       Component() = default;
+
+      template <typename ModelDataP>
+      Component([[maybe_unused]] const ModelDataP& data)
+      {
+      }
 
       virtual ~Component()
       {
@@ -54,8 +58,8 @@ namespace GridKit
       std::vector<ScalarT> wb_;
       std::vector<ScalarT> h_;
 
-      RealT time_;
-      RealT alpha_;
+      RealT time_{};
+      RealT alpha_{};
 
       /*
 

--- a/GridKit/Model/PhasorDynamics/ConnectedElement.hpp
+++ b/GridKit/Model/PhasorDynamics/ConnectedElement.hpp
@@ -1,0 +1,178 @@
+#pragma once
+
+#include <memory>
+
+#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
+#include <GridKit/Model/PhasorDynamics/GridElement.hpp>
+#include <GridKit/Model/VariableMonitor.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    template <typename ElementP>
+    struct ConnectedElementTraits
+    {
+    };
+
+    /**
+     * @brief Model base class for all system constituents
+     */
+    template <typename ElementP>
+    class ConnectedElement : public ConnectedElementTraits<ElementP>::InterfaceT
+    {
+    public:
+      using Traits     = ConnectedElementTraits<ElementP>;
+      using Superclass = typename Traits::InterfaceT;
+      using ScalarT    = typename Traits::ScalarT;
+      using IdxT       = typename Traits::IdxT;
+      using RealT      = typename Model::Evaluator<ScalarT, IdxT>::RealT;
+      using MatrixT    = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
+      using ModelDataT = typename Traits::ModelDataT;
+      using MonitorT   = Model::VariableMonitor<ElementP>;
+
+      using InternalVariablesT = typename Traits::InternalVariablesT;
+      using ExternalVariablesT = typename Traits::ExternalVariablesT;
+
+      ConnectedElement() = default;
+
+      ConnectedElement(const ModelDataT& data);
+
+      virtual ~ConnectedElement();
+
+      auto getSignals()
+          -> ComponentSignals<ScalarT,
+                              IdxT,
+                              InternalVariablesT,
+                              ExternalVariablesT>&
+      {
+        return signals_;
+      }
+
+      const Model::VariableMonitorBase* getMonitor() const override;
+
+    protected:
+      /// Component signal extension
+      ComponentSignals<ScalarT, IdxT, InternalVariablesT, ExternalVariablesT> signals_;
+
+      /// Variable monitor
+      std::unique_ptr<MonitorT> monitor_;
+
+      using NotImplementedError = GridKit::Utilities::NotImplementedError;
+
+    public:
+      // TODO: evaluate how this complies with xSDK guidelines
+
+      [[noreturn]] IdxT sizeQuadrature() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] IdxT sizeParams() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& yB() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& yB() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& ypB() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& ypB() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& param() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& param() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& param_up() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& param_up() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& param_lo() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& param_lo() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] int evaluateIntegrand() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] int initializeAdjoint() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] int evaluateAdjointResidual() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] int evaluateAdjointIntegrand() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& getIntegrand() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& getIntegrand() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& getAdjointResidual() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& getAdjointResidual() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] std::vector<ScalarT>& getAdjointIntegrand() override
+      {
+        throw NotImplementedError(__func__);
+      }
+
+      [[noreturn]] const std::vector<ScalarT>& getAdjointIntegrand() const override
+      {
+        throw NotImplementedError(__func__);
+      }
+    };
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp
@@ -1,0 +1,28 @@
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
+#include <GridKit/Model/PhasorDynamics/GridElementImpl.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+
+    template <typename ElementP>
+    ConnectedElement<ElementP>::ConnectedElement(const ModelDataT& data)
+      : Superclass(data),
+        monitor_(std::make_unique<MonitorT>(data))
+    {
+    }
+
+    template <typename ElementP>
+    ConnectedElement<ElementP>::~ConnectedElement()
+    {
+    }
+
+    template <typename ElementP>
+    const Model::VariableMonitorBase* ConnectedElement<ElementP>::getMonitor() const
+    {
+      return monitor_.get();
+    }
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/CMakeLists.txt
@@ -14,11 +14,10 @@ if(GRIDKIT_ENABLE_ENZYME)
     Ieeet1Enzyme.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PUBLIC GridKit::phasor_dynamics_core
       PUBLIC GridKit::phasor_dynamics_signal
+      PRIVATE GridKit::phasor_dynamics_utils
       PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
       PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
@@ -28,21 +27,19 @@ else()
       Ieeet1.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
-      GridKit::phasor_dynamics_core
-      GridKit::phasor_dynamics_signal)
+      PRIVATE GridKit::phasor_dynamics_utils
+      PUBLIC GridKit::phasor_dynamics_core
+      PUBLIC GridKit::phasor_dynamics_signal)
 endif()
 
 gridkit_add_library(phasor_dynamics_exciter_ieeet1_dependency_tracking
   SOURCES
     Ieeet1DependencyTracking.cpp
-  INCLUDE_DIRECTORIES
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
   LINK_LIBRARIES
-    GridKit::phasor_dynamics_core
-    GridKit::phasor_dynamics_signal_dependency_tracking)
+    PRIVATE GridKit::phasor_dynamics_utils
+    PUBLIC GridKit::phasor_dynamics_core
+    PUBLIC GridKit::phasor_dynamics_signal_dependency_tracking)
 
 # Link to interface target for all components
 target_link_libraries(phasor_dynamics_components

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -10,8 +10,7 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 
 // Forward declarations
 namespace GridKit
@@ -20,14 +19,14 @@ namespace GridKit
   {
     namespace Exciter
     {
-      template <typename RealT, typename IdxT>
+      template <typename RealP, typename IdxP>
       struct Ieeet1Data;
     } // namespace Exciter
 
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class BusBase;
 
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class SignalNode;
 
   } // namespace PhasorDynamics
@@ -39,6 +38,9 @@ namespace GridKit
   {
     namespace Exciter
     {
+      template <typename, typename>
+      class Ieeet1;
+
       /// Internal variables of a `Ieeet1`
       enum class Ieeet1InternalVariables : size_t
       {
@@ -63,41 +65,65 @@ namespace GridKit
         VS,    ///< Stabilizer output signal
         MAXIMUM,
       };
+    } // namespace Exciter
 
-      template <class ScalarT, typename IdxT>
-      class Ieeet1 : public Component<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<Exciter::Ieeet1<ScalarP, IdxP>>
+    {
+      using Ieeet1T = Exciter::Ieeet1<ScalarP, IdxP>;
+
+      using ElementT           = Ieeet1T;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = Exciter::Ieeet1Data<RealT, IdxT>;
+      using InternalVariablesT = Exciter::Ieeet1InternalVariables;
+      using ExternalVariablesT = Exciter::Ieeet1ExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
+    namespace Exciter
+    {
+      template <typename ScalarP, typename IdxP>
+      class Ieeet1 : public ConnectedElement<Ieeet1<ScalarP, IdxP>>
       {
-        using Component<ScalarT, IdxT>::gridkit_component_id_;
-        using Component<ScalarT, IdxT>::alpha_;
-        using Component<ScalarT, IdxT>::f_;
-        using Component<ScalarT, IdxT>::nnz_;
-        using Component<ScalarT, IdxT>::size_;
-        using Component<ScalarT, IdxT>::tag_;
-        using Component<ScalarT, IdxT>::time_;
-        using Component<ScalarT, IdxT>::y_;
-        using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::wb_;
-        using Component<ScalarT, IdxT>::J_;
-        using Component<ScalarT, IdxT>::J_rows_buffer_;
-        using Component<ScalarT, IdxT>::J_cols_buffer_;
-        using Component<ScalarT, IdxT>::J_vals_buffer_;
-        using Component<ScalarT, IdxT>::variable_indices_;
-        using Component<ScalarT, IdxT>::residual_indices_;
+        using ConnectedElement<Ieeet1>::gridkit_component_id_;
+        using ConnectedElement<Ieeet1>::alpha_;
+        using ConnectedElement<Ieeet1>::f_;
+        using ConnectedElement<Ieeet1>::nnz_;
+        using ConnectedElement<Ieeet1>::size_;
+        using ConnectedElement<Ieeet1>::tag_;
+        using ConnectedElement<Ieeet1>::time_;
+        using ConnectedElement<Ieeet1>::y_;
+        using ConnectedElement<Ieeet1>::yp_;
+        using ConnectedElement<Ieeet1>::wb_;
+        using ConnectedElement<Ieeet1>::J_;
+        using ConnectedElement<Ieeet1>::J_rows_buffer_;
+        using ConnectedElement<Ieeet1>::J_cols_buffer_;
+        using ConnectedElement<Ieeet1>::J_vals_buffer_;
+        using ConnectedElement<Ieeet1>::variable_indices_;
+        using ConnectedElement<Ieeet1>::residual_indices_;
+        using ConnectedElement<Ieeet1>::signals_;
+        using ConnectedElement<Ieeet1>::monitor_;
 
       public:
-        using RealT           = typename Component<ScalarT, IdxT>::RealT;
-        using model_data_type = Ieeet1Data<RealT, IdxT>;
-        using signal_type     = SignalNode<ScalarT, IdxT>;
-        using bus_type        = BusBase<ScalarT, IdxT>;
-        using MonitorT        = Model::VariableMonitor<Ieeet1, Ieeet1Data>;
+        using ScalarT    = typename ConnectedElement<Ieeet1>::ScalarT;
+        using IdxT       = typename ConnectedElement<Ieeet1>::IdxT;
+        using RealT      = typename ConnectedElement<Ieeet1>::RealT;
+        using ModelDataT = Ieeet1Data<RealT, IdxT>;
+        using SignalT    = SignalNode<ScalarT, IdxT>;
+        using BusT       = BusBase<ScalarT, IdxT>;
+        using MonitorT   = typename ConnectedElement<Ieeet1>::MonitorT;
 
-        Ieeet1(bus_type* bus);
-        Ieeet1(signal_type*           efd_signal,
-               signal_type*           speed_signal,
-               bus_type*              bus,
-               const model_data_type& data);
-        Ieeet1(bus_type*              bus,
-               const model_data_type& data);
+        Ieeet1(BusT* bus);
+
+        Ieeet1(SignalT*          efd_signal,
+               SignalT*          speed_signal,
+               BusT*             bus,
+               const ModelDataT& data);
+
+        Ieeet1(BusT* bus, const ModelDataT& data);
+
         ~Ieeet1();
 
         int setGridKitComponentID(IdxT) override final;
@@ -108,25 +134,13 @@ namespace GridKit
         int evaluateResidual() override final;
         int evaluateJacobian() override final;
 
-        /// Get the `ComponentSignals` from this `Ieeet1`
-        auto getSignals()
-            -> ComponentSignals<ScalarT,
-                                IdxT,
-                                Ieeet1InternalVariables,
-                                Ieeet1ExternalVariables>&
-        {
-          return signals_;
-        }
-
-        const Model::VariableMonitorBase* getMonitor() const override;
-
         __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
       private:
         // Signal pointers
-        signal_type* efd_signal_;
-        signal_type* speed_signal_;
-        bus_type*    bus_;
+        SignalT* efd_signal_;
+        SignalT* speed_signal_;
+        BusT*    bus_;
 
         // Model Input parameters
         RealT Tr_;      ///< Time constant for voltage sensing
@@ -157,14 +171,8 @@ namespace GridKit
         ScalarT vS_{0};
         ScalarT Ec_{0}; // "Compensated" terminal measurment, currently unused
 
-        /// Component signal extension
-        ComponentSignals<ScalarT, IdxT, Ieeet1InternalVariables, Ieeet1ExternalVariables> signals_;
-
-        /// Variable monitor
-        std::unique_ptr<MonitorT> monitor_;
-
         // Parameter initialization function
-        void initModelParams(const model_data_type& data);
+        void initModelParams(const ModelDataT& data);
 
         /// Associate variable getter functions with enum values
         void initializeMonitor();

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
@@ -7,6 +7,8 @@
  *
  */
 
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+
 #include "Ieeet1Impl.hpp"
 
 namespace GridKit

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -11,10 +11,10 @@
 #include <iostream>
 
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 #include <GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp>
 #include <GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp>
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
 #define _USE_MATH_DEFINES
@@ -30,11 +30,9 @@ namespace GridKit
       /**
        * @brief  Constructor for IEEET1 Exciter
        *
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
        */
-      template <class ScalarT, typename IdxT>
-      Ieeet1<ScalarT, IdxT>::Ieeet1(bus_type* bus)
+      template <typename ScalarP, typename IdxP>
+      Ieeet1<ScalarP, IdxP>::Ieeet1(BusT* bus)
         : bus_(bus)
       {
         size_ = 9;
@@ -47,20 +45,17 @@ namespace GridKit
        * @param bus   Signal used for terminal reference vmag
        * @param speed Signal used for machine relative speed
        * @param efd   Signal used for E field
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
        */
-      template <class ScalarT, typename IdxT>
-      Ieeet1<ScalarT, IdxT>::Ieeet1(signal_type*           efd_signal,
-                                    signal_type*           speed_signal,
-                                    bus_type*              bus,
-                                    const model_data_type& data)
-        : efd_signal_(efd_signal),
+      template <typename ScalarP, typename IdxP>
+      Ieeet1<ScalarP, IdxP>::Ieeet1(SignalT*          efd_signal,
+                                    SignalT*          speed_signal,
+                                    BusT*             bus,
+                                    const ModelDataT& data)
+        : ConnectedElement<Ieeet1>(data),
+          efd_signal_(efd_signal),
           speed_signal_(speed_signal),
-          bus_(bus),
-          monitor_(std::make_unique<MonitorT>(data))
+          bus_(bus)
       {
-
         // Parse data struct into model
         this->initModelParams(data);
 
@@ -75,15 +70,12 @@ namespace GridKit
        *
        * @param bus   Signal used for terminal reference vmag
        * @param data  Data object to store parameters
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
        */
-      template <class ScalarT, typename IdxT>
-      Ieeet1<ScalarT, IdxT>::Ieeet1(bus_type*              bus,
-                                    const model_data_type& data)
-        : bus_(bus),
-          monitor_(std::make_unique<MonitorT>(data))
+      template <typename ScalarP, typename IdxP>
+      Ieeet1<ScalarP, IdxP>::Ieeet1(BusT* bus, const ModelDataT& data)
+        : bus_(bus)
       {
+        monitor_ = std::make_unique<MonitorT>(data);
 
         // Parse data struct into model
         this->initModelParams(data);
@@ -94,16 +86,16 @@ namespace GridKit
         size_ = 9;
       }
 
-      template <class ScalarT, typename IdxT>
-      Ieeet1<ScalarT, IdxT>::~Ieeet1()
+      template <typename ScalarP, typename IdxP>
+      Ieeet1<ScalarP, IdxP>::~Ieeet1()
       {
       }
 
       /**
        * @brief Set the component ID
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      template <typename ScalarP, typename IdxP>
+      int Ieeet1<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
       {
         gridkit_component_id_ = component_id;
         return 0;
@@ -113,8 +105,8 @@ namespace GridKit
        * @brief Allocate memory for model
        *
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::allocate()
+      template <typename ScalarP, typename IdxP>
+      int Ieeet1<ScalarP, IdxP>::allocate()
       {
         // Resize component model data
         auto size = static_cast<size_t>(size_); // avoid compiler warnings
@@ -155,8 +147,8 @@ namespace GridKit
       /**
        * @brief verify method checks that attached signals are also linked
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::verify() const
+      template <typename ScalarP, typename IdxP>
+      int Ieeet1<ScalarP, IdxP>::verify() const
       {
         static constexpr auto OMEGA = Ieeet1ExternalVariables::OMEGA;
         static constexpr auto VS    = Ieeet1ExternalVariables::VS;
@@ -197,8 +189,8 @@ namespace GridKit
        *
        * Saturation is included via ksat computed from efdp and SA, SB.
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::initialize()
+      template <typename ScalarP, typename IdxP>
+      int Ieeet1<ScalarP, IdxP>::initialize()
       {
 
         // External Variables
@@ -263,12 +255,10 @@ namespace GridKit
       /**
        * @brief  Identify differential variables.
        *
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
        * @return int 0
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::tagDifferentiable()
+      template <typename ScalarP, typename IdxP>
+      int Ieeet1<ScalarP, IdxP>::tagDifferentiable()
       {
 
         tag_[0] = true;  // y0 - vts  - Sensed term volt
@@ -288,8 +278,8 @@ namespace GridKit
        * @brief Internal Residual
        *
        */
-      template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int Ieeet1<ScalarT, IdxT>::evaluateInternalResidual(
+      template <typename ScalarP, typename IdxP>
+      __attribute__((always_inline)) inline int Ieeet1<ScalarP, IdxP>::evaluateInternalResidual(
           ScalarT* y,
           ScalarT* yp,
           ScalarT* wb,
@@ -349,8 +339,8 @@ namespace GridKit
        * @brief Residual evaluation
        *
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::evaluateResidual()
+      template <typename ScalarP, typename IdxP>
+      int Ieeet1<ScalarP, IdxP>::evaluateResidual()
       {
         // Set Input Variables
         // Meta PR Note: This seems to be very slow,
@@ -389,65 +379,65 @@ namespace GridKit
       /**
        * @brief Initialization Exciter Parameters from data structure
        */
-      template <class ScalarT, typename IdxT>
-      void Ieeet1<ScalarT, IdxT>::initModelParams(const model_data_type& data)
+      template <typename ScalarP, typename IdxP>
+      void Ieeet1<ScalarP, IdxP>::initModelParams(const ModelDataT& data)
       {
 
-        if (data.parameters.contains(model_data_type::Parameters::Tr))
+        if (data.parameters.contains(ModelDataT::Parameters::Tr))
         {
-          Tr_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tr));
+          Tr_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tr));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ka))
+        if (data.parameters.contains(ModelDataT::Parameters::Ka))
         {
-          Ka_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ka));
+          Ka_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ka));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ta))
+        if (data.parameters.contains(ModelDataT::Parameters::Ta))
         {
-          Ta_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ta));
+          Ta_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ta));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ke))
+        if (data.parameters.contains(ModelDataT::Parameters::Ke))
         {
-          Ke_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ke));
+          Ke_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ke));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Te))
+        if (data.parameters.contains(ModelDataT::Parameters::Te))
         {
-          Te_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Te));
+          Te_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Te));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Kf))
+        if (data.parameters.contains(ModelDataT::Parameters::Kf))
         {
-          Kf_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Kf));
+          Kf_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Kf));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Tf))
+        if (data.parameters.contains(ModelDataT::Parameters::Tf))
         {
-          Tf_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tf));
+          Tf_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tf));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Vrmin))
+        if (data.parameters.contains(ModelDataT::Parameters::Vrmin))
         {
-          Vrmin_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Vrmin));
+          Vrmin_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vrmin));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Vrmax))
+        if (data.parameters.contains(ModelDataT::Parameters::Vrmax))
         {
-          Vrmax_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Vrmax));
+          Vrmax_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vrmax));
         }
-        if (data.parameters.contains(model_data_type::Parameters::E1))
+        if (data.parameters.contains(ModelDataT::Parameters::E1))
         {
-          E1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::E1));
+          E1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::E1));
         }
-        if (data.parameters.contains(model_data_type::Parameters::E2))
+        if (data.parameters.contains(ModelDataT::Parameters::E2))
         {
-          E2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::E2));
+          E2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::E2));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Se1))
+        if (data.parameters.contains(ModelDataT::Parameters::Se1))
         {
-          Se1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Se1));
+          Se1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Se1));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Se2))
+        if (data.parameters.contains(ModelDataT::Parameters::Se2))
         {
-          Se2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Se2));
+          Se2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Se2));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ispdlim))
+        if (data.parameters.contains(ModelDataT::Parameters::Ispdlim))
         {
-          Ispdlim_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ispdlim));
+          Ispdlim_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ispdlim));
         }
 
         // Derived Parameters
@@ -458,16 +448,10 @@ namespace GridKit
         SB_ = Se1_ / (E1_ - SA_) / (E1_ - SA_);
       }
 
-      template <class ScalarT, typename IdxT>
-      const Model::VariableMonitorBase* Ieeet1<ScalarT, IdxT>::getMonitor() const
+      template <typename ScalarP, typename IdxP>
+      void Ieeet1<ScalarP, IdxP>::initializeMonitor()
       {
-        return monitor_.get();
-      }
-
-      template <class ScalarT, typename IdxT>
-      void Ieeet1<ScalarT, IdxT>::initializeMonitor()
-      {
-        using Variable = model_data_type::MonitorableVariables;
+        using Variable = ModelDataT::MonitorableVariables;
         monitor_->set(Variable::efd, [this]
                       { return efd_signal_->read(); });
         monitor_->set(Variable::ksat, [this]

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/CMakeLists.txt
@@ -13,11 +13,10 @@ if(GRIDKIT_ENABLE_ENZYME)
       SexsPtiEnzyme.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PUBLIC GridKit::phasor_dynamics_core
       PUBLIC GridKit::phasor_dynamics_signal
+      PRIVATE GridKit::phasor_dynamics_utils
       PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
       PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
@@ -27,21 +26,19 @@ else()
       SexsPti.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
-      GridKit::phasor_dynamics_core
-      GridKit::phasor_dynamics_signal)
+      PRIVATE GridKit::phasor_dynamics_utils
+      PUBLIC GridKit::phasor_dynamics_core
+      PUBLIC GridKit::phasor_dynamics_signal)
 endif()
 
 gridkit_add_library(phasor_dynamics_exciter_sexspti_dependency_tracking
   SOURCES
     SexsPtiDependencyTracking.cpp
-  INCLUDE_DIRECTORIES
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
   LINK_LIBRARIES
-    GridKit::phasor_dynamics_core
-    GridKit::phasor_dynamics_signal_dependency_tracking)
+    PRIVATE GridKit::phasor_dynamics_utils
+    PUBLIC GridKit::phasor_dynamics_core
+    PUBLIC GridKit::phasor_dynamics_signal_dependency_tracking)
 
 target_link_libraries(phasor_dynamics_components
   INTERFACE GridKit::phasor_dynamics_exciter_sexspti)

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPti.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPti.hpp
@@ -7,8 +7,7 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 
 namespace GridKit
 {
@@ -16,14 +15,14 @@ namespace GridKit
   {
     namespace Exciter
     {
-      template <typename RealT, typename IdxT>
+      template <typename RealP, typename IdxP>
       struct SexsPtiData;
     } // namespace Exciter
 
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class BusBase;
 
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class SignalNode;
 
   } // namespace PhasorDynamics
@@ -35,6 +34,9 @@ namespace GridKit
   {
     namespace Exciter
     {
+      template <typename, typename>
+      class SexsPti;
+
       /// Internal variables of a `SexsPti`.
       enum class SexsPtiInternalVariables : size_t
       {
@@ -50,36 +52,58 @@ namespace GridKit
         VS, ///< Stabilizer output signal
         MAXIMUM,
       };
+    } // namespace Exciter
 
-      template <class ScalarT, typename IdxT>
-      class SexsPti : public Component<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<Exciter::SexsPti<ScalarP, IdxP>>
+    {
+      using SexsPtiT = Exciter::SexsPti<ScalarP, IdxP>;
+
+      using ElementT           = SexsPtiT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = Exciter::SexsPtiData<RealT, IdxT>;
+      using InternalVariablesT = Exciter::SexsPtiInternalVariables;
+      using ExternalVariablesT = Exciter::SexsPtiExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
+    namespace Exciter
+    {
+      template <typename ScalarP, typename IdxP>
+      class SexsPti : public ConnectedElement<SexsPti<ScalarP, IdxP>>
       {
-        using Component<ScalarT, IdxT>::gridkit_component_id_;
-        using Component<ScalarT, IdxT>::alpha_;
-        using Component<ScalarT, IdxT>::f_;
-        using Component<ScalarT, IdxT>::nnz_;
-        using Component<ScalarT, IdxT>::size_;
-        using Component<ScalarT, IdxT>::tag_;
-        using Component<ScalarT, IdxT>::time_;
-        using Component<ScalarT, IdxT>::y_;
-        using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::wb_;
-        using Component<ScalarT, IdxT>::J_;
-        using Component<ScalarT, IdxT>::J_rows_buffer_;
-        using Component<ScalarT, IdxT>::J_cols_buffer_;
-        using Component<ScalarT, IdxT>::J_vals_buffer_;
-        using Component<ScalarT, IdxT>::variable_indices_;
-        using Component<ScalarT, IdxT>::residual_indices_;
+        using ConnectedElement<SexsPti>::gridkit_component_id_;
+        using ConnectedElement<SexsPti>::alpha_;
+        using ConnectedElement<SexsPti>::f_;
+        using ConnectedElement<SexsPti>::nnz_;
+        using ConnectedElement<SexsPti>::size_;
+        using ConnectedElement<SexsPti>::tag_;
+        using ConnectedElement<SexsPti>::time_;
+        using ConnectedElement<SexsPti>::y_;
+        using ConnectedElement<SexsPti>::yp_;
+        using ConnectedElement<SexsPti>::wb_;
+        using ConnectedElement<SexsPti>::J_;
+        using ConnectedElement<SexsPti>::J_rows_buffer_;
+        using ConnectedElement<SexsPti>::J_cols_buffer_;
+        using ConnectedElement<SexsPti>::J_vals_buffer_;
+        using ConnectedElement<SexsPti>::variable_indices_;
+        using ConnectedElement<SexsPti>::residual_indices_;
+        using ConnectedElement<SexsPti>::signals_;
+        using ConnectedElement<SexsPti>::monitor_;
 
       public:
-        using RealT           = typename Component<ScalarT, IdxT>::RealT;
-        using model_data_type = SexsPtiData<RealT, IdxT>;
-        using signal_type     = SignalNode<ScalarT, IdxT>;
-        using bus_type        = BusBase<ScalarT, IdxT>;
-        using MonitorT        = Model::VariableMonitor<SexsPti, SexsPtiData>;
+        using ScalarT    = typename ConnectedElement<SexsPti>::ScalarT;
+        using IdxT       = typename ConnectedElement<SexsPti>::IdxT;
+        using RealT      = typename ConnectedElement<SexsPti>::RealT;
+        using ModelDataT = SexsPtiData<RealT, IdxT>;
+        using SignalT    = SignalNode<ScalarT, IdxT>;
+        using BusT       = BusBase<ScalarT, IdxT>;
+        using MonitorT   = typename ConnectedElement<SexsPti>::MonitorT;
 
-        SexsPti(bus_type* bus);
-        SexsPti(bus_type* bus, const model_data_type& data);
+        SexsPti(BusT* bus);
+        SexsPti(BusT* bus, const ModelDataT& data);
         ~SexsPti();
 
         int setGridKitComponentID(IdxT) override final;
@@ -90,22 +114,11 @@ namespace GridKit
         int evaluateResidual() override final;
         int evaluateJacobian() override final;
 
-        auto getSignals()
-            -> ComponentSignals<ScalarT,
-                                IdxT,
-                                SexsPtiInternalVariables,
-                                SexsPtiExternalVariables>&
-        {
-          return signals_;
-        }
-
-        const Model::VariableMonitorBase* getMonitor() const override;
-
         __attribute__((always_inline)) inline int evaluateInternalResidual(
             ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
       private:
-        bus_type* bus_{nullptr};
+        BusT* bus_{nullptr};
 
         RealT Ta_{0};
         RealT Tb_{0};
@@ -120,11 +133,7 @@ namespace GridKit
         ScalarT vOEL_{0};
         ScalarT vUEL_{0};
 
-        ComponentSignals<ScalarT, IdxT, SexsPtiInternalVariables, SexsPtiExternalVariables> signals_;
-
-        std::unique_ptr<MonitorT> monitor_;
-
-        void initModelParams(const model_data_type& data);
+        void initModelParams(const ModelDataT& data);
         void initializeMonitor();
 
         std::vector<ScalarT> ws_;

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiDependencyTracking.cpp
@@ -4,6 +4,8 @@
  * @brief Dependency-tracking instantiations for the SEXS-PTI exciter model.
  */
 
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+
 #include "SexsPtiImpl.hpp"
 
 namespace GridKit

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiImpl.hpp
@@ -10,10 +10,10 @@
 #include <iostream>
 
 #include <GridKit/Model/PhasorDynamics/BusBase.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 #include <GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPti.hpp>
 #include <GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiData.hpp>
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
 namespace GridKit
@@ -24,38 +24,37 @@ namespace GridKit
     {
       using Log = ::GridKit::Utilities::Logger;
 
-      template <class ScalarT, typename IdxT>
-      SexsPti<ScalarT, IdxT>::SexsPti(bus_type* bus)
+      template <typename ScalarP, typename IdxP>
+      SexsPti<ScalarP, IdxP>::SexsPti(BusT* bus)
         : bus_(bus)
       {
         size_ = 3;
       }
 
-      template <class ScalarT, typename IdxT>
-      SexsPti<ScalarT, IdxT>::SexsPti(bus_type*              bus,
-                                      const model_data_type& data)
-        : bus_(bus),
-          monitor_(std::make_unique<MonitorT>(data))
+      template <typename ScalarP, typename IdxP>
+      SexsPti<ScalarP, IdxP>::SexsPti(BusT* bus, const ModelDataT& data)
+        : ConnectedElement<SexsPti>(data),
+          bus_(bus)
       {
         initModelParams(data);
         initializeMonitor();
         size_ = 3;
       }
 
-      template <class ScalarT, typename IdxT>
-      SexsPti<ScalarT, IdxT>::~SexsPti()
+      template <typename ScalarP, typename IdxP>
+      SexsPti<ScalarP, IdxP>::~SexsPti()
       {
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      template <typename ScalarP, typename IdxP>
+      int SexsPti<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
       {
         gridkit_component_id_ = component_id;
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::allocate()
+      template <typename ScalarP, typename IdxP>
+      int SexsPti<ScalarP, IdxP>::allocate()
       {
         auto size = static_cast<size_t>(size_);
         f_.resize(size);
@@ -87,8 +86,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::verify() const
+      template <typename ScalarP, typename IdxP>
+      int SexsPti<ScalarP, IdxP>::verify() const
       {
         int ret = missing_param_count_;
 
@@ -141,8 +140,8 @@ namespace GridKit
         return ret;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::initialize()
+      template <typename ScalarP, typename IdxP>
+      int SexsPti<ScalarP, IdxP>::initialize()
       {
         ScalarT efd0{0.0};
         if (signals_.template isAssigned<SexsPtiInternalVariables::EFD>())
@@ -170,8 +169,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::tagDifferentiable()
+      template <typename ScalarP, typename IdxP>
+      int SexsPti<ScalarP, IdxP>::tagDifferentiable()
       {
         tag_[0] = true;
         tag_[1] = true;
@@ -180,8 +179,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int SexsPti<ScalarT, IdxT>::evaluateInternalResidual(
+      template <typename ScalarP, typename IdxP>
+      __attribute__((always_inline)) inline int SexsPti<ScalarP, IdxP>::evaluateInternalResidual(
           ScalarT* y,
           ScalarT* yp,
           ScalarT* wb,
@@ -208,8 +207,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::evaluateResidual()
+      template <typename ScalarP, typename IdxP>
+      int SexsPti<ScalarP, IdxP>::evaluateResidual()
       {
         ws_[0]         = 0.0;
         ws_indices_[0] = INVALID_INDEX<IdxT>;
@@ -227,10 +226,10 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      void SexsPti<ScalarT, IdxT>::initModelParams(const model_data_type& data)
+      template <typename ScalarP, typename IdxP>
+      void SexsPti<ScalarP, IdxP>::initModelParams(const ModelDataT& data)
       {
-        using Params = typename model_data_type::Parameters;
+        using Params = typename ModelDataT::Parameters;
 
         missing_param_count_ = 0;
 
@@ -255,16 +254,10 @@ namespace GridKit
         load(Params::Efdmin, Efdmin_, "Efdmin");
       }
 
-      template <class ScalarT, typename IdxT>
-      const Model::VariableMonitorBase* SexsPti<ScalarT, IdxT>::getMonitor() const
+      template <typename ScalarP, typename IdxP>
+      void SexsPti<ScalarP, IdxP>::initializeMonitor()
       {
-        return monitor_.get();
-      }
-
-      template <class ScalarT, typename IdxT>
-      void SexsPti<ScalarT, IdxT>::initializeMonitor()
-      {
-        using Variable = typename model_data_type::MonitorableVariables;
+        using Variable = typename ModelDataT::MonitorableVariables;
         monitor_->set(Variable::efd, [this]
                       { return y_[1]; });
       }

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
@@ -15,6 +15,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     HEADERS
       ${_install_headers}
     LINK_LIBRARIES
+      PRIVATE GridKit::phasor_dynamics_utils
       PUBLIC GridKit::phasor_dynamics_core
       PUBLIC GridKit::phasor_dynamics_signal
       PRIVATE ClangEnzymeFlags
@@ -27,14 +28,16 @@ else()
     HEADERS
       ${_install_headers}
     LINK_LIBRARIES
-      GridKit::phasor_dynamics_core
-      GridKit::phasor_dynamics_signal)
+      PRIVATE GridKit::phasor_dynamics_utils
+      PUBLIC GridKit::phasor_dynamics_core
+      PUBLIC GridKit::phasor_dynamics_signal)
 endif()
 
 gridkit_add_library(phasor_dynamics_governortgov1_dependency_tracking
   SOURCES
     Tgov1DependencyTracking.cpp
   LINK_LIBRARIES
+    PRIVATE GridKit::phasor_dynamics_utils
     PUBLIC GridKit::phasor_dynamics_core
     PUBLIC GridKit::phasor_dynamics_signal_dependency_tracking)
 

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 
 // Forward declarations
 namespace GridKit
@@ -19,14 +19,14 @@ namespace GridKit
   {
     namespace Governor
     {
-      template <typename RealT, typename IdxT>
+      template <typename RealP, typename IdxP>
       struct Tgov1Data;
     } // namespace Governor
 
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class Genrou;
 
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class SignalNode;
 
   } // namespace PhasorDynamics
@@ -38,6 +38,9 @@ namespace GridKit
   {
     namespace Governor
     {
+      template <typename, typename>
+      class Tgov1;
+
       /// Internal variables of a `Tgov1`
       enum class Tgov1InternalVariables : size_t
       {
@@ -54,36 +57,57 @@ namespace GridKit
         PREF,       ///< $P_{ref}$
         MAXIMUM,
       };
+    } // namespace Governor
 
-      template <class ScalarT, typename IdxT>
-      class Tgov1 : public Component<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<Governor::Tgov1<ScalarP, IdxP>>
+    {
+      using Tgov1T = Governor::Tgov1<ScalarP, IdxP>;
+
+      using ElementT           = Tgov1T;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = Governor::Tgov1Data<RealT, IdxT>;
+      using InternalVariablesT = Governor::Tgov1InternalVariables;
+      using ExternalVariablesT = Governor::Tgov1ExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
+    namespace Governor
+    {
+      template <typename ScalarP, typename IdxP>
+      class Tgov1 : public ConnectedElement<Tgov1<ScalarP, IdxP>>
       {
-        using Component<ScalarT, IdxT>::gridkit_component_id_;
-        using Component<ScalarT, IdxT>::alpha_;
-        using Component<ScalarT, IdxT>::f_;
-        using Component<ScalarT, IdxT>::nnz_;
-        using Component<ScalarT, IdxT>::size_;
-        using Component<ScalarT, IdxT>::tag_;
-        using Component<ScalarT, IdxT>::time_;
-        using Component<ScalarT, IdxT>::y_;
-        using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::wb_;
-        using Component<ScalarT, IdxT>::h_;
-        using Component<ScalarT, IdxT>::J_;
-        using Component<ScalarT, IdxT>::J_rows_buffer_;
-        using Component<ScalarT, IdxT>::J_cols_buffer_;
-        using Component<ScalarT, IdxT>::J_vals_buffer_;
-        using Component<ScalarT, IdxT>::variable_indices_;
-        using Component<ScalarT, IdxT>::residual_indices_;
-
-        using RealT           = typename Component<ScalarT, IdxT>::RealT;
-        using model_data_type = Tgov1Data<RealT, IdxT>;
-        using signal_type     = SignalNode<ScalarT, IdxT>;
+        using ConnectedElement<Tgov1>::gridkit_component_id_;
+        using ConnectedElement<Tgov1>::alpha_;
+        using ConnectedElement<Tgov1>::f_;
+        using ConnectedElement<Tgov1>::nnz_;
+        using ConnectedElement<Tgov1>::size_;
+        using ConnectedElement<Tgov1>::tag_;
+        using ConnectedElement<Tgov1>::time_;
+        using ConnectedElement<Tgov1>::y_;
+        using ConnectedElement<Tgov1>::yp_;
+        using ConnectedElement<Tgov1>::wb_;
+        using ConnectedElement<Tgov1>::h_;
+        using ConnectedElement<Tgov1>::J_;
+        using ConnectedElement<Tgov1>::J_rows_buffer_;
+        using ConnectedElement<Tgov1>::J_cols_buffer_;
+        using ConnectedElement<Tgov1>::J_vals_buffer_;
+        using ConnectedElement<Tgov1>::variable_indices_;
+        using ConnectedElement<Tgov1>::residual_indices_;
+        using ConnectedElement<Tgov1>::signals_;
 
       public:
+        using ScalarT    = typename ConnectedElement<Tgov1>::ScalarT;
+        using IdxT       = typename ConnectedElement<Tgov1>::IdxT;
+        using RealT      = typename ConnectedElement<Tgov1>::RealT;
+        using ModelDataT = Tgov1Data<RealT, IdxT>;
+        using SignalT    = SignalNode<ScalarT, IdxT>;
+
         Tgov1();
-        Tgov1(signal_type*, signal_type*);
-        Tgov1(const model_data_type&);
+        Tgov1(SignalT*, SignalT*);
+        Tgov1(const ModelDataT&);
         ~Tgov1() = default;
 
         int setGridKitComponentID(IdxT) override final;
@@ -95,16 +119,6 @@ namespace GridKit
 
         // Still to be implemented
         int evaluateJacobian() override final;
-
-        /// Get the `ComponentSignals` from this `Tgov1`
-        auto getSignals()
-            -> ComponentSignals<ScalarT,
-                                IdxT,
-                                Tgov1InternalVariables,
-                                Tgov1ExternalVariables>&
-        {
-          return signals_;
-        }
 
       public:
         __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
@@ -122,11 +136,8 @@ namespace GridKit
         // Input States (which can be parameters)
         ScalarT pref_{0};
 
-        /// Component signal extension
-        ComponentSignals<ScalarT, IdxT, Tgov1InternalVariables, Tgov1ExternalVariables> signals_;
-
         // Parameter initialization function
-        void initializeParameters(const model_data_type& data);
+        void initializeParameters(const ModelDataT& data);
 
         /* Local copies of signal variables */
         std::vector<ScalarT> ws_;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
@@ -37,8 +37,8 @@ namespace GridKit
       enum class Tgov1Ports
       {
         bus,
-        speed,
-        pmech,
+        speed, // input (attach)
+        pmech, // output (assign)
       };
 
       /**

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1DependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1DependencyTracking.cpp
@@ -3,6 +3,8 @@
  *
  */
 
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+
 #include "Tgov1Impl.hpp"
 
 namespace GridKit

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <iostream>
 
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 #include <GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp>
 #include <GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp>
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
@@ -30,8 +31,8 @@ namespace GridKit
        * @brief Constructs a Tgov1 governor model without setting its parameters
        *
        */
-      template <class ScalarT, typename IdxT>
-      Tgov1<ScalarT, IdxT>::Tgov1()
+      template <typename ScalarP, typename IdxP>
+      Tgov1<ScalarP, IdxP>::Tgov1()
       {
         size_ = 3;
       }
@@ -42,8 +43,8 @@ namespace GridKit
        * @param pmech $P_m$ internal variable signal node
        * @param omega $\Delta_\omega$ external variable signal node
        */
-      template <class ScalarT, typename IdxT>
-      Tgov1<ScalarT, IdxT>::Tgov1(signal_type* pmech, signal_type* omega)
+      template <typename ScalarP, typename IdxP>
+      Tgov1<ScalarP, IdxP>::Tgov1(SignalT* pmech, SignalT* omega)
         : R_(0.05),
           Pvmin_(0),
           Pvmax_(1),
@@ -64,8 +65,9 @@ namespace GridKit
        *
        * @param data Data to initialize the model from.
        */
-      template <class ScalarT, typename IdxT>
-      Tgov1<ScalarT, IdxT>::Tgov1(const model_data_type& data)
+      template <typename ScalarP, typename IdxP>
+      Tgov1<ScalarP, IdxP>::Tgov1(const ModelDataT& data)
+        : ConnectedElement<Tgov1>(data)
       {
         initializeParameters(data);
         size_ = 3;
@@ -74,55 +76,55 @@ namespace GridKit
       /**
        * @brief Helper function to extract and assign model parameters.
        *
-       * Parses values from the model_data_type and assigns them to internal
+       * Parses values from the ModelDataT and assigns them to internal
        * parameters.
        *
        * @param data Structure containing model parameters.
        */
-      template <class ScalarT, typename IdxT>
-      void Tgov1<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
+      template <typename ScalarP, typename IdxP>
+      void Tgov1<ScalarP, IdxP>::initializeParameters(const ModelDataT& data)
       {
-        if (data.parameters.contains(model_data_type::Parameters::R))
+        if (data.parameters.contains(ModelDataT::Parameters::R))
         {
-          R_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::R));
+          R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::Pvmin))
+        if (data.parameters.contains(ModelDataT::Parameters::Pvmin))
         {
-          Pvmin_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Pvmin));
+          Pvmin_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Pvmin));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::Pvmax))
+        if (data.parameters.contains(ModelDataT::Parameters::Pvmax))
         {
-          Pvmax_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Pvmax));
+          Pvmax_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Pvmax));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::T1))
+        if (data.parameters.contains(ModelDataT::Parameters::T1))
         {
-          T1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T1));
+          T1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T1));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::T2))
+        if (data.parameters.contains(ModelDataT::Parameters::T2))
         {
-          T2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T2));
+          T2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T2));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::T3))
+        if (data.parameters.contains(ModelDataT::Parameters::T3))
         {
-          T3_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T3));
+          T3_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T3));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::Dt))
+        if (data.parameters.contains(ModelDataT::Parameters::Dt))
         {
-          Dt_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Dt));
+          Dt_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Dt));
         }
       }
 
       /**
        * @brief Set the component ID
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      template <typename ScalarP, typename IdxP>
+      int Tgov1<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
       {
         gridkit_component_id_ = component_id;
         return 0;
@@ -131,8 +133,8 @@ namespace GridKit
       /*!
        * @brief Allocate memory for model
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::allocate()
+      template <typename ScalarP, typename IdxP>
+      int Tgov1<ScalarP, IdxP>::allocate()
       {
         // Allocate local component data
         auto size = static_cast<size_t>(size_); // avoid compiler warnings
@@ -168,8 +170,8 @@ namespace GridKit
       /**
        * @brief verify method checks that attached signals are also linked
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::verify() const
+      template <typename ScalarP, typename IdxP>
+      int Tgov1<ScalarP, IdxP>::verify() const
       {
         static constexpr auto DELTAOMEGA = Tgov1ExternalVariables::DELTAOMEGA;
 
@@ -191,8 +193,8 @@ namespace GridKit
        * @brief Initialization of the Governor
        *
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::initialize()
+      template <typename ScalarP, typename IdxP>
+      int Tgov1<ScalarP, IdxP>::initialize()
       {
         ScalarT p0{0};
 
@@ -221,8 +223,8 @@ namespace GridKit
       /**
        * @brief Identify differential variables.
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::tagDifferentiable()
+      template <typename ScalarP, typename IdxP>
+      int Tgov1<ScalarP, IdxP>::tagDifferentiable()
       {
 
         tag_[0] = true;  // Pv
@@ -236,8 +238,8 @@ namespace GridKit
        * @brief Internal residuals
        *
        */
-      template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int Tgov1<ScalarT, IdxT>::evaluateInternalResidual(
+      template <typename ScalarP, typename IdxP>
+      __attribute__((always_inline)) inline int Tgov1<ScalarP, IdxP>::evaluateInternalResidual(
           ScalarT*                  y,
           ScalarT*                  yp,
           [[maybe_unused]] ScalarT* wb,
@@ -274,8 +276,8 @@ namespace GridKit
        * @brief Residuals of system equations
        *
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::evaluateResidual()
+      template <typename ScalarP, typename IdxP>
+      int Tgov1<ScalarP, IdxP>::evaluateResidual()
       {
         // Input Variables
         if (signals_.template isAttached<Tgov1ExternalVariables::DELTAOMEGA>())

--- a/GridKit/Model/PhasorDynamics/GridElement.hpp
+++ b/GridKit/Model/PhasorDynamics/GridElement.hpp
@@ -2,8 +2,6 @@
 
 #include <vector>
 
-#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
-#include <GridKit/CommonMath.hpp>
 #include <GridKit/Model/Evaluator.hpp>
 #include <GridKit/Utilities/Errors.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
@@ -12,35 +10,18 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    using Log = ::GridKit::Utilities::Logger;
-
-    /**
-     * @brief Model base class for all system constituents
-     */
-    template <class ScalarT, typename IdxT>
-    class GridElement : public Model::Evaluator<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    class GridElement : public Model::Evaluator<ScalarP, IdxP>
     {
     public:
+      using ScalarT = ScalarP;
+      using IdxT    = IdxP;
       using RealT   = typename Model::Evaluator<ScalarT, IdxT>::RealT;
       using MatrixT = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
 
-      GridElement()
-        : size_{0}
-      {
-      }
+      GridElement() = default;
 
-      virtual ~GridElement()
-      {
-        if (J_rows_buffer_ != nullptr)
-        {
-          delete[] J_rows_buffer_;
-          delete[] J_cols_buffer_;
-          delete[] J_vals_buffer_;
-          J_rows_buffer_ = nullptr;
-          J_cols_buffer_ = nullptr;
-          J_vals_buffer_ = nullptr;
-        }
-      }
+      virtual ~GridElement();
 
       virtual int verify() const = 0;
 
@@ -54,16 +35,9 @@ namespace GridKit
         return nnz_;
       }
 
-      void setTolerances(RealT& rtol, RealT& atol) const override
-      {
-        rtol = rel_tol_;
-        atol = abs_tol_;
-      }
+      void setTolerances(RealT& rtol, RealT& atol) const override;
 
-      void setMaxSteps(IdxT& msa) const override
-      {
-        msa = max_steps_;
-      }
+      void setMaxSteps(IdxT& msa) const override;
 
       std::vector<ScalarT>& y() override
       {
@@ -115,32 +89,18 @@ namespace GridKit
         return J_;
       }
 
-      int setVariableIndex(IdxT local_index, IdxT global_index)
-      {
-        variable_indices_[static_cast<size_t>(local_index)] = global_index;
-        return 0;
-      }
+      void setVariableIndex(IdxT local_index, IdxT global_index);
 
-      IdxT& getVariableIndex(IdxT local_index)
-      {
-        return variable_indices_[static_cast<size_t>(local_index)];
-      }
+      IdxT& getVariableIndex(IdxT local_index);
 
       const std::vector<IdxT>& getVariableIndices() const
       {
         return variable_indices_;
       }
 
-      int setResidualIndex(IdxT local_index, IdxT global_index)
-      {
-        residual_indices_[static_cast<size_t>(local_index)] = global_index;
-        return 0;
-      }
+      void setResidualIndex(IdxT local_index, IdxT global_index);
 
-      IdxT& getResidualIndex(IdxT local_index)
-      {
-        return residual_indices_[static_cast<size_t>(local_index)];
-      }
+      IdxT& getResidualIndex(IdxT local_index);
 
       const std::vector<IdxT>& getResidualIndices() const
       {
@@ -183,121 +143,6 @@ namespace GridKit
       std::vector<ScalarT> param_{};
       std::vector<ScalarT> param_up_{};
       std::vector<ScalarT> param_lo_{};
-
-      using NotImplementedError = GridKit::Utilities::NotImplementedError;
-
-    public:
-      // TODO: evaluate how this complies with xSDK guidelines
-
-      [[noreturn]] IdxT sizeQuadrature() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] IdxT sizeParams() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] std::vector<ScalarT>& yB() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] const std::vector<ScalarT>& yB() const override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] std::vector<ScalarT>& ypB() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] const std::vector<ScalarT>& ypB() const override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] std::vector<ScalarT>& param() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] const std::vector<ScalarT>& param() const override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] std::vector<ScalarT>& param_up() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] const std::vector<ScalarT>& param_up() const override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] std::vector<ScalarT>& param_lo() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] const std::vector<ScalarT>& param_lo() const override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] int evaluateIntegrand() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] int initializeAdjoint() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] int evaluateAdjointResidual() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] int evaluateAdjointIntegrand() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] std::vector<ScalarT>& getIntegrand() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] const std::vector<ScalarT>& getIntegrand() const override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] std::vector<ScalarT>& getAdjointResidual() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] const std::vector<ScalarT>& getAdjointResidual() const override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] std::vector<ScalarT>& getAdjointIntegrand() override
-      {
-        throw NotImplementedError(__func__);
-      }
-
-      [[noreturn]] const std::vector<ScalarT>& getAdjointIntegrand() const override
-      {
-        throw NotImplementedError(__func__);
-      }
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/GridElementImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/GridElementImpl.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <GridKit/Model/PhasorDynamics/GridElement.hpp>
+#include <GridKit/Model/VariableMonitorImpl.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    using Log = ::GridKit::Utilities::Logger;
+
+    template <typename ScalarP, typename IdxP>
+    GridElement<ScalarP, IdxP>::~GridElement()
+    {
+      if (J_rows_buffer_ != nullptr)
+      {
+        delete[] J_rows_buffer_;
+        delete[] J_cols_buffer_;
+        delete[] J_vals_buffer_;
+        J_rows_buffer_ = nullptr;
+        J_cols_buffer_ = nullptr;
+        J_vals_buffer_ = nullptr;
+      }
+    }
+
+    template <typename ScalarP, typename IdxP>
+    void GridElement<ScalarP, IdxP>::setTolerances(RealT& rtol, RealT& atol) const
+    {
+      rtol = rel_tol_;
+      atol = abs_tol_;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    void GridElement<ScalarP, IdxP>::setMaxSteps(IdxT& msa) const
+    {
+      msa = max_steps_;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    void GridElement<ScalarP, IdxP>::setVariableIndex(IdxT local_index, IdxT global_index)
+    {
+      variable_indices_[static_cast<size_t>(local_index)] = global_index;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    IdxP& GridElement<ScalarP, IdxP>::getVariableIndex(IdxT local_index)
+    {
+      return variable_indices_[static_cast<size_t>(local_index)];
+    }
+
+    template <typename ScalarP, typename IdxP>
+    void GridElement<ScalarP, IdxP>::setResidualIndex(IdxT local_index, IdxT global_index)
+    {
+      residual_indices_[static_cast<size_t>(local_index)] = global_index;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    IdxP& GridElement<ScalarP, IdxP>::getResidualIndex(IdxT local_index)
+    {
+      return residual_indices_[static_cast<size_t>(local_index)];
+    }
+
+    template class GridElement<double, long int>;
+    template class GridElement<double, size_t>;
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/Load/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/Load/CMakeLists.txt
@@ -15,21 +15,19 @@ if(GRIDKIT_ENABLE_ENZYME)
       LoadEnzyme.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PRIVATE ClangEnzymeFlags
       PUBLIC GridKit::phasor_dynamics_core
+      PRIVATE GridKit::phasor_dynamics_utils
     COMPILE_OPTIONS
       PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
   gridkit_add_library(phasor_dynamics_load
     SOURCES
       Load.cpp
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PUBLIC GridKit::phasor_dynamics_core
+      PRIVATE GridKit::phasor_dynamics_utils
     HEADERS
       ${_install_headers})
 endif()
@@ -37,9 +35,8 @@ endif()
 gridkit_add_library(phasor_dynamics_load_dependency_tracking
   SOURCES 
     LoadDependencyTracking.cpp
-  INCLUDE_DIRECTORIES 
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
   LINK_LIBRARIES
+    PRIVATE GridKit::phasor_dynamics_utils
     PUBLIC GridKit::phasor_dynamics_core)
 
 # Link to interface target for all components

--- a/GridKit/Model/PhasorDynamics/Load/Load.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/Load.hpp
@@ -1,19 +1,18 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 #include <GridKit/Model/PhasorDynamics/Load/LoadData.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
 
 // Forward declarations.
 namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class BusBase;
 
-    template <typename RealT, typename IdxT>
+    template <typename RealP, typename IdxP>
     struct LoadData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -22,38 +21,68 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    template <typename, typename>
+    class Load;
+
+    enum class LoadInternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    enum class LoadExternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<Load<ScalarP, IdxP>>
+    {
+      using LoadT = Load<ScalarP, IdxP>;
+
+      using ElementT           = LoadT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = LoadData<RealT, IdxT>;
+      using InternalVariablesT = LoadInternalVariables;
+      using ExternalVariablesT = LoadExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
     /*!
      * @brief Implementation of a constant load.
      *
      */
-    template <class ScalarT, typename IdxT>
-    class Load : public Component<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    class Load : public ConnectedElement<Load<ScalarP, IdxP>>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using ConnectedElement<Load>::gridkit_component_id_;
+      using ConnectedElement<Load>::size_;
+      using ConnectedElement<Load>::nnz_;
+      using ConnectedElement<Load>::time_;
+      using ConnectedElement<Load>::alpha_;
+      using ConnectedElement<Load>::y_;
+      using ConnectedElement<Load>::yp_;
+      using ConnectedElement<Load>::tag_;
+      using ConnectedElement<Load>::wb_;
+      using ConnectedElement<Load>::h_;
+      using ConnectedElement<Load>::J_rows_buffer_;
+      using ConnectedElement<Load>::J_cols_buffer_;
+      using ConnectedElement<Load>::J_vals_buffer_;
+      using ConnectedElement<Load>::variable_indices_;
+      using ConnectedElement<Load>::residual_indices_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using bus_type        = BusBase<ScalarT, IdxT>;
-      using model_data_type = LoadData<RealT, IdxT>;
-      using MonitorT        = Model::VariableMonitor<Load, LoadData>;
+      using ScalarT    = typename ConnectedElement<Load>::ScalarT;
+      using IdxT       = typename ConnectedElement<Load>::IdxT;
+      using RealT      = typename ConnectedElement<Load>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = LoadData<RealT, IdxT>;
+      using MonitorT   = typename ConnectedElement<Load>::MonitorT;
 
-      Load(bus_type* bus);
-      Load(bus_type* bus, RealT R, RealT X);
-      Load(bus_type* bus, const model_data_type& data);
+      Load(BusT* bus);
+      Load(BusT* bus, RealT R, RealT X);
+      Load(BusT* bus, const ModelDataT& data);
       virtual ~Load();
 
       virtual int setGridKitComponentID(IdxT) override final;
@@ -103,21 +132,17 @@ namespace GridKit
         return bus_->Ii();
       }
 
-      const Model::VariableMonitorBase* getMonitor() const override;
-
     public:
       __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
-      bus_type* bus_{nullptr};
-      RealT     R_{0.1};
-      RealT     X_{0.01};
+      BusT* bus_{nullptr};
+      RealT R_{0.1};
+      RealT X_{0.01};
 
       /* Derivied parameters */
       RealT b_;
       RealT g_;
-
-      std::unique_ptr<MonitorT> monitor_;
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Load/LoadDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadDependencyTracking.cpp
@@ -1,3 +1,4 @@
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 
 #include "LoadImpl.hpp"
 

--- a/GridKit/Model/PhasorDynamics/Load/LoadImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadImpl.hpp
@@ -4,9 +4,9 @@
 #include <iostream>
 
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 #include <GridKit/Model/PhasorDynamics/Load/Load.hpp>
 #include <GridKit/Model/PhasorDynamics/Load/LoadData.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
 
 namespace GridKit
 {
@@ -19,17 +19,15 @@ namespace GridKit
      * - Number of equations = 0
      * - Number of independent variables = 0
      */
-    template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::Load(bus_type* bus)
+    template <typename ScalarP, typename IdxP>
+    Load<ScalarP, IdxP>::Load(BusT* bus)
       : bus_(bus)
     {
       size_ = 0;
     }
 
-    template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::Load(bus_type* bus,
-                              RealT     R,
-                              RealT     X)
+    template <typename ScalarP, typename IdxP>
+    Load<ScalarP, IdxP>::Load(BusT* bus, RealT R, RealT X)
       : bus_(bus),
         R_(R),
         X_(X)
@@ -38,22 +36,22 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::Load(bus_type*              bus,
-                              const model_data_type& data)
-      : bus_(bus)
+    template <typename ScalarP, typename IdxP>
+    Load<ScalarP, IdxP>::Load(BusT* bus, const ModelDataT& data)
+      : ConnectedElement<Load>(data),
+        bus_(bus)
     {
-      if (data.parameters.contains(model_data_type::Parameters::R))
+      if (data.parameters.contains(ModelDataT::Parameters::R))
       {
-        R_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::R));
+        R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::X))
+      if (data.parameters.contains(ModelDataT::Parameters::X))
       {
-        X_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::X));
+        X_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::X));
       }
 
-      // using Variable = typename model_data_type::MonitorableVariables;
+      // using Variable = typename ModelDataT::MonitorableVariables;
       // monitor_->set(Variable::p, [this] { return ?; });
       // monitor_->set(Variable::q, [this] { return ?; });
 
@@ -61,8 +59,8 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::~Load()
+    template <typename ScalarP, typename IdxP>
+    Load<ScalarP, IdxP>::~Load()
     {
       // std::cout << "Destroy Load..." << std::endl;
     }
@@ -70,8 +68,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename ScalarP, typename IdxP>
+    int Load<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -80,8 +78,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::allocate()
+    template <typename ScalarP, typename IdxP>
+    int Load<ScalarP, IdxP>::allocate()
     {
       // std::cout << "Allocate Load..." << std::endl;
 
@@ -95,8 +93,8 @@ namespace GridKit
      * Initialization of the load model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::initialize()
+    template <typename ScalarP, typename IdxP>
+    int Load<ScalarP, IdxP>::initialize()
     {
       return 0;
     }
@@ -104,8 +102,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::tagDifferentiable()
+    template <typename ScalarP, typename IdxP>
+    int Load<ScalarP, IdxP>::tagDifferentiable()
     {
       return 0;
     }
@@ -114,8 +112,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Load<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) int Load<ScalarP, IdxP>::evaluateBusResidual(
         [[maybe_unused]] ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* wb, ScalarT* h)
     {
       ScalarT Vr = wb[0];
@@ -132,8 +130,8 @@ namespace GridKit
      * @brief Residual contribution of the load is pushed to the bus.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::evaluateResidual()
+    template <typename ScalarP, typename IdxP>
+    int Load<ScalarP, IdxP>::evaluateResidual()
     {
       wb_[0] = Vr();
       wb_[1] = Vi();
@@ -148,17 +146,11 @@ namespace GridKit
      * @brief Derived parameters
      *
      */
-    template <class ScalarT, typename IdxT>
-    void Load<ScalarT, IdxT>::setDerivedParams()
+    template <typename ScalarP, typename IdxP>
+    void Load<ScalarP, IdxP>::setDerivedParams()
     {
       b_ = -X_ / (R_ * R_ + X_ * X_);
       g_ = R_ / (R_ * R_ + X_ * X_);
-    }
-
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* Load<ScalarT, IdxT>::getMonitor() const
-    {
-      return monitor_.get();
     }
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/LoadZIP/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/CMakeLists.txt
@@ -9,31 +9,28 @@ if(GRIDKIT_ENABLE_ENZYME)
       LoadZIPEnzyme.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PRIVATE ClangEnzymeFlags
       PUBLIC GridKit::phasor_dynamics_core
+      PRIVATE GridKit::phasor_dynamics_utils
     COMPILE_OPTIONS
       PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
   gridkit_add_library(phasor_dynamics_loadzip
     SOURCES
       LoadZIP.cpp
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PUBLIC GridKit::phasor_dynamics_core
+      PRIVATE GridKit::phasor_dynamics_utils
     HEADERS
       ${_install_headers})
 endif()
 
 gridkit_add_library(phasor_dynamics_loadzip_dependency_tracking
-  SOURCES 
+  SOURCES
     LoadZIPDependencyTracking.cpp
-  INCLUDE_DIRECTORIES 
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
   LINK_LIBRARIES
+    PRIVATE GridKit::phasor_dynamics_utils
     PUBLIC GridKit::phasor_dynamics_core)
 
 # Link to interface target for all components

--- a/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIP.hpp
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIP.hpp
@@ -1,19 +1,18 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 #include <GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPData.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
 
 // Forward declarations.
 namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class BusBase;
 
-    template <typename RealT, typename IdxT>
+    template <typename RealP, typename IdxP>
     struct LoadZIPData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -22,40 +21,69 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    template <typename, typename>
+    class LoadZIP;
+
+    enum class LoadZIPInternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    enum class LoadZIPExternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<LoadZIP<ScalarP, IdxP>>
+    {
+      using LoadZIPT = LoadZIP<ScalarP, IdxP>;
+
+      using ElementT           = LoadZIPT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = LoadZIPData<RealT, IdxT>;
+      using InternalVariablesT = LoadZIPInternalVariables;
+      using ExternalVariablesT = LoadZIPExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
     /*!
      * @brief Implementation of a ZIP load.
      *
      */
-    template <class ScalarT, typename IdxT>
-    class LoadZIP : public Component<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    class LoadZIP : public ConnectedElement<LoadZIP<ScalarP, IdxP>>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using ConnectedElement<LoadZIP>::gridkit_component_id_;
+      using ConnectedElement<LoadZIP>::size_;
+      using ConnectedElement<LoadZIP>::nnz_;
+      using ConnectedElement<LoadZIP>::time_;
+      using ConnectedElement<LoadZIP>::alpha_;
+      using ConnectedElement<LoadZIP>::y_;
+      using ConnectedElement<LoadZIP>::yp_;
+      using ConnectedElement<LoadZIP>::tag_;
+      using ConnectedElement<LoadZIP>::wb_;
+      using ConnectedElement<LoadZIP>::h_;
+      using ConnectedElement<LoadZIP>::f_;
+      using ConnectedElement<LoadZIP>::J_;
+      using ConnectedElement<LoadZIP>::J_rows_buffer_;
+      using ConnectedElement<LoadZIP>::J_cols_buffer_;
+      using ConnectedElement<LoadZIP>::J_vals_buffer_;
+      using ConnectedElement<LoadZIP>::variable_indices_;
+      using ConnectedElement<LoadZIP>::residual_indices_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using bus_type        = BusBase<ScalarT, IdxT>;
-      using model_data_type = LoadZIPData<RealT, IdxT>;
-      using MonitorT        = Model::VariableMonitor<LoadZIP, LoadZIPData>;
+      using ScalarT    = typename ConnectedElement<LoadZIP>::ScalarT;
+      using IdxT       = typename ConnectedElement<LoadZIP>::IdxT;
+      using RealT      = typename ConnectedElement<LoadZIP>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = LoadZIPData<RealT, IdxT>;
 
-      LoadZIP(bus_type* bus);
-      LoadZIP(bus_type* bus, RealT P0, RealT Q0, RealT V0, RealT alphaI, RealT alphaP);
-      LoadZIP(bus_type* bus, const model_data_type& data);
+      LoadZIP(BusT* bus);
+      LoadZIP(BusT* bus, RealT P0, RealT Q0, RealT V0, RealT alphaI, RealT alphaP);
+      LoadZIP(BusT* bus, const ModelDataT& data);
       ~LoadZIP();
 
       int setGridKitComponentID(IdxT) override final;
@@ -119,21 +147,17 @@ namespace GridKit
         return bus_->Ii();
       }
 
-      const Model::VariableMonitorBase* getMonitor() const override;
-
     public:
       __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
       __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
-      bus_type* bus_{nullptr};
-      RealT     P0_{0};
-      RealT     Q0_{0};
-      RealT     V0_{1.0};
-      RealT     alphaI_{0};
-      RealT     alphaP_{0};
-
-      std::unique_ptr<MonitorT> monitor_;
+      BusT* bus_{nullptr};
+      RealT P0_{0};
+      RealT Q0_{0};
+      RealT V0_{1.0};
+      RealT alphaI_{0};
+      RealT alphaP_{0};
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPDependencyTracking.cpp
@@ -1,3 +1,4 @@
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 
 #include "LoadZIPImpl.hpp"
 

--- a/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPImpl.hpp
@@ -4,9 +4,9 @@
 #include <iostream>
 
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 #include <GridKit/Model/PhasorDynamics/LoadZIP/LoadZIP.hpp>
 #include <GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPData.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
 
 namespace GridKit
 {
@@ -19,15 +19,15 @@ namespace GridKit
      * - Number of equations = 2
      * - Number of independent variables = 2
      */
-    template <class ScalarT, typename IdxT>
-    LoadZIP<ScalarT, IdxT>::LoadZIP(bus_type* bus)
+    template <typename ScalarP, typename IdxP>
+    LoadZIP<ScalarP, IdxP>::LoadZIP(BusT* bus)
       : bus_(bus)
     {
       size_ = 2;
     }
 
-    template <class ScalarT, typename IdxT>
-    LoadZIP<ScalarT, IdxT>::LoadZIP(bus_type* bus, RealT P0, RealT Q0, RealT V0, RealT alphaI, RealT alphaP)
+    template <typename ScalarP, typename IdxP>
+    LoadZIP<ScalarP, IdxP>::LoadZIP(BusT* bus, RealT P0, RealT Q0, RealT V0, RealT alphaI, RealT alphaP)
       : bus_(bus),
         P0_(P0),
         Q0_(Q0),
@@ -39,37 +39,37 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    LoadZIP<ScalarT, IdxT>::LoadZIP(bus_type*              bus,
-                                    const model_data_type& data)
-      : bus_(bus)
+    template <typename ScalarP, typename IdxP>
+    LoadZIP<ScalarP, IdxP>::LoadZIP(BusT* bus, const ModelDataT& data)
+      : ConnectedElement<LoadZIP>(data),
+        bus_(bus)
     {
-      if (data.parameters.contains(model_data_type::Parameters::P0))
+      if (data.parameters.contains(ModelDataT::Parameters::P0))
       {
-        P0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::P0));
+        P0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::P0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Q0))
+      if (data.parameters.contains(ModelDataT::Parameters::Q0))
       {
-        Q0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Q0));
+        Q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Q0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::V0))
+      if (data.parameters.contains(ModelDataT::Parameters::V0))
       {
-        V0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::V0));
+        V0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::V0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::alphaI))
+      if (data.parameters.contains(ModelDataT::Parameters::alphaI))
       {
-        alphaI_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::alphaI));
+        alphaI_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::alphaI));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::alphaP))
+      if (data.parameters.contains(ModelDataT::Parameters::alphaP))
       {
-        alphaP_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::alphaP));
+        alphaP_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::alphaP));
       }
 
-      // using Variable = typename model_data_type::MonitorableVariables;
+      // using Variable = typename ModelDataT::MonitorableVariables;
       // monitor_->set(Variable::p, [this] { return ?; });
       // monitor_->set(Variable::q, [this] { return ?; });
 
@@ -77,8 +77,8 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    LoadZIP<ScalarT, IdxT>::~LoadZIP()
+    template <typename ScalarP, typename IdxP>
+    LoadZIP<ScalarP, IdxP>::~LoadZIP()
     {
       // std::cout << "Destroy LoadZIP..." << std::endl;
     }
@@ -86,8 +86,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename ScalarP, typename IdxP>
+    int LoadZIP<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -96,8 +96,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::allocate()
+    template <typename ScalarP, typename IdxP>
+    int LoadZIP<ScalarP, IdxP>::allocate()
     {
       // std::cout << "Allocate Load..." << std::endl;
 
@@ -127,8 +127,8 @@ namespace GridKit
      * Initialization of the load model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::initialize()
+    template <typename ScalarP, typename IdxP>
+    int LoadZIP<ScalarP, IdxP>::initialize()
     {
       ScalarT vr    = Vr();
       ScalarT vi    = Vi();
@@ -150,8 +150,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::tagDifferentiable()
+    template <typename ScalarP, typename IdxP>
+    int LoadZIP<ScalarP, IdxP>::tagDifferentiable()
     {
       tag_[0] = false;
       tag_[1] = false;
@@ -162,8 +162,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int LoadZIP<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) int LoadZIP<ScalarP, IdxP>::evaluateBusResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         [[maybe_unused]] ScalarT* wb,
@@ -181,8 +181,8 @@ namespace GridKit
      * @brief Residual contribution of the load is pushed to the bus.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::evaluateResidual()
+    template <typename ScalarP, typename IdxP>
+    int LoadZIP<ScalarP, IdxP>::evaluateResidual()
     {
       wb_[0] = Vr();
       wb_[1] = Vi();
@@ -198,8 +198,8 @@ namespace GridKit
      * @brief Internal residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int LoadZIP<ScalarT, IdxT>::evaluateInternalResidual(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) int LoadZIP<ScalarP, IdxP>::evaluateInternalResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -223,16 +223,10 @@ namespace GridKit
      * @brief Derived parameters
      *
      */
-    template <class ScalarT, typename IdxT>
-    void LoadZIP<ScalarT, IdxT>::setDerivedParams()
+    template <typename ScalarP, typename IdxP>
+    void LoadZIP<ScalarP, IdxP>::setDerivedParams()
     {
       return;
-    }
-
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* LoadZIP<ScalarT, IdxT>::getMonitor() const
-    {
-      return monitor_.get();
     }
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp
@@ -7,7 +7,7 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename RealT, typename IdxT>
+    template <typename RealP, typename IdxP>
     struct SignalNodeData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -20,11 +20,13 @@ namespace GridKit
      * @brief SignalNode model implementation base class.
      *
      */
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class SignalNode
     {
     public:
-      using RealT = typename GridKit::ScalarTraits<ScalarT>::RealT;
+      using ScalarT = ScalarP;
+      using IdxT    = IdxP;
+      using RealT   = typename GridKit::ScalarTraits<ScalarT>::RealT;
 
       SignalNode();
       SignalNode(const SignalNodeData<RealT, IdxT>& data);

--- a/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
@@ -8,38 +8,38 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
-    SignalNode<ScalarT, IdxT>::SignalNode()
+    template <typename ScalarP, typename IdxP>
+    SignalNode<ScalarP, IdxP>::SignalNode()
     {
     }
 
-    template <class ScalarT, typename IdxT>
-    SignalNode<ScalarT, IdxT>::SignalNode(const SignalNodeData<RealT, IdxT>& data)
+    template <typename ScalarP, typename IdxP>
+    SignalNode<ScalarP, IdxP>::SignalNode(const SignalNodeData<RealT, IdxT>& data)
       : signal_id_(data.signal_id)
     {
     }
 
-    template <class ScalarT, typename IdxT>
-    void SignalNode<ScalarT, IdxT>::set(ScalarT* signal, IdxT* variable_index)
+    template <typename ScalarP, typename IdxP>
+    void SignalNode<ScalarP, IdxP>::set(ScalarT* signal, IdxT* variable_index)
     {
       signal_         = signal;
       variable_index_ = variable_index;
     }
 
-    template <class ScalarT, typename IdxT>
-    bool SignalNode<ScalarT, IdxT>::linked() const
+    template <typename ScalarP, typename IdxP>
+    bool SignalNode<ScalarP, IdxP>::linked() const
     {
       return (signal_) && (variable_index_);
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT SignalNode<ScalarT, IdxT>::read() const
+    template <typename ScalarP, typename IdxP>
+    ScalarP SignalNode<ScalarP, IdxP>::read() const
     {
       return *signal_;
     }
 
-    template <class ScalarT, typename IdxT>
-    void SignalNode<ScalarT, IdxT>::init(ScalarT signal)
+    template <typename ScalarP, typename IdxP>
+    void SignalNode<ScalarP, IdxP>::init(ScalarT signal)
     {
       *signal_ = signal;
     }

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/CMakeLists.txt
@@ -13,11 +13,10 @@ if(GRIDKIT_ENABLE_ENZYME)
       IeeestEnzyme.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PUBLIC GridKit::phasor_dynamics_core
       PUBLIC GridKit::phasor_dynamics_signal
+      PRIVATE GridKit::phasor_dynamics_utils
       PRIVATE ClangEnzymeFlags
     COMPILE_OPTIONS
       PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
@@ -27,9 +26,8 @@ else()
       Ieeest.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
+      PRIVATE GridKit::phasor_dynamics_utils
       PUBLIC GridKit::phasor_dynamics_core
       PUBLIC GridKit::phasor_dynamics_signal)
 endif()
@@ -37,9 +35,8 @@ endif()
 gridkit_add_library(phasor_dynamics_stabilizer_ieeest_dependency_tracking
   SOURCES
     IeeestDependencyTracking.cpp
-  INCLUDE_DIRECTORIES
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
   LINK_LIBRARIES
+    PRIVATE GridKit::phasor_dynamics_utils
     PUBLIC GridKit::phasor_dynamics_core
     PUBLIC GridKit::phasor_dynamics_signal_dependency_tracking)
 

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/Ieeest.hpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/Ieeest.hpp
@@ -7,8 +7,7 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 
 namespace GridKit
 {
@@ -16,13 +15,9 @@ namespace GridKit
   {
     namespace Stabilizer
     {
-      template <typename RealT, typename IdxT>
+      template <typename RealP, typename IdxP>
       struct IeeestData;
     } // namespace Stabilizer
-
-    template <class ScalarT, typename IdxT>
-    class SignalNode;
-
   } // namespace PhasorDynamics
 } // namespace GridKit
 
@@ -32,6 +27,9 @@ namespace GridKit
   {
     namespace Stabilizer
     {
+      template <typename, typename>
+      class Ieeest;
+
       /// Internal variables of a `Ieeest`
       enum class IeeestInternalVariables : size_t
       {
@@ -58,36 +56,57 @@ namespace GridKit
         VCT, ///< Cutout signal
         MAXIMUM,
       };
+    } // namespace Stabilizer
 
-      template <class ScalarT, typename IdxT>
-      class Ieeest : public Component<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<Stabilizer::Ieeest<ScalarP, IdxP>>
+    {
+      using IeeestT = Stabilizer::Ieeest<ScalarP, IdxP>;
+
+      using ElementT           = IeeestT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = Stabilizer::IeeestData<RealT, IdxT>;
+      using InternalVariablesT = Stabilizer::IeeestInternalVariables;
+      using ExternalVariablesT = Stabilizer::IeeestExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
+    namespace Stabilizer
+    {
+      template <typename ScalarP, typename IdxP>
+      class Ieeest : public ConnectedElement<Ieeest<ScalarP, IdxP>>
       {
-        using Component<ScalarT, IdxT>::gridkit_component_id_;
-        using Component<ScalarT, IdxT>::alpha_;
-        using Component<ScalarT, IdxT>::f_;
-        using Component<ScalarT, IdxT>::nnz_;
-        using Component<ScalarT, IdxT>::size_;
-        using Component<ScalarT, IdxT>::tag_;
-        using Component<ScalarT, IdxT>::time_;
-        using Component<ScalarT, IdxT>::y_;
-        using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::wb_;
-        using Component<ScalarT, IdxT>::h_;
-        using Component<ScalarT, IdxT>::J_;
-        using Component<ScalarT, IdxT>::J_rows_buffer_;
-        using Component<ScalarT, IdxT>::J_cols_buffer_;
-        using Component<ScalarT, IdxT>::J_vals_buffer_;
-        using Component<ScalarT, IdxT>::variable_indices_;
-        using Component<ScalarT, IdxT>::residual_indices_;
+        using ConnectedElement<Ieeest>::gridkit_component_id_;
+        using ConnectedElement<Ieeest>::alpha_;
+        using ConnectedElement<Ieeest>::f_;
+        using ConnectedElement<Ieeest>::nnz_;
+        using ConnectedElement<Ieeest>::size_;
+        using ConnectedElement<Ieeest>::tag_;
+        using ConnectedElement<Ieeest>::time_;
+        using ConnectedElement<Ieeest>::y_;
+        using ConnectedElement<Ieeest>::yp_;
+        using ConnectedElement<Ieeest>::wb_;
+        using ConnectedElement<Ieeest>::h_;
+        using ConnectedElement<Ieeest>::J_;
+        using ConnectedElement<Ieeest>::J_rows_buffer_;
+        using ConnectedElement<Ieeest>::J_cols_buffer_;
+        using ConnectedElement<Ieeest>::J_vals_buffer_;
+        using ConnectedElement<Ieeest>::variable_indices_;
+        using ConnectedElement<Ieeest>::residual_indices_;
+        using ConnectedElement<Ieeest>::monitor_;
+        using ConnectedElement<Ieeest>::signals_;
 
       public:
-        using RealT           = typename Component<ScalarT, IdxT>::RealT;
-        using model_data_type = IeeestData<RealT, IdxT>;
-        using signal_type     = SignalNode<ScalarT, IdxT>;
-        using MonitorT        = Model::VariableMonitor<Ieeest, IeeestData>;
+        using ScalarT    = typename ConnectedElement<Ieeest>::ScalarT;
+        using IdxT       = typename ConnectedElement<Ieeest>::IdxT;
+        using RealT      = typename ConnectedElement<Ieeest>::RealT;
+        using ModelDataT = IeeestData<RealT, IdxT>;
+        using MonitorT   = typename ConnectedElement<Ieeest>::MonitorT;
 
         Ieeest();
-        Ieeest(const model_data_type& data);
+        Ieeest(const ModelDataT& data);
         ~Ieeest();
 
         int setGridKitComponentID(IdxT) override final;
@@ -97,18 +116,6 @@ namespace GridKit
         int tagDifferentiable() override final;
         int evaluateResidual() override final;
         int evaluateJacobian() override final;
-
-        /// Get the `ComponentSignals` from this `Ieeest`
-        auto getSignals()
-            -> ComponentSignals<ScalarT,
-                                IdxT,
-                                IeeestInternalVariables,
-                                IeeestExternalVariables>&
-        {
-          return signals_;
-        }
-
-        const Model::VariableMonitorBase* getMonitor() const override;
 
         __attribute__((always_inline)) inline int evaluateInternalResidual(
             ScalarT*,
@@ -164,11 +171,7 @@ namespace GridKit
         RealT use_cutout_{1};
         RealT bypass_cutout_{0};
 
-        ComponentSignals<ScalarT, IdxT, IeeestInternalVariables, IeeestExternalVariables> signals_;
-
-        std::unique_ptr<MonitorT> monitor_;
-
-        void initializeParameters(const model_data_type& data);
+        void initializeParameters(const ModelDataT& data);
         void initializeMonitor();
 
         std::vector<ScalarT> ws_;

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestDependencyTracking.cpp
@@ -4,6 +4,8 @@
  * @brief DependencyTracking Jacobian stub and template instantiations for IEEEST Stabilizer.
  */
 
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+
 #include "IeeestImpl.hpp"
 
 namespace GridKit

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestImpl.hpp
@@ -9,10 +9,10 @@
 #include <cmath>
 #include <iostream>
 
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
 #include <GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/Ieeest.hpp>
 #include <GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestData.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
 namespace GridKit
@@ -23,100 +23,100 @@ namespace GridKit
     {
       using Log = ::GridKit::Utilities::Logger;
 
-      template <class ScalarT, typename IdxT>
-      Ieeest<ScalarT, IdxT>::Ieeest()
+      template <typename ScalarP, typename IdxP>
+      Ieeest<ScalarP, IdxP>::Ieeest()
       {
         size_ = 13;
       }
 
-      template <class ScalarT, typename IdxT>
-      Ieeest<ScalarT, IdxT>::Ieeest(const model_data_type& data)
-        : monitor_(std::make_unique<MonitorT>(data))
+      template <typename ScalarP, typename IdxP>
+      Ieeest<ScalarP, IdxP>::Ieeest(const ModelDataT& data)
+        : ConnectedElement<Ieeest>(data)
       {
         initializeParameters(data);
         initializeMonitor();
         size_ = 13;
       }
 
-      template <class ScalarT, typename IdxT>
-      Ieeest<ScalarT, IdxT>::~Ieeest()
+      template <typename ScalarP, typename IdxP>
+      Ieeest<ScalarP, IdxP>::~Ieeest()
       {
       }
 
-      template <class ScalarT, typename IdxT>
-      void Ieeest<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
+      template <typename ScalarP, typename IdxP>
+      void Ieeest<ScalarP, IdxP>::initializeParameters(const ModelDataT& data)
       {
-        if (data.parameters.contains(model_data_type::Parameters::A1))
+        if (data.parameters.contains(ModelDataT::Parameters::A1))
         {
-          A1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A1));
+          A1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A1));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A2))
+        if (data.parameters.contains(ModelDataT::Parameters::A2))
         {
-          A2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A2));
+          A2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A2));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A3))
+        if (data.parameters.contains(ModelDataT::Parameters::A3))
         {
-          A3_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A3));
+          A3_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A3));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A4))
+        if (data.parameters.contains(ModelDataT::Parameters::A4))
         {
-          A4_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A4));
+          A4_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A4));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A5))
+        if (data.parameters.contains(ModelDataT::Parameters::A5))
         {
-          A5_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A5));
+          A5_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A5));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A6))
+        if (data.parameters.contains(ModelDataT::Parameters::A6))
         {
-          A6_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A6));
+          A6_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A6));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T1))
+        if (data.parameters.contains(ModelDataT::Parameters::T1))
         {
-          T1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T1));
+          T1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T1));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T2))
+        if (data.parameters.contains(ModelDataT::Parameters::T2))
         {
-          T2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T2));
+          T2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T2));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T3))
+        if (data.parameters.contains(ModelDataT::Parameters::T3))
         {
-          T3_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T3));
+          T3_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T3));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T4))
+        if (data.parameters.contains(ModelDataT::Parameters::T4))
         {
-          T4_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T4));
+          T4_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T4));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T5))
+        if (data.parameters.contains(ModelDataT::Parameters::T5))
         {
-          T5_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T5));
+          T5_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T5));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T6))
+        if (data.parameters.contains(ModelDataT::Parameters::T6))
         {
-          T6_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T6));
+          T6_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T6));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ks))
+        if (data.parameters.contains(ModelDataT::Parameters::Ks))
         {
-          Ks_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ks));
+          Ks_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ks));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Lsmin))
+        if (data.parameters.contains(ModelDataT::Parameters::Lsmin))
         {
-          Lsmin_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Lsmin));
+          Lsmin_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Lsmin));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Lsmax))
+        if (data.parameters.contains(ModelDataT::Parameters::Lsmax))
         {
-          Lsmax_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Lsmax));
+          Lsmax_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Lsmax));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Vcl))
+        if (data.parameters.contains(ModelDataT::Parameters::Vcl))
         {
-          Vcl_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Vcl));
+          Vcl_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vcl));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Vcu))
+        if (data.parameters.contains(ModelDataT::Parameters::Vcu))
         {
-          Vcu_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Vcu));
+          Vcu_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vcu));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Tdelay))
+        if (data.parameters.contains(ModelDataT::Parameters::Tdelay))
         {
-          Tdelay_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tdelay));
+          Tdelay_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdelay));
         }
 
         a0_ = 1;
@@ -153,15 +153,15 @@ namespace GridKit
         bypass_cutout_ = 1.0 - use_cutout_;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      template <typename ScalarP, typename IdxP>
+      int Ieeest<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
       {
         gridkit_component_id_ = component_id;
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::allocate()
+      template <typename ScalarP, typename IdxP>
+      int Ieeest<ScalarP, IdxP>::allocate()
       {
         auto size = static_cast<size_t>(size_);
         f_.resize(size);
@@ -193,8 +193,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::verify() const
+      template <typename ScalarP, typename IdxP>
+      int Ieeest<ScalarP, IdxP>::verify() const
       {
         int ret = 0;
 
@@ -230,8 +230,8 @@ namespace GridKit
         return ret;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::initialize()
+      template <typename ScalarP, typename IdxP>
+      int Ieeest<ScalarP, IdxP>::initialize()
       {
         for (IdxT i = 0; i < size_; ++i)
         {
@@ -242,8 +242,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::tagDifferentiable()
+      template <typename ScalarP, typename IdxP>
+      int Ieeest<ScalarP, IdxP>::tagDifferentiable()
       {
         tag_[0]  = true;
         tag_[1]  = true;
@@ -262,8 +262,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int Ieeest<ScalarT, IdxT>::evaluateInternalResidual(
+      template <typename ScalarP, typename IdxP>
+      __attribute__((always_inline)) inline int Ieeest<ScalarP, IdxP>::evaluateInternalResidual(
           ScalarT*                  y,
           ScalarT*                  yp,
           [[maybe_unused]] ScalarT* wb,
@@ -321,8 +321,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::evaluateResidual()
+      template <typename ScalarP, typename IdxP>
+      int Ieeest<ScalarP, IdxP>::evaluateResidual()
       {
         if (signals_.template isAttached<IeeestExternalVariables::U>())
         {
@@ -342,16 +342,10 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      const Model::VariableMonitorBase* Ieeest<ScalarT, IdxT>::getMonitor() const
+      template <typename ScalarP, typename IdxP>
+      void Ieeest<ScalarP, IdxP>::initializeMonitor()
       {
-        return monitor_.get();
-      }
-
-      template <class ScalarT, typename IdxT>
-      void Ieeest<ScalarT, IdxT>::initializeMonitor()
-      {
-        using Variable = typename model_data_type::MonitorableVariables;
+        using Variable = typename ModelDataT::MonitorableVariables;
         monitor_->set(Variable::vs, [this]
                       { return y_[12]; });
       }

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/CMakeLists.txt
@@ -9,9 +9,8 @@ if(GRIDKIT_ENABLE_ENZYME)
       GenrouEnzyme.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
+      PRIVATE GridKit::phasor_dynamics_utils
       PUBLIC GridKit::phasor_dynamics_core
       PUBLIC GridKit::phasor_dynamics_signal 
       PRIVATE ClangEnzymeFlags
@@ -23,9 +22,8 @@ else()
       Genrou.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
+      PRIVATE GridKit::phasor_dynamics_utils
       PUBLIC GridKit::phasor_dynamics_core
       PUBLIC GridKit::phasor_dynamics_signal)
 endif()
@@ -33,9 +31,8 @@ endif()
 gridkit_add_library(phasor_dynamics_genrou_dependency_tracking
   SOURCES
     GenrouDependencyTracking.cpp
-  INCLUDE_DIRECTORIES
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
   LINK_LIBRARIES
+    PRIVATE GridKit::phasor_dynamics_utils
     PUBLIC GridKit::phasor_dynamics_core
     PUBLIC GridKit::phasor_dynamics_signal_dependency_tracking)
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -9,22 +9,21 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
 
 // Forward declarations.
 namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class BusBase;
 
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class SignalNode;
 
-    template <typename RealT, typename IdxT>
+    template <typename RealP, typename IdxP>
     struct GenrouData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -33,6 +32,9 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    template <typename, typename>
+    class Genrou;
+
     /// Internal variables of a `Genrou`
     enum class GenrouInternalVariables : size_t
     {
@@ -66,66 +68,85 @@ namespace GridKit
       MAXIMUM,
     };
 
-    template <class ScalarT, typename IdxT>
-    class Genrou : public Component<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<Genrou<ScalarP, IdxP>>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::mva_system_base_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using GenrouT = Genrou<ScalarP, IdxP>;
+
+      using ElementT           = GenrouT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = GenrouData<RealT, IdxT>;
+      using InternalVariablesT = GenrouInternalVariables;
+      using ExternalVariablesT = GenrouExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
+    template <class ScalarP, typename IdxP>
+    class Genrou : public ConnectedElement<Genrou<ScalarP, IdxP>>
+    {
+      using ConnectedElement<Genrou>::gridkit_component_id_;
+      using ConnectedElement<Genrou>::alpha_;
+      using ConnectedElement<Genrou>::f_;
+      using ConnectedElement<Genrou>::nnz_;
+      using ConnectedElement<Genrou>::size_;
+      using ConnectedElement<Genrou>::tag_;
+      using ConnectedElement<Genrou>::time_;
+      using ConnectedElement<Genrou>::y_;
+      using ConnectedElement<Genrou>::yp_;
+      using ConnectedElement<Genrou>::wb_;
+      using ConnectedElement<Genrou>::h_;
+      using ConnectedElement<Genrou>::J_;
+      using ConnectedElement<Genrou>::J_rows_buffer_;
+      using ConnectedElement<Genrou>::J_cols_buffer_;
+      using ConnectedElement<Genrou>::J_vals_buffer_;
+      using ConnectedElement<Genrou>::mva_system_base_;
+      using ConnectedElement<Genrou>::variable_indices_;
+      using ConnectedElement<Genrou>::residual_indices_;
+      using ConnectedElement<Genrou>::monitor_;
+      using ConnectedElement<Genrou>::signals_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using bus_type        = BusBase<ScalarT, IdxT>;
-      using model_data_type = GenrouData<RealT, IdxT>;
-      using signal_type     = SignalNode<ScalarT, IdxT>;
-      using MonitorT        = Model::VariableMonitor<Genrou, GenrouData>;
+      using ScalarT    = typename ConnectedElement<Genrou>::ScalarT;
+      using IdxT       = typename ConnectedElement<Genrou>::IdxT;
+      using RealT      = typename ConnectedElement<Genrou>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = GenrouData<RealT, IdxT>;
+      using MonitorT   = typename ConnectedElement<Genrou>::MonitorT;
+      using SignalT    = SignalNode<ScalarT, IdxT>;
 
-      Genrou(bus_type* bus, IdxT unit_id);
-      Genrou(bus_type*              bus,
-             signal_type*           omega,
-             signal_type*           pmech,
-             const model_data_type& data);
-      Genrou(bus_type*              bus,
-             signal_type*           omega,
-             signal_type*           pmech,
-             signal_type*           efd,
-             const model_data_type& data);
-      Genrou(bus_type* bus, const model_data_type& data);
-      Genrou(bus_type* bus,
-             IdxT      unit_id,
-             RealT     p0,
-             RealT     q0,
-             RealT     H,
-             RealT     D,
-             RealT     Ra,
-             RealT     Tdop,
-             RealT     Tdopp,
-             RealT     Tqopp,
-             RealT     Tqop,
-             RealT     Xd,
-             RealT     Xdp,
-             RealT     Xdpp,
-             RealT     Xq,
-             RealT     Xqp,
-             RealT     Xqpp,
-             RealT     Xl,
-             RealT     S10,
-             RealT     S12);
+      Genrou(BusT* bus, IdxT unit_id);
+      Genrou(BusT*             bus,
+             SignalT*          omega,
+             SignalT*          pmech,
+             const ModelDataT& data);
+      Genrou(BusT*             bus,
+             SignalT*          omega,
+             SignalT*          pmech,
+             SignalT*          efd,
+             const ModelDataT& data);
+      Genrou(BusT* bus, const ModelDataT& data);
+      Genrou(BusT* bus,
+             IdxT  unit_id,
+             RealT p0,
+             RealT q0,
+             RealT H,
+             RealT D,
+             RealT Ra,
+             RealT Tdop,
+             RealT Tdopp,
+             RealT Tqopp,
+             RealT Tqop,
+             RealT Xd,
+             RealT Xdp,
+             RealT Xdpp,
+             RealT Xq,
+             RealT Xqp,
+             RealT Xqpp,
+             RealT Xl,
+             RealT S10,
+             RealT S12);
       ~Genrou();
 
       int setGridKitComponentID(IdxT) override final;
@@ -143,20 +164,8 @@ namespace GridKit
       ScalarT getSpeed();
       ScalarT getTorque();
 
-      /// Get the `ComponentSignals` from this `Genrou`
-      auto getSignals()
-          -> ComponentSignals<ScalarT,
-                              IdxT,
-                              GenrouInternalVariables,
-                              GenrouExternalVariables>&
-      {
-        return signals_;
-      }
-
-      const Model::VariableMonitorBase* getMonitor() const override;
-
     private:
-      void initializeParameters(const model_data_type& data);
+      void initializeParameters(const ModelDataT& data);
       /// Associate variable getter functions with enum values
       void initializeMonitor();
       void setDerivedParams();
@@ -187,12 +196,9 @@ namespace GridKit
 
     private:
       /* Identification */
-      bus_type* bus_;
-      IdxT      bus_id_{0};
-      IdxT      unit_id_; //< @todo this should be removed
-
-      /// Component signal extension
-      ComponentSignals<ScalarT, IdxT, GenrouInternalVariables, GenrouExternalVariables> signals_;
+      BusT* bus_;
+      IdxT  bus_id_{0};
+      IdxT  unit_id_; //< @todo this should be removed
 
       /* Initial terminal conditions */
       RealT p0_{0.0};
@@ -241,9 +247,6 @@ namespace GridKit
       /* Local copies of signal variables */
       std::vector<ScalarT> ws_;
       std::vector<IdxT>    ws_indices_;
-
-      /// Variable monitor
-      std::unique_ptr<MonitorT> monitor_;
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouDependencyTracking.cpp
@@ -1,3 +1,5 @@
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+
 #include "GenrouImpl.hpp"
 
 namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -5,11 +5,11 @@
 #include <iostream>
 
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 #include <GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp> // <- TODO: Temporary, to be removed.
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
 #include <GridKit/Utilities/Logger/Logger.hpp>
 
 namespace GridKit
@@ -27,8 +27,8 @@ namespace GridKit
      * - Number of quadratures = 0
      * - Number of optimization parameters = 0
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, IdxT unit_id)
+    template <typename ScalarP, typename IdxP>
+    Genrou<ScalarP, IdxP>::Genrou(BusT* bus, IdxT unit_id)
       : bus_(bus),
         bus_id_(0),
         unit_id_(unit_id),
@@ -59,27 +59,27 @@ namespace GridKit
     /**
      * @brief Constructor for a GENROU generator model with saturation
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus,
-                                  IdxT      unit_id,
-                                  RealT     p0,
-                                  RealT     q0,
-                                  RealT     H,
-                                  RealT     D,
-                                  RealT     Ra,
-                                  RealT     Tdop,
-                                  RealT     Tdopp,
-                                  RealT     Tqopp,
-                                  RealT     Tqop,
-                                  RealT     Xd,
-                                  RealT     Xdp,
-                                  RealT     Xdpp,
-                                  RealT     Xq,
-                                  RealT     Xqp,
-                                  RealT     Xqpp,
-                                  RealT     Xl,
-                                  RealT     S10,
-                                  RealT     S12)
+    template <typename ScalarP, typename IdxP>
+    Genrou<ScalarP, IdxP>::Genrou(BusT* bus,
+                                  IdxT  unit_id,
+                                  RealT p0,
+                                  RealT q0,
+                                  RealT H,
+                                  RealT D,
+                                  RealT Ra,
+                                  RealT Tdop,
+                                  RealT Tdopp,
+                                  RealT Tqopp,
+                                  RealT Tqop,
+                                  RealT Xd,
+                                  RealT Xdp,
+                                  RealT Xdpp,
+                                  RealT Xq,
+                                  RealT Xqp,
+                                  RealT Xqpp,
+                                  RealT Xl,
+                                  RealT S10,
+                                  RealT S12)
       : bus_(bus),
         bus_id_(0),
         unit_id_(unit_id),
@@ -110,11 +110,11 @@ namespace GridKit
     /**
      * @brief Constructor for a GENROU generator model with saturation
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, const model_data_type& data)
-      : bus_(bus),
-        unit_id_(1),
-        monitor_(std::make_unique<MonitorT>(data))
+    template <typename ScalarP, typename IdxP>
+    Genrou<ScalarP, IdxP>::Genrou(BusT* bus, const ModelDataT& data)
+      : ConnectedElement<Genrou>(data),
+        bus_(bus),
+        unit_id_(1)
     {
       initializeParameters(data);
       initializeMonitor();
@@ -126,11 +126,11 @@ namespace GridKit
     /**
      * @brief Constructor for a GENROU generator model with saturation
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, signal_type* omega, signal_type* pmech, const model_data_type& data)
-      : bus_(bus),
-        unit_id_(1),
-        monitor_(std::make_unique<MonitorT>(data))
+    template <typename ScalarP, typename IdxP>
+    Genrou<ScalarP, IdxP>::Genrou(BusT* bus, SignalT* omega, SignalT* pmech, const ModelDataT& data)
+      : ConnectedElement<Genrou>(data),
+        bus_(bus),
+        unit_id_(1)
     {
       signals_.template attachSignalNode<GenrouExternalVariables::PM>(pmech);
       signals_.template assignSignalNode<GenrouInternalVariables::OMEGA>(omega);
@@ -144,11 +144,11 @@ namespace GridKit
     /**
      * @brief Constructor for a GENROU generator model with saturation
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, signal_type* omega, signal_type* pmech, signal_type* efd, const model_data_type& data)
-      : bus_(bus),
-        unit_id_(1),
-        monitor_(std::make_unique<MonitorT>(data))
+    template <typename ScalarP, typename IdxP>
+    Genrou<ScalarP, IdxP>::Genrou(BusT* bus, SignalT* omega, SignalT* pmech, SignalT* efd, const ModelDataT& data)
+      : ConnectedElement<Genrou>(data),
+        bus_(bus),
+        unit_id_(1)
     {
       signals_.template attachSignalNode<GenrouExternalVariables::PM>(pmech);
       signals_.template assignSignalNode<GenrouInternalVariables::OMEGA>(omega);
@@ -160,127 +160,121 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::~Genrou()
+    template <typename ScalarP, typename IdxP>
+    Genrou<ScalarP, IdxP>::~Genrou()
     {
     }
 
     /// Helper function to extract and assign model parameters from the model's associated
     /// data structure.
-    template <class ScalarT, typename IdxT>
-    void Genrou<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
+    template <typename ScalarP, typename IdxP>
+    void Genrou<ScalarP, IdxP>::initializeParameters(const ModelDataT& data)
     {
-      if (data.parameters.contains(model_data_type::Parameters::p0))
+      if (data.parameters.contains(ModelDataT::Parameters::p0))
       {
-        p0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::p0));
+        p0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::p0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::q0))
+      if (data.parameters.contains(ModelDataT::Parameters::q0))
       {
-        q0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::q0));
+        q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::q0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::H))
+      if (data.parameters.contains(ModelDataT::Parameters::H))
       {
-        H_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::H));
+        H_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::H));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::D))
+      if (data.parameters.contains(ModelDataT::Parameters::D))
       {
-        D_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::D));
+        D_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::D));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Ra))
+      if (data.parameters.contains(ModelDataT::Parameters::Ra))
       {
-        Ra_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ra));
+        Ra_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ra));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tdop))
+      if (data.parameters.contains(ModelDataT::Parameters::Tdop))
       {
-        Tdop_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tdop));
+        Tdop_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdop));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tdopp))
+      if (data.parameters.contains(ModelDataT::Parameters::Tdopp))
       {
-        Tdopp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tdopp));
+        Tdopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdopp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tqopp))
+      if (data.parameters.contains(ModelDataT::Parameters::Tqopp))
       {
-        Tqopp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tqopp));
+        Tqopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tqopp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tqop))
+      if (data.parameters.contains(ModelDataT::Parameters::Tqop))
       {
-        Tqop_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tqop));
+        Tqop_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tqop));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xd))
+      if (data.parameters.contains(ModelDataT::Parameters::Xd))
       {
-        Xd_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xd));
+        Xd_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xd));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xdp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xdp))
       {
-        Xdp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xdp));
+        Xdp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xdpp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xdpp))
       {
-        Xdpp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xdpp));
+        Xdpp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdpp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xq))
+      if (data.parameters.contains(ModelDataT::Parameters::Xq))
       {
-        Xq_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xq));
+        Xq_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xq));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xqp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xqp))
       {
-        Xqp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xqp));
+        Xqp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xqp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xqpp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xqpp))
       {
-        Xqpp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xqpp));
+        Xqpp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xqpp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xl))
+      if (data.parameters.contains(ModelDataT::Parameters::Xl))
       {
-        Xl_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xl));
+        Xl_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xl));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::S10))
+      if (data.parameters.contains(ModelDataT::Parameters::S10))
       {
-        S10_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::S10));
+        S10_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S10));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::S12))
+      if (data.parameters.contains(ModelDataT::Parameters::S12))
       {
-        S12_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::S12));
+        S12_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S12));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::mva_base))
+      if (data.parameters.contains(ModelDataT::Parameters::mva_base))
       {
-        mva_base_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::mva_base));
+        mva_base_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::mva_base));
       }
 
-      if (data.ports.contains(model_data_type::Ports::bus))
+      if (data.ports.contains(ModelDataT::Ports::bus))
       {
-        bus_id_ = data.ports.at(model_data_type::Ports::bus);
+        bus_id_ = data.ports.at(ModelDataT::Ports::bus);
       }
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* Genrou<ScalarT, IdxT>::getMonitor() const
+    template <typename ScalarP, typename IdxP>
+    void Genrou<ScalarP, IdxP>::initializeMonitor()
     {
-      return monitor_.get();
-    }
-
-    template <class ScalarT, typename IdxT>
-    void Genrou<ScalarT, IdxT>::initializeMonitor()
-    {
-      using Variable = typename model_data_type::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::ir, [this]
                     { return y_[15]; });
       monitor_->set(Variable::ii, [this]
@@ -300,8 +294,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename ScalarP, typename IdxP>
+    int Genrou<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -310,8 +304,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::allocate()
+    template <typename ScalarP, typename IdxP>
+    int Genrou<ScalarP, IdxP>::allocate()
     {
       // Resize component model data
       auto size = static_cast<size_t>(size_);
@@ -351,8 +345,8 @@ namespace GridKit
     /**
      * @brief verify method checks that attached signals are also linked
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::verify() const
+    template <typename ScalarP, typename IdxP>
+    int Genrou<ScalarP, IdxP>::verify() const
     {
       static constexpr auto PM  = GenrouExternalVariables::PM;
       static constexpr auto EFD = GenrouExternalVariables::EFD;
@@ -384,8 +378,8 @@ namespace GridKit
      * Initialization of the branch model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::initialize()
+    template <typename ScalarP, typename IdxP>
+    int Genrou<ScalarP, IdxP>::initialize()
     {
       // Saturated initialization with ksat iteration.
       // See README "With Saturation" and plan for derivation.
@@ -498,8 +492,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::tagDifferentiable()
+    template <typename ScalarP, typename IdxP>
+    int Genrou<ScalarP, IdxP>::tagDifferentiable()
     {
       for (IdxT i = 0; i < size_; ++i)
       {
@@ -512,8 +506,8 @@ namespace GridKit
      * @brief Internal residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateInternalResidual(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) inline int Genrou<ScalarP, IdxP>::evaluateInternalResidual(
         ScalarT* y,
         ScalarT* yp,
         ScalarT* wb,
@@ -589,8 +583,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) inline int Genrou<ScalarP, IdxP>::evaluateBusResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -611,8 +605,8 @@ namespace GridKit
      * \brief Residual evaluation and contribution to the connected bus
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::evaluateResidual()
+    template <typename ScalarP, typename IdxP>
+    int Genrou<ScalarP, IdxP>::evaluateResidual()
     {
       // Mechanical Power
       ws_[0] = pmech_set_;
@@ -648,24 +642,22 @@ namespace GridKit
     /**
      * @brief Access generator relative speed
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    ScalarT Genrou<ScalarT, IdxT>::getSpeed()
+    template <typename ScalarP, typename IdxP>
+    Genrou<ScalarP, IdxP>::ScalarT Genrou<ScalarP, IdxP>::getSpeed()
     {
       return y_[1];
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT Genrou<ScalarT, IdxT>::getTorque()
+    template <typename ScalarP, typename IdxP>
+    Genrou<ScalarP, IdxP>::ScalarT Genrou<ScalarP, IdxP>::getTorque()
     {
       return y_[12];
     }
 
-    template <class ScalarT, typename IdxT>
-    void Genrou<ScalarT, IdxT>::setDerivedParams()
+    template <typename ScalarP, typename IdxP>
+    void Genrou<ScalarP, IdxP>::setDerivedParams()
     {
       SA_ = 0;
       SB_ = 0;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
@@ -14,11 +14,10 @@ if(GRIDKIT_ENABLE_ENZYME)
       GenClassicalEnzyme.cpp
     HEADERS
       ${_install_headers}
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
       PRIVATE ClangEnzymeFlags
       PUBLIC GridKit::phasor_dynamics_core
+      PRIVATE GridKit::phasor_dynamics_utils
     COMPILE_OPTIONS
       PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
@@ -28,18 +27,16 @@ else()
     HEADERS
       ${_install_headers}
     LINK_LIBRARIES
-      PUBLIC GridKit::phasor_dynamics_core
-    INCLUDE_DIRECTORIES
-      PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+      PRIVATE GridKit::phasor_dynamics_utils
+      PUBLIC GridKit::phasor_dynamics_core)
 endif()
 
 gridkit_add_library(phasor_dynamics_gen_classical_dependency_tracking
   SOURCES 
     GenClassicalDependencyTracking.cpp
   LINK_LIBRARIES
-    PUBLIC GridKit::phasor_dynamics_core
-  INCLUDE_DIRECTORIES 
-    PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+    PRIVATE GridKit::phasor_dynamics_utils
+    PUBLIC GridKit::phasor_dynamics_core)
 
 # Link to interface target for all components
 target_link_libraries(phasor_dynamics_components

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -8,19 +8,18 @@
 #pragma once
 
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
-#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp>
-#include <GridKit/Model/VariableMonitor.hpp>
 
 // Forward declarations.
 namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename ScalarP, typename IdxP>
     class BusBase;
 
-    template <typename RealT, typename IdxT>
+    template <typename RealP, typename IdxP>
     struct GenClassicalData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -29,45 +28,76 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    template <typename, typename>
+    class GenClassical;
 
-    template <class ScalarT, typename IdxT>
-    class GenClassical : public Component<ScalarT, IdxT>
+    enum class GenClassicalInternalVariables : size_t
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::mva_system_base_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      MAXIMUM
+    };
+
+    enum class GenClassicalExternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<GenClassical<ScalarP, IdxP>>
+    {
+      using GenClassicalT = GenClassical<ScalarP, IdxP>;
+
+      using ElementT           = GenClassicalT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = GenClassicalData<RealT, IdxT>;
+      using InternalVariablesT = GenClassicalInternalVariables;
+      using ExternalVariablesT = GenClassicalExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
+    template <typename ScalarP, typename IdxP>
+    class GenClassical : public ConnectedElement<GenClassical<ScalarP, IdxP>>
+    {
+      using ConnectedElement<GenClassical>::gridkit_component_id_;
+      using ConnectedElement<GenClassical>::alpha_;
+      using ConnectedElement<GenClassical>::f_;
+      using ConnectedElement<GenClassical>::nnz_;
+      using ConnectedElement<GenClassical>::size_;
+      using ConnectedElement<GenClassical>::tag_;
+      using ConnectedElement<GenClassical>::time_;
+      using ConnectedElement<GenClassical>::y_;
+      using ConnectedElement<GenClassical>::yp_;
+      using ConnectedElement<GenClassical>::wb_;
+      using ConnectedElement<GenClassical>::h_;
+      using ConnectedElement<GenClassical>::J_;
+      using ConnectedElement<GenClassical>::J_rows_buffer_;
+      using ConnectedElement<GenClassical>::J_cols_buffer_;
+      using ConnectedElement<GenClassical>::J_vals_buffer_;
+      using ConnectedElement<GenClassical>::mva_system_base_;
+      using ConnectedElement<GenClassical>::variable_indices_;
+      using ConnectedElement<GenClassical>::residual_indices_;
+      using ConnectedElement<GenClassical>::monitor_;
+      using ConnectedElement<GenClassical>::signals_;
 
     public:
-      using bus_type = BusBase<ScalarT, IdxT>;
-      using RealT    = typename Component<ScalarT, IdxT>::RealT;
-      using DataT    = GenClassicalData<RealT, IdxT>;
-      using MonitorT = Model::VariableMonitor<GenClassical, GenClassicalData>;
+      using ScalarT    = typename ConnectedElement<GenClassical>::ScalarT;
+      using IdxT       = typename ConnectedElement<GenClassical>::IdxT;
+      using RealT      = typename ConnectedElement<GenClassical>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using MonitorT   = typename ConnectedElement<GenClassical>::MonitorT;
+      using ModelDataT = GenClassicalData<RealT, IdxT>;
 
-      GenClassical(bus_type* bus, int unit_id);
-      GenClassical(bus_type* bus,
-                   int       unit_id,
-                   RealT     p0,
-                   RealT     q0,
-                   RealT     H,
-                   RealT     D,
-                   RealT     Ra,
-                   RealT     Xdp);
-      GenClassical(bus_type* bus, const DataT& data);
+      GenClassical(BusT* bus, int unit_id);
+      GenClassical(BusT* bus,
+                   int   unit_id,
+                   RealT p0,
+                   RealT q0,
+                   RealT H,
+                   RealT D,
+                   RealT Ra,
+                   RealT Xdp);
+      GenClassical(BusT* bus, const ModelDataT& data);
       ~GenClassical();
 
       int setGridKitComponentID(IdxT) override final;
@@ -93,8 +123,6 @@ namespace GridKit
       {
         ep_set_ = ep;
       }
-
-      const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
       void initializeMonitor();
@@ -126,9 +154,9 @@ namespace GridKit
 
     private:
       /* Identification */
-      bus_type* bus_;
-      IdxT      bus_id_{0};
-      int       unit_id_; //< @todo this should be removed
+      BusT* bus_;
+      IdxT  bus_id_{0};
+      int   unit_id_; //< @todo this should be removed
 
       /* Initial terminal conditions */
       RealT p0_{0.0};
@@ -148,9 +176,6 @@ namespace GridKit
       /* Setpoints for control variables (determined at initialization) */
       ScalarT pmech_set_;
       ScalarT ep_set_;
-
-      /// Variable monitor
-      std::unique_ptr<MonitorT> monitor_;
     };
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalDependencyTracking.cpp
@@ -1,3 +1,4 @@
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 
 #include "GenClassicalImpl.hpp"
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -11,9 +11,9 @@
 #include <iostream>
 
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp>
-#include <GridKit/Model/VariableMonitorImpl.hpp>
 
 namespace GridKit
 {
@@ -22,8 +22,8 @@ namespace GridKit
     /**
      * @brief Constructor for a classical generator model
      */
-    template <class ScalarT, typename IdxT>
-    GenClassical<ScalarT, IdxT>::GenClassical(bus_type* bus, int unit_id)
+    template <typename ScalarP, typename IdxP>
+    GenClassical<ScalarP, IdxP>::GenClassical(BusT* bus, int unit_id)
       : bus_(bus),
         bus_id_(0),
         unit_id_(unit_id),
@@ -42,15 +42,15 @@ namespace GridKit
     /**
      * @brief Constructor for a classical generator model
      */
-    template <class ScalarT, typename IdxT>
-    GenClassical<ScalarT, IdxT>::GenClassical(bus_type* bus,
-                                              int       unit_id,
-                                              RealT     p0,
-                                              RealT     q0,
-                                              RealT     H,
-                                              RealT     D,
-                                              RealT     Ra,
-                                              RealT     Xdp)
+    template <typename ScalarP, typename IdxP>
+    GenClassical<ScalarP, IdxP>::GenClassical(BusT* bus,
+                                              int   unit_id,
+                                              RealT p0,
+                                              RealT q0,
+                                              RealT H,
+                                              RealT D,
+                                              RealT Ra,
+                                              RealT Xdp)
       : bus_(bus),
         bus_id_(0),
         unit_id_(unit_id),
@@ -69,50 +69,50 @@ namespace GridKit
     /**
      * @brief Constructor for a classical generator model
      */
-    template <class ScalarT, typename IdxT>
-    GenClassical<ScalarT, IdxT>::GenClassical(bus_type* bus, const DataT& data)
-      : bus_(bus),
-        unit_id_(1),
-        monitor_(std::make_unique<MonitorT>(data))
+    template <typename ScalarP, typename IdxP>
+    GenClassical<ScalarP, IdxP>::GenClassical(BusT* bus, const ModelDataT& data)
+      : ConnectedElement<GenClassical>(data),
+        bus_(bus),
+        unit_id_(1)
     {
-      if (data.parameters.contains(DataT::Parameters::p0))
+      if (data.parameters.contains(ModelDataT::Parameters::p0))
       {
-        p0_ = std::get<RealT>(data.parameters.at(DataT::Parameters::p0));
+        p0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::p0));
       }
 
-      if (data.parameters.contains(DataT::Parameters::q0))
+      if (data.parameters.contains(ModelDataT::Parameters::q0))
       {
-        q0_ = std::get<RealT>(data.parameters.at(DataT::Parameters::q0));
+        q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::q0));
       }
 
-      if (data.parameters.contains(DataT::Parameters::H))
+      if (data.parameters.contains(ModelDataT::Parameters::H))
       {
-        H_ = std::get<RealT>(data.parameters.at(DataT::Parameters::H));
+        H_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::H));
       }
 
-      if (data.parameters.contains(DataT::Parameters::D))
+      if (data.parameters.contains(ModelDataT::Parameters::D))
       {
-        D_ = std::get<RealT>(data.parameters.at(DataT::Parameters::D));
+        D_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::D));
       }
 
-      if (data.parameters.contains(DataT::Parameters::Ra))
+      if (data.parameters.contains(ModelDataT::Parameters::Ra))
       {
-        Ra_ = std::get<RealT>(data.parameters.at(DataT::Parameters::Ra));
+        Ra_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ra));
       }
 
-      if (data.parameters.contains(DataT::Parameters::Xdp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xdp))
       {
-        Xdp_ = std::get<RealT>(data.parameters.at(DataT::Parameters::Xdp));
+        Xdp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdp));
       }
 
-      if (data.parameters.contains(DataT::Parameters::mva_base))
+      if (data.parameters.contains(ModelDataT::Parameters::mva_base))
       {
-        mva_base_ = std::get<RealT>(data.parameters.at(DataT::Parameters::mva_base));
+        mva_base_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::mva_base));
       }
 
-      if (data.ports.contains(DataT::Ports::bus))
+      if (data.ports.contains(ModelDataT::Ports::bus))
       {
-        bus_id_ = data.ports.at(DataT::Ports::bus);
+        bus_id_ = data.ports.at(ModelDataT::Ports::bus);
       }
 
       initializeMonitor();
@@ -121,21 +121,15 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    GenClassical<ScalarT, IdxT>::~GenClassical()
+    template <typename ScalarP, typename IdxP>
+    GenClassical<ScalarP, IdxP>::~GenClassical()
     {
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* GenClassical<ScalarT, IdxT>::getMonitor() const
+    template <typename ScalarP, typename IdxP>
+    void GenClassical<ScalarP, IdxP>::initializeMonitor()
     {
-      return monitor_.get();
-    }
-
-    template <class ScalarT, typename IdxT>
-    void GenClassical<ScalarT, IdxT>::initializeMonitor()
-    {
-      using Variable = typename DataT::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::ir, [this]
                     { return y_[3]; });
       monitor_->set(Variable::ii, [this]
@@ -153,8 +147,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename ScalarP, typename IdxP>
+    int GenClassical<ScalarP, IdxP>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -163,8 +157,8 @@ namespace GridKit
     /**
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::allocate()
+    template <typename ScalarP, typename IdxP>
+    int GenClassical<ScalarP, IdxP>::allocate()
     {
       // Resize component model data
       auto size = static_cast<size_t>(size_);
@@ -192,8 +186,8 @@ namespace GridKit
     /**
      * Initialization of the generator model
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::initialize()
+    template <typename ScalarP, typename IdxP>
+    int GenClassical<ScalarP, IdxP>::initialize()
     {
       ScalarT vr    = Vr();
       ScalarT vi    = Vi();
@@ -226,8 +220,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::tagDifferentiable()
+    template <typename ScalarP, typename IdxP>
+    int GenClassical<ScalarP, IdxP>::tagDifferentiable()
     {
       for (IdxT i = 0; i < size_; ++i)
       {
@@ -240,8 +234,8 @@ namespace GridKit
      * @brief Internal residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateInternalResidual(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) int GenClassical<ScalarP, IdxP>::evaluateInternalResidual(
         ScalarT* y,
         ScalarT* yp,
         ScalarT* wb,
@@ -281,8 +275,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename ScalarP, typename IdxP>
+    __attribute__((always_inline)) int GenClassical<ScalarP, IdxP>::evaluateBusResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         [[maybe_unused]] ScalarT* wb,
@@ -300,8 +294,8 @@ namespace GridKit
      * \brief Residual for the generator model.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::evaluateResidual()
+    template <typename ScalarP, typename IdxP>
+    int GenClassical<ScalarP, IdxP>::evaluateResidual()
     {
       wb_[0] = Vr();
       wb_[1] = Vi();
@@ -315,8 +309,8 @@ namespace GridKit
       return 0;
     }
 
-    template <class ScalarT, typename IdxT>
-    void GenClassical<ScalarT, IdxT>::setDerivedParams()
+    template <typename ScalarP, typename IdxP>
+    void GenClassical<ScalarP, IdxP>::setDerivedParams()
     {
       G_ = Ra_ / (Ra_ * Ra_ + Xdp_ * Xdp_);
       B_ = -Xdp_ / (Ra_ * Ra_ + Xdp_ * Xdp_);

--- a/GridKit/Model/PhasorDynamics/SystemModel.cpp
+++ b/GridKit/Model/PhasorDynamics/SystemModel.cpp
@@ -1,0 +1,13 @@
+#include "SystemModelImpl.hpp"
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+
+    // Available template instantiations
+    // template class SystemModel<double, long int>;
+    template class SystemModel<double, size_t>;
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SystemModel.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModel.hpp
@@ -8,6 +8,7 @@
 #include <GridKit/Model/PhasorDynamics/Bus/BusFactory.hpp>
 #include <GridKit/Model/PhasorDynamics/BusBase.hpp>
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
+#include <GridKit/Model/PhasorDynamics/ConnectedElement.hpp>
 #include <GridKit/Model/PhasorDynamics/SystemModelData.hpp>
 #include <GridKit/Model/VariableMonitorController.hpp>
 #include <GridKit/ScalarTraits.hpp>
@@ -19,6 +20,34 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    template <typename, typename>
+    class SystemModel;
+
+    enum class SystemModelInternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    enum class SystemModelExternalVariables : size_t
+    {
+      MAXIMUM
+    };
+
+    template <typename ScalarP, typename IdxP>
+    struct ConnectedElementTraits<SystemModel<ScalarP, IdxP>>
+    {
+      using SystemModelT = SystemModel<ScalarP, IdxP>;
+
+      using ElementT           = SystemModelT;
+      using ScalarT            = ScalarP;
+      using IdxT               = IdxP;
+      using RealT              = typename ScalarTraits<ScalarT>::RealT;
+      using ModelDataT         = SystemModelData<RealT, IdxT>;
+      using InternalVariablesT = SystemModelInternalVariables;
+      using ExternalVariablesT = SystemModelExternalVariables;
+      using InterfaceT         = Component<ScalarT, IdxT>;
+    };
+
     /**
      * @brief Prototype for a system model class
      *
@@ -29,41 +58,38 @@ namespace GridKit
      * @todo Address thread safety for the system model methods.
      *
      */
-    template <class ScalarT, typename IdxT>
-    class SystemModel : public PhasorDynamics::Component<ScalarT, IdxT>
+    template <typename ScalarP, typename IdxP>
+    class SystemModel : public ConnectedElement<SystemModel<ScalarP, IdxP>>
     {
-      using bus_type       = PhasorDynamics::BusBase<ScalarT, IdxT>;
-      using signal_type    = PhasorDynamics::SignalNode<ScalarT, IdxT>;
-      using component_type = PhasorDynamics::Component<ScalarT, IdxT>;
-      using RealT          = typename Model::Evaluator<ScalarT, IdxT>::RealT;
-      using CsrMatrixT     = typename Model::Evaluator<ScalarT, IdxT>::CsrMatrixT;
-
-      using PhasorDynamics::Component<ScalarT, IdxT>::gridkit_component_id_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::size_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::nnz_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::time_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::alpha_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::y_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::yp_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::tag_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::f_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::J_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::rel_tol_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::abs_tol_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::variable_indices_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::residual_indices_;
+      using ConnectedElement<SystemModel>::gridkit_component_id_;
+      using ConnectedElement<SystemModel>::size_;
+      using ConnectedElement<SystemModel>::nnz_;
+      using ConnectedElement<SystemModel>::time_;
+      using ConnectedElement<SystemModel>::alpha_;
+      using ConnectedElement<SystemModel>::y_;
+      using ConnectedElement<SystemModel>::yp_;
+      using ConnectedElement<SystemModel>::tag_;
+      using ConnectedElement<SystemModel>::f_;
+      using ConnectedElement<SystemModel>::J_;
+      using ConnectedElement<SystemModel>::rel_tol_;
+      using ConnectedElement<SystemModel>::abs_tol_;
+      using ConnectedElement<SystemModel>::variable_indices_;
+      using ConnectedElement<SystemModel>::residual_indices_;
 
     public:
+      using ScalarT    = typename ConnectedElement<SystemModel>::ScalarT;
+      using IdxT       = typename ConnectedElement<SystemModel>::IdxT;
+      using RealT      = typename ConnectedElement<SystemModel>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using SignalT    = SignalNode<ScalarT, IdxT>;
+      using ComponentT = Component<ScalarT, IdxT>;
+      using CsrMatrixT = typename Model::Evaluator<ScalarT, IdxT>::CsrMatrixT;
+      using ModelDataT = SystemModelData<RealT, IdxT>;
+
       /**
        * @brief Constructor for the system model
        */
-      SystemModel()
-      {
-        // Set system model tolerances
-        rel_tol_         = 1e-7;
-        abs_tol_         = 1e-9;
-        this->max_steps_ = 2000;
-      }
+      SystemModel();
 
       /**
        * @brief Construct a new System Model object
@@ -76,246 +102,7 @@ namespace GridKit
        * @post All component models in SystemModelData are created, and
        * correctly connected into the system model.
        */
-      SystemModel(SystemModelData<RealT, IdxT>& data)
-        : monitor_(time_)
-      {
-        using namespace Governor;
-        using namespace Exciter;
-        using namespace Stabilizer;
-
-        // Set system model tolerances
-        rel_tol_         = 1e-7;
-        abs_tol_         = 1e-9;
-        this->max_steps_ = 2000;
-
-        owns_components_ = true;
-
-        // Add electrical buses
-        for (const auto& busdata : data.bus)
-        {
-          BusBase<ScalarT, IdxT>* bus = BusFactory<ScalarT, IdxT>::create(busdata);
-          addBus(bus);
-        }
-
-        /// @todo Signal data needs to be populated by the parser.
-        /// See TODOs in SystemModelDataJSONParser
-        for (const auto& signaldata : data.signal)
-        {
-          SignalNode<ScalarT, IdxT>* signal = new SignalNode<ScalarT, IdxT>(signaldata);
-          addSignal(signal);
-        }
-
-        // Add branches
-        for (const auto& branchdata : data.branch)
-        {
-          IdxT bus1_index = 0;
-          if (branchdata.ports.contains(BranchData<ScalarT, IdxT>::Ports::bus1))
-          {
-            bus1_index = branchdata.ports.at(BranchData<ScalarT, IdxT>::Ports::bus1);
-          }
-
-          IdxT bus2_index = 0;
-          if (branchdata.ports.contains(BranchData<ScalarT, IdxT>::Ports::bus2))
-          {
-            bus2_index = branchdata.ports.at(BranchData<ScalarT, IdxT>::Ports::bus2);
-          }
-
-          auto* branch = new Branch<ScalarT, IdxT>(getBus(bus1_index), getBus(bus2_index), branchdata);
-          addComponent(branch);
-        }
-
-        // Add loads
-        /// @todo Add loads to JSON parser
-        for (const auto& loaddata : data.load)
-        {
-          IdxT bus_index = 0;
-          if (loaddata.ports.contains(LoadData<ScalarT, IdxT>::Ports::bus))
-          {
-            bus_index = loaddata.ports.at(LoadData<ScalarT, IdxT>::Ports::bus);
-          }
-          auto* load = new Load<ScalarT, IdxT>(getBus(bus_index), loaddata);
-          addComponent(load);
-        }
-
-        // Add zip loads
-        /// @todo Add zip loads to JSON parser
-        for (const auto& loadzipdata : data.loadzip)
-        {
-          IdxT bus_index = 0;
-          if (loadzipdata.ports.contains(LoadZIPData<ScalarT, IdxT>::Ports::bus))
-          {
-            bus_index = loadzipdata.ports.at(LoadZIPData<ScalarT, IdxT>::Ports::bus);
-          }
-          auto* loadzip = new LoadZIP<ScalarT, IdxT>(getBus(bus_index), loadzipdata);
-          addComponent(loadzip);
-        }
-
-        // Add GENROU generators
-        for (const auto& gendata : data.genrou)
-        {
-          IdxT bus_index = 0;
-          if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::bus))
-          {
-            bus_index = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::bus);
-          }
-
-          auto* gen = new Genrou<ScalarT, IdxT>(getBus(bus_index), gendata);
-
-          /// @todo Genrou (and likely other components) would need to name multiple
-          /// signal inlets and outlets. For now we have only speed out and mechanical
-          /// power in.
-          if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::speed))
-          {
-            IdxT speed = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::speed);
-            gen->getSignals().template assignSignalNode<GenrouInternalVariables::OMEGA>(getSignal(speed));
-          }
-
-          if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::pmech))
-          {
-            IdxT pmech = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::pmech);
-            gen->getSignals().template attachSignalNode<GenrouExternalVariables::PM>(getSignal(pmech));
-          }
-
-          if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::efd))
-          {
-            IdxT efd = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::efd);
-            gen->getSignals().template attachSignalNode<GenrouExternalVariables::EFD>(getSignal(efd));
-          }
-
-          addComponent(gen);
-        }
-
-        // Add classical generators
-        for (const auto& gendata : data.genclassical)
-        {
-          IdxT bus_index = 0;
-          if (gendata.ports.contains(GenClassicalData<ScalarT, IdxT>::Ports::bus))
-          {
-            bus_index = gendata.ports.at(GenClassicalData<ScalarT, IdxT>::Ports::bus);
-          }
-          auto* gen = new GenClassical<ScalarT, IdxT>(getBus(bus_index), gendata);
-          addComponent(gen);
-        }
-
-        // Add Tgov1 governors
-        for (const auto& govdata : data.gov)
-        {
-          auto* gov = new Tgov1<ScalarT, IdxT>(govdata);
-
-          if (govdata.ports.contains(Tgov1Data<ScalarT, IdxT>::Ports::speed))
-          {
-            IdxT speed = govdata.ports.at(Tgov1Data<ScalarT, IdxT>::Ports::speed);
-            gov->getSignals().template attachSignalNode<Tgov1ExternalVariables::DELTAOMEGA>(getSignal(speed));
-          }
-
-          if (govdata.ports.contains(Tgov1Data<ScalarT, IdxT>::Ports::pmech))
-          {
-            IdxT pmech = govdata.ports.at(Tgov1Data<ScalarT, IdxT>::Ports::pmech);
-            gov->getSignals().template assignSignalNode<Tgov1InternalVariables::PM>(getSignal(pmech));
-          }
-
-          addComponent(gov);
-        }
-
-        for (const auto& excitedata : data.exciter)
-        {
-          IdxT bus_index = 0;
-          if (excitedata.ports.contains(Ieeet1Data<ScalarT, IdxT>::Ports::bus))
-          {
-            bus_index = excitedata.ports.at(Ieeet1Data<ScalarT, IdxT>::Ports::bus);
-          }
-
-          auto* exciter = new Ieeet1<ScalarT, IdxT>(getBus(bus_index), excitedata);
-
-          if (excitedata.ports.contains(Ieeet1Data<ScalarT, IdxT>::Ports::speed))
-          {
-            IdxT speed = excitedata.ports.at(Ieeet1Data<ScalarT, IdxT>::Ports::speed);
-            exciter->getSignals().template attachSignalNode<Ieeet1ExternalVariables::OMEGA>(getSignal(speed));
-          }
-
-          if (excitedata.ports.contains(Ieeet1Data<ScalarT, IdxT>::Ports::efd))
-          {
-            IdxT efd = excitedata.ports.at(Ieeet1Data<ScalarT, IdxT>::Ports::efd);
-            exciter->getSignals().template assignSignalNode<Ieeet1InternalVariables::EFD>(getSignal(efd));
-          }
-
-          if (excitedata.ports.contains(Ieeet1Data<ScalarT, IdxT>::Ports::vs))
-          {
-            IdxT vs = excitedata.ports.at(Ieeet1Data<ScalarT, IdxT>::Ports::vs);
-            exciter->getSignals().template attachSignalNode<Ieeet1ExternalVariables::VS>(getSignal(vs));
-          }
-
-          addComponent(exciter);
-        }
-
-        for (const auto& excitedata : data.sexspti)
-        {
-          IdxT bus_index = 0;
-          if (excitedata.ports.contains(SexsPtiData<ScalarT, IdxT>::Ports::bus))
-          {
-            bus_index = excitedata.ports.at(SexsPtiData<ScalarT, IdxT>::Ports::bus);
-          }
-
-          auto* exciter = new SexsPti<ScalarT, IdxT>(getBus(bus_index), excitedata);
-
-          if (excitedata.ports.contains(SexsPtiData<ScalarT, IdxT>::Ports::efd))
-          {
-            IdxT efd = excitedata.ports.at(SexsPtiData<ScalarT, IdxT>::Ports::efd);
-            exciter->getSignals().template assignSignalNode<SexsPtiInternalVariables::EFD>(getSignal(efd));
-          }
-
-          if (excitedata.ports.contains(SexsPtiData<ScalarT, IdxT>::Ports::vs))
-          {
-            IdxT vs = excitedata.ports.at(SexsPtiData<ScalarT, IdxT>::Ports::vs);
-            exciter->getSignals().template attachSignalNode<SexsPtiExternalVariables::VS>(getSignal(vs));
-          }
-
-          addComponent(exciter);
-        }
-
-        // Add IEEEST stabilizers
-        for (const auto& stabdata : data.stabilizer)
-        {
-          auto* stabilizer = new Ieeest<ScalarT, IdxT>(stabdata);
-
-          if (stabdata.ports.contains(IeeestPorts::input))
-          {
-            IdxT input = stabdata.ports.at(IeeestPorts::input);
-            stabilizer->getSignals().template attachSignalNode<IeeestExternalVariables::U>(getSignal(input));
-          }
-
-          if (stabdata.ports.contains(IeeestPorts::cutout))
-          {
-            IdxT cutout = stabdata.ports.at(IeeestPorts::cutout);
-            stabilizer->getSignals().template attachSignalNode<IeeestExternalVariables::VCT>(getSignal(cutout));
-          }
-
-          if (stabdata.ports.contains(IeeestPorts::output))
-          {
-            IdxT output = stabdata.ports.at(IeeestPorts::output);
-            stabilizer->getSignals().template assignSignalNode<IeeestInternalVariables::VS>(getSignal(output));
-          }
-
-          addComponent(stabilizer);
-        }
-
-        // Add faults
-        for (const auto& faultdata : data.bus_fault)
-        {
-          IdxT bus_index = 0;
-          if (faultdata.ports.contains(BusFaultData<ScalarT, IdxT>::Ports::bus))
-          {
-            bus_index = faultdata.ports.at(BusFaultData<ScalarT, IdxT>::Ports::bus);
-          }
-          auto* fault = new BusFault<ScalarT, IdxT>(getBus(bus_index), faultdata);
-          addFault(fault);
-        }
-
-        for (const auto& sink : data.monitor_sink)
-        {
-          monitor_.addSink(sink);
-        }
-      }
+      SystemModel(const ModelDataT& data);
 
       /**
        * @brief Destructor for the system model
@@ -323,36 +110,7 @@ namespace GridKit
        * If the SystemModel owns the components, it needs to delete them upon
        * destructor call.
        */
-      virtual ~SystemModel()
-      {
-        if (owns_components_)
-        {
-          for (auto component : components_)
-          {
-            delete component;
-          }
-
-          for (auto bus : buses_)
-          {
-            delete bus;
-          }
-
-          for (auto signal : signals_)
-          {
-            delete signal;
-          }
-        }
-        if (csr_jac_ != nullptr)
-        {
-          delete csr_jac_;
-          csr_jac_ = nullptr;
-        }
-        if (map_to_csr_ != nullptr)
-        {
-          delete[] map_to_csr_;
-          map_to_csr_ = nullptr;
-        }
-      }
+      virtual ~SystemModel();
 
       /**
        * @brief Set component ID
@@ -376,74 +134,7 @@ namespace GridKit
        * @post size_ >= 1
        *
        */
-      int allocate() override
-      {
-        size_ = 0;
-
-        // Allocate all buses
-        for (const auto& bus : buses_)
-        {
-          bus->allocate();
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            bus->setVariableIndex(j, size_ + j);
-            bus->setResidualIndex(j, size_ + j);
-          }
-          size_ += bus->size();
-        }
-
-        // Allocate all components
-        for (const auto& component : components_)
-        {
-          component->allocate();
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            component->setVariableIndex(j, size_ + j);
-            component->setResidualIndex(j, size_ + j);
-          }
-          size_ += component->size();
-        }
-
-        // Allocate global vectors
-        y_.resize(size_);
-        yp_.resize(size_);
-        f_.resize(size_);
-        tag_.resize(size_);
-        variable_indices_.resize(size_);
-        residual_indices_.resize(size_);
-
-        // Default variable and residual index mapping to local index
-        for (IdxT j = 0; j < size_; ++j)
-        {
-          this->setVariableIndex(j, j);
-          this->setResidualIndex(j, j);
-        }
-
-        // Verify component configuration
-        int errorCount = this->verify();
-        if (errorCount > 0)
-        {
-          Log::error() << "Component errors: " << errorCount << std::endl;
-          throw std::runtime_error("SystemModel allocation failed");
-        }
-
-        // Start variable monitors
-        initializeMonitor();
-        startMonitor();
-
-        // Perform an initial Jacobian evaluation for sparse Jacobians, such that
-        // the dynamic solver can querry the NNZ value when it is configured.
-        // @todo Replace with a sparsity analysis that sets the NNZ and allocates the Jacobian
-        // without needing the Jacobian values.
-        if (hasJacobian())
-        {
-          initialize();
-          evaluateResidual();
-          evaluateJacobian();
-        }
-
-        return 0;
-      }
+      int allocate() override;
 
       /**
        * @brief Verify all components are configured correctly
@@ -451,18 +142,7 @@ namespace GridKit
        * This method accumulates and returns the number of errors given by
        * components. It should return 0 when all is well.
        */
-      int verify() const override
-      {
-        int ret = 0;
-
-        // Verify components
-        for (const auto& component : components_)
-        {
-          ret += component->verify();
-        }
-
-        return ret;
-      }
+      int verify() const override;
 
       /**
        * @brief Check components for Jacobian availability
@@ -470,27 +150,7 @@ namespace GridKit
        * @return true
        * @return false
        */
-      bool hasJacobian() override
-      {
-        bool has_jacobian = false;
-#ifdef GRIDKIT_ENABLE_ENZYME
-        has_jacobian = true;
-        for (const auto& component : components_)
-        {
-          has_jacobian = has_jacobian && component->hasJacobian();
-        }
-
-        if (!has_jacobian)
-        {
-          Log::warning() << "GritKit was built with Enzyme, but some models don't have Jacobians available. "
-                         << "Falling back to dense Jacobians in PhasorDynamics.\n";
-        }
-#else
-        Log::warning() << "GritKit was not built with Enzyme. "
-                       << "Falling back to dense Jacobians in PhasorDynamics.\n";
-#endif
-        return has_jacobian;
-      }
+      bool hasJacobian() override;
 
       /**
        * @brief Initialize buses first, then all the other components.
@@ -510,63 +170,12 @@ namespace GridKit
        * @note Currently assuming each component stores variables contiguously in memory and
        * that these are simply concateneted in the global system.
        */
-      int initialize() override
-      {
-        for (const auto& bus : buses_)
-        {
-          bus->initialize();
-        }
-
-        for (const auto& bus : buses_)
-        {
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            y_[bus->getVariableIndex(j)]  = bus->y()[j];
-            yp_[bus->getVariableIndex(j)] = bus->yp()[j];
-          }
-        }
-
-        // Initialize components
-        for (const auto& component : components_)
-        {
-          component->initialize();
-        }
-
-        for (const auto& component : components_)
-        {
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            y_[component->getVariableIndex(j)]  = component->y()[j];
-            yp_[component->getVariableIndex(j)] = component->yp()[j];
-          }
-        }
-
-        return 0;
-      }
+      int initialize() override;
 
       /**
        * @brief Add monitors from buses and components and start monitor
        */
-      void initializeMonitor()
-      {
-        for (const auto* bus : buses_)
-        {
-          auto* mon = bus->getMonitor();
-          if (mon && !mon->empty())
-          {
-            monitor_.addMonitor(mon);
-          }
-        }
-
-        for (const auto* component : components_)
-        {
-          auto* mon = component->getMonitor();
-          if (mon && !mon->empty())
-          {
-            monitor_.addMonitor(mon);
-          }
-        }
-      }
+      void initializeMonitor();
 
       void startMonitor() override
       {
@@ -585,29 +194,7 @@ namespace GridKit
        * equations are differential variables, i.e. their derivatives
        * appear in the equations.
        */
-      int tagDifferentiable() override
-      {
-        // Set initial values for global solution vectors
-        for (const auto& bus : buses_)
-        {
-          bus->tagDifferentiable();
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            tag_[bus->getVariableIndex(j)] = bus->tag()[j];
-          }
-        }
-
-        for (const auto& component : components_)
-        {
-          component->tagDifferentiable();
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            tag_[component->getVariableIndex(j)] = component->tag()[j];
-          }
-        }
-
-        return 0;
-      }
+      int tagDifferentiable() override;
 
       /**
        * @brief Compute system residual vector
@@ -627,39 +214,7 @@ namespace GridKit
        * to global system vectors. Make components write to the system
        * vectors directly.
        */
-      int evaluateResidual() override
-      {
-        updateVariables();
-
-        for (const auto& bus : buses_)
-        {
-          bus->evaluateResidual();
-        }
-
-        for (const auto& component : components_)
-        {
-          component->evaluateResidual();
-        }
-
-        // Update residual vector
-        for (const auto& bus : buses_)
-        {
-          for (IdxT j = 0; j < bus->size(); ++j)
-          {
-            f_[bus->getResidualIndex(j)] = bus->getResidual()[j];
-          }
-        }
-
-        for (const auto& component : components_)
-        {
-          for (IdxT j = 0; j < component->size(); ++j)
-          {
-            f_[component->getResidualIndex(j)] = component->getResidual()[j];
-          }
-        }
-
-        return 0;
-      }
+      int evaluateResidual() override;
 
       /**
        * @brief Evaluate system Jacobian.
@@ -674,153 +229,7 @@ namespace GridKit
        * slow otherwise.
        *
        */
-      int evaluateJacobian() override
-      {
-        // Initialize bus Jacobians
-        for (const auto& bus : buses_)
-        {
-          bus->evaluateJacobian();
-        }
-
-        // Evaluate component Jacobians and update bus Jacobians
-        for (const auto& component : components_)
-        {
-          component->evaluateJacobian();
-        }
-
-        // Build or update system CSR Jacobian
-        if (csr_jac_ == nullptr)
-        {
-          // Count the number of non-zeros
-          IdxT nnz_dup = 0;
-          for (const auto& component : components_)
-          {
-            auto component_jacobian = component->getJacobian();
-
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries(false);
-            const auto [rows, columns, values]                                                                 = component_jacobian_entries;
-            for (size_t i = 0; i < rows.size(); ++i)
-            {
-              ++nnz_dup;
-            }
-          }
-          for (const auto& bus : buses_)
-          {
-            auto bus_jacobian = bus->getJacobian();
-
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries(false);
-            const auto [rows, columns, values]                                                           = bus_jacobian_entries;
-            for (size_t i = 0; i < rows.size(); ++i)
-            {
-              ++nnz_dup;
-            }
-          }
-
-          // Allocate COO triplet arrays (we own these until we hand off to CsrMatrix)
-          IdxT*  rows_dup = new IdxT[nnz_dup];
-          IdxT*  cols_dup = new IdxT[nnz_dup];
-          RealT* vals_dup = new RealT[nnz_dup];
-
-          IdxT counter = 0;
-          for (const auto& component : components_)
-          {
-            auto component_jacobian = component->getJacobian();
-
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries(false);
-            const auto [rows, columns, values]                                                                 = component_jacobian_entries;
-            for (size_t i = 0; i < rows.size(); ++i)
-            {
-              rows_dup[counter] = rows[i];
-              cols_dup[counter] = columns[i];
-              vals_dup[counter] = values[i];
-              counter++;
-            }
-          }
-          for (const auto& bus : buses_)
-          {
-            auto bus_jacobian = bus->getJacobian();
-
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries(false);
-            const auto [rows, columns, values]                                                           = bus_jacobian_entries;
-            for (size_t i = 0; i < rows.size(); ++i)
-            {
-              rows_dup[counter] = rows[i];
-              cols_dup[counter] = columns[i];
-              vals_dup[counter] = values[i];
-              counter++;
-            }
-          }
-
-          // Build the system COO Jacobian
-          LinearAlgebra::CooMatrix<RealT, IdxT> jac(size_, size_, nnz_dup, &rows_dup, &cols_dup, &vals_dup);
-
-          // Populate CSR data with sort and deduplicate
-          IdxT* row_ptrs = jac.getCsrRowData();
-
-          // Deduplicated nnz
-          nnz_ = jac.getNnz();
-
-          // Allocate cols/vals with deduplicated nnz
-          IdxT*  cols = new IdxT[nnz_];
-          RealT* vals = new RealT[nnz_];
-
-          std::copy(jac.getColData(), jac.getColData() + nnz_, cols);
-          std::copy(jac.getValues(), jac.getValues() + nnz_, vals);
-
-          // Create the CSR Jacobian
-          csr_jac_ = new CsrMatrixT(size_, size_, nnz_, &row_ptrs, &cols, &vals);
-
-          const IdxT* map_to_sorted = jac.getMapToSorted();
-          const IdxT* map_to_dedup  = jac.getMapToDeduplicated();
-
-          // Build a mappping from original COO index to CSR index
-          map_to_csr_ = new IdxT[nnz_dup];
-          for (IdxT i = 0; i < nnz_dup; ++i)
-          {
-            map_to_csr_[map_to_sorted[i]] = map_to_dedup[i];
-          }
-        }
-        else
-        {
-          // Zero out values
-          RealT* vals = csr_jac_->getValues();
-          for (IdxT i = 0; i < csr_jac_->getNnz(); ++i)
-          {
-            vals[i] = 0.0;
-          }
-
-          // Update CSR values from component and bus Jacobians
-          IdxT counter = 0;
-          for (const auto& component : components_)
-          {
-            auto component_jacobian = component->getJacobian();
-
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries(false);
-            const auto [rows, columns, values]                                                                 = component_jacobian_entries;
-            for (size_t i = 0; i < rows.size(); ++i)
-            {
-              vals[map_to_csr_[counter]] += values[i];
-              ++counter;
-            }
-          }
-          for (const auto& bus : buses_)
-          {
-            auto bus_jacobian = bus->getJacobian();
-
-            std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries(false);
-            const auto [rows, columns, values]                                                           = bus_jacobian_entries;
-            for (size_t i = 0; i < rows.size(); ++i)
-            {
-              vals[map_to_csr_[counter]] += values[i];
-              ++counter;
-            }
-          }
-        }
-
-        // J_.printMatrix("System Jacobian");
-
-        return 0;
-      }
+      int evaluateJacobian() override;
 
       CsrMatrixT* getCsrJacobian() const override
       {
@@ -882,7 +291,7 @@ namespace GridKit
        * Add bus at the end of the bus array and map bus ID with GridKit's ID for the bus
        *
        */
-      void addBus(bus_type* bus)
+      void addBus(BusT* bus)
       {
         IdxT gridkit_bus_id                = static_cast<IdxT>(buses_.size());
         gridkit_bus_indices_[bus->busID()] = gridkit_bus_id;
@@ -895,7 +304,7 @@ namespace GridKit
        * Add signal at the end of the signals array and map signal ID with GridKit's ID for the signal
        *
        */
-      void addSignal(signal_type* signal)
+      void addSignal(SignalT* signal)
       {
         IdxT gridkit_signal_id                      = static_cast<IdxT>(signals_.size());
         gridkit_signal_indices_[signal->signalId()] = gridkit_signal_id;
@@ -911,7 +320,7 @@ namespace GridKit
        * component ID to the disambiguation_string
        *
        */
-      void addComponent(component_type* component)
+      void addComponent(ComponentT* component)
       {
         IdxT gridkit_component_id = static_cast<IdxT>(components_.size());
         component->setGridKitComponentID(gridkit_component_id);
@@ -925,7 +334,7 @@ namespace GridKit
        * location, so it can easily be accessed.
        *
        */
-      void addFault(component_type* component)
+      void addFault(ComponentT* component)
       {
         IdxT gridkit_component_id                = static_cast<IdxT>(components_.size());
         IdxT gridkit_fault_id                    = static_cast<IdxT>(gridkit_fault_indices_.size());
@@ -937,7 +346,7 @@ namespace GridKit
        * @brief Return pointer to a bus
        *
        */
-      bus_type* getBus(IdxT bus_id)
+      BusT* getBus(IdxT bus_id)
       {
         // Should fail if user-provided bus_id is incorrect
         IdxT gridkit_bus_id = gridkit_bus_indices_.at(bus_id);
@@ -949,7 +358,7 @@ namespace GridKit
        * @brief Return pointer to a signal
        *
        */
-      signal_type* getSignal(IdxT signal_id)
+      SignalT* getSignal(IdxT signal_id)
       {
         // Should fail if user-provided signal_id is incorrect
         IdxT gridkit_signal_id = gridkit_signal_indices_.at(signal_id);
@@ -961,7 +370,7 @@ namespace GridKit
        * @brief Return pointer to a component
        *
        */
-      component_type* getComponent(IdxT gridkit_component_id)
+      ComponentT* getComponent(IdxT gridkit_component_id)
       {
         // gridkit_component_id_ is set by System model and guarantied to be unique
         return components_[gridkit_component_id];
@@ -981,9 +390,9 @@ namespace GridKit
       }
 
     private:
-      std::vector<bus_type*>       buses_;
-      std::vector<signal_type*>    signals_;
-      std::vector<component_type*> components_;
+      std::vector<BusT*>       buses_;
+      std::vector<SignalT*>    signals_;
+      std::vector<ComponentT*> components_;
 
       std::map<IdxT, IdxT> gridkit_bus_indices_;    ///< Map between gridkit_bus_id and bus_id
       std::map<IdxT, IdxT> gridkit_signal_indices_; ///< Map between gridkit_signal_id and signal_id

--- a/GridKit/Model/PhasorDynamics/SystemModelData.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.hpp
@@ -24,6 +24,11 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    enum class SystemModelMonitorableVariables
+    {
+      none
+    };
+
     /// A structure containing all of the data needed to reproduce a
     /// system model
     ///
@@ -32,19 +37,20 @@ namespace GridKit
     template <typename RealT = double, typename IdxT = size_t>
     struct SystemModelData
     {
-      using BranchDataT       = BranchData<RealT, IdxT>;
-      using BusDataT          = BusData<RealT, IdxT>;
-      using BusFaultDataT     = BusFaultData<RealT, IdxT>;
-      using Tgov1DataT        = Governor::Tgov1Data<RealT, IdxT>;
-      using Ieeet1DataT       = Exciter::Ieeet1Data<RealT, IdxT>;
-      using SexsPtiDataT      = Exciter::SexsPtiData<RealT, IdxT>;
-      using IeeestDataT       = Stabilizer::IeeestData<RealT, IdxT>;
-      using GenrouDataT       = GenrouData<RealT, IdxT>;
-      using GenClassicalDataT = GenClassicalData<RealT, IdxT>;
-      using LoadDataT         = LoadData<RealT, IdxT>;
-      using LoadZIPDataT      = LoadZIPData<RealT, IdxT>;
-      using SignalDataT       = SignalNodeData<RealT, IdxT>;
-      using MonitorSinkSpec   = Model::VariableMonitorBase::SinkSpec;
+      using BranchDataT          = BranchData<RealT, IdxT>;
+      using BusDataT             = BusData<RealT, IdxT>;
+      using BusFaultDataT        = BusFaultData<RealT, IdxT>;
+      using Tgov1DataT           = Governor::Tgov1Data<RealT, IdxT>;
+      using Ieeet1DataT          = Exciter::Ieeet1Data<RealT, IdxT>;
+      using SexsPtiDataT         = Exciter::SexsPtiData<RealT, IdxT>;
+      using IeeestDataT          = Stabilizer::IeeestData<RealT, IdxT>;
+      using GenrouDataT          = GenrouData<RealT, IdxT>;
+      using GenClassicalDataT    = GenClassicalData<RealT, IdxT>;
+      using LoadDataT            = LoadData<RealT, IdxT>;
+      using LoadZIPDataT         = LoadZIPData<RealT, IdxT>;
+      using SignalDataT          = SignalNodeData<RealT, IdxT>;
+      using MonitorSinkSpec      = Model::VariableMonitorBase::SinkSpec;
+      using MonitorableVariables = SystemModelMonitorableVariables;
 
       /// The version of the grid dynamics case format this system model was
       /// parsed from

--- a/GridKit/Model/PhasorDynamics/SystemModelDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelDependencyTracking.cpp
@@ -1,15 +1,15 @@
-
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 
-#include "BusInfiniteImpl.hpp"
+#include "SystemModelImpl.hpp"
 
 namespace GridKit
 {
   namespace PhasorDynamics
   {
+
     // Available template instantiations
-    template class BusInfinite<DependencyTracking::Variable, long int>;
-    template class BusInfinite<DependencyTracking::Variable, size_t>;
+    // template class SystemModel<DependencyTracking::Variable, long int>;
+    template class SystemModel<DependencyTracking::Variable, size_t>;
 
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
@@ -1,0 +1,667 @@
+
+#include <GridKit/Model/PhasorDynamics/ConnectedElementImpl.hpp>
+#include <GridKit/Model/PhasorDynamics/SystemModel.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    template <typename ScalarP, typename IdxP>
+    SystemModel<ScalarP, IdxP>::SystemModel()
+    {
+      // Set system model tolerances
+      rel_tol_         = 1e-7;
+      abs_tol_         = 1e-9;
+      this->max_steps_ = 2000;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    SystemModel<ScalarP, IdxP>::SystemModel(const ModelDataT& data)
+      : monitor_(time_)
+    {
+      using namespace Governor;
+      using namespace Exciter;
+      using namespace Stabilizer;
+
+      // Set system model tolerances
+      rel_tol_         = 1e-7;
+      abs_tol_         = 1e-9;
+      this->max_steps_ = 2000;
+
+      owns_components_ = true;
+
+      // Add electrical buses
+      for (const auto& busdata : data.bus)
+      {
+        BusBase<ScalarT, IdxT>* bus = BusFactory<ScalarT, IdxT>::create(busdata);
+        addBus(bus);
+      }
+
+      /// @todo Signal data needs to be populated by the parser.
+      /// See TODOs in SystemModelDataJSONParser
+      for (const auto& signaldata : data.signal)
+      {
+        SignalNode<ScalarT, IdxT>* signal = new SignalNode<ScalarT, IdxT>(signaldata);
+        addSignal(signal);
+      }
+
+      // Add branches
+      for (const auto& branchdata : data.branch)
+      {
+        IdxT bus1_index = 0;
+        if (branchdata.ports.contains(BranchData<ScalarT, IdxT>::Ports::bus1))
+        {
+          bus1_index = branchdata.ports.at(BranchData<ScalarT, IdxT>::Ports::bus1);
+        }
+
+        IdxT bus2_index = 0;
+        if (branchdata.ports.contains(BranchData<ScalarT, IdxT>::Ports::bus2))
+        {
+          bus2_index = branchdata.ports.at(BranchData<ScalarT, IdxT>::Ports::bus2);
+        }
+
+        auto* branch = new Branch<ScalarT, IdxT>(getBus(bus1_index), getBus(bus2_index), branchdata);
+        addComponent(branch);
+      }
+
+      // Add loads
+      /// @todo Add loads to JSON parser
+      for (const auto& loaddata : data.load)
+      {
+        IdxT bus_index = 0;
+        if (loaddata.ports.contains(LoadData<ScalarT, IdxT>::Ports::bus))
+        {
+          bus_index = loaddata.ports.at(LoadData<ScalarT, IdxT>::Ports::bus);
+        }
+        auto* load = new Load<ScalarT, IdxT>(getBus(bus_index), loaddata);
+        addComponent(load);
+      }
+
+      // Add zip loads
+      /// @todo Add zip loads to JSON parser
+      for (const auto& loadzipdata : data.loadzip)
+      {
+        IdxT bus_index = 0;
+        if (loadzipdata.ports.contains(LoadZIPData<ScalarT, IdxT>::Ports::bus))
+        {
+          bus_index = loadzipdata.ports.at(LoadZIPData<ScalarT, IdxT>::Ports::bus);
+        }
+        auto* loadzip = new LoadZIP<ScalarT, IdxT>(getBus(bus_index), loadzipdata);
+        addComponent(loadzip);
+      }
+
+      // Add GENROU generators
+      for (const auto& gendata : data.genrou)
+      {
+        IdxT bus_index = 0;
+        if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::bus))
+        {
+          bus_index = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::bus);
+        }
+
+        auto* gen = new Genrou<ScalarT, IdxT>(getBus(bus_index), gendata);
+
+        /// @todo Genrou (and likely other components) would need to name multiple
+        /// signal inlets and outlets. For now we have only speed out and mechanical
+        /// power in.
+        if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::speed))
+        {
+          IdxT speed = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::speed);
+          gen->getSignals().template assignSignalNode<GenrouInternalVariables::OMEGA>(getSignal(speed));
+        }
+
+        if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::pmech))
+        {
+          IdxT pmech = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::pmech);
+          gen->getSignals().template attachSignalNode<GenrouExternalVariables::PM>(getSignal(pmech));
+        }
+
+        if (gendata.ports.contains(GenrouData<ScalarT, IdxT>::Ports::efd))
+        {
+          IdxT efd = gendata.ports.at(GenrouData<ScalarT, IdxT>::Ports::efd);
+          gen->getSignals().template attachSignalNode<GenrouExternalVariables::EFD>(getSignal(efd));
+        }
+
+        addComponent(gen);
+      }
+
+      // Add classical generators
+      for (const auto& gendata : data.genclassical)
+      {
+        IdxT bus_index = 0;
+        if (gendata.ports.contains(GenClassicalData<ScalarT, IdxT>::Ports::bus))
+        {
+          bus_index = gendata.ports.at(GenClassicalData<ScalarT, IdxT>::Ports::bus);
+        }
+        auto* gen = new GenClassical<ScalarT, IdxT>(getBus(bus_index), gendata);
+        addComponent(gen);
+      }
+
+      // Add Tgov1 governors
+      for (const auto& govdata : data.gov)
+      {
+        auto* gov = new Tgov1<ScalarT, IdxT>(govdata);
+
+        if (govdata.ports.contains(Tgov1Data<ScalarT, IdxT>::Ports::speed))
+        {
+          IdxT speed = govdata.ports.at(Tgov1Data<ScalarT, IdxT>::Ports::speed);
+          gov->getSignals().template attachSignalNode<Tgov1ExternalVariables::DELTAOMEGA>(getSignal(speed));
+        }
+
+        if (govdata.ports.contains(Tgov1Data<ScalarT, IdxT>::Ports::pmech))
+        {
+          IdxT pmech = govdata.ports.at(Tgov1Data<ScalarT, IdxT>::Ports::pmech);
+          gov->getSignals().template assignSignalNode<Tgov1InternalVariables::PM>(getSignal(pmech));
+        }
+
+        addComponent(gov);
+      }
+
+      for (const auto& excitedata : data.exciter)
+      {
+        IdxT bus_index = 0;
+        if (excitedata.ports.contains(Ieeet1Data<ScalarT, IdxT>::Ports::bus))
+        {
+          bus_index = excitedata.ports.at(Ieeet1Data<ScalarT, IdxT>::Ports::bus);
+        }
+
+        auto* exciter = new Ieeet1<ScalarT, IdxT>(getBus(bus_index), excitedata);
+
+        if (excitedata.ports.contains(Ieeet1Data<ScalarT, IdxT>::Ports::speed))
+        {
+          IdxT speed = excitedata.ports.at(Ieeet1Data<ScalarT, IdxT>::Ports::speed);
+          exciter->getSignals().template attachSignalNode<Ieeet1ExternalVariables::OMEGA>(getSignal(speed));
+        }
+
+        if (excitedata.ports.contains(Ieeet1Data<ScalarT, IdxT>::Ports::efd))
+        {
+          IdxT efd = excitedata.ports.at(Ieeet1Data<ScalarT, IdxT>::Ports::efd);
+          exciter->getSignals().template assignSignalNode<Ieeet1InternalVariables::EFD>(getSignal(efd));
+        }
+
+        if (excitedata.ports.contains(Ieeet1Data<ScalarT, IdxT>::Ports::vs))
+        {
+          IdxT vs = excitedata.ports.at(Ieeet1Data<ScalarT, IdxT>::Ports::vs);
+          exciter->getSignals().template attachSignalNode<Ieeet1ExternalVariables::VS>(getSignal(vs));
+        }
+
+        addComponent(exciter);
+      }
+
+      for (const auto& excitedata : data.sexspti)
+      {
+        IdxT bus_index = 0;
+        if (excitedata.ports.contains(SexsPtiData<ScalarT, IdxT>::Ports::bus))
+        {
+          bus_index = excitedata.ports.at(SexsPtiData<ScalarT, IdxT>::Ports::bus);
+        }
+
+        auto* exciter = new SexsPti<ScalarT, IdxT>(getBus(bus_index), excitedata);
+
+        if (excitedata.ports.contains(SexsPtiData<ScalarT, IdxT>::Ports::efd))
+        {
+          IdxT efd = excitedata.ports.at(SexsPtiData<ScalarT, IdxT>::Ports::efd);
+          exciter->getSignals().template assignSignalNode<SexsPtiInternalVariables::EFD>(getSignal(efd));
+        }
+
+        if (excitedata.ports.contains(SexsPtiData<ScalarT, IdxT>::Ports::vs))
+        {
+          IdxT vs = excitedata.ports.at(SexsPtiData<ScalarT, IdxT>::Ports::vs);
+          exciter->getSignals().template attachSignalNode<SexsPtiExternalVariables::VS>(getSignal(vs));
+        }
+
+        addComponent(exciter);
+      }
+
+      // Add IEEEST stabilizers
+      for (const auto& stabdata : data.stabilizer)
+      {
+        auto* stabilizer = new Ieeest<ScalarT, IdxT>(stabdata);
+
+        if (stabdata.ports.contains(IeeestPorts::input))
+        {
+          IdxT input = stabdata.ports.at(IeeestPorts::input);
+          stabilizer->getSignals().template attachSignalNode<IeeestExternalVariables::U>(getSignal(input));
+        }
+
+        if (stabdata.ports.contains(IeeestPorts::cutout))
+        {
+          IdxT cutout = stabdata.ports.at(IeeestPorts::cutout);
+          stabilizer->getSignals().template attachSignalNode<IeeestExternalVariables::VCT>(getSignal(cutout));
+        }
+
+        if (stabdata.ports.contains(IeeestPorts::output))
+        {
+          IdxT output = stabdata.ports.at(IeeestPorts::output);
+          stabilizer->getSignals().template assignSignalNode<IeeestInternalVariables::VS>(getSignal(output));
+        }
+
+        addComponent(stabilizer);
+      }
+
+      // Add faults
+      for (const auto& faultdata : data.bus_fault)
+      {
+        IdxT bus_index = 0;
+        if (faultdata.ports.contains(BusFaultData<ScalarT, IdxT>::Ports::bus))
+        {
+          bus_index = faultdata.ports.at(BusFaultData<ScalarT, IdxT>::Ports::bus);
+        }
+        auto* fault = new BusFault<ScalarT, IdxT>(getBus(bus_index), faultdata);
+        addFault(fault);
+      }
+
+      for (const auto& sink : data.monitor_sink)
+      {
+        monitor_.addSink(sink);
+      }
+    }
+
+    template <typename ScalarP, typename IdxP>
+    SystemModel<ScalarP, IdxP>::~SystemModel()
+    {
+      if (owns_components_)
+      {
+        for (auto component : components_)
+        {
+          delete component;
+        }
+
+        for (auto bus : buses_)
+        {
+          delete bus;
+        }
+
+        for (auto signal : signals_)
+        {
+          delete signal;
+        }
+      }
+      if (csr_jac_ != nullptr)
+      {
+        delete csr_jac_;
+        csr_jac_ = nullptr;
+      }
+      if (map_to_csr_ != nullptr)
+      {
+        delete[] map_to_csr_;
+        map_to_csr_ = nullptr;
+      }
+    }
+
+    template <typename ScalarP, typename IdxP>
+    int SystemModel<ScalarP, IdxP>::allocate()
+    {
+      size_ = 0;
+
+      // Allocate all buses
+      for (const auto& bus : buses_)
+      {
+        bus->allocate();
+        for (IdxT j = 0; j < bus->size(); ++j)
+        {
+          bus->setVariableIndex(j, size_ + j);
+          bus->setResidualIndex(j, size_ + j);
+        }
+        size_ += bus->size();
+      }
+
+      // Allocate all components
+      for (const auto& component : components_)
+      {
+        component->allocate();
+        for (IdxT j = 0; j < component->size(); ++j)
+        {
+          component->setVariableIndex(j, size_ + j);
+          component->setResidualIndex(j, size_ + j);
+        }
+        size_ += component->size();
+      }
+
+      // Allocate global vectors
+      auto size = static_cast<std::size_t>(size_);
+      y_.resize(size);
+      yp_.resize(size);
+      f_.resize(size);
+      tag_.resize(size);
+      variable_indices_.resize(size);
+      residual_indices_.resize(size);
+
+      // Default variable and residual index mapping to local index
+      for (IdxT j = 0; j < size_; ++j)
+      {
+        this->setVariableIndex(j, j);
+        this->setResidualIndex(j, j);
+      }
+
+      // Verify component configuration
+      int errorCount = this->verify();
+      if (errorCount > 0)
+      {
+        Log::error() << "Component errors: " << errorCount << std::endl;
+        throw std::runtime_error("SystemModel allocation failed");
+      }
+
+      // Start variable monitors
+      initializeMonitor();
+      startMonitor();
+
+      // Perform an initial Jacobian evaluation for sparse Jacobians, such that
+      // the dynamic solver can querry the NNZ value when it is configured.
+      // @todo Replace with a sparsity analysis that sets the NNZ and allocates the Jacobian
+      // without needing the Jacobian values.
+      if (hasJacobian())
+      {
+        initialize();
+        evaluateResidual();
+        evaluateJacobian();
+      }
+
+      return 0;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    int SystemModel<ScalarP, IdxP>::verify() const
+    {
+      int ret = 0;
+
+      // Verify components
+      for (const auto& component : components_)
+      {
+        ret += component->verify();
+      }
+
+      return ret;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    bool SystemModel<ScalarP, IdxP>::hasJacobian()
+    {
+      bool has_jacobian = false;
+#ifdef GRIDKIT_ENABLE_ENZYME
+      has_jacobian = true;
+      for (const auto& component : components_)
+      {
+        has_jacobian = has_jacobian && component->hasJacobian();
+      }
+
+      if (!has_jacobian)
+      {
+        Log::warning() << "GritKit was built with Enzyme, but some models don't have Jacobians available. "
+                       << "Falling back to dense Jacobians in PhasorDynamics.\n";
+      }
+#else
+      Log::warning() << "GritKit was not built with Enzyme. "
+                     << "Falling back to dense Jacobians in PhasorDynamics.\n";
+#endif
+      return has_jacobian;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    int SystemModel<ScalarP, IdxP>::initialize()
+    {
+      for (const auto& bus : buses_)
+      {
+        bus->initialize();
+      }
+
+      for (const auto& bus : buses_)
+      {
+        for (IdxT j = 0; j < bus->size(); ++j)
+        {
+          y_[bus->getVariableIndex(j)]  = bus->y()[j];
+          yp_[bus->getVariableIndex(j)] = bus->yp()[j];
+        }
+      }
+
+      // Initialize components
+      for (const auto& component : components_)
+      {
+        component->initialize();
+      }
+
+      for (const auto& component : components_)
+      {
+        for (IdxT j = 0; j < component->size(); ++j)
+        {
+          y_[component->getVariableIndex(j)]  = component->y()[j];
+          yp_[component->getVariableIndex(j)] = component->yp()[j];
+        }
+      }
+
+      return 0;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    void SystemModel<ScalarP, IdxP>::initializeMonitor()
+    {
+      for (const auto* bus : buses_)
+      {
+        auto* mon = bus->getMonitor();
+        if (mon && !mon->empty())
+        {
+          monitor_.addMonitor(mon);
+        }
+      }
+
+      for (const auto* component : components_)
+      {
+        auto* mon = component->getMonitor();
+        if (mon && !mon->empty())
+        {
+          monitor_.addMonitor(mon);
+        }
+      }
+    }
+
+    template <typename ScalarP, typename IdxP>
+    int SystemModel<ScalarP, IdxP>::tagDifferentiable()
+    {
+      // Set initial values for global solution vectors
+      for (const auto& bus : buses_)
+      {
+        bus->tagDifferentiable();
+        for (IdxT j = 0; j < bus->size(); ++j)
+        {
+          tag_[bus->getVariableIndex(j)] = bus->tag()[j];
+        }
+      }
+
+      for (const auto& component : components_)
+      {
+        component->tagDifferentiable();
+        for (IdxT j = 0; j < component->size(); ++j)
+        {
+          tag_[component->getVariableIndex(j)] = component->tag()[j];
+        }
+      }
+
+      return 0;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    int SystemModel<ScalarP, IdxP>::evaluateResidual()
+    {
+      updateVariables();
+
+      for (const auto& bus : buses_)
+      {
+        bus->evaluateResidual();
+      }
+
+      for (const auto& component : components_)
+      {
+        component->evaluateResidual();
+      }
+
+      // Update residual vector
+      for (const auto& bus : buses_)
+      {
+        for (IdxT j = 0; j < bus->size(); ++j)
+        {
+          f_[bus->getResidualIndex(j)] = bus->getResidual()[j];
+        }
+      }
+
+      for (const auto& component : components_)
+      {
+        for (IdxT j = 0; j < component->size(); ++j)
+        {
+          f_[component->getResidualIndex(j)] = component->getResidual()[j];
+        }
+      }
+
+      return 0;
+    }
+
+    template <typename ScalarP, typename IdxP>
+    int SystemModel<ScalarP, IdxP>::evaluateJacobian()
+    {
+      // Initialize bus Jacobians
+      for (const auto& bus : buses_)
+      {
+        bus->evaluateJacobian();
+      }
+
+      // Evaluate component Jacobians and update bus Jacobians
+      for (const auto& component : components_)
+      {
+        component->evaluateJacobian();
+      }
+
+      // Build or update system CSR Jacobian
+      if (csr_jac_ == nullptr)
+      {
+        // Count the number of non-zeros
+        IdxT nnz_dup = 0;
+        for (const auto& component : components_)
+        {
+          auto component_jacobian = component->getJacobian();
+
+          std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries(false);
+          const auto [rows, columns, values]                                                                 = component_jacobian_entries;
+          for (size_t i = 0; i < rows.size(); ++i)
+          {
+            ++nnz_dup;
+          }
+        }
+        for (const auto& bus : buses_)
+        {
+          auto bus_jacobian = bus->getJacobian();
+
+          std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries(false);
+          const auto [rows, columns, values]                                                           = bus_jacobian_entries;
+          for (size_t i = 0; i < rows.size(); ++i)
+          {
+            ++nnz_dup;
+          }
+        }
+
+        // Allocate COO triplet arrays (we own these until we hand off to CsrMatrix)
+        IdxT*  rows_dup = new IdxT[nnz_dup];
+        IdxT*  cols_dup = new IdxT[nnz_dup];
+        RealT* vals_dup = new RealT[nnz_dup];
+
+        IdxT counter = 0;
+        for (const auto& component : components_)
+        {
+          auto component_jacobian = component->getJacobian();
+
+          std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries(false);
+          const auto [rows, columns, values]                                                                 = component_jacobian_entries;
+          for (size_t i = 0; i < rows.size(); ++i)
+          {
+            rows_dup[counter] = rows[i];
+            cols_dup[counter] = columns[i];
+            vals_dup[counter] = values[i];
+            counter++;
+          }
+        }
+        for (const auto& bus : buses_)
+        {
+          auto bus_jacobian = bus->getJacobian();
+
+          std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries(false);
+          const auto [rows, columns, values]                                                           = bus_jacobian_entries;
+          for (size_t i = 0; i < rows.size(); ++i)
+          {
+            rows_dup[counter] = rows[i];
+            cols_dup[counter] = columns[i];
+            vals_dup[counter] = values[i];
+            counter++;
+          }
+        }
+
+        // Build the system COO Jacobian
+        LinearAlgebra::CooMatrix<RealT, IdxT> jac(size_, size_, nnz_dup, &rows_dup, &cols_dup, &vals_dup);
+
+        // Populate CSR data with sort and deduplicate
+        IdxT* row_ptrs = jac.getCsrRowData();
+
+        // Deduplicated nnz
+        nnz_ = jac.getNnz();
+
+        // Allocate cols/vals with deduplicated nnz
+        IdxT*  cols = new IdxT[nnz_];
+        RealT* vals = new RealT[nnz_];
+
+        std::copy(jac.getColData(), jac.getColData() + nnz_, cols);
+        std::copy(jac.getValues(), jac.getValues() + nnz_, vals);
+
+        // Create the CSR Jacobian
+        csr_jac_ = new CsrMatrixT(size_, size_, nnz_, &row_ptrs, &cols, &vals);
+
+        const IdxT* map_to_sorted = jac.getMapToSorted();
+        const IdxT* map_to_dedup  = jac.getMapToDeduplicated();
+
+        // Build a mappping from original COO index to CSR index
+        map_to_csr_ = new IdxT[nnz_dup];
+        for (IdxT i = 0; i < nnz_dup; ++i)
+        {
+          map_to_csr_[map_to_sorted[i]] = map_to_dedup[i];
+        }
+      }
+      else
+      {
+        // Zero out values
+        RealT* vals = csr_jac_->getValues();
+        for (IdxT i = 0; i < csr_jac_->getNnz(); ++i)
+        {
+          vals[i] = 0.0;
+        }
+
+        // Update CSR values from component and bus Jacobians
+        IdxT counter = 0;
+        for (const auto& component : components_)
+        {
+          auto component_jacobian = component->getJacobian();
+
+          std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> component_jacobian_entries = component_jacobian.getEntries(false);
+          const auto [rows, columns, values]                                                                 = component_jacobian_entries;
+          for (size_t i = 0; i < rows.size(); ++i)
+          {
+            vals[map_to_csr_[counter]] += values[i];
+            ++counter;
+          }
+        }
+        for (const auto& bus : buses_)
+        {
+          auto bus_jacobian = bus->getJacobian();
+
+          std::tuple<std::vector<IdxT>&, std::vector<IdxT>&, std::vector<RealT>&> bus_jacobian_entries = bus_jacobian.getEntries(false);
+          const auto [rows, columns, values]                                                           = bus_jacobian_entries;
+          for (size_t i = 0; i < rows.size(); ++i)
+          {
+            vals[map_to_csr_[counter]] += values[i];
+            ++counter;
+          }
+        }
+      }
+
+      // J_.printMatrix("System Jacobian");
+
+      return 0;
+    }
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/VariableMonitor.hpp
+++ b/GridKit/Model/VariableMonitor.hpp
@@ -15,13 +15,11 @@
 #include <variant>
 #include <vector>
 
-#include <GridKit/ScalarTraits.hpp>
-
 namespace GridKit
 {
   namespace Model
   {
-    template <typename ScalarT>
+    template <typename ScalarP>
     class VariableMonitorController;
 
     /**
@@ -137,7 +135,7 @@ namespace GridKit
       ///@}
     };
 
-    template <typename EvalT, template <typename, typename> typename DataT>
+    template <typename EvalP>
     class VariableMonitor;
 
   } // namespace Model

--- a/GridKit/Model/VariableMonitorController.hpp
+++ b/GridKit/Model/VariableMonitorController.hpp
@@ -7,6 +7,8 @@
 #include <ostream>
 #include <string>
 
+#include <GridKit/ScalarTraits.hpp>
+
 namespace GridKit
 {
   namespace Model
@@ -18,10 +20,12 @@ namespace GridKit
      * High-level print functions (without parameters) manage printing for all
      * monitors for multiple output sinks.
      */
-    template <typename ScalarT>
+    template <typename ScalarP>
     class VariableMonitorController : public VariableMonitorBase
     {
     public:
+      /// Simulation scalar value type
+      using ScalarT  = ScalarP;
       /// Underlying real value type
       using RealT    = typename GridKit::ScalarTraits<ScalarT>::RealT;
       ///@{

--- a/GridKit/Model/VariableMonitorImpl.hpp
+++ b/GridKit/Model/VariableMonitorImpl.hpp
@@ -25,23 +25,21 @@ namespace GridKit
      * break. That way other monitors can print likewise on the same line, and
      * the line can be ended by the control monitor.
      */
-    template <typename ScalarT,
-              typename IdxT,
-              template <typename, typename> typename EvalT,
-              template <typename, typename> typename DataT>
-    class VariableMonitor<EvalT<ScalarT, IdxT>, DataT>
-      : public VariableMonitorBase
+    template <typename EvalP>
+    class VariableMonitor : public VariableMonitorBase
     {
       template <typename>
       friend class VariableMonitorController;
 
     public:
+      /// Simulation scalar value type
+      using ScalarT      = typename EvalP::RealT;
       /// Underlying real value type
-      using RealT        = typename GridKit::ScalarTraits<ScalarT>::RealT;
-      /// Type of (EvalT)Data class expected to have MonitorableVariables enum
-      using ObjData      = DataT<RealT, IdxT>;
+      using RealT        = typename EvalP::RealT;
+      /// Type of (EvalP)Data class expected to have MonitorableVariables enum
+      using ModelDataT   = typename EvalP::ModelDataT;
       /// Enum of valid monitorable variables
-      using VariableEnum = typename ObjData::MonitorableVariables;
+      using VariableEnum = typename ModelDataT::MonitorableVariables;
       ///@{
       /// @brief Alias
       using Csv          = VariableMonitorBase::Csv;
@@ -67,13 +65,13 @@ namespace GridKit
       }
 
       /**
-       * @brief Construct from ObjData object
+       * @brief Construct from ModelDataT object
        *
        * Constructs the monitor label from elements of the data object
        *
        * @param data Expected to be derived from ComponentData
        */
-      VariableMonitor(const ObjData& data)
+      VariableMonitor(const ModelDataT& data)
         : VariableMonitor(data.device_class + "_" + data.disambiguation_string,
                           data.monitored_variables)
       {


### PR DESCRIPTION
## Description
 
- Refactor class hierarchy for buses and components to consolidate code for signals and monitors
- Encapsulate implementation of `SystemModel`
- Use new style for template parameters and make public interface types consistent (addresses #366 for phasor dynamics code)

 ## Proposed changes

This inserts a class (`ConnectedElement`) into the phasor dynamics hierarchy which will manage signal node ports and monitors. This new class takes its child class as its template parameter and uses traits to get more detailed type information (for variable enums, etc...) and also to customize the inheritance graph. Each leaf node device type must inherit from `ConnectedElementTraits` with itself as the template argument and define a customization of `ConnectedElementTraits` with the appropriate type information. The `InterfaceT` member determines which interface is inherited. For example...

For `Bus`
```c++
    template <typename ScalarP, typename IdxP>
    struct ConnectedElementTraits<Bus<ScalarP, IdxP>>
    {
      using BusT = Bus<ScalarP, IdxP>;

      using ElementT           = BusT;
      using ScalarT            = ScalarP;
      using IdxT               = IdxP;
      using RealT              = typename ScalarTraits<ScalarT>::RealT;
      using ModelDataT         = BusData<RealT, IdxT>;
      using InternalVariablesT = BusInternalVariables;
      using ExternalVariablesT = BusExternalVariables;
      using InterfaceT         = BusBase<ScalarT, IdxT>;  // using BusBase interface
    };

    template <typename ScalarP, typename IdxP>
    class Bus : public ConnectedElement<Bus<ScalarP, IdxP>>
    { /*...*/ };

// The inheritance graph for Bus is then:
// Bus <- ConnectedElement<Bus> <- BusBase <- GridElement <- Model::Evaluator
```

And for `Branch`
```c++
    template <typename ScalarP, typename IdxP>
    struct ConnectedElementTraits<Branch<ScalarP, IdxP>>
    {
      using BranchT = Branch<ScalarP, IdxP>;

      using ElementT           = BranchT;
      using ScalarT            = ScalarP;
      using IdxT               = IdxP;
      using RealT              = typename ScalarTraits<ScalarT>::RealT;
      using ModelDataT         = BranchData<RealT, IdxT>;
      using InternalVariablesT = BranchInternalVariables;
      using ExternalVariablesT = BranchExternalVariables;
      using InterfaceT         = Component<ScalarT, IdxT>;
    };

    template <typename ScalarP, typename IdxP>
    class Branch : public ConnectedElement<Branch<ScalarP, IdxP>>
    { /* ... */ };

// The inheritance graph for Branch is then:
// Branch <- ConnectedElement<Branch> <- Component <- GridElement <- Model::Evaluator
```
 ## Checklist

- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [1] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [2] The feature branch is rebased with respect to the target branch.
- [ ] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.

1. This PR changes the style guidelines with respect to template parameters and type aliases.

2. This PR was developed on top of #381 and will need to be rebased.

 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc..._
 
