### PR TITLE
Event System Design Specification

### DIFF
--- a/GridKit/Model/PhasorDynamics/Branch/README.md
+++ b/GridKit/Model/PhasorDynamics/Branch/README.md
@@ -147,6 +147,23 @@ The branch current relation is $0 = -\mathbf{I} + \mathbf{Y}\mathbf{V}$.
 These current contributions are added to the connected bus residuals with
 positive sign because branch current is oriented entering the bus.
 
+## Actions
+
+This component accepts the following runtime events via `apply(Action)`. See
+[EVENTS.md](../EVENTS.md) for the dispatch model and JSON schema.
+
+JSON `"action"` | Params              | Effect
+----------------|---------------------|----------------------------------------------------------------------
+`"open"`        | none                | Sets line status $S = 0$.
+`"close"`       | none                | Sets line status $S = 1$.
+`"fault"`       | `R`, `X`, `percent` | Applies a fault impedance at fraction $f = \text{percent}/100$ from bus 1.
+`"clear"`       | none                | Clears the active fault.
+
+The line status $S$ masks branch residual contributions, so the Jacobian
+sparsity pattern remains fixed across open and close events. While a fault is
+engaged, the line is split at the fault location and the fault admittance is
+included in the equivalent two-port admittance. Line charging is unchanged.
+
 ## Initialization
 
 The Branch model has no internal state to initialize. During construction or

--- a/GridKit/Model/PhasorDynamics/Bus/README.md
+++ b/GridKit/Model/PhasorDynamics/Bus/README.md
@@ -17,7 +17,7 @@ sign.
 
 <div align="center">
    <img align="center" src="../../../../docs/Figures/bus_variables.jpg">
-   
+
   Figure 1: Needs to be changed to represent current balance instead of power
   balance.
 </div>
@@ -28,3 +28,27 @@ sign.
 **Other Parameters**
 Buses are uniquely defined by their ID (number or name). Besides, each bus
 should have associated Nominal Voltage value.
+
+## Actions
+
+This component accepts the following runtime events via `apply(Action)`. See
+[EVENTS.md](../EVENTS.md) for the dispatch model and JSON schema.
+
+JSON  | Params   | Effect
+----------------|----------|--------------------------------------------------------------------
+`"fault"`       | `R`, `X` | Stores the fault impedance and engages the fault ($U = 1$).
+`"clear"`       | none     | Disengages the fault ($U = 0$). Stored impedance is unchanged.
+
+While the fault is engaged, the bus current balance gains the contributions:
+
+``` math
+\begin{aligned}
+  G_f &= \dfrac{R}{R^2 + X^2}, \quad B_f = -\dfrac{X}{R^2 + X^2} \\
+  \Delta I_{rk} &= U(-G_f V_{rk} + B_f V_{ik}) \\
+  \Delta I_{ik} &= U(-B_f V_{rk} - G_f V_{ik})
+\end{aligned}
+```
+
+The `percent` parameter of `Fault` is ignored by `Bus`. The fault gate $U$
+is implemented as a mask (0 or 1) on the fault residual term,
+so the Jacobian sparsity pattern is fixed across `Fault`/`Clear` cycles.

