### PR TITLE
IEEET1 exciter tests

### DIFF
--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/CMakeLists.txt
@@ -9,7 +9,7 @@ set(_install_headers
   Tgov1Data.hpp)
 
 if(GRIDKIT_ENABLE_ENZYME)
-  gridkit_add_library(phasor_dynamics_governortgov1
+  gridkit_add_library(phasor_dynamics_governor_tgov1
     SOURCES
       Tgov1Enzyme.cpp
     HEADERS
@@ -21,7 +21,7 @@ if(GRIDKIT_ENABLE_ENZYME)
     COMPILE_OPTIONS
       PRIVATE -mllvm -enzyme-auto-sparsity=1 -fno-math-errno)
 else()
-  gridkit_add_library(phasor_dynamics_governortgov1
+  gridkit_add_library(phasor_dynamics_governor_tgov1
     SOURCES
       Tgov1.cpp
     HEADERS
@@ -31,7 +31,7 @@ else()
       GridKit::phasor_dynamics_signal)
 endif()
 
-gridkit_add_library(phasor_dynamics_governortgov1_dependency_tracking
+gridkit_add_library(phasor_dynamics_governor_tgov1_dependency_tracking
   SOURCES
     Tgov1DependencyTracking.cpp
   LINK_LIBRARIES
@@ -40,6 +40,6 @@ gridkit_add_library(phasor_dynamics_governortgov1_dependency_tracking
 
 # Link to interface target for all components
 target_link_libraries(phasor_dynamics_components
-  INTERFACE GridKit::phasor_dynamics_governortgov1)
+  INTERFACE GridKit::phasor_dynamics_governor_tgov1)
 target_link_libraries(phasor_dynamics_components_dependency_tracking
-  INTERFACE GridKit::phasor_dynamics_governortgov1_dependency_tracking)
+  INTERFACE GridKit::phasor_dynamics_governor_tgov1_dependency_tracking)

--- a/tests/UnitTests/PhasorDynamics/CMakeLists.txt
+++ b/tests/UnitTests/PhasorDynamics/CMakeLists.txt
@@ -39,16 +39,22 @@ target_link_libraries(test_phasor_genrou GridKit::definitions
                                          GridKit::phasor_dynamics_bus_dependency_tracking
                                          GridKit::testing)
 
-add_executable(test_phasor_governortgov1 runGovernorTgov1Tests.cpp)
-target_link_libraries(test_phasor_governortgov1 GridKit::definitions
-                                                GridKit::phasor_dynamics_genrou
-                                                GridKit::phasor_dynamics_genrou_dependency_tracking
-                                                GridKit::phasor_dynamics_governortgov1
-                                                GridKit::phasor_dynamics_governortgov1_dependency_tracking
-                                                GridKit::phasor_dynamics_signal
-                                                GridKit::phasor_dynamics_bus
-                                                GridKit::phasor_dynamics_bus_dependency_tracking
-                                                GridKit::testing)
+add_executable(test_phasor_governor_tgov1 runGovernorTgov1Tests.cpp)
+target_link_libraries(test_phasor_governor_tgov1 GridKit::definitions
+                                                 GridKit::phasor_dynamics_genrou
+                                                 GridKit::phasor_dynamics_genrou_dependency_tracking
+                                                 GridKit::phasor_dynamics_governor_tgov1
+                                                 GridKit::phasor_dynamics_governor_tgov1_dependency_tracking
+                                                 GridKit::phasor_dynamics_signal
+                                                 GridKit::phasor_dynamics_bus
+                                                 GridKit::phasor_dynamics_bus_dependency_tracking
+                                                 GridKit::testing)
+
+add_executable(test_phasor_exciter_ieeet1 runExciterIeeet1Tests.cpp)
+target_link_libraries(test_phasor_exciter_ieeet1 GridKit::definitions
+                                                 GridKit::phasor_dynamics_components
+                                                 GridKit::phasor_dynamics_components_dependency_tracking
+                                                 GridKit::testing)
 
 add_executable(test_phasor_exciter_sexspti runExciterSexsPtiTests.cpp)
 target_link_libraries(test_phasor_exciter_sexspti GridKit::definitions
@@ -89,7 +95,8 @@ target_link_libraries(test_phasor_system_single_component GridKit::phasor_dynami
 add_test(NAME PhasorDynamicsBusTest COMMAND test_phasor_bus)
 add_test(NAME PhasorDynamicsBranchTest COMMAND test_phasor_branch)
 add_test(NAME PhasorDynamicsGenrouTest COMMAND test_phasor_genrou)
-add_test(NAME PhasorDynamicsGovernorTgov1Test COMMAND test_phasor_governortgov1)
+add_test(NAME PhasorDynamicsGovernorTgov1Test COMMAND test_phasor_governor_tgov1)
+add_test(NAME PhasorDynamicsExciterIeeet1Test COMMAND test_phasor_exciter_ieeet1)
 add_test(NAME PhasorDynamicsExciterSexsPtiTest COMMAND test_phasor_exciter_sexspti)
 add_test(NAME PhasorDynamicsStabilizerIeeestTest COMMAND test_phasor_stabilizer_ieeest)
 add_test(NAME PhasorDynamicsGenClassicalTest COMMAND test_phasor_gen_classical)
@@ -104,7 +111,8 @@ install(TARGETS test_phasor_bus
                 test_phasor_load
                 test_phasor_loadzip
                 test_phasor_genrou
-                test_phasor_governortgov1
+                test_phasor_governor_tgov1
+                test_phasor_exciter_ieeet1
                 test_phasor_exciter_sexspti
                 test_phasor_stabilizer_ieeest
                 test_phasor_gen_classical

--- a/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+
+#include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
+#include <GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp>
+#include <GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp>
+#include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
+#include <GridKit/Testing/TestHelpers.hpp>
+#include <GridKit/Testing/Testing.hpp>
+
+namespace GridKit
+{
+  namespace Testing
+  {
+    template <class ScalarT, typename IdxT>
+    class ExciterIeeet1Tests
+    {
+    public:
+      using RealT = typename PhasorDynamics::Component<ScalarT, IdxT>::RealT;
+
+      ExciterIeeet1Tests()  = default;
+      ~ExciterIeeet1Tests() = default;
+
+      TestOutcome constructor()
+      {
+        TestStatus success = true;
+
+        PhasorDynamics::Bus<ScalarT, IdxT> bus(3.0, 4.0);
+        auto                               data    = makeTestData();
+        auto*                              exciter = new PhasorDynamics::Exciter::Ieeet1<ScalarT, IdxT>(&bus, data);
+
+        success *= (exciter != nullptr);
+        success *= (exciter->size() == 9);
+        success *= (exciter->getMonitor() != nullptr);
+
+        delete exciter;
+
+        return success.report(__func__);
+      }
+
+    private:
+      auto makeTestData() -> PhasorDynamics::Exciter::Ieeet1Data<RealT, IdxT>
+      {
+        using Params = PhasorDynamics::Exciter::Ieeet1Parameters;
+
+        PhasorDynamics::Exciter::Ieeet1Data<RealT, IdxT> data;
+        data.device_class          = "exciter";
+        data.disambiguation_string = "ieeet1_test";
+        data.monitored_variables.insert(PhasorDynamics::Exciter::Ieeet1MonitorableVariables::efd);
+
+        data.parameters[Params::Tr]      = 0.001;
+        data.parameters[Params::Ka]      = 50.0;
+        data.parameters[Params::Ta]      = 0.04;
+        data.parameters[Params::Ke]      = -0.06;
+        data.parameters[Params::Te]      = 0.6;
+        data.parameters[Params::Kf]      = 0.09;
+        data.parameters[Params::Tf]      = 1.46;
+        data.parameters[Params::Vrmin]   = -1.0;
+        data.parameters[Params::Vrmax]   = 1.0;
+        data.parameters[Params::E1]      = 2.8;
+        data.parameters[Params::E2]      = 3.373;
+        data.parameters[Params::Se1]     = 0.04;
+        data.parameters[Params::Se2]     = 0.33;
+        data.parameters[Params::Ispdlim] = 0.0;
+
+        return data;
+      }
+    };
+  } // namespace Testing
+} // namespace GridKit

--- a/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
@@ -49,6 +49,7 @@ namespace GridKit
         TestStatus success = true;
 
         auto data = makeTestData();
+
         PhasorDynamics::Bus<ScalarT, IdxT>             bus(3.0, 4.0);
         PhasorDynamics::Exciter::Ieeet1<ScalarT, IdxT> exciter(&bus, data);
 

--- a/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
@@ -4,12 +4,15 @@
 #include <iostream>
 #include <limits>
 
+#include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
+#include <GridKit/Definitions.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
 #include <GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp>
 #include <GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp>
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
+#include <GridKit/Utilities/MapFromCOO.hpp>
 
 namespace GridKit
 {
@@ -40,6 +43,189 @@ namespace GridKit
 
         return success.report(__func__);
       }
+
+      TestOutcome zeroInitialResidual()
+      {
+        TestStatus success = true;
+
+        auto data = makeTestData();
+        PhasorDynamics::Bus<ScalarT, IdxT>             bus(3.0, 4.0);
+        PhasorDynamics::Exciter::Ieeet1<ScalarT, IdxT> exciter(&bus, data);
+
+        bus.allocate();
+        exciter.allocate();
+
+        bus.initialize();
+        exciter.initialize();
+
+        exciter.evaluateResidual();
+
+        const auto& residual = exciter.getResidual();
+        for (size_t i = 0; i < residual.size(); ++i)
+        {
+          if (!isEqual(residual[i], static_cast<ScalarT>(0.0)))
+          {
+            std::cout << "Non-zero Ieeet1 residual at index " << i << ": " << residual[i] << "\n";
+            success = false;
+          }
+        }
+
+        return success.report(__func__);
+      }
+
+#ifdef GRIDKIT_ENABLE_ENZYME
+      /**
+       * @brief Checks Jacobian evaluation.
+       */
+      TestOutcome jacobian()
+      {
+        TestStatus success = true;
+
+        auto tol = 10 * std::numeric_limits<RealT>::epsilon();
+
+        // Jacobian via DependencyTracking
+        std::vector<DependencyTracking::Variable::DependencyMap> dependency_tracking_jacobian = DependencyTrackingJacobian();
+
+        // Jacobian via Enzyme
+        std::vector<DependencyTracking::Variable::DependencyMap> enzyme_jacobian = EnzymeJacobian();
+
+        // Compare DependencyTracking dependencies to Enzyme's
+        for (size_t i = 0; i < dependency_tracking_jacobian.size(); ++i)
+        {
+          success *= (GridKit::Testing::isEqual(dependency_tracking_jacobian[i], enzyme_jacobian[i], tol));
+        }
+
+        return success.report(__func__);
+      }
+
+    private:
+      std::vector<DependencyTracking::Variable::DependencyMap> DependencyTrackingJacobian()
+      {
+        auto data = makeTestData();
+
+        DependencyTracking::Variable                                        Vr1{3.0};
+        DependencyTracking::Variable                                        Vi1{4.0};
+        PhasorDynamics::Bus<DependencyTracking::Variable, IdxT>             bus(Vr1, Vi1);
+        PhasorDynamics::Exciter::Ieeet1<DependencyTracking::Variable, IdxT> exciter(&bus, data);
+
+        bus.allocate();
+        exciter.allocate();
+
+        // Get d/dy
+        bus.initialize();
+        exciter.initialize();
+
+        for (size_t i = 0; i < exciter.size(); ++i)
+        {
+          exciter.y()[i].setVariableNumber(i); ///< Exciter independent variables
+        }
+        for (size_t i = 0; i < bus.size(); ++i)
+        {
+          bus.y()[i].setVariableNumber(i + exciter.size()); // Bus independent variables
+        }
+
+        bus.evaluateResidual();
+        exciter.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
+                                    ///< the dependencies
+        std::vector<DependencyTracking::Variable> residual_y = exciter.getResidual();
+
+        // Get d/dy'
+        bus.initialize();
+        exciter.initialize();
+
+        for (size_t i = 0; i < exciter.size(); ++i)
+        {
+          exciter.yp()[i].setVariableNumber(i); ///< Exciter independent variables
+        }
+
+        bus.evaluateResidual();
+        exciter.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
+                                    ///< the dependencies
+        std::vector<DependencyTracking::Variable> residual_yp = exciter.getResidual();
+
+        // Print the dependencies
+        for (size_t i = 0; i < residual_y.size(); ++i)
+        {
+          std::cout << i << "th residual, y: ";
+          (residual_y[i]).print(std::cout);
+          std::cout << "\n";
+          std::cout << i << "th residual, yp: ";
+          (residual_yp[i]).print(std::cout);
+          std::cout << "\n";
+        }
+
+        // Extract the dependencies and add d/dy' to d/dy
+        std::vector<DependencyTracking::Variable::DependencyMap> dependencies(residual_y.size());
+        for (IdxT i = 0; i < residual_y.size(); ++i)
+        {
+          DependencyTracking::Variable::DependencyMap dependency_y  = (residual_y[i]).getDependencies();
+          DependencyTracking::Variable::DependencyMap dependency_yp = (residual_yp[i]).getDependencies();
+
+          for (const auto& pair_y : dependency_y)
+          {
+            auto index_y = pair_y.first;
+            auto value_y = pair_y.second;
+            auto it_yp   = dependency_yp.find(index_y);
+            if (it_yp != dependency_yp.end())
+            {
+              auto value_yp = it_yp->second;
+              dependencies[i].insert(std::make_pair(index_y, value_y + value_yp));
+            }
+            else
+            {
+              dependencies[i].insert(std::make_pair(index_y, value_y));
+            }
+          }
+
+          // Insert yp dependencies that did not exist in the y dependencies
+          for (const auto& pair_yp : dependency_yp)
+          {
+            auto index_yp = pair_yp.first;
+            auto value_yp = pair_yp.second;
+            auto it_y     = dependency_y.find(index_yp);
+            if (it_y == dependency_y.end())
+            {
+              dependencies[i].insert(std::make_pair(index_yp, value_yp));
+            }
+          }
+        }
+
+        return dependencies;
+      }
+
+      std::vector<DependencyTracking::Variable::DependencyMap> EnzymeJacobian()
+      {
+        auto data = makeTestData();
+
+        PhasorDynamics::Bus<ScalarT, IdxT>             bus(3.0, 4.0);
+        PhasorDynamics::Exciter::Ieeet1<ScalarT, IdxT> exciter(&bus, data);
+
+        bus.allocate();
+        exciter.allocate();
+
+        bus.initialize();
+        exciter.initialize();
+
+        exciter.updateTime(0.0, 1.0); // Set alpha to 1.0 to verify d/dy' term
+
+        for (size_t i = 0; i < bus.size(); ++i)
+        {
+          bus.setVariableIndex(i, i + exciter.size()); // Reset bus variable indices
+          bus.setResidualIndex(i, i + exciter.size()); // Reset bus residual indices
+        }
+
+        bus.evaluateResidual();
+        exciter.evaluateResidual();
+
+        bus.evaluateJacobian();
+        exciter.evaluateJacobian();
+        GridKit::LinearAlgebra::COO_Matrix<ScalarT, IdxT>& model_jacobian = exciter.getJacobian();
+        model_jacobian.deduplicate();
+        model_jacobian.printMatrix("Model Jacobian");
+
+        return GridKit::Testing::MapFromCOO(model_jacobian);
+      }
+#endif
 
     private:
       auto makeTestData() -> PhasorDynamics::Exciter::Ieeet1Data<RealT, IdxT>

--- a/tests/UnitTests/PhasorDynamics/runExciterIeeet1Tests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runExciterIeeet1Tests.cpp
@@ -1,0 +1,12 @@
+#include "ExciterIeeet1Tests.hpp"
+
+int main()
+{
+  GridKit::Testing::TestingResults result;
+
+  GridKit::Testing::ExciterIeeet1Tests<double, size_t> test;
+
+  result += test.constructor();
+
+  return result.summary();
+}

--- a/tests/UnitTests/PhasorDynamics/runExciterIeeet1Tests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runExciterIeeet1Tests.cpp
@@ -7,6 +7,10 @@ int main()
   GridKit::Testing::ExciterIeeet1Tests<double, size_t> test;
 
   result += test.constructor();
+  result += test.zeroInitialResidual();
+#ifdef GRIDKIT_ENABLE_ENZYME
+  result += test.jacobian();
+#endif
 
   return result.summary();
 }


### PR DESCRIPTION
## Description
 
This add some unit tests for the IEEET1 exciter. Mostly to make sure I don't break these while refactoring.
 
Partially addresses #198. Missing non-zero residual test.
 
 ## Proposed changes
 
- Added `ExciterIeeet1Tests.hpp` and `runExciterIeeet1Tests.cpp`. The implemented tests are `constructor`, `zeroInitialResidual` and `jacobian`.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