--- a/GridKit/Model/PhasorDynamics/EVENTS.md
+++ b/GridKit/Model/PhasorDynamics/EVENTS.md
@@ -1,0 +1,115 @@
+# Phasor Dynamics Events
+
+## Overview
+
+This document describes the runtime event system for PhasorDynamics
+components. A runtime event mutates the state of a single component during simulation. Events are scheduled in a solver file
+(see [PDSim](../../../application/PhasorDynamics/README.md)) and delivered to components by `SystemModel` at their scheduled times. Buses are addressed for events by their existing `number`; devices by their
+existing `id`.
+
+## Event
+
+An event is a triple of fields:
+
+Name     | Description
+---------|------------------------------------------------------
+`time`   | Simulation time at which the event fires, in seconds
+`target` | Routing key for the component receiving the event
+`action` | The mutation to perform, drawn from the action vocabulary
+
+For buses, the `target` is the bus's `number` rendered as a string
+(e.g. `"1001"`). For devices, it is the device's `id` field from the case
+file (e.g. `"BR_1001_1064_1"`). Buses and devices share a single routing
+namespace; collisions between a bus number and a device id are an error at registration.
+
+
+```cpp
+struct Event {
+    double      time;
+    std::string target;
+    Action      action;
+};
+```
+
+## Action vocabulary
+
+`Action` is a `std::variant` of action structs in
+`GridKit::PhasorDynamics::Actions`. Each struct has a canonical name string
+exposed as `static constexpr std::string_view name`.
+
+C++ type         | JSON name | Params              | Applies to
+-----------------|-----------|---------------------|----------------
+`Actions::Open`  | `open`    | none                | `Branch`
+`Actions::Close` | `close`   | none                | `Branch`
+`Actions::Fault` | `fault`   | `R`, `X`, `percent` | `Bus`, `Branch`
+`Actions::Clear` | `clear`   | none                | `Bus`, `Branch`
+
+The semantics of each action are documented in the receiving component's
+README. For `fault`, the `percent` parameter (position along the line as a
+percent in `[0, 100]`) is used by `Branch` and ignored by `Bus`.
+
+## Dispatch
+
+`Component::apply(const Action&)` is virtual on the base class. The default
+throws. Components that handle events override it with a `std::visit` over
+the variant, dispatching to per-action handlers and falling through to a
+generic catch-all for unhandled action types:
+
+```cpp
+void Bus::apply(const Action& a) override {
+  std::visit(overloaded{
+    [this](const Actions::Fault& f) {},
+    [this](const Actions::Clear&)   {},
+    [this](const auto& other) {
+      using A = std::decay_t<decltype(other)>;
+      throw std::runtime_error("Bus does not handle action '" + std::string(A::name) + "'");
+    }
+  }, a);
+}
+```
+
+`SystemModel::apply(const Event&)` looks up the target by string id and
+forwards the action to the component.
+
+## Schedule
+
+The `schedule` field of the solver file is an array of events. The parser
+stable-sorts the schedule by `time` on read. If the input was not already
+sorted, an info line is logged and parsing continues.
+
+Multiple events at the same time are applied sequentially in listing order in a single re-init of the integrator (`IDACalcIC`). When two same-time events conflict on a single target, the last-listed event wins.
+
+The same-time grouping uses exact `double` equality on `time`. Both sides of the comparison are read from the parsed event records, so events with the same JSON literal compare equal.
+
+## Example schedule
+
+A schedule that faults bus `2` at `t=1.0`, clears the fault at `t=1.1`, and
+simultaneously opens line `L23` at `t=1.1`:
+
+```json
+"schedule": [
+  { "time": 1.0, "target": "2",   "action": "fault", "params": { "R": 0.0, "X": 1.0e-5 } },
+  { "time": 1.1, "target": "2",   "action": "clear" },
+  { "time": 1.1, "target": "L23", "action": "open"  }
+]
+```
+
+## Errors
+
+Failure                        | Source              | Message
+-------------------------------|---------------------|--------
+Unknown target id              | `SystemModel`       | `No event target with id '<id>'`
+Unhandled action for component | `Component::apply`  | `Component '<class>' does not handle action '<name>'`
+Unknown action string          | parser              | `unknown action '<str>' (valid: open, close, fault, clear)`
+Missing required `params`      | parser              | `action '<name>' requires params field with <fields>`
+Schedule entry past `tmax`     | parser              | `schedule entry at t=<t> exceeds tmax=<tmax>`
+
+## Adding a new action
+
+1. Add a struct to `GridKit::PhasorDynamics::Actions` with a
+   `static constexpr std::string_view name` and any payload fields.
+2. Add the struct to the `Action` variant alias.
+3. Add a parser case mapping the JSON name to the struct.
+4. Override `apply` in the receiving component(s) to handle the new action.
+5. Add a row to the action vocabulary table above and an entry in each
+   receiving component's README Actions section.

--- a/application/PhasorDynamics/README.md
+++ b/application/PhasorDynamics/README.md
@@ -1,25 +1,88 @@
-# Input file for GridKit phasor dynamics application
+# PDSim (Phasor Dynamics Simulation)
 
-## Root elements
 
-   Name               | Value
- ---------------------|-------------------------------------------------------
-  `system_model_file` | Path to the system model file[^1]
-  `dt`                | A floating point value for time step size
-  `tmax`              | A floating point value for max time
-  `events`            | An array of event groups (see [Events](#events) below)
-  `output_file`       | Path to output (CSV) file
-  `reference_file`    | A string containing the name of the case
-  `error_tolerance`   | A string containing the name of the case
+PDSim runs a phasor-dynamics simulation defined by a *solver file*
+(`*.solver.json`) and a *case file* (`*.case.json`). The case file specifies
+the system model, and the solver file specifies the simulation enviornment, including
+any runtime events scheduled during the simulation.
 
-[^1]: See system model [case format](../../Model/PhasorDynamics/INPUT_FORMAT.md)
+The runtime event system (action vocabulary, dispatch model, schedule
+semantics) is documented in [`Model/PhasorDynamics/EVENTS.md`](../../GridKit/Model/PhasorDynamics/EVENTS.md).
 
-## Events
+## Usage
 
-Each event group describes a system event that occurs at a given time point
+```
+pdsim <solver-file.solver.json>
+```
 
-   Name              | Value
- --------------------|-------------------------------------------------------
-  `time`             | A floating point value for time event occurs
-  `type`             | Event type (one of { "fault_on", "fault_off" })
-  `element_id`       | An integer value referencing the element associated with the event (e.g., bus fault id)
+Relative paths in `case_file`, `output_file`, and `reference_file` are
+resolved against the solver file's directory. Absolute paths are used as
+given.
+
+## Solver file format
+
+### Top-level fields
+
+Name              | Required | Description
+------------------|----------|------------------------------------------------------
+`format_version`  | no       | Format version integer. Default `1`. Parser rejects unknown versions.
+`case_file`       | yes      | Path to the case file
+`dt`              | yes      | Reporting time step in seconds
+`tmax`            | yes      | End time in seconds
+`schedule`        | no       | Ordered array of events (see below). May be empty or omitted.
+`output_file`     | no       | Path to monitor output (CSV)
+`reference_file`  | no       | Path to reference CSV for validation
+`error_tolerance` | no       | Maximum allowed error vs reference. Default `1e-4`.
+
+### Schedule
+
+The `schedule` field is an array of events. Each event has the shape:
+
+Name     | Required           | Description
+---------|--------------------|------------------------------------------------------
+`time`   | yes                | Simulation time at which the event fires, in seconds. Must be `≤ tmax`.
+`target` | yes                | Routing key of the component receiving the event (bus `number` or device `id`)
+`action` | yes                | Action name; one of `open`, `close`, `fault`, `clear`
+`params` | iff action carries | Action payload (e.g. `{ R, X, percent }` for `fault`)
+
+The action vocabulary, dispatch model, schedule canonicalization (stable
+sort by time, last-listed wins on conflicts), and same-time semantics are
+documented in
+[`EVENTS.md`](../../GridKit/Model/PhasorDynamics/EVENTS.md).
+
+## Output and validation
+
+If `output_file` is given, it sets the destination for the case file's
+default CSV monitor sink. Other monitor sinks declared in the case file
+are unaffected. Output formatting (channels, delimiter) is controlled by
+the case file's monitor declarations.
+
+If both `output_file` and `reference_file` are given, PDSim compares the
+output against the reference and exits with status `0` if the maximum
+error is within `error_tolerance`, `1` otherwise.
+
+## Example
+
+```json
+{
+    "format_version":  1,
+    "case_file":       "texas.json",
+    "dt":              0.00416666666666,
+    "tmax":            20.0,
+    "schedule": [
+        { "time": 10.0,  "target": "1001",           "action": "fault",
+          "params": { "R": 0.0, "X": 1.0e-5 } },
+        { "time": 10.15, "target": "1001",           "action": "clear" },
+        { "time": 10.15, "target": "BR_1001_1064_1", "action": "open"  }
+    ],
+    "output_file":     "texas.csv",
+    "reference_file":  "texas.ref.csv",
+    "error_tolerance": 1.0e-4
+}
+```
+
+This run faults bus `1001` at `t=10`, clears the fault and trips line
+`BR_1001_1064_1` simultaneously at `t=10.15` (a 9-cycle fault followed by
+isolation of the faulted equipment), and integrates to `t=20`. The two
+events at `t=10.15` batch into one IDA re-init. Output is compared against
+the reference file with tolerance `1e-4`.


### PR DESCRIPTION
## Description
 
A draft of the event system draft with three supported events (fault on bus and branch, and branch opening).
 
 ## Proposed changes
 
- `EVENTS.md` detailing how to invoke `apply` and typed Actions
- `README.md` for `PDSim` detailing solver file format
- A new `Actions` section for `Bus` and `Branch`, which details the supported actions for each respective component.

@pelesh Thinking through this is helping inform some downstream concerns with other models and behavior. If you have a different design direction you want to consider, I am all ears; this is just what is intuitive to me personally.

## Further comments

This will allow us to remove `BusFault`, simplifying case creation and reducing bloat in case files. My external tool that translates cases from PowerWorld can then support what PW calls `contingencies`, which is on a par with the `schedule` I proposed here (allowing me to further streamline verification)