### PR TITLE
Fix (most) template formatting issues in phasor dynamics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,15 +240,17 @@ Always declare type aliases with the `using` keyword rather than `typedef typena
   typedef typename GridKit::ScalarTraits<ScalarT>::RealT RealT; // No
 ```
 
-Types that are used as template parameters should use uppercase camel name format, 
-similar to classes, with the `T` suffix to indicate that it is a type. 
-For consistency, use the same name everywhere the same type is used.
+Types that are used as template parameters should use `snake_case` format, with
+the `_type` suffix to indicate that it is a type.  Types used within class
+implementation code and provided in the public class interface should use
+`UpperCamelT` format, similar to class names, but with a `T` suffix.  For
+consistency, create aliases for template type parameters (*e.g.,* `using ScalarT
+= scalar_type;`) and use the same name everywhere the same type is used.
 
 ```c++
-  template <typename RealT> ...; // Yes
-  template <typename real_type>; // No, `_type` used in a template parameter name
+  template <typename real_type> ...; // Yes
+  template <typename RealT>; // No, using format reserved for interface types
 ```
-
 
 ### Constants
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,15 +241,35 @@ Always declare type aliases with the `using` keyword rather than `typedef typena
 ```
 
 Types that are used as template parameters should use `snake_case` format, with
-the `_type` suffix to indicate that it is a type.  Types used within class
-implementation code and provided in the public class interface should use
-`UpperCamelT` format, similar to class names, but with a `T` suffix.  For
-consistency, create aliases for template type parameters (*e.g.,* `using ScalarT
-= scalar_type;`) and use the same name everywhere the same type is used.
+the `_type` suffix to indicate that it is a type. Use the keyword `typename`
+rather than `class` for template type parameters.
 
 ```c++
-  template <typename real_type> ...; // Yes
   template <typename RealT>; // No, using format reserved for interface types
+  template <class real_type>; // No, using `class` keyword
+
+  template <typename real_type> ...; // Yes
+```
+Types used within class implementation code and provided in the public class
+interface should use `UpperCamelT` format, similar to class names, but with a
+`T` suffix.  For consistency, create aliases for template type parameters
+(*e.g.,* `using ScalarT = scalar_type;`) and use the same name everywhere the
+same type is used. This applies across multiple classes in which the type has
+the same meaning.
+
+```c++
+  template <typename scalar_type, typename index_type>
+  class ExTemp
+  {
+    // Convention used in all applicable classes for scalar, index, and
+    // primitive floating-point types
+    using ScalarT = scalar_type;
+    using IdxT    = index_type;
+    using RealT   = GridKit::ScalarTraits<ScalarT>::RealT;
+
+    // void foo(scalar_type value); // No, using template type parameter
+    void foo(ScalarT value); // Yes, using interface types in code
+  };
 ```
 
 ### Constants

--- a/GridKit/Model/Evaluator.hpp
+++ b/GridKit/Model/Evaluator.hpp
@@ -17,10 +17,12 @@ namespace GridKit
      * @brief Abstract class describing a model.
      *
      */
-    template <class ScalarT, typename IdxT>
+    template <class scalar_type, typename index_type>
     class Evaluator
     {
     public:
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
       using RealT      = typename GridKit::ScalarTraits<ScalarT>::RealT;
       using MatrixT    = GridKit::LinearAlgebra::COO_Matrix<RealT, IdxT>; //\todo Use CsrMatrix
       using CsrMatrixT = GridKit::LinearAlgebra::CsrMatrix<RealT, IdxT>;

--- a/GridKit/Model/PhasorDynamics/Branch/Branch.cpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.cpp
@@ -13,12 +13,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Branch<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Branch..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
@@ -18,10 +18,10 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class BusBase;
 
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct BranchData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -37,43 +37,45 @@ namespace GridKit
      * direction is into the busses.
      *
      */
-    template <class ScalarT, typename IdxT>
-    class Branch : public Component<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class Branch : public Component<scalar_type, index_type>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using Component<scalar_type, index_type>::gridkit_component_id_;
+      using Component<scalar_type, index_type>::size_;
+      using Component<scalar_type, index_type>::nnz_;
+      using Component<scalar_type, index_type>::time_;
+      using Component<scalar_type, index_type>::alpha_;
+      using Component<scalar_type, index_type>::y_;
+      using Component<scalar_type, index_type>::yp_;
+      using Component<scalar_type, index_type>::tag_;
+      using Component<scalar_type, index_type>::f_;
+      using Component<scalar_type, index_type>::wb_;
+      using Component<scalar_type, index_type>::h_;
+      using Component<scalar_type, index_type>::J_;
+      using Component<scalar_type, index_type>::J_rows_buffer_;
+      using Component<scalar_type, index_type>::J_cols_buffer_;
+      using Component<scalar_type, index_type>::J_vals_buffer_;
+      using Component<scalar_type, index_type>::variable_indices_;
+      using Component<scalar_type, index_type>::residual_indices_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using bus_type        = BusBase<ScalarT, IdxT>;
-      using model_data_type = BranchData<RealT, IdxT>;
-      using MonitorT        = Model::VariableMonitor<Branch, BranchData>;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Component<ScalarT, IdxT>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = BranchData<RealT, IdxT>;
+      using MonitorT   = Model::VariableMonitor<Branch, BranchData>;
 
-      Branch(bus_type* bus1, bus_type* bus2);
-      Branch(bus_type* bus1,
-             bus_type* bus2,
-             RealT     R,
-             RealT     X,
-             RealT     G,
-             RealT     B,
-             RealT     tap   = 1.0,
-             RealT     phase = 0.0);
-      Branch(bus_type* bus1, bus_type* bus2, const model_data_type& data);
+      Branch(BusT* bus1, BusT* bus2);
+      Branch(BusT* bus1,
+             BusT* bus2,
+             RealT R,
+             RealT X,
+             RealT G,
+             RealT B,
+             RealT tap   = 1.0,
+             RealT phase = 0.0);
+      Branch(BusT* bus1, BusT* bus2, const ModelDataT& data);
       virtual ~Branch();
 
       virtual int setGridKitComponentID(IdxT) override final;
@@ -123,20 +125,22 @@ namespace GridKit
       const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
-      void                                              initializeParameters(const model_data_type& data);
-      void                                              initializeMonitor();
-      void                                              setDerivedParams();
-      void                                              terminalCurrent1(ScalarT& Ir, ScalarT& Ii);
-      void                                              terminalCurrent2(ScalarT& Ir, ScalarT& Ii);
-      bool                                              readRealParameter(const model_data_type&               data,
-                                                                          typename model_data_type::Parameters parameter,
-                                                                          RealT&                               target);
+      void initializeParameters(const ModelDataT& data);
+      void initializeMonitor();
+      void setDerivedParams();
+      void terminalCurrent1(ScalarT& Ir, ScalarT& Ii);
+      void terminalCurrent2(ScalarT& Ir, ScalarT& Ii);
+      bool readRealParameter(const ModelDataT&               data,
+                             typename ModelDataT::Parameters parameter,
+                             RealT&                          target);
+
       static __attribute__((always_inline)) inline void addAdmittanceContribution(RealT          G,
                                                                                   RealT          B,
                                                                                   const ScalarT& Vr,
                                                                                   const ScalarT& Vi,
                                                                                   ScalarT&       Ir,
                                                                                   ScalarT&       Ii);
+
       static __attribute__((always_inline)) inline void evaluateAdmittanceBlock(RealT          G,
                                                                                 RealT          B,
                                                                                 const ScalarT* wb,
@@ -189,16 +193,16 @@ namespace GridKit
       __attribute__((always_inline)) inline int evaluateBusResidual22(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
-      bus_type* bus1_;
-      bus_type* bus2_;
-      RealT     R_{0.0};
-      RealT     X_{0.0};
-      RealT     G_{0.0};
-      RealT     B_{0.0};
-      RealT     tap_{1.0};
-      RealT     phase_{0.0};
-      IdxT      bus1_id_{0};
-      IdxT      bus2_id_{0};
+      BusT* bus1_;
+      BusT* bus2_;
+      RealT R_{0.0};
+      RealT X_{0.0};
+      RealT G_{0.0};
+      RealT B_{0.0};
+      RealT tap_{1.0};
+      RealT phase_{0.0};
+      IdxT  bus1_id_{0};
+      IdxT  bus2_id_{0};
 
       RealT g11_{0.0};
       RealT b11_{0.0};

--- a/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
@@ -48,14 +48,14 @@ namespace GridKit
     /**
      * @brief Contains modeling data for a Branch
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
      */
-    template <typename RealT, typename IdxT>
-    struct BranchData : public ComponentData<RealT,
-                                             IdxT,
+    template <typename real_type, typename index_type>
+    struct BranchData : public ComponentData<real_type,
+                                             index_type,
                                              BranchParameters,
                                              BranchPorts,
                                              BranchMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/Branch/BranchDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchDependencyTracking.cpp
@@ -13,12 +13,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Branch<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Branch..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchEnzyme.cpp
@@ -15,12 +15,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation experimental
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Branch<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Branch..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -28,8 +28,8 @@ namespace GridKit
      * - Number of equations = 0
      * - Number of internal variables = 0
      */
-    template <class ScalarT, typename IdxT>
-    Branch<ScalarT, IdxT>::Branch(bus_type* bus1, bus_type* bus2)
+    template <typename scalar_type, typename index_type>
+    Branch<scalar_type, index_type>::Branch(BusT* bus1, BusT* bus2)
       : bus1_(bus1),
         bus2_(bus2),
         R_(0.0),
@@ -48,8 +48,6 @@ namespace GridKit
     /**
      * @brief Construct a new Branch
      *
-     * @tparam ScalarT - scalar type
-     * @tparam IdxT    - matrix/vector index type
      * @param bus1 - pointer to bus-1
      * @param bus2 - pointer to bus-2
      * @param R - line series resistance
@@ -59,15 +57,15 @@ namespace GridKit
      * @param tap - off-nominal tap magnitude on bus1 side
      * @param phase - phase shift angle in radians
      */
-    template <class ScalarT, typename IdxT>
-    Branch<ScalarT, IdxT>::Branch(bus_type* bus1,
-                                  bus_type* bus2,
-                                  RealT     R,
-                                  RealT     X,
-                                  RealT     G,
-                                  RealT     B,
-                                  RealT     tap,
-                                  RealT     phase)
+    template <typename scalar_type, typename index_type>
+    Branch<scalar_type, index_type>::Branch(BusT* bus1,
+                                            BusT* bus2,
+                                            RealT R,
+                                            RealT X,
+                                            RealT G,
+                                            RealT B,
+                                            RealT tap,
+                                            RealT phase)
       : bus1_(bus1),
         bus2_(bus2),
         R_(R),
@@ -83,8 +81,8 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    Branch<ScalarT, IdxT>::Branch(bus_type* bus1, bus_type* bus2, const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    Branch<scalar_type, index_type>::Branch(BusT* bus1, BusT* bus2, const ModelDataT& data)
       : bus1_(bus1),
         bus2_(bus2),
         monitor_(std::make_unique<MonitorT>(data))
@@ -99,19 +97,17 @@ namespace GridKit
     /**
      * @brief Destroy the Branch
      *
-     * @tparam ScalarT
-     * @tparam IdxT
      */
-    template <class ScalarT, typename IdxT>
-    Branch<ScalarT, IdxT>::~Branch()
+    template <typename scalar_type, typename index_type>
+    Branch<scalar_type, index_type>::~Branch()
     {
     }
 
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename scalar_type, typename index_type>
+    int Branch<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -120,8 +116,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int Branch<scalar_type, index_type>::allocate()
     {
       wb_.resize(2);
       h_.resize(2);
@@ -133,8 +129,8 @@ namespace GridKit
      * Initialization of the branch model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int Branch<scalar_type, index_type>::initialize()
     {
       return 0;
     }
@@ -142,14 +138,14 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int Branch<scalar_type, index_type>::tagDifferentiable()
     {
       return 0;
     }
 
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::verify() const
+    template <typename scalar_type, typename index_type>
+    int Branch<scalar_type, index_type>::verify() const
     {
       int ret = parameter_error_count_;
 
@@ -177,8 +173,8 @@ namespace GridKit
       return ret;
     }
 
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline void Branch<ScalarT, IdxT>::addAdmittanceContribution(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) inline void Branch<scalar_type, index_type>::addAdmittanceContribution(
         RealT          G,
         RealT          B,
         const ScalarT& Vr,
@@ -190,8 +186,8 @@ namespace GridKit
       Ii += B * Vr + G * Vi;
     }
 
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline void Branch<ScalarT, IdxT>::evaluateAdmittanceBlock(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) inline void Branch<scalar_type, index_type>::evaluateAdmittanceBlock(
         RealT          G,
         RealT          B,
         const ScalarT* wb,
@@ -208,8 +204,8 @@ namespace GridKit
      * @brief Bus 1 residual contribution from bus 1 variables
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Branch<ScalarT, IdxT>::evaluateBusResidual11(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) inline int Branch<scalar_type, index_type>::evaluateBusResidual11(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -224,8 +220,8 @@ namespace GridKit
      * @brief Bus 1 residual contribution from bus 2 variables
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Branch<ScalarT, IdxT>::evaluateBusResidual12(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) inline int Branch<scalar_type, index_type>::evaluateBusResidual12(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -240,8 +236,8 @@ namespace GridKit
      * @brief Bus 2 residual contribution from bus 1 variables
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual21(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) int Branch<scalar_type, index_type>::evaluateBusResidual21(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -256,8 +252,8 @@ namespace GridKit
      * @brief Bus 2 residual contribution from bus 2 variables
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Branch<ScalarT, IdxT>::evaluateBusResidual22(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) int Branch<scalar_type, index_type>::evaluateBusResidual22(
         [[maybe_unused]] ScalarT* y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -272,8 +268,8 @@ namespace GridKit
      * @brief Residual contribution of the branch is computed and pushed to the terminal buses.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Branch<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int Branch<scalar_type, index_type>::evaluateResidual()
     {
       ScalarT ir1{0.0};
       ScalarT ii1{0.0};
@@ -291,8 +287,8 @@ namespace GridKit
       return 0;
     }
 
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::terminalCurrent1(ScalarT& Ir, ScalarT& Ii)
+    template <typename scalar_type, typename index_type>
+    void Branch<scalar_type, index_type>::terminalCurrent1(ScalarT& Ir, ScalarT& Ii)
     {
       Ir = ScalarT{0.0};
       Ii = ScalarT{0.0};
@@ -301,8 +297,8 @@ namespace GridKit
       addAdmittanceContribution(g12_, b12_, Vr2(), Vi2(), Ir, Ii);
     }
 
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::terminalCurrent2(ScalarT& Ir, ScalarT& Ii)
+    template <typename scalar_type, typename index_type>
+    void Branch<scalar_type, index_type>::terminalCurrent2(ScalarT& Ir, ScalarT& Ii)
     {
       Ir = ScalarT{0.0};
       Ii = ScalarT{0.0};
@@ -311,31 +307,31 @@ namespace GridKit
       addAdmittanceContribution(g22_, b22_, Vr2(), Vi2(), Ir, Ii);
     }
 
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    void Branch<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
-      readRealParameter(data, model_data_type::Parameters::R, R_);
-      readRealParameter(data, model_data_type::Parameters::X, X_);
-      readRealParameter(data, model_data_type::Parameters::G, G_);
-      readRealParameter(data, model_data_type::Parameters::B, B_);
-      readRealParameter(data, model_data_type::Parameters::tap, tap_);
-      readRealParameter(data, model_data_type::Parameters::phase, phase_);
+      readRealParameter(data, ModelDataT::Parameters::R, R_);
+      readRealParameter(data, ModelDataT::Parameters::X, X_);
+      readRealParameter(data, ModelDataT::Parameters::G, G_);
+      readRealParameter(data, ModelDataT::Parameters::B, B_);
+      readRealParameter(data, ModelDataT::Parameters::tap, tap_);
+      readRealParameter(data, ModelDataT::Parameters::phase, phase_);
 
-      if (data.ports.contains(model_data_type::Ports::bus1))
+      if (data.ports.contains(ModelDataT::Ports::bus1))
       {
-        bus1_id_ = data.ports.at(model_data_type::Ports::bus1);
+        bus1_id_ = data.ports.at(ModelDataT::Ports::bus1);
       }
 
-      if (data.ports.contains(model_data_type::Ports::bus2))
+      if (data.ports.contains(ModelDataT::Ports::bus2))
       {
-        bus2_id_ = data.ports.at(model_data_type::Ports::bus2);
+        bus2_id_ = data.ports.at(ModelDataT::Ports::bus2);
       }
     }
 
-    template <class ScalarT, typename IdxT>
-    bool Branch<ScalarT, IdxT>::readRealParameter(const model_data_type&               data,
-                                                  typename model_data_type::Parameters parameter,
-                                                  RealT&                               target)
+    template <typename scalar_type, typename index_type>
+    bool Branch<scalar_type, index_type>::readRealParameter(const ModelDataT&               data,
+                                                            typename ModelDataT::Parameters parameter,
+                                                            RealT&                          target)
     {
       if (!data.parameters.contains(parameter))
       {
@@ -361,16 +357,16 @@ namespace GridKit
       return false;
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* Branch<ScalarT, IdxT>::getMonitor() const
+    template <typename scalar_type, typename index_type>
+    const Model::VariableMonitorBase* Branch<scalar_type, index_type>::getMonitor() const
     {
       return monitor_.get();
     }
 
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::initializeMonitor()
+    template <typename scalar_type, typename index_type>
+    void Branch<scalar_type, index_type>::initializeMonitor()
     {
-      using Variable = typename model_data_type::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::ir1, [this]
                     {
                       ScalarT Ir;
@@ -437,8 +433,8 @@ namespace GridKit
      * @brief Derived parameters
      *
      */
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::setDerivedParams()
+    template <typename scalar_type, typename index_type>
+    void Branch<scalar_type, index_type>::setDerivedParams()
     {
       g11_ = RealT{0.0};
       b11_ = RealT{0.0};

--- a/GridKit/Model/PhasorDynamics/Bus/Bus.cpp
+++ b/GridKit/Model/PhasorDynamics/Bus/Bus.cpp
@@ -8,12 +8,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - data type for Jacobian elements
-     * @tparam IdxT    - data type for matrix indices
      * @return int - error code
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Bus<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Bus..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Bus/Bus.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/Bus.hpp
@@ -15,32 +15,34 @@ namespace GridKit
      *
      *
      */
-    template <class ScalarT, typename IdxT>
-    class Bus : public BusBase<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class Bus : public BusBase<scalar_type, index_type>
     {
-      using BusBase<ScalarT, IdxT>::bus_id_;
-      using BusBase<ScalarT, IdxT>::monitor_;
-      using BusBase<ScalarT, IdxT>::size_;
-      using BusBase<ScalarT, IdxT>::y_;
-      using BusBase<ScalarT, IdxT>::yp_;
-      using BusBase<ScalarT, IdxT>::f_;
-      using BusBase<ScalarT, IdxT>::J_;
-      using BusBase<ScalarT, IdxT>::J_rows_buffer_;
-      using BusBase<ScalarT, IdxT>::J_cols_buffer_;
-      using BusBase<ScalarT, IdxT>::J_vals_buffer_;
-      using BusBase<ScalarT, IdxT>::tag_;
-      using BusBase<ScalarT, IdxT>::variable_indices_;
-      using BusBase<ScalarT, IdxT>::residual_indices_;
+      using BusBase<scalar_type, index_type>::bus_id_;
+      using BusBase<scalar_type, index_type>::size_;
+      using BusBase<scalar_type, index_type>::y_;
+      using BusBase<scalar_type, index_type>::yp_;
+      using BusBase<scalar_type, index_type>::f_;
+      using BusBase<scalar_type, index_type>::J_;
+      using BusBase<scalar_type, index_type>::J_rows_buffer_;
+      using BusBase<scalar_type, index_type>::J_cols_buffer_;
+      using BusBase<scalar_type, index_type>::J_vals_buffer_;
+      using BusBase<scalar_type, index_type>::tag_;
+      using BusBase<scalar_type, index_type>::variable_indices_;
+      using BusBase<scalar_type, index_type>::residual_indices_;
+      using BusBase<scalar_type, index_type>::monitor_;
 
     public:
-      using RealT    = typename BusBase<ScalarT, IdxT>::RealT;
-      using MonitorT = typename BusBase<ScalarT, IdxT>::MonitorT;
-      using DataT    = BusData<RealT, IdxT>;
-      using BusTypeT = typename BusData<RealT, IdxT>::BusType;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename BusBase<ScalarT, IdxT>::RealT;
+      using MonitorT   = typename BusBase<ScalarT, IdxT>::MonitorT;
+      using ModelDataT = BusData<RealT, IdxT>;
+      using BusTypeT   = typename BusData<RealT, IdxT>::BusType;
 
       Bus();
       Bus(ScalarT Vr, ScalarT Vi);
-      Bus(const DataT& data);
+      Bus(const ModelDataT& data);
       virtual ~Bus();
 
       virtual int setBusID(IdxT) override final;

--- a/GridKit/Model/PhasorDynamics/Bus/BusData.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusData.hpp
@@ -27,16 +27,19 @@ namespace GridKit
     /**
      * @brief Contains modeling data for a Bus
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
      *
      * @todo Decide on naming scheme for model parameters.
      */
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct BusData
     {
+      using RealT = real_type;
+      using IdxT  = index_type;
+
       std::string name; ///< A name given to this bus
 
       RealT Vr0{1.0}; ///< Initial value for the real bus voltage

--- a/GridKit/Model/PhasorDynamics/Bus/BusDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusDependencyTracking.cpp
@@ -8,12 +8,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - data type for Jacobian elements
-     * @tparam IdxT    - data type for matrix indices
      * @return int - error code
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Bus<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Bus..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Bus/BusEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusEnzyme.cpp
@@ -17,12 +17,10 @@ namespace GridKit
      * @warning This implementation assumes bus Jacobians are always evaluated
      * _before_ component model Jacobians.
      *
-     * @tparam ScalarT - data type for Jacobian elements
-     * @tparam IdxT    - data type for matrix indices
      * @return int - error code
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Bus<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Bus..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Bus/BusFactory.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusFactory.hpp
@@ -9,10 +9,12 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename ScalarT = double, typename IdxT = int>
+    template <typename scalar_type = double, typename index_type = int>
     class BusFactory
     {
     public:
+      using ScalarT  = scalar_type;
+      using IdxT     = index_type;
       using RealT    = typename Model::Evaluator<ScalarT, IdxT>::RealT;
       using BusData  = GridKit::PhasorDynamics::BusData<RealT, IdxT>;
       using BusTypeT = typename GridKit::PhasorDynamics::BusData<RealT, IdxT>::BusType;

--- a/GridKit/Model/PhasorDynamics/Bus/BusImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusImpl.hpp
@@ -10,11 +10,11 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename ScalarT, typename IdxT>
-    BusBase<ScalarT, IdxT>::~BusBase() = default;
+    template <typename scalar_type, typename index_type>
+    BusBase<scalar_type, index_type>::~BusBase() = default;
 
-    template <typename ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* BusBase<ScalarT, IdxT>::getMonitor() const
+    template <typename scalar_type, typename index_type>
+    const Model::VariableMonitorBase* BusBase<scalar_type, index_type>::getMonitor() const
     {
       return monitor_.get();
     }
@@ -30,8 +30,8 @@ namespace GridKit
      * - Number of quadratures = 0
      * - Number of optimization parameters = 0
      */
-    template <class ScalarT, typename IdxT>
-    Bus<ScalarT, IdxT>::Bus()
+    template <typename scalar_type, typename index_type>
+    Bus<scalar_type, index_type>::Bus()
       : Vr0_(0.0), Vi0_(0.0)
     {
       size_ = 2;
@@ -48,8 +48,8 @@ namespace GridKit
      * - Number of quadratures = 0
      * - Number of optimization parameters = 0
      */
-    template <class ScalarT, typename IdxT>
-    Bus<ScalarT, IdxT>::Bus(ScalarT Vr, ScalarT Vi)
+    template <typename scalar_type, typename index_type>
+    Bus<scalar_type, index_type>::Bus(ScalarT Vr, ScalarT Vi)
       : Vr0_(Vr), Vi0_(Vi)
     {
       size_ = 2;
@@ -58,19 +58,17 @@ namespace GridKit
     /**
      * @brief Construct a new Bus
      *
-     * @tparam ScalarT - type of scalar variables
-     * @tparam IdxT    - type for vector/matrix indices
      * @param[in] data - structure with bus data
      */
-    template <class ScalarT, typename IdxT>
-    Bus<ScalarT, IdxT>::Bus(const DataT& data)
+    template <typename scalar_type, typename index_type>
+    Bus<scalar_type, index_type>::Bus(const ModelDataT& data)
       : Vr0_(data.Vr0),
         Vi0_(data.Vi0)
     {
       bus_id_        = data.bus_id;
       size_          = 2;
       monitor_       = std::make_unique<MonitorT>("Bus_" + data.name, data.monitored_variables);
-      using Variable = typename DataT::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::Vr, [this]
                     { return Vr(); });
       monitor_->set(Variable::Vi, [this]
@@ -81,8 +79,8 @@ namespace GridKit
                     { return std::atan2(Vi(), Vr()); });
     }
 
-    template <class ScalarT, typename IdxT>
-    Bus<ScalarT, IdxT>::~Bus()
+    template <typename scalar_type, typename index_type>
+    Bus<scalar_type, index_type>::~Bus()
     {
       // std::cout << "Destroy PQ bus ..." << std::endl;
     }
@@ -90,8 +88,8 @@ namespace GridKit
     /*!
      * @brief allocate method resizes local solution and residual vectors.
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int Bus<scalar_type, index_type>::allocate()
     {
       // Temporary while we use std::vector in the code
       size_t size = static_cast<size_t>(size_);
@@ -117,8 +115,8 @@ namespace GridKit
     /**
      * @brief Set the bus ID
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::setBusID(IdxT bus_id)
+    template <typename scalar_type, typename index_type>
+    int Bus<scalar_type, index_type>::setBusID(IdxT bus_id)
     {
       bus_id_ = bus_id;
       return 0;
@@ -127,8 +125,8 @@ namespace GridKit
     /*!
      * @brief Bus variables are algebraic.
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int Bus<scalar_type, index_type>::tagDifferentiable()
     {
       tag_[0] = false;
       tag_[1] = false;
@@ -138,8 +136,8 @@ namespace GridKit
     /*!
      * @brief initialize method sets bus variables to stored initial values.
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int Bus<scalar_type, index_type>::initialize()
     {
       // std::cout << "Initialize Bus..." << std::endl;
       y_[0]  = Vr0_;
@@ -157,8 +155,8 @@ namespace GridKit
      * _before_ component model residuals.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Bus<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int Bus<scalar_type, index_type>::evaluateResidual()
     {
       // std::cout << "Evaluating residual of a PQ bus ...\n";
       f_[0] = 0.0;

--- a/GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp
@@ -13,28 +13,30 @@ namespace GridKit
      *
      *
      */
-    template <class ScalarT, typename IdxT>
-    class BusInfinite : public BusBase<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class BusInfinite : public BusBase<scalar_type, index_type>
     {
-      using BusBase<ScalarT, IdxT>::bus_id_;
-      using BusBase<ScalarT, IdxT>::monitor_;
-      using BusBase<ScalarT, IdxT>::size_;
-      using BusBase<ScalarT, IdxT>::y_;
-      using BusBase<ScalarT, IdxT>::yp_;
-      using BusBase<ScalarT, IdxT>::f_;
-      using BusBase<ScalarT, IdxT>::J_;
-      using BusBase<ScalarT, IdxT>::variable_indices_;
-      using BusBase<ScalarT, IdxT>::residual_indices_;
+      using BusBase<scalar_type, index_type>::bus_id_;
+      using BusBase<scalar_type, index_type>::size_;
+      using BusBase<scalar_type, index_type>::y_;
+      using BusBase<scalar_type, index_type>::yp_;
+      using BusBase<scalar_type, index_type>::f_;
+      using BusBase<scalar_type, index_type>::J_;
+      using BusBase<scalar_type, index_type>::variable_indices_;
+      using BusBase<scalar_type, index_type>::residual_indices_;
+      using BusBase<scalar_type, index_type>::monitor_;
 
     public:
-      using RealT    = typename BusBase<ScalarT, IdxT>::RealT;
-      using MonitorT = typename BusBase<ScalarT, IdxT>::MonitorT;
-      using DataT    = BusData<RealT, IdxT>;
-      using BusTypeT = typename BusData<RealT, IdxT>::BusType;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename BusBase<ScalarT, IdxT>::RealT;
+      using MonitorT   = typename BusBase<ScalarT, IdxT>::MonitorT;
+      using ModelDataT = BusData<RealT, IdxT>;
+      using BusTypeT   = typename BusData<RealT, IdxT>::BusType;
 
       BusInfinite();
       BusInfinite(ScalarT Vr, ScalarT Vi);
-      BusInfinite(const DataT& data);
+      BusInfinite(const ModelDataT& data);
       virtual ~BusInfinite();
 
       virtual int setBusID(IdxT) override final;

--- a/GridKit/Model/PhasorDynamics/Bus/BusInfiniteImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusInfiniteImpl.hpp
@@ -10,11 +10,11 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename ScalarT, typename IdxT>
-    BusBase<ScalarT, IdxT>::~BusBase() = default;
+    template <typename scalar_type, typename index_type>
+    BusBase<scalar_type, index_type>::~BusBase() = default;
 
-    template <typename ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* BusBase<ScalarT, IdxT>::getMonitor() const
+    template <typename scalar_type, typename index_type>
+    const Model::VariableMonitorBase* BusBase<scalar_type, index_type>::getMonitor() const
     {
       return monitor_.get();
     }
@@ -28,8 +28,8 @@ namespace GridKit
      * - Number of equations = 0 (size_)
      * - Number of variables = 0 (size_)
      */
-    template <class ScalarT, typename IdxT>
-    BusInfinite<ScalarT, IdxT>::BusInfinite()
+    template <typename scalar_type, typename index_type>
+    BusInfinite<scalar_type, index_type>::BusInfinite()
     {
       size_ = 0;
     }
@@ -43,8 +43,8 @@ namespace GridKit
      * - Number of equations = 0 (size_)
      * - Number of variables = 0 (size_)
      */
-    template <class ScalarT, typename IdxT>
-    BusInfinite<ScalarT, IdxT>::BusInfinite(ScalarT Vr, ScalarT Vi)
+    template <typename scalar_type, typename index_type>
+    BusInfinite<scalar_type, index_type>::BusInfinite(ScalarT Vr, ScalarT Vi)
       : Vr_(Vr), Vi_(Vi)
     {
       size_ = 0;
@@ -57,19 +57,17 @@ namespace GridKit
      * - Number of equations = 0 (size_)
      * - Number of variables = 0 (size_)
 
-     * @tparam ScalarT - type of scalar variables
-     * @tparam IdxT    - type for vector/matrix indices
      * @param[in] data - structure with bus data
      */
-    template <class ScalarT, typename IdxT>
-    BusInfinite<ScalarT, IdxT>::BusInfinite(const DataT& data)
+    template <typename scalar_type, typename index_type>
+    BusInfinite<scalar_type, index_type>::BusInfinite(const ModelDataT& data)
       : Vr_(data.Vr0),
         Vi_(data.Vi0)
     {
       bus_id_        = data.bus_id;
       size_          = 0;
       monitor_       = std::make_unique<MonitorT>("Bus_" + data.name, data.monitored_variables);
-      using Variable = typename DataT::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::Vr, [this]
                     { return Vr(); });
       monitor_->set(Variable::Vi, [this]
@@ -80,16 +78,16 @@ namespace GridKit
                     { return std::atan2(Vi(), Vr()); });
     }
 
-    template <class ScalarT, typename IdxT>
-    BusInfinite<ScalarT, IdxT>::~BusInfinite()
+    template <typename scalar_type, typename index_type>
+    BusInfinite<scalar_type, index_type>::~BusInfinite()
     {
     }
 
     /**
      * @brief Set the bus ID
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::setBusID(IdxT bus_id)
+    template <typename scalar_type, typename index_type>
+    int BusInfinite<scalar_type, index_type>::setBusID(IdxT bus_id)
     {
       bus_id_ = bus_id;
       return 0;
@@ -98,8 +96,8 @@ namespace GridKit
     /*!
      * @brief allocate method resizes local solution and residual vectors.
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int BusInfinite<scalar_type, index_type>::allocate()
     {
       return 0;
     }
@@ -107,8 +105,8 @@ namespace GridKit
     /**
      * @brief Tag differentiable variables
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int BusInfinite<scalar_type, index_type>::tagDifferentiable()
     {
       return 0;
     }
@@ -116,8 +114,8 @@ namespace GridKit
     /*!
      * @brief initialize method sets bus variables to stored initial values.
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int BusInfinite<scalar_type, index_type>::initialize()
     {
       return 0;
     }
@@ -134,8 +132,8 @@ namespace GridKit
      * _before_ component model residuals.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int BusInfinite<scalar_type, index_type>::evaluateResidual()
     {
       Ir_ = 0.0;
       Ii_ = 0.0;
@@ -145,12 +143,10 @@ namespace GridKit
     /**
      * @brief There is no Jacobian for slack variables
      *
-     * @tparam ScalarT - data type for Jacobian elements
-     * @tparam IdxT    - data type for matrix indices
      * @return int - error code
      */
-    template <class ScalarT, typename IdxT>
-    int BusInfinite<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int BusInfinite<scalar_type, index_type>::evaluateJacobian()
     {
       return 0;
     }

--- a/GridKit/Model/PhasorDynamics/BusBase.hpp
+++ b/GridKit/Model/PhasorDynamics/BusBase.hpp
@@ -23,10 +23,12 @@ namespace GridKit
      * @brief BusBase model implementation base class.
      *
      */
-    template <typename ScalarT, typename IdxT>
-    class BusBase : public Model::Evaluator<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class BusBase : public Model::Evaluator<scalar_type, index_type>
     {
     public:
+      using ScalarT  = scalar_type;
+      using IdxT     = index_type;
       using RealT    = typename Model::Evaluator<ScalarT, IdxT>::RealT;
       using MatrixT  = typename Model::Evaluator<ScalarT, IdxT>::MatrixT;
       using BusTypeT = typename BusData<RealT, IdxT>::BusType;

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFault.cpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFault.cpp
@@ -15,12 +15,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented yet
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int BusFault<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for BusFault..." << std::endl;
       Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp
@@ -11,7 +11,7 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct BusFaultData;
   }
 } // namespace GridKit
@@ -20,32 +20,34 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
-    class BusFault : public Component<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class BusFault : public Component<scalar_type, index_type>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
+      using Component<scalar_type, index_type>::gridkit_component_id_;
+      using Component<scalar_type, index_type>::alpha_;
+      using Component<scalar_type, index_type>::nnz_;
+      using Component<scalar_type, index_type>::size_;
+      using Component<scalar_type, index_type>::tag_;
+      using Component<scalar_type, index_type>::time_;
+      using Component<scalar_type, index_type>::y_;
+      using Component<scalar_type, index_type>::yp_;
+      using Component<scalar_type, index_type>::wb_;
+      using Component<scalar_type, index_type>::h_;
+      using Component<scalar_type, index_type>::J_rows_buffer_;
+      using Component<scalar_type, index_type>::J_cols_buffer_;
+      using Component<scalar_type, index_type>::J_vals_buffer_;
 
     public:
-      using bus_type = BusBase<ScalarT, IdxT>;
-      using RealT    = typename Component<ScalarT, IdxT>::RealT;
-      using DataT    = BusFaultData<RealT, IdxT>;
-      using MonitorT = Model::VariableMonitor<BusFault, BusFaultData>;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Component<ScalarT, IdxT>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = BusFaultData<RealT, IdxT>;
+      using MonitorT   = Model::VariableMonitor<BusFault, BusFaultData>;
 
-      BusFault(bus_type* bus);
-      BusFault(bus_type* bus, RealT R, RealT X, int status);
-      BusFault(bus_type* bus, const DataT& data);
+      BusFault(BusT* bus);
+      BusFault(BusT* bus, RealT R, RealT X, int status);
+      BusFault(BusT* bus, const ModelDataT& data);
       ~BusFault();
 
       int setGridKitComponentID(IdxT) override final;
@@ -111,11 +113,11 @@ namespace GridKit
       __attribute__((always_inline)) inline int evaluateBusResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
-      bus_type* bus_;
-      RealT     R_{0.0};
-      RealT     X_{0.0};
-      bool      status_{false};
-      IdxT      bus_id_{0};
+      BusT* bus_;
+      RealT R_{0.0};
+      RealT X_{0.0};
+      bool  status_{false};
+      IdxT  bus_id_{0};
 
       /* Derivied parameters */
       RealT B_;

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultData.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultData.hpp
@@ -38,14 +38,14 @@ namespace GridKit
     /**
      * @brief Contains modeling data for a short-to-ground fault
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
      */
-    template <typename RealT, typename IdxT>
-    struct BusFaultData : public ComponentData<RealT,
-                                               IdxT,
+    template <typename real_type, typename index_type>
+    struct BusFaultData : public ComponentData<real_type,
+                                               index_type,
                                                BusFaultParameters,
                                                BusFaultPorts,
                                                BusFaultMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultDependencyTracking.cpp
@@ -7,12 +7,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented yet
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::evaluateJacobian()
+    template <class scalar_type, typename index_type>
+    int BusFault<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for BusFault..." << std::endl;
       Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
@@ -15,12 +15,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation experimental
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::evaluateJacobian()
+    template <class scalar_type, typename index_type>
+    int BusFault<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for BusFault..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
@@ -19,8 +19,8 @@ namespace GridKit
      * - Number of equations = 0
      * - Number of independent variables = 0
      */
-    template <class ScalarT, typename IdxT>
-    BusFault<ScalarT, IdxT>::BusFault(bus_type* bus)
+    template <typename scalar_type, typename index_type>
+    BusFault<scalar_type, index_type>::BusFault(BusT* bus)
       : bus_(bus), R_(0), X_(0.01), status_(0), bus_id_(0)
     {
       (void) bus_id_;
@@ -31,8 +31,6 @@ namespace GridKit
     /**
      * @brief Construct a new BusFault
      *
-     * @tparam ScalarT - scalar type
-     * @tparam IdxT    - matrix/vector index type
      * @param bus1 - pointer to bus-1
      * @param bus2 - pointer to bus-2
      * @param R - line series resistance
@@ -40,8 +38,8 @@ namespace GridKit
      * @param G - line shunt conductance
      * @param B - line shunt charging
      */
-    template <class ScalarT, typename IdxT>
-    BusFault<ScalarT, IdxT>::BusFault(bus_type* bus, RealT R, RealT X, int status)
+    template <typename scalar_type, typename index_type>
+    BusFault<scalar_type, index_type>::BusFault(BusT* bus, RealT R, RealT X, int status)
       : bus_(bus), R_(R), X_(X), status_(status), bus_id_(0)
     {
       size_ = 0;
@@ -51,37 +49,35 @@ namespace GridKit
     /**
      * @brief Construct a new BusFault
      *
-     * @tparam ScalarT - scalar type
-     * @tparam IdxT    - matrix/vector index type
      * @param bus1 - pointer to bus-1
      * @param bus2 - pointer to bus-2
      */
-    template <class ScalarT, typename IdxT>
-    BusFault<ScalarT, IdxT>::BusFault(bus_type* bus, const DataT& data)
+    template <typename scalar_type, typename index_type>
+    BusFault<scalar_type, index_type>::BusFault(BusT* bus, const ModelDataT& data)
       : bus_(bus),
         monitor_(std::make_unique<MonitorT>(data))
     {
-      if (data.parameters.contains(DataT::Parameters::R))
+      if (data.parameters.contains(ModelDataT::Parameters::R))
       {
-        R_ = std::get<RealT>(data.parameters.at(DataT::Parameters::R));
+        R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
       }
 
-      if (data.parameters.contains(DataT::Parameters::X))
+      if (data.parameters.contains(ModelDataT::Parameters::X))
       {
-        X_ = std::get<RealT>(data.parameters.at(DataT::Parameters::X));
+        X_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::X));
       }
 
-      if (data.parameters.contains(DataT::Parameters::state0))
+      if (data.parameters.contains(ModelDataT::Parameters::state0))
       {
-        status_ = std::get<bool>(data.parameters.at(DataT::Parameters::state0));
+        status_ = std::get<bool>(data.parameters.at(ModelDataT::Parameters::state0));
       }
 
-      if (data.ports.contains(DataT::Ports::bus))
+      if (data.ports.contains(ModelDataT::Ports::bus))
       {
-        bus_id_ = data.ports.at(DataT::Ports::bus);
+        bus_id_ = data.ports.at(ModelDataT::Ports::bus);
       }
 
-      using Variable = typename DataT::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::state, [this]
                     { return status_; });
       monitor_->set(Variable::ir, [this]
@@ -93,16 +89,16 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    BusFault<ScalarT, IdxT>::~BusFault()
+    template <typename scalar_type, typename index_type>
+    BusFault<scalar_type, index_type>::~BusFault()
     {
     }
 
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename scalar_type, typename index_type>
+    int BusFault<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -111,8 +107,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int BusFault<scalar_type, index_type>::allocate()
     {
       // std::cout << "Allocate BusFault..." << std::endl;
 
@@ -126,8 +122,8 @@ namespace GridKit
      * Initialization of the branch model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int BusFault<scalar_type, index_type>::initialize()
     {
       return 0;
     }
@@ -135,8 +131,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int BusFault<scalar_type, index_type>::tagDifferentiable()
     {
       return 0;
     }
@@ -145,8 +141,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int BusFault<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) int BusFault<scalar_type, index_type>::evaluateBusResidual(
         [[maybe_unused]] ScalarT* y, [[maybe_unused]] ScalarT* yp, ScalarT* wb, ScalarT* h)
     {
       ScalarT Vr = wb[0];
@@ -164,8 +160,8 @@ namespace GridKit
      * two terminal buses.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int BusFault<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int BusFault<scalar_type, index_type>::evaluateResidual()
     {
       if (status_)
       {
@@ -178,8 +174,8 @@ namespace GridKit
       return 0;
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* BusFault<ScalarT, IdxT>::getMonitor() const
+    template <typename scalar_type, typename index_type>
+    const Model::VariableMonitorBase* BusFault<scalar_type, index_type>::getMonitor() const
     {
       return monitor_.get();
     }
@@ -188,8 +184,8 @@ namespace GridKit
      * @brief Derived parameters
      *
      */
-    template <class ScalarT, typename IdxT>
-    void BusFault<ScalarT, IdxT>::setDerivedParams()
+    template <typename scalar_type, typename index_type>
+    void BusFault<scalar_type, index_type>::setDerivedParams()
     {
       B_ = -X_ / (X_ * X_ + R_ * R_);
       G_ = R_ / (X_ * X_ + R_ * R_);

--- a/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapter.hpp
+++ b/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapter.hpp
@@ -16,13 +16,13 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct BusToSignalAdapterData;
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class BusBase;
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class SignalNode;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -53,19 +53,21 @@ namespace GridKit
       MAXIMUM,
     };
 
-    template <class ScalarT, typename IdxT>
-    class BusToSignalAdapter : public Component<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class BusToSignalAdapter : public Component<scalar_type, index_type>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::size_;
+      using Component<scalar_type, index_type>::gridkit_component_id_;
+      using Component<scalar_type, index_type>::size_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using model_data_type = BusToSignalAdapterData<RealT, IdxT>;
-      using signal_type     = SignalNode<ScalarT, IdxT>;
-      using bus_type        = BusBase<ScalarT, IdxT>;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Component<ScalarT, IdxT>::RealT;
+      using ModelDataT = BusToSignalAdapterData<RealT, IdxT>;
+      using SignalT    = SignalNode<ScalarT, IdxT>;
+      using BusT       = BusBase<ScalarT, IdxT>;
 
-      BusToSignalAdapter(bus_type* bus);
+      BusToSignalAdapter(BusT* bus);
       ~BusToSignalAdapter();
 
       int setGridKitComponentID(IdxT) override final;
@@ -92,9 +94,9 @@ namespace GridKit
       IdxT vi_index_{INVALID_INDEX<IdxT>};
 
       // Signal pointers
-      signal_type* ir_signal_;
-      signal_type* ii_signal_;
-      bus_type*    bus_;
+      SignalT* ir_signal_;
+      SignalT* ii_signal_;
+      BusT*    bus_;
 
       /// Component signal extension
       ComponentSignals<ScalarT, IdxT, BusToSignalAdapterInternalVariables, BusToSignalAdapterExternalVariables> signals_;

--- a/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapterData.hpp
+++ b/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapterData.hpp
@@ -49,10 +49,10 @@ namespace GridKit
      * @tparam RealT Real number type (e.g., double)
      * @tparam IdxT  Index type (e.g., size_t)
      */
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct BusToSignalAdapterData
-      : public ComponentData<RealT,
-                             IdxT,
+      : public ComponentData<real_type,
+                             index_type,
                              BusToSignalAdapterParameters,
                              BusToSignalAdapterPorts,
                              BusToSignalAdapterMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapterImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapterImpl.hpp
@@ -24,23 +24,23 @@ namespace GridKit
      * @param bus   Signal used for voltage
      * @param data  Data object
      */
-    template <typename ScalarT, typename IdxT>
-    BusToSignalAdapter<ScalarT, IdxT>::BusToSignalAdapter(bus_type* bus)
+    template <typename scalar_type, typename index_type>
+    BusToSignalAdapter<scalar_type, index_type>::BusToSignalAdapter(BusT* bus)
       : bus_(bus)
     {
       size_ = 0;
     }
 
-    template <class ScalarT, typename IdxT>
-    BusToSignalAdapter<ScalarT, IdxT>::~BusToSignalAdapter()
+    template <typename scalar_type, typename index_type>
+    BusToSignalAdapter<scalar_type, index_type>::~BusToSignalAdapter()
     {
     }
 
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int BusToSignalAdapter<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename scalar_type, typename index_type>
+    int BusToSignalAdapter<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -49,8 +49,8 @@ namespace GridKit
     /**
      * @brief Allocate memory for model
      */
-    template <class ScalarT, typename IdxT>
-    int BusToSignalAdapter<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int BusToSignalAdapter<scalar_type, index_type>::allocate()
     {
       static constexpr auto VREAL = BusToSignalAdapterInternalVariables::VREAL;
       static constexpr auto VIMAG = BusToSignalAdapterInternalVariables::VIMAG;
@@ -73,8 +73,8 @@ namespace GridKit
     /**
      * @brief verify method checks that attached signals are also linked
      */
-    template <class ScalarT, typename IdxT>
-    int BusToSignalAdapter<ScalarT, IdxT>::verify() const
+    template <typename scalar_type, typename index_type>
+    int BusToSignalAdapter<scalar_type, index_type>::verify() const
     {
       static constexpr auto IREAL = BusToSignalAdapterExternalVariables::IREAL;
       static constexpr auto IIMAG = BusToSignalAdapterExternalVariables::IIMAG;
@@ -105,8 +105,8 @@ namespace GridKit
     /**
      * @brief Initialize the adapter
      */
-    template <class ScalarT, typename IdxT>
-    int BusToSignalAdapter<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int BusToSignalAdapter<scalar_type, index_type>::initialize()
     {
       return 0;
     }
@@ -114,8 +114,8 @@ namespace GridKit
     /**
      * @brief No variables to differentiate
      */
-    template <class ScalarT, typename IdxT>
-    int BusToSignalAdapter<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int BusToSignalAdapter<scalar_type, index_type>::tagDifferentiable()
     {
       return 0;
     }
@@ -123,8 +123,8 @@ namespace GridKit
     /**
      * @brief Residual evaluation
      */
-    template <class ScalarT, typename IdxT>
-    int BusToSignalAdapter<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int BusToSignalAdapter<scalar_type, index_type>::evaluateResidual()
     {
       static constexpr auto IREAL = BusToSignalAdapterExternalVariables::IREAL;
       static constexpr auto IIMAG = BusToSignalAdapterExternalVariables::IIMAG;
@@ -144,8 +144,8 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation
      */
-    template <class ScalarT, typename IdxT>
-    int BusToSignalAdapter<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int BusToSignalAdapter<scalar_type, index_type>::evaluateJacobian()
     {
       return 0;
     }

--- a/GridKit/Model/PhasorDynamics/ComponentData.hpp
+++ b/GridKit/Model/PhasorDynamics/ComponentData.hpp
@@ -14,11 +14,11 @@ namespace GridKit
     /**
      * @brief Unified interface for `Component` data containers
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      */
-    template <typename RealT,
-              typename IdxT,
+    template <typename real_type,
+              typename index_type,
               typename Parameters,
               typename Ports,
               typename MonitorableVariables>
@@ -27,6 +27,11 @@ namespace GridKit
                && std::is_enum_v<MonitorableVariables>
     struct ComponentData
     {
+      /// Real value type
+      using RealT = real_type;
+      /// Index type
+      using IdxT  = index_type;
+
       /// Class of device this is for
       std::string device_class;
 

--- a/GridKit/Model/PhasorDynamics/ComponentSignals.hpp
+++ b/GridKit/Model/PhasorDynamics/ComponentSignals.hpp
@@ -31,8 +31,8 @@ namespace GridKit
     /// This is used by adding an instance in a field to your class and
     /// exposing this field to others
     ///
-    /// @tparam ScalarT Scalar value type
-    /// @tparam IdxT Index type
+    /// @tparam scalar_type Scalar value type
+    /// @tparam index_type Index type
     /// @tparam InternalVariables An enumeration satisfying
     ///         `EnumHasMaximumValueAndIsSizeT` enumerating internal variables
     ///         for the component
@@ -43,12 +43,17 @@ namespace GridKit
     ///            integer value of the enum
     /// @invariant ExternalVariables::MAXIMUM is the greatest attainable
     ///            integer value of the enum
-    template <class ScalarT, typename IdxT, typename InternalVariables, typename ExternalVariables>
+    template <typename scalar_type, typename index_type, typename InternalVariables, typename ExternalVariables>
       requires EnumHasMaximumValueAndIsSizeT<InternalVariables>
                && EnumHasMaximumValueAndIsSizeT<ExternalVariables>
     class ComponentSignals
     {
     public:
+      /// Scalar value type
+      using ScalarT = scalar_type;
+      /// Index type
+      using IdxT    = index_type;
+
       /// Attaches a signal node to an external variable on this component
       ///
       /// @tparam variable The external variable to attach the provided

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.cpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.cpp
@@ -18,12 +18,10 @@ namespace GridKit
       /**
        * @brief Jacobian evaluation not implemented yet
        *
-       * @tparam ScalarT - Scalar data type
-       * @tparam IdxT    - Index data type
        * @return int - error code, 0 = success
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int Ieeet1<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for Ieeet1..." << std::endl;
         Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -20,14 +20,14 @@ namespace GridKit
   {
     namespace Exciter
     {
-      template <typename RealT, typename IdxT>
+      template <typename real_type, typename index_type>
       struct Ieeet1Data;
     } // namespace Exciter
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class BusBase;
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class SignalNode;
 
   } // namespace PhasorDynamics
@@ -64,40 +64,42 @@ namespace GridKit
         MAXIMUM,
       };
 
-      template <class ScalarT, typename IdxT>
-      class Ieeet1 : public Component<ScalarT, IdxT>
+      template <typename scalar_type, typename index_type>
+      class Ieeet1 : public Component<scalar_type, index_type>
       {
-        using Component<ScalarT, IdxT>::gridkit_component_id_;
-        using Component<ScalarT, IdxT>::alpha_;
-        using Component<ScalarT, IdxT>::f_;
-        using Component<ScalarT, IdxT>::nnz_;
-        using Component<ScalarT, IdxT>::size_;
-        using Component<ScalarT, IdxT>::tag_;
-        using Component<ScalarT, IdxT>::time_;
-        using Component<ScalarT, IdxT>::y_;
-        using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::wb_;
-        using Component<ScalarT, IdxT>::J_;
-        using Component<ScalarT, IdxT>::J_rows_buffer_;
-        using Component<ScalarT, IdxT>::J_cols_buffer_;
-        using Component<ScalarT, IdxT>::J_vals_buffer_;
-        using Component<ScalarT, IdxT>::variable_indices_;
-        using Component<ScalarT, IdxT>::residual_indices_;
+        using Component<scalar_type, index_type>::gridkit_component_id_;
+        using Component<scalar_type, index_type>::alpha_;
+        using Component<scalar_type, index_type>::f_;
+        using Component<scalar_type, index_type>::nnz_;
+        using Component<scalar_type, index_type>::size_;
+        using Component<scalar_type, index_type>::tag_;
+        using Component<scalar_type, index_type>::time_;
+        using Component<scalar_type, index_type>::y_;
+        using Component<scalar_type, index_type>::yp_;
+        using Component<scalar_type, index_type>::wb_;
+        using Component<scalar_type, index_type>::J_;
+        using Component<scalar_type, index_type>::J_rows_buffer_;
+        using Component<scalar_type, index_type>::J_cols_buffer_;
+        using Component<scalar_type, index_type>::J_vals_buffer_;
+        using Component<scalar_type, index_type>::variable_indices_;
+        using Component<scalar_type, index_type>::residual_indices_;
 
       public:
-        using RealT           = typename Component<ScalarT, IdxT>::RealT;
-        using model_data_type = Ieeet1Data<RealT, IdxT>;
-        using signal_type     = SignalNode<ScalarT, IdxT>;
-        using bus_type        = BusBase<ScalarT, IdxT>;
-        using MonitorT        = Model::VariableMonitor<Ieeet1, Ieeet1Data>;
+        using ScalarT    = scalar_type;
+        using IdxT       = index_type;
+        using RealT      = typename Component<ScalarT, IdxT>::RealT;
+        using BusT       = BusBase<ScalarT, IdxT>;
+        using ModelDataT = Ieeet1Data<RealT, IdxT>;
+        using SignalT    = SignalNode<ScalarT, IdxT>;
+        using MonitorT   = Model::VariableMonitor<Ieeet1, Ieeet1Data>;
 
-        Ieeet1(bus_type* bus);
-        Ieeet1(signal_type*           efd_signal,
-               signal_type*           speed_signal,
-               bus_type*              bus,
-               const model_data_type& data);
-        Ieeet1(bus_type*              bus,
-               const model_data_type& data);
+        Ieeet1(BusT* bus);
+        Ieeet1(SignalT*          efd_signal,
+               SignalT*          speed_signal,
+               BusT*             bus,
+               const ModelDataT& data);
+        Ieeet1(BusT*             bus,
+               const ModelDataT& data);
         ~Ieeet1();
 
         int setGridKitComponentID(IdxT) override final;
@@ -124,9 +126,9 @@ namespace GridKit
 
       private:
         // Signal pointers
-        signal_type* efd_signal_;
-        signal_type* speed_signal_;
-        bus_type*    bus_;
+        SignalT* efd_signal_;
+        SignalT* speed_signal_;
+        BusT*    bus_;
 
         // Model Input parameters
         RealT Tr_;      ///< Time constant for voltage sensing
@@ -164,7 +166,7 @@ namespace GridKit
         std::unique_ptr<MonitorT> monitor_;
 
         // Parameter initialization function
-        void initModelParams(const model_data_type& data);
+        void initModelParams(const ModelDataT& data);
 
         /// Associate variable getter functions with enum values
         void initializeMonitor();

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
@@ -53,14 +53,14 @@ namespace GridKit
       /**
        * @brief Contains modeling data for a IEEET1 Exciter model.
        *
-       * @tparam RealT Real parameter data type
-       * @tparam IdxT  Integer parameter data type
+       * @tparam real_type  Real parameter data type
+       * @tparam index_type Integer parameter data type
        *
        * Integer parameters are of the same type as matrix and vector indices.
        */
-      template <typename RealT, typename IdxT>
-      struct Ieeet1Data : public ComponentData<RealT,
-                                               IdxT,
+      template <typename real_type, typename index_type>
+      struct Ieeet1Data : public ComponentData<real_type,
+                                               index_type,
                                                Ieeet1Parameters,
                                                Ieeet1Ports,
                                                Ieeet1MonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1DependencyTracking.cpp
@@ -18,12 +18,10 @@ namespace GridKit
       /**
        * @brief Jacobian evaluation not implemented yet
        *
-       * @tparam ScalarT - Scalar data type
-       * @tparam IdxT    - Index data type
        * @return int - error code, 0 = success
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int Ieeet1<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for Ieeet1..." << std::endl;
         Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Enzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Enzyme.cpp
@@ -17,12 +17,10 @@ namespace GridKit
       /**
        * @brief Jacobian evaluation not implemented yet
        *
-       * @tparam ScalarT - Scalar data type
-       * @tparam IdxT    - Index data type
        * @return int - error code, 0 = success
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::evaluateJacobian()
+      template <class scalar_type, typename index_type>
+      int Ieeet1<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for Ieeet1..." << std::endl;
         Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -29,12 +29,9 @@ namespace GridKit
 
       /**
        * @brief  Constructor for IEEET1 Exciter
-       *
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
        */
-      template <class ScalarT, typename IdxT>
-      Ieeet1<ScalarT, IdxT>::Ieeet1(bus_type* bus)
+      template <typename scalar_type, typename index_type>
+      Ieeet1<scalar_type, index_type>::Ieeet1(BusT* bus)
         : bus_(bus)
       {
         size_ = 9;
@@ -47,14 +44,12 @@ namespace GridKit
        * @param bus   Signal used for terminal reference vmag
        * @param speed Signal used for machine relative speed
        * @param efd   Signal used for E field
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
        */
-      template <class ScalarT, typename IdxT>
-      Ieeet1<ScalarT, IdxT>::Ieeet1(signal_type*           efd_signal,
-                                    signal_type*           speed_signal,
-                                    bus_type*              bus,
-                                    const model_data_type& data)
+      template <typename scalar_type, typename index_type>
+      Ieeet1<scalar_type, index_type>::Ieeet1(SignalT*          efd_signal,
+                                              SignalT*          speed_signal,
+                                              BusT*             bus,
+                                              const ModelDataT& data)
         : efd_signal_(efd_signal),
           speed_signal_(speed_signal),
           bus_(bus),
@@ -75,12 +70,10 @@ namespace GridKit
        *
        * @param bus   Signal used for terminal reference vmag
        * @param data  Data object to store parameters
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
        */
-      template <class ScalarT, typename IdxT>
-      Ieeet1<ScalarT, IdxT>::Ieeet1(bus_type*              bus,
-                                    const model_data_type& data)
+      template <typename scalar_type, typename index_type>
+      Ieeet1<scalar_type, index_type>::Ieeet1(BusT*             bus,
+                                              const ModelDataT& data)
         : bus_(bus),
           monitor_(std::make_unique<MonitorT>(data))
       {
@@ -94,16 +87,16 @@ namespace GridKit
         size_ = 9;
       }
 
-      template <class ScalarT, typename IdxT>
-      Ieeet1<ScalarT, IdxT>::~Ieeet1()
+      template <typename scalar_type, typename index_type>
+      Ieeet1<scalar_type, index_type>::~Ieeet1()
       {
       }
 
       /**
        * @brief Set the component ID
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      template <typename scalar_type, typename index_type>
+      int Ieeet1<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
       {
         gridkit_component_id_ = component_id;
         return 0;
@@ -113,8 +106,8 @@ namespace GridKit
        * @brief Allocate memory for model
        *
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::allocate()
+      template <typename scalar_type, typename index_type>
+      int Ieeet1<scalar_type, index_type>::allocate()
       {
         // Resize component model data
         auto size = static_cast<size_t>(size_); // avoid compiler warnings
@@ -155,8 +148,8 @@ namespace GridKit
       /**
        * @brief verify method checks that attached signals are also linked
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::verify() const
+      template <typename scalar_type, typename index_type>
+      int Ieeet1<scalar_type, index_type>::verify() const
       {
         static constexpr auto OMEGA = Ieeet1ExternalVariables::OMEGA;
         static constexpr auto VS    = Ieeet1ExternalVariables::VS;
@@ -197,8 +190,8 @@ namespace GridKit
        *
        * Saturation is included via ksat computed from efdp and SA, SB.
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::initialize()
+      template <typename scalar_type, typename index_type>
+      int Ieeet1<scalar_type, index_type>::initialize()
       {
 
         // External Variables
@@ -262,12 +255,10 @@ namespace GridKit
       /**
        * @brief  Identify differential variables.
        *
-       * @tparam ScalarT Scalar data type
-       * @tparam IdxT Index data type
        * @return int 0
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::tagDifferentiable()
+      template <typename scalar_type, typename index_type>
+      int Ieeet1<scalar_type, index_type>::tagDifferentiable()
       {
 
         tag_[0] = true;  // y0 - vts  - Sensed term volt
@@ -287,8 +278,8 @@ namespace GridKit
        * @brief Internal Residual
        *
        */
-      template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int Ieeet1<ScalarT, IdxT>::evaluateInternalResidual(
+      template <typename scalar_type, typename index_type>
+      __attribute__((always_inline)) inline int Ieeet1<scalar_type, index_type>::evaluateInternalResidual(
           ScalarT* y,
           ScalarT* yp,
           ScalarT* wb,
@@ -347,8 +338,8 @@ namespace GridKit
        * @brief Residual evaluation
        *
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeet1<ScalarT, IdxT>::evaluateResidual()
+      template <typename scalar_type, typename index_type>
+      int Ieeet1<scalar_type, index_type>::evaluateResidual()
       {
         // Set Input Variables
         // Meta PR Note: This seems to be very slow,
@@ -387,65 +378,65 @@ namespace GridKit
       /**
        * @brief Initialization Exciter Parameters from data structure
        */
-      template <class ScalarT, typename IdxT>
-      void Ieeet1<ScalarT, IdxT>::initModelParams(const model_data_type& data)
+      template <typename scalar_type, typename index_type>
+      void Ieeet1<scalar_type, index_type>::initModelParams(const ModelDataT& data)
       {
 
-        if (data.parameters.contains(model_data_type::Parameters::Tr))
+        if (data.parameters.contains(ModelDataT::Parameters::Tr))
         {
-          Tr_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tr));
+          Tr_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tr));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ka))
+        if (data.parameters.contains(ModelDataT::Parameters::Ka))
         {
-          Ka_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ka));
+          Ka_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ka));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ta))
+        if (data.parameters.contains(ModelDataT::Parameters::Ta))
         {
-          Ta_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ta));
+          Ta_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ta));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ke))
+        if (data.parameters.contains(ModelDataT::Parameters::Ke))
         {
-          Ke_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ke));
+          Ke_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ke));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Te))
+        if (data.parameters.contains(ModelDataT::Parameters::Te))
         {
-          Te_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Te));
+          Te_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Te));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Kf))
+        if (data.parameters.contains(ModelDataT::Parameters::Kf))
         {
-          Kf_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Kf));
+          Kf_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Kf));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Tf))
+        if (data.parameters.contains(ModelDataT::Parameters::Tf))
         {
-          Tf_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tf));
+          Tf_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tf));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Vrmin))
+        if (data.parameters.contains(ModelDataT::Parameters::Vrmin))
         {
-          Vrmin_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Vrmin));
+          Vrmin_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vrmin));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Vrmax))
+        if (data.parameters.contains(ModelDataT::Parameters::Vrmax))
         {
-          Vrmax_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Vrmax));
+          Vrmax_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vrmax));
         }
-        if (data.parameters.contains(model_data_type::Parameters::E1))
+        if (data.parameters.contains(ModelDataT::Parameters::E1))
         {
-          E1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::E1));
+          E1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::E1));
         }
-        if (data.parameters.contains(model_data_type::Parameters::E2))
+        if (data.parameters.contains(ModelDataT::Parameters::E2))
         {
-          E2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::E2));
+          E2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::E2));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Se1))
+        if (data.parameters.contains(ModelDataT::Parameters::Se1))
         {
-          Se1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Se1));
+          Se1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Se1));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Se2))
+        if (data.parameters.contains(ModelDataT::Parameters::Se2))
         {
-          Se2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Se2));
+          Se2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Se2));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ispdlim))
+        if (data.parameters.contains(ModelDataT::Parameters::Ispdlim))
         {
-          Ispdlim_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ispdlim));
+          Ispdlim_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ispdlim));
         }
 
         // Derived Parameters
@@ -456,16 +447,16 @@ namespace GridKit
         SB_ = Se1_ / (E1_ - SA_) / (E1_ - SA_);
       }
 
-      template <class ScalarT, typename IdxT>
-      const Model::VariableMonitorBase* Ieeet1<ScalarT, IdxT>::getMonitor() const
+      template <typename scalar_type, typename index_type>
+      const Model::VariableMonitorBase* Ieeet1<scalar_type, index_type>::getMonitor() const
       {
         return monitor_.get();
       }
 
-      template <class ScalarT, typename IdxT>
-      void Ieeet1<ScalarT, IdxT>::initializeMonitor()
+      template <typename scalar_type, typename index_type>
+      void Ieeet1<scalar_type, index_type>::initializeMonitor()
       {
-        using Variable = model_data_type::MonitorableVariables;
+        using Variable = ModelDataT::MonitorableVariables;
         monitor_->set(Variable::efd, [this]
                       { return efd_signal_->read(); });
         monitor_->set(Variable::ksat, [this]

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPti.cpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPti.cpp
@@ -12,8 +12,8 @@ namespace GridKit
   {
     namespace Exciter
     {
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int SexsPti<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for SexsPti..." << std::endl;
         Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPti.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPti.hpp
@@ -16,14 +16,14 @@ namespace GridKit
   {
     namespace Exciter
     {
-      template <typename RealT, typename IdxT>
+      template <typename real_type, typename index_type>
       struct SexsPtiData;
     } // namespace Exciter
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class BusBase;
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class SignalNode;
 
   } // namespace PhasorDynamics
@@ -51,35 +51,37 @@ namespace GridKit
         MAXIMUM,
       };
 
-      template <class ScalarT, typename IdxT>
-      class SexsPti : public Component<ScalarT, IdxT>
+      template <typename scalar_type, typename index_type>
+      class SexsPti : public Component<scalar_type, index_type>
       {
-        using Component<ScalarT, IdxT>::gridkit_component_id_;
-        using Component<ScalarT, IdxT>::alpha_;
-        using Component<ScalarT, IdxT>::f_;
-        using Component<ScalarT, IdxT>::nnz_;
-        using Component<ScalarT, IdxT>::size_;
-        using Component<ScalarT, IdxT>::tag_;
-        using Component<ScalarT, IdxT>::time_;
-        using Component<ScalarT, IdxT>::y_;
-        using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::wb_;
-        using Component<ScalarT, IdxT>::J_;
-        using Component<ScalarT, IdxT>::J_rows_buffer_;
-        using Component<ScalarT, IdxT>::J_cols_buffer_;
-        using Component<ScalarT, IdxT>::J_vals_buffer_;
-        using Component<ScalarT, IdxT>::variable_indices_;
-        using Component<ScalarT, IdxT>::residual_indices_;
+        using Component<scalar_type, index_type>::gridkit_component_id_;
+        using Component<scalar_type, index_type>::alpha_;
+        using Component<scalar_type, index_type>::f_;
+        using Component<scalar_type, index_type>::nnz_;
+        using Component<scalar_type, index_type>::size_;
+        using Component<scalar_type, index_type>::tag_;
+        using Component<scalar_type, index_type>::time_;
+        using Component<scalar_type, index_type>::y_;
+        using Component<scalar_type, index_type>::yp_;
+        using Component<scalar_type, index_type>::wb_;
+        using Component<scalar_type, index_type>::J_;
+        using Component<scalar_type, index_type>::J_rows_buffer_;
+        using Component<scalar_type, index_type>::J_cols_buffer_;
+        using Component<scalar_type, index_type>::J_vals_buffer_;
+        using Component<scalar_type, index_type>::variable_indices_;
+        using Component<scalar_type, index_type>::residual_indices_;
 
       public:
-        using RealT           = typename Component<ScalarT, IdxT>::RealT;
-        using model_data_type = SexsPtiData<RealT, IdxT>;
-        using signal_type     = SignalNode<ScalarT, IdxT>;
-        using bus_type        = BusBase<ScalarT, IdxT>;
-        using MonitorT        = Model::VariableMonitor<SexsPti, SexsPtiData>;
+        using ScalarT    = scalar_type;
+        using IdxT       = index_type;
+        using RealT      = typename Component<ScalarT, IdxT>::RealT;
+        using BusT       = BusBase<ScalarT, IdxT>;
+        using ModelDataT = SexsPtiData<RealT, IdxT>;
+        using SignalT    = SignalNode<ScalarT, IdxT>;
+        using MonitorT   = Model::VariableMonitor<SexsPti, SexsPtiData>;
 
-        SexsPti(bus_type* bus);
-        SexsPti(bus_type* bus, const model_data_type& data);
+        SexsPti(BusT* bus);
+        SexsPti(BusT* bus, const ModelDataT& data);
         ~SexsPti();
 
         int setGridKitComponentID(IdxT) override final;
@@ -105,7 +107,7 @@ namespace GridKit
             ScalarT*, ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
       private:
-        bus_type* bus_{nullptr};
+        BusT* bus_{nullptr};
 
         RealT Ta_{0};
         RealT Tb_{0};
@@ -124,7 +126,7 @@ namespace GridKit
 
         std::unique_ptr<MonitorT> monitor_;
 
-        void initModelParams(const model_data_type& data);
+        void initModelParams(const ModelDataT& data);
         void initializeMonitor();
 
         std::vector<ScalarT> ws_;

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiData.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiData.hpp
@@ -39,9 +39,9 @@ namespace GridKit
         efd ///< Field voltage output
       };
 
-      template <typename RealT, typename IdxT>
-      struct SexsPtiData : public ComponentData<RealT,
-                                                IdxT,
+      template <typename real_type, typename index_type>
+      struct SexsPtiData : public ComponentData<real_type,
+                                                index_type,
                                                 SexsPtiParameters,
                                                 SexsPtiPorts,
                                                 SexsPtiMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiDependencyTracking.cpp
@@ -12,8 +12,8 @@ namespace GridKit
   {
     namespace Exciter
     {
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int SexsPti<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for SexsPti..." << std::endl;
         Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiEnzyme.cpp
@@ -14,8 +14,8 @@ namespace GridKit
   {
     namespace Exciter
     {
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int SexsPti<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for SexsPti..." << std::endl;
         Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiImpl.hpp
@@ -24,16 +24,16 @@ namespace GridKit
     {
       using Log = ::GridKit::Utilities::Logger;
 
-      template <class ScalarT, typename IdxT>
-      SexsPti<ScalarT, IdxT>::SexsPti(bus_type* bus)
+      template <typename scalar_type, typename index_type>
+      SexsPti<scalar_type, index_type>::SexsPti(BusT* bus)
         : bus_(bus)
       {
         size_ = 3;
       }
 
-      template <class ScalarT, typename IdxT>
-      SexsPti<ScalarT, IdxT>::SexsPti(bus_type*              bus,
-                                      const model_data_type& data)
+      template <typename scalar_type, typename index_type>
+      SexsPti<scalar_type, index_type>::SexsPti(BusT*             bus,
+                                                const ModelDataT& data)
         : bus_(bus),
           monitor_(std::make_unique<MonitorT>(data))
       {
@@ -42,20 +42,20 @@ namespace GridKit
         size_ = 3;
       }
 
-      template <class ScalarT, typename IdxT>
-      SexsPti<ScalarT, IdxT>::~SexsPti()
+      template <typename scalar_type, typename index_type>
+      SexsPti<scalar_type, index_type>::~SexsPti()
       {
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      template <typename scalar_type, typename index_type>
+      int SexsPti<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
       {
         gridkit_component_id_ = component_id;
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::allocate()
+      template <typename scalar_type, typename index_type>
+      int SexsPti<scalar_type, index_type>::allocate()
       {
         auto size = static_cast<size_t>(size_);
         f_.resize(size);
@@ -87,8 +87,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::verify() const
+      template <typename scalar_type, typename index_type>
+      int SexsPti<scalar_type, index_type>::verify() const
       {
         int ret = missing_param_count_;
 
@@ -141,8 +141,8 @@ namespace GridKit
         return ret;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::initialize()
+      template <typename scalar_type, typename index_type>
+      int SexsPti<scalar_type, index_type>::initialize()
       {
         ScalarT efd0{0.0};
         if (signals_.template isAssigned<SexsPtiInternalVariables::EFD>())
@@ -170,8 +170,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::tagDifferentiable()
+      template <typename scalar_type, typename index_type>
+      int SexsPti<scalar_type, index_type>::tagDifferentiable()
       {
         tag_[0] = true;
         tag_[1] = true;
@@ -180,8 +180,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int SexsPti<ScalarT, IdxT>::evaluateInternalResidual(
+      template <typename scalar_type, typename index_type>
+      __attribute__((always_inline)) inline int SexsPti<scalar_type, index_type>::evaluateInternalResidual(
           ScalarT* y,
           ScalarT* yp,
           ScalarT* wb,
@@ -208,8 +208,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int SexsPti<ScalarT, IdxT>::evaluateResidual()
+      template <typename scalar_type, typename index_type>
+      int SexsPti<scalar_type, index_type>::evaluateResidual()
       {
         ws_[0]         = 0.0;
         ws_indices_[0] = INVALID_INDEX<IdxT>;
@@ -227,10 +227,10 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      void SexsPti<ScalarT, IdxT>::initModelParams(const model_data_type& data)
+      template <typename scalar_type, typename index_type>
+      void SexsPti<scalar_type, index_type>::initModelParams(const ModelDataT& data)
       {
-        using Params = typename model_data_type::Parameters;
+        using Params = typename ModelDataT::Parameters;
 
         missing_param_count_ = 0;
 
@@ -255,16 +255,16 @@ namespace GridKit
         load(Params::Efdmin, Efdmin_, "Efdmin");
       }
 
-      template <class ScalarT, typename IdxT>
-      const Model::VariableMonitorBase* SexsPti<ScalarT, IdxT>::getMonitor() const
+      template <typename scalar_type, typename index_type>
+      const Model::VariableMonitorBase* SexsPti<scalar_type, index_type>::getMonitor() const
       {
         return monitor_.get();
       }
 
-      template <class ScalarT, typename IdxT>
-      void SexsPti<ScalarT, IdxT>::initializeMonitor()
+      template <typename scalar_type, typename index_type>
+      void SexsPti<scalar_type, index_type>::initializeMonitor()
       {
-        using Variable = typename model_data_type::MonitorableVariables;
+        using Variable = typename ModelDataT::MonitorableVariables;
         monitor_->set(Variable::efd, [this]
                       { return y_[1]; });
       }

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.cpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.cpp
@@ -14,12 +14,10 @@ namespace GridKit
       /**
        * @brief Jacobian evaluation not implemented yet
        *
-       * @tparam ScalarT - Scalar data type
-       * @tparam IdxT    - Index data type
        * @return int - error code, 0 = success
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int Tgov1<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for Tgov1..." << std::endl;
         Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -19,14 +19,14 @@ namespace GridKit
   {
     namespace Governor
     {
-      template <typename RealT, typename IdxT>
+      template <typename real_type, typename index_type>
       struct Tgov1Data;
     } // namespace Governor
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class Genrou;
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class SignalNode;
 
   } // namespace PhasorDynamics
@@ -55,35 +55,37 @@ namespace GridKit
         MAXIMUM,
       };
 
-      template <class ScalarT, typename IdxT>
-      class Tgov1 : public Component<ScalarT, IdxT>
+      template <typename scalar_type, typename index_type>
+      class Tgov1 : public Component<scalar_type, index_type>
       {
-        using Component<ScalarT, IdxT>::gridkit_component_id_;
-        using Component<ScalarT, IdxT>::alpha_;
-        using Component<ScalarT, IdxT>::f_;
-        using Component<ScalarT, IdxT>::nnz_;
-        using Component<ScalarT, IdxT>::size_;
-        using Component<ScalarT, IdxT>::tag_;
-        using Component<ScalarT, IdxT>::time_;
-        using Component<ScalarT, IdxT>::y_;
-        using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::wb_;
-        using Component<ScalarT, IdxT>::h_;
-        using Component<ScalarT, IdxT>::J_;
-        using Component<ScalarT, IdxT>::J_rows_buffer_;
-        using Component<ScalarT, IdxT>::J_cols_buffer_;
-        using Component<ScalarT, IdxT>::J_vals_buffer_;
-        using Component<ScalarT, IdxT>::variable_indices_;
-        using Component<ScalarT, IdxT>::residual_indices_;
-
-        using RealT           = typename Component<ScalarT, IdxT>::RealT;
-        using model_data_type = Tgov1Data<RealT, IdxT>;
-        using signal_type     = SignalNode<ScalarT, IdxT>;
+        using Component<scalar_type, index_type>::gridkit_component_id_;
+        using Component<scalar_type, index_type>::alpha_;
+        using Component<scalar_type, index_type>::f_;
+        using Component<scalar_type, index_type>::nnz_;
+        using Component<scalar_type, index_type>::size_;
+        using Component<scalar_type, index_type>::tag_;
+        using Component<scalar_type, index_type>::time_;
+        using Component<scalar_type, index_type>::y_;
+        using Component<scalar_type, index_type>::yp_;
+        using Component<scalar_type, index_type>::wb_;
+        using Component<scalar_type, index_type>::h_;
+        using Component<scalar_type, index_type>::J_;
+        using Component<scalar_type, index_type>::J_rows_buffer_;
+        using Component<scalar_type, index_type>::J_cols_buffer_;
+        using Component<scalar_type, index_type>::J_vals_buffer_;
+        using Component<scalar_type, index_type>::variable_indices_;
+        using Component<scalar_type, index_type>::residual_indices_;
 
       public:
+        using ScalarT    = scalar_type;
+        using IdxT       = index_type;
+        using RealT      = typename Component<ScalarT, IdxT>::RealT;
+        using ModelDataT = Tgov1Data<RealT, IdxT>;
+        using SignalT    = SignalNode<ScalarT, IdxT>;
+
         Tgov1();
-        Tgov1(signal_type*, signal_type*);
-        Tgov1(const model_data_type&);
+        Tgov1(SignalT*, SignalT*);
+        Tgov1(const ModelDataT&);
         ~Tgov1() = default;
 
         int setGridKitComponentID(IdxT) override final;
@@ -126,7 +128,7 @@ namespace GridKit
         ComponentSignals<ScalarT, IdxT, Tgov1InternalVariables, Tgov1ExternalVariables> signals_;
 
         // Parameter initialization function
-        void initializeParameters(const model_data_type& data);
+        void initializeParameters(const ModelDataT& data);
 
         /* Local copies of signal variables */
         std::vector<ScalarT> ws_;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
@@ -52,11 +52,15 @@ namespace GridKit
       /**
        * @brief Modeling data for TGOV1 Governor using ComponentData base.
        *
-       * @tparam RealT Real number type (e.g., double)
-       * @tparam IdxT  Index type (e.g., size_t)
+       * @tparam real_type  Real number type (e.g., double)
+       * @tparam index_type Index type (e.g., size_t)
        */
-      template <typename RealT, typename IdxT>
-      struct Tgov1Data : public ComponentData<RealT, IdxT, Tgov1Parameters, Tgov1Ports, Tgov1MonitorableVariables>
+      template <typename real_type, typename index_type>
+      struct Tgov1Data : public ComponentData<real_type,
+                                              index_type,
+                                              Tgov1Parameters,
+                                              Tgov1Ports,
+                                              Tgov1MonitorableVariables>
       {
         Tgov1Data() = default;
 

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1DependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1DependencyTracking.cpp
@@ -14,12 +14,10 @@ namespace GridKit
       /**
        * @brief Jacobian evaluation not implemented yet
        *
-       * @tparam ScalarT - Scalar data type
-       * @tparam IdxT    - Index data type
        * @return int - error code, 0 = success
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int Tgov1<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for Tgov1..." << std::endl;
         Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Enzyme.cpp
@@ -17,12 +17,10 @@ namespace GridKit
       /**
        * @brief Jacobian evaluation experimental
        *
-       * @tparam ScalarT - Scalar data type
-       * @tparam IdxT    - Index data type
        * @return int - error code, 0 = success
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int Tgov1<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for Tgov1..." << std::endl;
         Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -30,8 +30,8 @@ namespace GridKit
        * @brief Constructs a Tgov1 governor model without setting its parameters
        *
        */
-      template <class ScalarT, typename IdxT>
-      Tgov1<ScalarT, IdxT>::Tgov1()
+      template <typename scalar_type, typename index_type>
+      Tgov1<scalar_type, index_type>::Tgov1()
       {
         size_ = 3;
       }
@@ -42,8 +42,8 @@ namespace GridKit
        * @param pmech $P_m$ internal variable signal node
        * @param omega $\Delta_\omega$ external variable signal node
        */
-      template <class ScalarT, typename IdxT>
-      Tgov1<ScalarT, IdxT>::Tgov1(signal_type* pmech, signal_type* omega)
+      template <typename scalar_type, typename index_type>
+      Tgov1<scalar_type, index_type>::Tgov1(SignalT* pmech, SignalT* omega)
         : R_(0.05),
           Pvmin_(0),
           Pvmax_(1),
@@ -64,8 +64,8 @@ namespace GridKit
        *
        * @param data Data to initialize the model from.
        */
-      template <class ScalarT, typename IdxT>
-      Tgov1<ScalarT, IdxT>::Tgov1(const model_data_type& data)
+      template <typename scalar_type, typename index_type>
+      Tgov1<scalar_type, index_type>::Tgov1(const ModelDataT& data)
       {
         initializeParameters(data);
         size_ = 3;
@@ -74,55 +74,55 @@ namespace GridKit
       /**
        * @brief Helper function to extract and assign model parameters.
        *
-       * Parses values from the model_data_type and assigns them to internal
+       * Parses values from the ModelDataT and assigns them to internal
        * parameters.
        *
        * @param data Structure containing model parameters.
        */
-      template <class ScalarT, typename IdxT>
-      void Tgov1<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
+      template <typename scalar_type, typename index_type>
+      void Tgov1<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
       {
-        if (data.parameters.contains(model_data_type::Parameters::R))
+        if (data.parameters.contains(ModelDataT::Parameters::R))
         {
-          R_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::R));
+          R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::Pvmin))
+        if (data.parameters.contains(ModelDataT::Parameters::Pvmin))
         {
-          Pvmin_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Pvmin));
+          Pvmin_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Pvmin));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::Pvmax))
+        if (data.parameters.contains(ModelDataT::Parameters::Pvmax))
         {
-          Pvmax_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Pvmax));
+          Pvmax_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Pvmax));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::T1))
+        if (data.parameters.contains(ModelDataT::Parameters::T1))
         {
-          T1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T1));
+          T1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T1));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::T2))
+        if (data.parameters.contains(ModelDataT::Parameters::T2))
         {
-          T2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T2));
+          T2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T2));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::T3))
+        if (data.parameters.contains(ModelDataT::Parameters::T3))
         {
-          T3_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T3));
+          T3_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T3));
         }
 
-        if (data.parameters.contains(model_data_type::Parameters::Dt))
+        if (data.parameters.contains(ModelDataT::Parameters::Dt))
         {
-          Dt_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Dt));
+          Dt_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Dt));
         }
       }
 
       /**
        * @brief Set the component ID
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      template <typename scalar_type, typename index_type>
+      int Tgov1<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
       {
         gridkit_component_id_ = component_id;
         return 0;
@@ -131,8 +131,8 @@ namespace GridKit
       /*!
        * @brief Allocate memory for model
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::allocate()
+      template <typename scalar_type, typename index_type>
+      int Tgov1<scalar_type, index_type>::allocate()
       {
         // Allocate local component data
         auto size = static_cast<size_t>(size_); // avoid compiler warnings
@@ -168,8 +168,8 @@ namespace GridKit
       /**
        * @brief verify method checks that attached signals are also linked
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::verify() const
+      template <typename scalar_type, typename index_type>
+      int Tgov1<scalar_type, index_type>::verify() const
       {
         static constexpr auto DELTAOMEGA = Tgov1ExternalVariables::DELTAOMEGA;
 
@@ -191,8 +191,8 @@ namespace GridKit
        * @brief Initialization of the Governor
        *
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::initialize()
+      template <typename scalar_type, typename index_type>
+      int Tgov1<scalar_type, index_type>::initialize()
       {
         ScalarT p0{0};
 
@@ -221,8 +221,8 @@ namespace GridKit
       /**
        * @brief Identify differential variables.
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::tagDifferentiable()
+      template <typename scalar_type, typename index_type>
+      int Tgov1<scalar_type, index_type>::tagDifferentiable()
       {
 
         tag_[0] = true;  // Pv
@@ -236,8 +236,8 @@ namespace GridKit
        * @brief Internal residuals
        *
        */
-      template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int Tgov1<ScalarT, IdxT>::evaluateInternalResidual(
+      template <typename scalar_type, typename index_type>
+      __attribute__((always_inline)) inline int Tgov1<scalar_type, index_type>::evaluateInternalResidual(
           ScalarT*                  y,
           ScalarT*                  yp,
           [[maybe_unused]] ScalarT* wb,
@@ -273,8 +273,8 @@ namespace GridKit
        * @brief Residuals of system equations
        *
        */
-      template <class ScalarT, typename IdxT>
-      int Tgov1<ScalarT, IdxT>::evaluateResidual()
+      template <typename scalar_type, typename index_type>
+      int Tgov1<scalar_type, index_type>::evaluateResidual()
       {
         // Input Variables
         if (signals_.template isAttached<Tgov1ExternalVariables::DELTAOMEGA>())

--- a/GridKit/Model/PhasorDynamics/Load/Load.cpp
+++ b/GridKit/Model/PhasorDynamics/Load/Load.cpp
@@ -8,12 +8,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Load<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Load..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Load/Load.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/Load.hpp
@@ -10,10 +10,10 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class BusBase;
 
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct LoadData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -26,36 +26,38 @@ namespace GridKit
      * @brief Implementation of a constant load.
      *
      */
-    template <class ScalarT, typename IdxT>
-    class Load : public Component<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class Load : public Component<scalar_type, index_type>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using Component<scalar_type, index_type>::gridkit_component_id_;
+      using Component<scalar_type, index_type>::size_;
+      using Component<scalar_type, index_type>::nnz_;
+      using Component<scalar_type, index_type>::time_;
+      using Component<scalar_type, index_type>::alpha_;
+      using Component<scalar_type, index_type>::y_;
+      using Component<scalar_type, index_type>::yp_;
+      using Component<scalar_type, index_type>::tag_;
+      using Component<scalar_type, index_type>::wb_;
+      using Component<scalar_type, index_type>::h_;
+      using Component<scalar_type, index_type>::f_;
+      using Component<scalar_type, index_type>::J_;
+      using Component<scalar_type, index_type>::J_rows_buffer_;
+      using Component<scalar_type, index_type>::J_cols_buffer_;
+      using Component<scalar_type, index_type>::J_vals_buffer_;
+      using Component<scalar_type, index_type>::variable_indices_;
+      using Component<scalar_type, index_type>::residual_indices_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using bus_type        = BusBase<ScalarT, IdxT>;
-      using model_data_type = LoadData<RealT, IdxT>;
-      using MonitorT        = Model::VariableMonitor<Load, LoadData>;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Component<ScalarT, IdxT>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = LoadData<RealT, IdxT>;
+      using MonitorT   = Model::VariableMonitor<Load, LoadData>;
 
-      Load(bus_type* bus);
-      Load(bus_type* bus, RealT R, RealT X);
-      Load(bus_type* bus, const model_data_type& data);
+      Load(BusT* bus);
+      Load(BusT* bus, RealT R, RealT X);
+      Load(BusT* bus, const ModelDataT& data);
       virtual ~Load();
 
       virtual int setGridKitComponentID(IdxT) override final;
@@ -112,9 +114,9 @@ namespace GridKit
       __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
-      bus_type* bus_{nullptr};
-      RealT     R_{0.1};
-      RealT     X_{0.01};
+      BusT* bus_{nullptr};
+      RealT R_{0.1};
+      RealT X_{0.01};
 
       /* Derivied parameters */
       RealT b_;

--- a/GridKit/Model/PhasorDynamics/Load/LoadData.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadData.hpp
@@ -35,14 +35,14 @@ namespace GridKit
     /**
      * @brief Contains modeling data for a load
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
      */
-    template <typename RealT, typename IdxT>
-    struct LoadData : public ComponentData<RealT,
-                                           IdxT,
+    template <typename real_type, typename index_type>
+    struct LoadData : public ComponentData<real_type,
+                                           index_type,
                                            LoadParameters,
                                            LoadPorts,
                                            LoadMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/Load/LoadDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadDependencyTracking.cpp
@@ -8,12 +8,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Load<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Load..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Load/LoadEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadEnzyme.cpp
@@ -15,12 +15,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation experimental
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Load<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Load..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Load/LoadImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadImpl.hpp
@@ -19,17 +19,17 @@ namespace GridKit
      * - Number of equations = 2
      * - Number of independent variables = 2
      */
-    template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::Load(bus_type* bus)
+    template <typename scalar_type, typename index_type>
+    Load<scalar_type, index_type>::Load(BusT* bus)
       : bus_(bus)
     {
       size_ = 2;
     }
 
-    template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::Load(bus_type* bus,
-                              RealT     R,
-                              RealT     X)
+    template <typename scalar_type, typename index_type>
+    Load<scalar_type, index_type>::Load(BusT* bus,
+                                        RealT R,
+                                        RealT X)
       : bus_(bus),
         R_(R),
         X_(X)
@@ -38,22 +38,22 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::Load(bus_type*              bus,
-                              const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    Load<scalar_type, index_type>::Load(BusT*             bus,
+                                        const ModelDataT& data)
       : bus_(bus)
     {
-      if (data.parameters.contains(model_data_type::Parameters::R))
+      if (data.parameters.contains(ModelDataT::Parameters::R))
       {
-        R_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::R));
+        R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::X))
+      if (data.parameters.contains(ModelDataT::Parameters::X))
       {
-        X_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::X));
+        X_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::X));
       }
 
-      // using Variable = typename model_data_type::MonitorableVariables;
+      // using Variable = typename ModelDataT::MonitorableVariables;
       // monitor_->set(Variable::p, [this] { return ?; });
       // monitor_->set(Variable::q, [this] { return ?; });
 
@@ -61,8 +61,8 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    Load<ScalarT, IdxT>::~Load()
+    template <typename scalar_type, typename index_type>
+    Load<scalar_type, index_type>::~Load()
     {
       // std::cout << "Destroy Load..." << std::endl;
     }
@@ -70,8 +70,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename scalar_type, typename index_type>
+    int Load<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -80,8 +80,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int Load<scalar_type, index_type>::allocate()
     {
       // std::cout << "Allocate Load..." << std::endl;
 
@@ -111,8 +111,8 @@ namespace GridKit
      * Initialization of the load model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int Load<scalar_type, index_type>::initialize()
     {
       ScalarT vr = Vr();
       ScalarT vi = Vi();
@@ -131,8 +131,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int Load<scalar_type, index_type>::tagDifferentiable()
     {
       tag_[0] = false;
       tag_[1] = false;
@@ -144,8 +144,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Load<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) int Load<scalar_type, index_type>::evaluateBusResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         [[maybe_unused]] ScalarT* wb,
@@ -163,8 +163,8 @@ namespace GridKit
      * @brief Internal residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int Load<ScalarT, IdxT>::evaluateInternalResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) int Load<scalar_type, index_type>::evaluateInternalResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -184,8 +184,8 @@ namespace GridKit
      * @brief Residual contribution of the load is pushed to the bus.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Load<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int Load<scalar_type, index_type>::evaluateResidual()
     {
       wb_[0] = Vr();
       wb_[1] = Vi();
@@ -201,15 +201,15 @@ namespace GridKit
      * @brief Derived parameters
      *
      */
-    template <class ScalarT, typename IdxT>
-    void Load<ScalarT, IdxT>::setDerivedParams()
+    template <typename scalar_type, typename index_type>
+    void Load<scalar_type, index_type>::setDerivedParams()
     {
       b_ = -X_ / (R_ * R_ + X_ * X_);
       g_ = R_ / (R_ * R_ + X_ * X_);
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* Load<ScalarT, IdxT>::getMonitor() const
+    template <typename scalar_type, typename index_type>
+    const Model::VariableMonitorBase* Load<scalar_type, index_type>::getMonitor() const
     {
       return monitor_.get();
     }

--- a/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIP.cpp
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIP.cpp
@@ -8,12 +8,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int LoadZIP<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for LoadZIP..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIP.hpp
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIP.hpp
@@ -10,10 +10,10 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class BusBase;
 
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct LoadZIPData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -26,36 +26,38 @@ namespace GridKit
      * @brief Implementation of a ZIP load.
      *
      */
-    template <class ScalarT, typename IdxT>
-    class LoadZIP : public Component<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class LoadZIP : public Component<scalar_type, index_type>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using Component<scalar_type, index_type>::gridkit_component_id_;
+      using Component<scalar_type, index_type>::size_;
+      using Component<scalar_type, index_type>::nnz_;
+      using Component<scalar_type, index_type>::time_;
+      using Component<scalar_type, index_type>::alpha_;
+      using Component<scalar_type, index_type>::y_;
+      using Component<scalar_type, index_type>::yp_;
+      using Component<scalar_type, index_type>::tag_;
+      using Component<scalar_type, index_type>::wb_;
+      using Component<scalar_type, index_type>::h_;
+      using Component<scalar_type, index_type>::f_;
+      using Component<scalar_type, index_type>::J_;
+      using Component<scalar_type, index_type>::J_rows_buffer_;
+      using Component<scalar_type, index_type>::J_cols_buffer_;
+      using Component<scalar_type, index_type>::J_vals_buffer_;
+      using Component<scalar_type, index_type>::variable_indices_;
+      using Component<scalar_type, index_type>::residual_indices_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using bus_type        = BusBase<ScalarT, IdxT>;
-      using model_data_type = LoadZIPData<RealT, IdxT>;
-      using MonitorT        = Model::VariableMonitor<LoadZIP, LoadZIPData>;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Component<ScalarT, IdxT>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = LoadZIPData<RealT, IdxT>;
+      using MonitorT   = Model::VariableMonitor<LoadZIP, LoadZIPData>;
 
-      LoadZIP(bus_type* bus);
-      LoadZIP(bus_type* bus, RealT P0, RealT Q0, RealT V0, RealT alphaI, RealT alphaP);
-      LoadZIP(bus_type* bus, const model_data_type& data);
+      LoadZIP(BusT* bus);
+      LoadZIP(BusT* bus, RealT P0, RealT Q0, RealT V0, RealT alphaI, RealT alphaP);
+      LoadZIP(BusT* bus, const ModelDataT& data);
       ~LoadZIP();
 
       int setGridKitComponentID(IdxT) override final;
@@ -126,12 +128,12 @@ namespace GridKit
       __attribute__((always_inline)) inline int evaluateInternalResidual(ScalarT*, ScalarT*, ScalarT*, ScalarT*);
 
     private:
-      bus_type* bus_{nullptr};
-      RealT     P0_{0};
-      RealT     Q0_{0};
-      RealT     V0_{1.0};
-      RealT     alphaI_{0};
-      RealT     alphaP_{0};
+      BusT* bus_{nullptr};
+      RealT P0_{0};
+      RealT Q0_{0};
+      RealT V0_{1.0};
+      RealT alphaI_{0};
+      RealT alphaP_{0};
 
       std::unique_ptr<MonitorT> monitor_;
     };

--- a/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPData.hpp
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPData.hpp
@@ -36,14 +36,14 @@ namespace GridKit
     /**
      * @brief Contains modeling data for a load
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
      */
-    template <typename RealT, typename IdxT>
-    struct LoadZIPData : public ComponentData<RealT,
-                                              IdxT,
+    template <typename real_type, typename index_type>
+    struct LoadZIPData : public ComponentData<real_type,
+                                              index_type,
                                               LoadZIPParameters,
                                               LoadZIPPorts,
                                               LoadZIPMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPDependencyTracking.cpp
@@ -8,12 +8,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int LoadZIP<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for LoadZIP..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPEnzyme.cpp
@@ -10,12 +10,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation experimental
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int LoadZIP<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for LoadZIP..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/LoadZIP/LoadZIPImpl.hpp
@@ -19,15 +19,15 @@ namespace GridKit
      * - Number of equations = 2
      * - Number of independent variables = 2
      */
-    template <class ScalarT, typename IdxT>
-    LoadZIP<ScalarT, IdxT>::LoadZIP(bus_type* bus)
+    template <typename scalar_type, typename index_type>
+    LoadZIP<scalar_type, index_type>::LoadZIP(BusT* bus)
       : bus_(bus)
     {
       size_ = 2;
     }
 
-    template <class ScalarT, typename IdxT>
-    LoadZIP<ScalarT, IdxT>::LoadZIP(bus_type* bus, RealT P0, RealT Q0, RealT V0, RealT alphaI, RealT alphaP)
+    template <typename scalar_type, typename index_type>
+    LoadZIP<scalar_type, index_type>::LoadZIP(BusT* bus, RealT P0, RealT Q0, RealT V0, RealT alphaI, RealT alphaP)
       : bus_(bus),
         P0_(P0),
         Q0_(Q0),
@@ -39,37 +39,37 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    LoadZIP<ScalarT, IdxT>::LoadZIP(bus_type*              bus,
-                                    const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    LoadZIP<scalar_type, index_type>::LoadZIP(BusT*             bus,
+                                              const ModelDataT& data)
       : bus_(bus)
     {
-      if (data.parameters.contains(model_data_type::Parameters::P0))
+      if (data.parameters.contains(ModelDataT::Parameters::P0))
       {
-        P0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::P0));
+        P0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::P0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Q0))
+      if (data.parameters.contains(ModelDataT::Parameters::Q0))
       {
-        Q0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Q0));
+        Q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Q0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::V0))
+      if (data.parameters.contains(ModelDataT::Parameters::V0))
       {
-        V0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::V0));
+        V0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::V0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::alphaI))
+      if (data.parameters.contains(ModelDataT::Parameters::alphaI))
       {
-        alphaI_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::alphaI));
+        alphaI_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::alphaI));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::alphaP))
+      if (data.parameters.contains(ModelDataT::Parameters::alphaP))
       {
-        alphaP_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::alphaP));
+        alphaP_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::alphaP));
       }
 
-      // using Variable = typename model_data_type::MonitorableVariables;
+      // using Variable = typename ModelDataT::MonitorableVariables;
       // monitor_->set(Variable::p, [this] { return ?; });
       // monitor_->set(Variable::q, [this] { return ?; });
 
@@ -77,8 +77,8 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    LoadZIP<ScalarT, IdxT>::~LoadZIP()
+    template <typename scalar_type, typename index_type>
+    LoadZIP<scalar_type, index_type>::~LoadZIP()
     {
       // std::cout << "Destroy LoadZIP..." << std::endl;
     }
@@ -86,8 +86,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename scalar_type, typename index_type>
+    int LoadZIP<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -96,8 +96,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int LoadZIP<scalar_type, index_type>::allocate()
     {
       // std::cout << "Allocate Load..." << std::endl;
 
@@ -127,8 +127,8 @@ namespace GridKit
      * Initialization of the load model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int LoadZIP<scalar_type, index_type>::initialize()
     {
       ScalarT vr    = Vr();
       ScalarT vi    = Vi();
@@ -150,8 +150,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int LoadZIP<scalar_type, index_type>::tagDifferentiable()
     {
       tag_[0] = false;
       tag_[1] = false;
@@ -162,8 +162,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int LoadZIP<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) int LoadZIP<scalar_type, index_type>::evaluateBusResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         [[maybe_unused]] ScalarT* wb,
@@ -181,8 +181,8 @@ namespace GridKit
      * @brief Residual contribution of the load is pushed to the bus.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int LoadZIP<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int LoadZIP<scalar_type, index_type>::evaluateResidual()
     {
       wb_[0] = Vr();
       wb_[1] = Vi();
@@ -198,8 +198,8 @@ namespace GridKit
      * @brief Internal residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int LoadZIP<ScalarT, IdxT>::evaluateInternalResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) int LoadZIP<scalar_type, index_type>::evaluateInternalResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -223,14 +223,14 @@ namespace GridKit
      * @brief Derived parameters
      *
      */
-    template <class ScalarT, typename IdxT>
-    void LoadZIP<ScalarT, IdxT>::setDerivedParams()
+    template <typename scalar_type, typename index_type>
+    void LoadZIP<scalar_type, index_type>::setDerivedParams()
     {
       return;
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* LoadZIP<ScalarT, IdxT>::getMonitor() const
+    template <typename scalar_type, typename index_type>
+    const Model::VariableMonitorBase* LoadZIP<scalar_type, index_type>::getMonitor() const
     {
       return monitor_.get();
     }

--- a/GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp
@@ -7,7 +7,7 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct SignalNodeData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -20,11 +20,13 @@ namespace GridKit
      * @brief SignalNode model implementation base class.
      *
      */
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class SignalNode
     {
     public:
-      using RealT = typename GridKit::ScalarTraits<ScalarT>::RealT;
+      using ScalarT = scalar_type;
+      using IdxT    = index_type;
+      using RealT   = typename GridKit::ScalarTraits<ScalarT>::RealT;
 
       SignalNode();
       SignalNode(const SignalNodeData<RealT, IdxT>& data);

--- a/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeData.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeData.hpp
@@ -18,16 +18,18 @@ namespace GridKit
     /**
      * @brief Contains modeling data for a Bus
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
      *
      * @todo Decide on naming scheme for model parameters.
      */
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct SignalNodeData
     {
+      using IdxT = index_type;
+
       std::string name;         ///< A name given to this bus
       IdxT        signal_id{0}; ///< The unique ID of the signal node
     };

--- a/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalNode/SignalNodeImpl.hpp
@@ -8,38 +8,38 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
-    SignalNode<ScalarT, IdxT>::SignalNode()
+    template <typename scalar_type, typename index_type>
+    SignalNode<scalar_type, index_type>::SignalNode()
     {
     }
 
-    template <class ScalarT, typename IdxT>
-    SignalNode<ScalarT, IdxT>::SignalNode(const SignalNodeData<RealT, IdxT>& data)
+    template <typename scalar_type, typename index_type>
+    SignalNode<scalar_type, index_type>::SignalNode(const SignalNodeData<RealT, IdxT>& data)
       : signal_id_(data.signal_id)
     {
     }
 
-    template <class ScalarT, typename IdxT>
-    void SignalNode<ScalarT, IdxT>::set(ScalarT* signal, IdxT* variable_index)
+    template <typename scalar_type, typename index_type>
+    void SignalNode<scalar_type, index_type>::set(ScalarT* signal, IdxT* variable_index)
     {
       signal_         = signal;
       variable_index_ = variable_index;
     }
 
-    template <class ScalarT, typename IdxT>
-    bool SignalNode<ScalarT, IdxT>::linked() const
+    template <typename scalar_type, typename index_type>
+    bool SignalNode<scalar_type, index_type>::linked() const
     {
       return (signal_) && (variable_index_);
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT SignalNode<ScalarT, IdxT>::read() const
+    template <typename scalar_type, typename index_type>
+    scalar_type SignalNode<scalar_type, index_type>::read() const
     {
       return *signal_;
     }
 
-    template <class ScalarT, typename IdxT>
-    void SignalNode<ScalarT, IdxT>::init(ScalarT signal)
+    template <typename scalar_type, typename index_type>
+    void SignalNode<scalar_type, index_type>::init(ScalarT signal)
     {
       *signal_ = signal;
     }

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/Ieeest.cpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/Ieeest.cpp
@@ -15,12 +15,10 @@ namespace GridKit
       /**
        * @brief Jacobian evaluation not implemented yet
        *
-       * @tparam ScalarT - Scalar data type
-       * @tparam IdxT    - Index data type
        * @return int - error code, 0 = success
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int Ieeest<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for Ieeest..." << std::endl;
         Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/Ieeest.hpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/Ieeest.hpp
@@ -16,11 +16,11 @@ namespace GridKit
   {
     namespace Stabilizer
     {
-      template <typename RealT, typename IdxT>
+      template <typename real_type, typename index_type>
       struct IeeestData;
     } // namespace Stabilizer
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class SignalNode;
 
   } // namespace PhasorDynamics
@@ -57,35 +57,37 @@ namespace GridKit
         MAXIMUM,
       };
 
-      template <class ScalarT, typename IdxT>
-      class Ieeest : public Component<ScalarT, IdxT>
+      template <typename scalar_type, typename index_type>
+      class Ieeest : public Component<scalar_type, index_type>
       {
-        using Component<ScalarT, IdxT>::gridkit_component_id_;
-        using Component<ScalarT, IdxT>::alpha_;
-        using Component<ScalarT, IdxT>::f_;
-        using Component<ScalarT, IdxT>::nnz_;
-        using Component<ScalarT, IdxT>::size_;
-        using Component<ScalarT, IdxT>::tag_;
-        using Component<ScalarT, IdxT>::time_;
-        using Component<ScalarT, IdxT>::y_;
-        using Component<ScalarT, IdxT>::yp_;
-        using Component<ScalarT, IdxT>::wb_;
-        using Component<ScalarT, IdxT>::h_;
-        using Component<ScalarT, IdxT>::J_;
-        using Component<ScalarT, IdxT>::J_rows_buffer_;
-        using Component<ScalarT, IdxT>::J_cols_buffer_;
-        using Component<ScalarT, IdxT>::J_vals_buffer_;
-        using Component<ScalarT, IdxT>::variable_indices_;
-        using Component<ScalarT, IdxT>::residual_indices_;
+        using Component<scalar_type, index_type>::gridkit_component_id_;
+        using Component<scalar_type, index_type>::alpha_;
+        using Component<scalar_type, index_type>::f_;
+        using Component<scalar_type, index_type>::nnz_;
+        using Component<scalar_type, index_type>::size_;
+        using Component<scalar_type, index_type>::tag_;
+        using Component<scalar_type, index_type>::time_;
+        using Component<scalar_type, index_type>::y_;
+        using Component<scalar_type, index_type>::yp_;
+        using Component<scalar_type, index_type>::wb_;
+        using Component<scalar_type, index_type>::h_;
+        using Component<scalar_type, index_type>::J_;
+        using Component<scalar_type, index_type>::J_rows_buffer_;
+        using Component<scalar_type, index_type>::J_cols_buffer_;
+        using Component<scalar_type, index_type>::J_vals_buffer_;
+        using Component<scalar_type, index_type>::variable_indices_;
+        using Component<scalar_type, index_type>::residual_indices_;
 
       public:
-        using RealT           = typename Component<ScalarT, IdxT>::RealT;
-        using model_data_type = IeeestData<RealT, IdxT>;
-        using signal_type     = SignalNode<ScalarT, IdxT>;
-        using MonitorT        = Model::VariableMonitor<Ieeest, IeeestData>;
+        using ScalarT    = scalar_type;
+        using IdxT       = index_type;
+        using RealT      = typename Component<ScalarT, IdxT>::RealT;
+        using ModelDataT = IeeestData<RealT, IdxT>;
+        using SignalT    = SignalNode<ScalarT, IdxT>;
+        using MonitorT   = Model::VariableMonitor<Ieeest, IeeestData>;
 
         Ieeest();
-        Ieeest(const model_data_type& data);
+        Ieeest(const ModelDataT& data);
         ~Ieeest();
 
         int setGridKitComponentID(IdxT) override final;
@@ -161,7 +163,7 @@ namespace GridKit
 
         std::unique_ptr<MonitorT> monitor_;
 
-        void initializeParameters(const model_data_type& data);
+        void initializeParameters(const ModelDataT& data);
         void initializeMonitor();
 
         std::vector<ScalarT> ws_;

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestData.hpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestData.hpp
@@ -59,12 +59,12 @@ namespace GridKit
       /**
        * @brief Contains modeling data for a IEEEST Stabilizer model.
        *
-       * @tparam RealT Real parameter data type
-       * @tparam IdxT  Integer parameter data type
+       * @tparam real_type  Real parameter data type
+       * @tparam index_type Integer parameter data type
        */
-      template <typename RealT, typename IdxT>
-      struct IeeestData : public ComponentData<RealT,
-                                               IdxT,
+      template <typename real_type, typename index_type>
+      struct IeeestData : public ComponentData<real_type,
+                                               index_type,
                                                IeeestParameters,
                                                IeeestPorts,
                                                IeeestMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestDependencyTracking.cpp
@@ -15,12 +15,10 @@ namespace GridKit
       /**
        * @brief Jacobian evaluation not implemented yet
        *
-       * @tparam ScalarT - Scalar data type
-       * @tparam IdxT    - Index data type
        * @return int - error code, 0 = success
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int Ieeest<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for Ieeest..." << std::endl;
         Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestEnzyme.cpp
@@ -21,8 +21,8 @@ namespace GridKit
        * @tparam IdxT    - Index data type
        * @return int - error code, 0 = success
        */
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::evaluateJacobian()
+      template <typename scalar_type, typename index_type>
+      int Ieeest<scalar_type, index_type>::evaluateJacobian()
       {
         Log::misc() << "Evaluate Jacobian for Ieeest..." << std::endl;
         Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestImpl.hpp
@@ -23,14 +23,14 @@ namespace GridKit
     {
       using Log = ::GridKit::Utilities::Logger;
 
-      template <class ScalarT, typename IdxT>
-      Ieeest<ScalarT, IdxT>::Ieeest()
+      template <typename scalar_type, typename index_type>
+      Ieeest<scalar_type, index_type>::Ieeest()
       {
         size_ = 12;
       }
 
-      template <class ScalarT, typename IdxT>
-      Ieeest<ScalarT, IdxT>::Ieeest(const model_data_type& data)
+      template <typename scalar_type, typename index_type>
+      Ieeest<scalar_type, index_type>::Ieeest(const ModelDataT& data)
         : monitor_(std::make_unique<MonitorT>(data))
       {
         initializeParameters(data);
@@ -38,85 +38,85 @@ namespace GridKit
         size_ = 12;
       }
 
-      template <class ScalarT, typename IdxT>
-      Ieeest<ScalarT, IdxT>::~Ieeest()
+      template <typename scalar_type, typename index_type>
+      Ieeest<scalar_type, index_type>::~Ieeest()
       {
       }
 
-      template <class ScalarT, typename IdxT>
-      void Ieeest<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
+      template <typename scalar_type, typename index_type>
+      void Ieeest<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
       {
-        if (data.parameters.contains(model_data_type::Parameters::A1))
+        if (data.parameters.contains(ModelDataT::Parameters::A1))
         {
-          A1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A1));
+          A1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A1));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A2))
+        if (data.parameters.contains(ModelDataT::Parameters::A2))
         {
-          A2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A2));
+          A2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A2));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A3))
+        if (data.parameters.contains(ModelDataT::Parameters::A3))
         {
-          A3_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A3));
+          A3_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A3));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A4))
+        if (data.parameters.contains(ModelDataT::Parameters::A4))
         {
-          A4_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A4));
+          A4_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A4));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A5))
+        if (data.parameters.contains(ModelDataT::Parameters::A5))
         {
-          A5_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A5));
+          A5_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A5));
         }
-        if (data.parameters.contains(model_data_type::Parameters::A6))
+        if (data.parameters.contains(ModelDataT::Parameters::A6))
         {
-          A6_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::A6));
+          A6_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A6));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T1))
+        if (data.parameters.contains(ModelDataT::Parameters::T1))
         {
-          T1_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T1));
+          T1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T1));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T2))
+        if (data.parameters.contains(ModelDataT::Parameters::T2))
         {
-          T2_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T2));
+          T2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T2));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T3))
+        if (data.parameters.contains(ModelDataT::Parameters::T3))
         {
-          T3_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T3));
+          T3_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T3));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T4))
+        if (data.parameters.contains(ModelDataT::Parameters::T4))
         {
-          T4_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T4));
+          T4_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T4));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T5))
+        if (data.parameters.contains(ModelDataT::Parameters::T5))
         {
-          T5_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T5));
+          T5_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T5));
         }
-        if (data.parameters.contains(model_data_type::Parameters::T6))
+        if (data.parameters.contains(ModelDataT::Parameters::T6))
         {
-          T6_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::T6));
+          T6_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T6));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Ks))
+        if (data.parameters.contains(ModelDataT::Parameters::Ks))
         {
-          Ks_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ks));
+          Ks_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ks));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Lsmin))
+        if (data.parameters.contains(ModelDataT::Parameters::Lsmin))
         {
-          Lsmin_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Lsmin));
+          Lsmin_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Lsmin));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Lsmax))
+        if (data.parameters.contains(ModelDataT::Parameters::Lsmax))
         {
-          Lsmax_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Lsmax));
+          Lsmax_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Lsmax));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Vcl))
+        if (data.parameters.contains(ModelDataT::Parameters::Vcl))
         {
-          Vcl_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Vcl));
+          Vcl_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vcl));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Vcu))
+        if (data.parameters.contains(ModelDataT::Parameters::Vcu))
         {
-          Vcu_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Vcu));
+          Vcu_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vcu));
         }
-        if (data.parameters.contains(model_data_type::Parameters::Tdelay))
+        if (data.parameters.contains(ModelDataT::Parameters::Tdelay))
         {
-          Tdelay_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tdelay));
+          Tdelay_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdelay));
         }
 
         a0_ = 1;
@@ -146,15 +146,15 @@ namespace GridKit
         bypass_T6_block_ = 1.0 - use_T6_block_;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+      template <typename scalar_type, typename index_type>
+      int Ieeest<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
       {
         gridkit_component_id_ = component_id;
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::allocate()
+      template <typename scalar_type, typename index_type>
+      int Ieeest<scalar_type, index_type>::allocate()
       {
         auto size = static_cast<size_t>(size_);
         f_.resize(size);
@@ -184,8 +184,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::verify() const
+      template <typename scalar_type, typename index_type>
+      int Ieeest<scalar_type, index_type>::verify() const
       {
         int ret = 0;
 
@@ -212,8 +212,8 @@ namespace GridKit
         return ret;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::initialize()
+      template <typename scalar_type, typename index_type>
+      int Ieeest<scalar_type, index_type>::initialize()
       {
         for (IdxT i = 0; i < size_; ++i)
         {
@@ -224,8 +224,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::tagDifferentiable()
+      template <typename scalar_type, typename index_type>
+      int Ieeest<scalar_type, index_type>::tagDifferentiable()
       {
         tag_[0]  = true;
         tag_[1]  = true;
@@ -243,8 +243,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      __attribute__((always_inline)) inline int Ieeest<ScalarT, IdxT>::evaluateInternalResidual(
+      template <typename scalar_type, typename index_type>
+      __attribute__((always_inline)) inline int Ieeest<scalar_type, index_type>::evaluateInternalResidual(
           ScalarT*                  y,
           ScalarT*                  yp,
           [[maybe_unused]] ScalarT* wb,
@@ -292,8 +292,8 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      int Ieeest<ScalarT, IdxT>::evaluateResidual()
+      template <typename scalar_type, typename index_type>
+      int Ieeest<scalar_type, index_type>::evaluateResidual()
       {
         if (signals_.template isAttached<IeeestExternalVariables::U>())
         {
@@ -306,16 +306,16 @@ namespace GridKit
         return 0;
       }
 
-      template <class ScalarT, typename IdxT>
-      const Model::VariableMonitorBase* Ieeest<ScalarT, IdxT>::getMonitor() const
+      template <typename scalar_type, typename index_type>
+      const Model::VariableMonitorBase* Ieeest<scalar_type, index_type>::getMonitor() const
       {
         return monitor_.get();
       }
 
-      template <class ScalarT, typename IdxT>
-      void Ieeest<ScalarT, IdxT>::initializeMonitor()
+      template <typename scalar_type, typename index_type>
+      void Ieeest<scalar_type, index_type>::initializeMonitor()
       {
-        using Variable = typename model_data_type::MonitorableVariables;
+        using Variable = typename ModelDataT::MonitorableVariables;
         monitor_->set(Variable::vss, [this]
                       { return y_[11]; });
       }

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.cpp
@@ -14,12 +14,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented yet
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Genrou<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Genrou..." << std::endl;
       Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp
@@ -18,13 +18,13 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class BusBase;
 
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class SignalNode;
 
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct GenrouData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -66,67 +66,69 @@ namespace GridKit
       MAXIMUM,
     };
 
-    template <class ScalarT, typename IdxT>
-    class Genrou : public Component<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class Genrou : public Component<scalar_type, index_type>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::freq_system_base_;
-      using Component<ScalarT, IdxT>::va_system_base_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using Component<scalar_type, index_type>::gridkit_component_id_;
+      using Component<scalar_type, index_type>::alpha_;
+      using Component<scalar_type, index_type>::f_;
+      using Component<scalar_type, index_type>::nnz_;
+      using Component<scalar_type, index_type>::size_;
+      using Component<scalar_type, index_type>::tag_;
+      using Component<scalar_type, index_type>::time_;
+      using Component<scalar_type, index_type>::y_;
+      using Component<scalar_type, index_type>::yp_;
+      using Component<scalar_type, index_type>::wb_;
+      using Component<scalar_type, index_type>::h_;
+      using Component<scalar_type, index_type>::J_;
+      using Component<scalar_type, index_type>::J_rows_buffer_;
+      using Component<scalar_type, index_type>::J_cols_buffer_;
+      using Component<scalar_type, index_type>::J_vals_buffer_;
+      using Component<scalar_type, index_type>::freq_system_base_;
+      using Component<scalar_type, index_type>::va_system_base_;
+      using Component<scalar_type, index_type>::variable_indices_;
+      using Component<scalar_type, index_type>::residual_indices_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using bus_type        = BusBase<ScalarT, IdxT>;
-      using model_data_type = GenrouData<RealT, IdxT>;
-      using signal_type     = SignalNode<ScalarT, IdxT>;
-      using MonitorT        = Model::VariableMonitor<Genrou, GenrouData>;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Component<ScalarT, IdxT>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = GenrouData<RealT, IdxT>;
+      using SignalT    = SignalNode<ScalarT, IdxT>;
+      using MonitorT   = Model::VariableMonitor<Genrou, GenrouData>;
 
-      Genrou(bus_type* bus, IdxT unit_id);
-      Genrou(bus_type*              bus,
-             signal_type*           omega,
-             signal_type*           pmech,
-             const model_data_type& data);
-      Genrou(bus_type*              bus,
-             signal_type*           omega,
-             signal_type*           pmech,
-             signal_type*           efd,
-             const model_data_type& data);
-      Genrou(bus_type* bus, const model_data_type& data);
-      Genrou(bus_type* bus,
-             IdxT      unit_id,
-             RealT     p0,
-             RealT     q0,
-             RealT     H,
-             RealT     D,
-             RealT     Ra,
-             RealT     Tdop,
-             RealT     Tdopp,
-             RealT     Tqopp,
-             RealT     Tqop,
-             RealT     Xd,
-             RealT     Xdp,
-             RealT     Xdpp,
-             RealT     Xq,
-             RealT     Xqp,
-             RealT     Xqpp,
-             RealT     Xl,
-             RealT     S10,
-             RealT     S12);
+      Genrou(BusT* bus, IdxT unit_id);
+      Genrou(BusT*             bus,
+             SignalT*          omega,
+             SignalT*          pmech,
+             const ModelDataT& data);
+      Genrou(BusT*             bus,
+             SignalT*          omega,
+             SignalT*          pmech,
+             SignalT*          efd,
+             const ModelDataT& data);
+      Genrou(BusT* bus, const ModelDataT& data);
+      Genrou(BusT* bus,
+             IdxT  unit_id,
+             RealT p0,
+             RealT q0,
+             RealT H,
+             RealT D,
+             RealT Ra,
+             RealT Tdop,
+             RealT Tdopp,
+             RealT Tqopp,
+             RealT Tqop,
+             RealT Xd,
+             RealT Xdp,
+             RealT Xdpp,
+             RealT Xq,
+             RealT Xqp,
+             RealT Xqpp,
+             RealT Xl,
+             RealT S10,
+             RealT S12);
       ~Genrou();
 
       int setGridKitComponentID(IdxT) override final;
@@ -157,7 +159,7 @@ namespace GridKit
       const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
-      void initializeParameters(const model_data_type& data);
+      void initializeParameters(const ModelDataT& data);
       /// Associate variable getter functions with enum values
       void initializeMonitor();
       void setDerivedParams();
@@ -208,9 +210,9 @@ namespace GridKit
 
     private:
       /* Identification */
-      bus_type* bus_;
-      IdxT      bus_id_{0};
-      IdxT      unit_id_; //< @todo this should be removed
+      BusT* bus_;
+      IdxT  bus_id_{0};
+      IdxT  unit_id_; //< @todo this should be removed
 
       /// Component signal extension
       ComponentSignals<ScalarT, IdxT, GenrouInternalVariables, GenrouExternalVariables> signals_;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp
@@ -60,14 +60,14 @@ namespace GridKit
     /**
      * @brief Contains modeling data for a Genrou generator model.
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
      */
-    template <typename RealT, typename IdxT>
-    struct GenrouData : public ComponentData<RealT,
-                                             IdxT,
+    template <typename real_type, typename index_type>
+    struct GenrouData : public ComponentData<real_type,
+                                             index_type,
                                              GenrouParameters,
                                              GenrouPorts,
                                              GenrouMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouDependencyTracking.cpp
@@ -7,12 +7,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented yet
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Genrou<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Genrou..." << std::endl;
       Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouEnzyme.cpp
@@ -15,12 +15,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation experimental
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Genrou<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Genrou..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouImpl.hpp
@@ -27,8 +27,8 @@ namespace GridKit
      * - Number of quadratures = 0
      * - Number of optimization parameters = 0
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, IdxT unit_id)
+    template <typename scalar_type, typename index_type>
+    Genrou<scalar_type, index_type>::Genrou(BusT* bus, IdxT unit_id)
       : bus_(bus),
         bus_id_(0),
         unit_id_(unit_id),
@@ -59,27 +59,27 @@ namespace GridKit
     /**
      * @brief Constructor for a GENROU generator model with saturation
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus,
-                                  IdxT      unit_id,
-                                  RealT     p0,
-                                  RealT     q0,
-                                  RealT     H,
-                                  RealT     D,
-                                  RealT     Ra,
-                                  RealT     Tdop,
-                                  RealT     Tdopp,
-                                  RealT     Tqopp,
-                                  RealT     Tqop,
-                                  RealT     Xd,
-                                  RealT     Xdp,
-                                  RealT     Xdpp,
-                                  RealT     Xq,
-                                  RealT     Xqp,
-                                  RealT     Xqpp,
-                                  RealT     Xl,
-                                  RealT     S10,
-                                  RealT     S12)
+    template <typename scalar_type, typename index_type>
+    Genrou<scalar_type, index_type>::Genrou(BusT* bus,
+                                            IdxT  unit_id,
+                                            RealT p0,
+                                            RealT q0,
+                                            RealT H,
+                                            RealT D,
+                                            RealT Ra,
+                                            RealT Tdop,
+                                            RealT Tdopp,
+                                            RealT Tqopp,
+                                            RealT Tqop,
+                                            RealT Xd,
+                                            RealT Xdp,
+                                            RealT Xdpp,
+                                            RealT Xq,
+                                            RealT Xqp,
+                                            RealT Xqpp,
+                                            RealT Xl,
+                                            RealT S10,
+                                            RealT S12)
       : bus_(bus),
         bus_id_(0),
         unit_id_(unit_id),
@@ -110,8 +110,8 @@ namespace GridKit
     /**
      * @brief Constructor for a GENROU generator model with saturation
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    Genrou<scalar_type, index_type>::Genrou(BusT* bus, const ModelDataT& data)
       : bus_(bus),
         unit_id_(1),
         monitor_(std::make_unique<MonitorT>(data))
@@ -126,8 +126,8 @@ namespace GridKit
     /**
      * @brief Constructor for a GENROU generator model with saturation
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, signal_type* omega, signal_type* pmech, const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    Genrou<scalar_type, index_type>::Genrou(BusT* bus, SignalT* omega, SignalT* pmech, const ModelDataT& data)
       : bus_(bus),
         unit_id_(1),
         monitor_(std::make_unique<MonitorT>(data))
@@ -144,8 +144,8 @@ namespace GridKit
     /**
      * @brief Constructor for a GENROU generator model with saturation
      */
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::Genrou(bus_type* bus, signal_type* omega, signal_type* pmech, signal_type* efd, const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    Genrou<scalar_type, index_type>::Genrou(BusT* bus, SignalT* omega, SignalT* pmech, SignalT* efd, const ModelDataT& data)
       : bus_(bus),
         unit_id_(1),
         monitor_(std::make_unique<MonitorT>(data))
@@ -160,139 +160,139 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    Genrou<ScalarT, IdxT>::~Genrou()
+    template <typename scalar_type, typename index_type>
+    Genrou<scalar_type, index_type>::~Genrou()
     {
     }
 
     /// Helper function to extract and assign model parameters from the model's associated
     /// data structure.
-    template <class ScalarT, typename IdxT>
-    void Genrou<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    void Genrou<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
-      if (data.parameters.contains(model_data_type::Parameters::p0))
+      if (data.parameters.contains(ModelDataT::Parameters::p0))
       {
-        p0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::p0));
+        p0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::p0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::q0))
+      if (data.parameters.contains(ModelDataT::Parameters::q0))
       {
-        q0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::q0));
+        q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::q0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::H))
+      if (data.parameters.contains(ModelDataT::Parameters::H))
       {
-        H_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::H));
+        H_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::H));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::D))
+      if (data.parameters.contains(ModelDataT::Parameters::D))
       {
-        D_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::D));
+        D_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::D));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Ra))
+      if (data.parameters.contains(ModelDataT::Parameters::Ra))
       {
-        Ra_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ra));
+        Ra_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ra));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tdop))
+      if (data.parameters.contains(ModelDataT::Parameters::Tdop))
       {
-        Tdop_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tdop));
+        Tdop_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdop));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tdopp))
+      if (data.parameters.contains(ModelDataT::Parameters::Tdopp))
       {
-        Tdopp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tdopp));
+        Tdopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdopp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tqopp))
+      if (data.parameters.contains(ModelDataT::Parameters::Tqopp))
       {
-        Tqopp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tqopp));
+        Tqopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tqopp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tqop))
+      if (data.parameters.contains(ModelDataT::Parameters::Tqop))
       {
-        Tqop_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tqop));
+        Tqop_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tqop));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xd))
+      if (data.parameters.contains(ModelDataT::Parameters::Xd))
       {
-        Xd_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xd));
+        Xd_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xd));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xdp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xdp))
       {
-        Xdp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xdp));
+        Xdp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xdpp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xdpp))
       {
-        Xdpp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xdpp));
+        Xdpp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdpp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xq))
+      if (data.parameters.contains(ModelDataT::Parameters::Xq))
       {
-        Xq_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xq));
+        Xq_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xq));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xqp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xqp))
       {
-        Xqp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xqp));
+        Xqp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xqp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xqpp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xqpp))
       {
-        Xqpp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xqpp));
+        Xqpp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xqpp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xl))
+      if (data.parameters.contains(ModelDataT::Parameters::Xl))
       {
-        Xl_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xl));
+        Xl_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xl));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::S10))
+      if (data.parameters.contains(ModelDataT::Parameters::S10))
       {
-        S10_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::S10));
+        S10_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S10));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::S12))
+      if (data.parameters.contains(ModelDataT::Parameters::S12))
       {
-        S12_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::S12));
+        S12_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S12));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::mva))
+      if (data.parameters.contains(ModelDataT::Parameters::mva))
       {
-        mva_base_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::mva));
+        mva_base_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::mva));
       }
 
-      if (data.ports.contains(model_data_type::Ports::bus))
+      if (data.ports.contains(ModelDataT::Ports::bus))
       {
-        bus_id_ = data.ports.at(model_data_type::Ports::bus);
+        bus_id_ = data.ports.at(ModelDataT::Ports::bus);
       }
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* Genrou<ScalarT, IdxT>::getMonitor() const
+    template <typename scalar_type, typename index_type>
+    const Model::VariableMonitorBase* Genrou<scalar_type, index_type>::getMonitor() const
     {
       return monitor_.get();
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT Genrou<ScalarT, IdxT>::toMachineBase(ScalarT value) const
+    template <typename scalar_type, typename index_type>
+    Genrou<scalar_type, index_type>::ScalarT Genrou<scalar_type, index_type>::toMachineBase(ScalarT value) const
     {
       return value * va_system_base_ / va_machine_base_;
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT Genrou<ScalarT, IdxT>::toSystemBase(ScalarT value) const
+    template <typename scalar_type, typename index_type>
+    Genrou<scalar_type, index_type>::ScalarT Genrou<scalar_type, index_type>::toSystemBase(ScalarT value) const
     {
       return value / toMachineBase(static_cast<ScalarT>(ONE<RealT>));
     }
 
-    template <class ScalarT, typename IdxT>
-    void Genrou<ScalarT, IdxT>::initializeMonitor()
+    template <typename scalar_type, typename index_type>
+    void Genrou<scalar_type, index_type>::initializeMonitor()
     {
-      using Variable = typename model_data_type::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::ir, [this]
                     { return toSystemBase(y_[15]); });
       monitor_->set(Variable::ii, [this]
@@ -312,8 +312,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename scalar_type, typename index_type>
+    int Genrou<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -322,8 +322,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int Genrou<scalar_type, index_type>::allocate()
     {
       // Resize component model data
       auto size = static_cast<size_t>(size_);
@@ -363,8 +363,8 @@ namespace GridKit
     /**
      * @brief verify method checks that attached signals are also linked
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::verify() const
+    template <typename scalar_type, typename index_type>
+    int Genrou<scalar_type, index_type>::verify() const
     {
       static constexpr auto PM  = GenrouExternalVariables::PM;
       static constexpr auto EFD = GenrouExternalVariables::EFD;
@@ -396,8 +396,8 @@ namespace GridKit
      * Initialization of the branch model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int Genrou<scalar_type, index_type>::initialize()
     {
       // Saturated initialization with ksat iteration.
       // See README "With Saturation" and plan for derivation.
@@ -513,8 +513,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int Genrou<scalar_type, index_type>::tagDifferentiable()
     {
       for (IdxT i = 0; i < size_; ++i)
       {
@@ -527,8 +527,8 @@ namespace GridKit
      * @brief Internal residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateInternalResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) inline int Genrou<scalar_type, index_type>::evaluateInternalResidual(
         ScalarT* y,
         ScalarT* yp,
         ScalarT* wb,
@@ -605,8 +605,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Genrou<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) inline int Genrou<scalar_type, index_type>::evaluateBusResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -627,8 +627,8 @@ namespace GridKit
      * \brief Residual evaluation and contribution to the connected bus
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Genrou<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int Genrou<scalar_type, index_type>::evaluateResidual()
     {
       // Mechanical Power
       ws_[0] = pmech_set_;
@@ -664,24 +664,22 @@ namespace GridKit
     /**
      * @brief Access generator relative speed
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    ScalarT Genrou<ScalarT, IdxT>::getSpeed()
+    template <typename scalar_type, typename index_type>
+    scalar_type Genrou<scalar_type, index_type>::getSpeed()
     {
       return y_[1];
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT Genrou<ScalarT, IdxT>::getTorque()
+    template <typename scalar_type, typename index_type>
+    scalar_type Genrou<scalar_type, index_type>::getTorque()
     {
       return y_[12];
     }
 
-    template <class ScalarT, typename IdxT>
-    void Genrou<ScalarT, IdxT>::setDerivedParams()
+    template <typename scalar_type, typename index_type>
+    void Genrou<scalar_type, index_type>::setDerivedParams()
     {
       SA_ = 0;
       SB_ = 0;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/Gensal.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/Gensal.cpp
@@ -13,12 +13,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented yet
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Gensal<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Gensal<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Gensal..." << std::endl;
       Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/Gensal.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/Gensal.hpp
@@ -17,10 +17,10 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class BusBase;
 
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct GensalData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -61,36 +61,38 @@ namespace GridKit
       MAXIMUM,
     };
 
-    template <class ScalarT, typename IdxT>
-    class Gensal : public Component<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class Gensal : public Component<scalar_type, index_type>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::freq_system_base_;
-      using Component<ScalarT, IdxT>::va_system_base_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using Component<scalar_type, index_type>::gridkit_component_id_;
+      using Component<scalar_type, index_type>::alpha_;
+      using Component<scalar_type, index_type>::f_;
+      using Component<scalar_type, index_type>::nnz_;
+      using Component<scalar_type, index_type>::size_;
+      using Component<scalar_type, index_type>::tag_;
+      using Component<scalar_type, index_type>::time_;
+      using Component<scalar_type, index_type>::y_;
+      using Component<scalar_type, index_type>::yp_;
+      using Component<scalar_type, index_type>::wb_;
+      using Component<scalar_type, index_type>::h_;
+      using Component<scalar_type, index_type>::J_;
+      using Component<scalar_type, index_type>::J_rows_buffer_;
+      using Component<scalar_type, index_type>::J_cols_buffer_;
+      using Component<scalar_type, index_type>::J_vals_buffer_;
+      using Component<scalar_type, index_type>::freq_system_base_;
+      using Component<scalar_type, index_type>::va_system_base_;
+      using Component<scalar_type, index_type>::variable_indices_;
+      using Component<scalar_type, index_type>::residual_indices_;
 
     public:
-      using RealT           = typename Component<ScalarT, IdxT>::RealT;
-      using bus_type        = BusBase<ScalarT, IdxT>;
-      using model_data_type = GensalData<RealT, IdxT>;
-      using MonitorT        = Model::VariableMonitor<Gensal, GensalData>;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Component<ScalarT, IdxT>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = GensalData<RealT, IdxT>;
+      using MonitorT   = Model::VariableMonitor<Gensal, GensalData>;
 
-      Gensal(bus_type* bus, const model_data_type& data);
+      Gensal(BusT* bus, const ModelDataT& data);
       ~Gensal();
 
       int setGridKitComponentID(IdxT) override final;
@@ -121,7 +123,7 @@ namespace GridKit
       const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
-      void initializeParameters(const model_data_type& data);
+      void initializeParameters(const ModelDataT& data);
       /// Associate variable getter functions with enum values
       void initializeMonitor();
       void setDerivedParams();
@@ -172,7 +174,7 @@ namespace GridKit
 
     private:
       /* Identification */
-      bus_type* bus_;
+      BusT* bus_;
 
       /// Component signal extension
       ComponentSignals<ScalarT, IdxT, GensalInternalVariables, GensalExternalVariables> signals_;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/GensalData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/GensalData.hpp
@@ -66,14 +66,14 @@ namespace GridKit
     /**
      * @brief Contains modeling data for a Gensal generator model.
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
      */
-    template <typename RealT, typename IdxT>
-    struct GensalData : public ComponentData<RealT,
-                                             IdxT,
+    template <typename real_type, typename index_type>
+    struct GensalData : public ComponentData<real_type,
+                                             index_type,
                                              GensalParameters,
                                              GensalPorts,
                                              GensalMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/GensalDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/GensalDependencyTracking.cpp
@@ -7,12 +7,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented yet
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Gensal<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Gensal<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Gensal..." << std::endl;
       Log::misc() << "Jacobian evaluation not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/GensalEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/GensalEnzyme.cpp
@@ -15,12 +15,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation experimental
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int Gensal<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int Gensal<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for Gensal..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/GensalImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/GensalImpl.hpp
@@ -19,8 +19,8 @@ namespace GridKit
     /**
      * @brief Constructor for a GENSAL generator model with saturation
      */
-    template <class ScalarT, typename IdxT>
-    Gensal<ScalarT, IdxT>::Gensal(bus_type* bus, const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    Gensal<scalar_type, index_type>::Gensal(BusT* bus, const ModelDataT& data)
       : bus_(bus),
         monitor_(std::make_unique<MonitorT>(data))
     {
@@ -31,119 +31,119 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    Gensal<ScalarT, IdxT>::~Gensal()
+    template <typename scalar_type, typename index_type>
+    Gensal<scalar_type, index_type>::~Gensal()
     {
     }
 
     /// Helper function to extract and assign model parameters from the model's associated
     /// data structure.
-    template <class ScalarT, typename IdxT>
-    void Gensal<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
+    template <typename scalar_type, typename index_type>
+    void Gensal<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
-      if (data.parameters.contains(model_data_type::Parameters::p0))
+      if (data.parameters.contains(ModelDataT::Parameters::p0))
       {
-        p0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::p0));
+        p0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::p0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::q0))
+      if (data.parameters.contains(ModelDataT::Parameters::q0))
       {
-        q0_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::q0));
+        q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::q0));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::H))
+      if (data.parameters.contains(ModelDataT::Parameters::H))
       {
-        H_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::H));
+        H_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::H));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::D))
+      if (data.parameters.contains(ModelDataT::Parameters::D))
       {
-        D_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::D));
+        D_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::D));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Ra))
+      if (data.parameters.contains(ModelDataT::Parameters::Ra))
       {
-        Ra_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Ra));
+        Ra_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ra));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tdop))
+      if (data.parameters.contains(ModelDataT::Parameters::Tdop))
       {
-        Tdop_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tdop));
+        Tdop_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdop));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tdopp))
+      if (data.parameters.contains(ModelDataT::Parameters::Tdopp))
       {
-        Tdopp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tdopp));
+        Tdopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdopp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Tqopp))
+      if (data.parameters.contains(ModelDataT::Parameters::Tqopp))
       {
-        Tqopp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Tqopp));
+        Tqopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tqopp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xd))
+      if (data.parameters.contains(ModelDataT::Parameters::Xd))
       {
-        Xd_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xd));
+        Xd_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xd));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xdp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xdp))
       {
-        Xdp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xdp));
+        Xdp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xdpp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xdpp))
       {
-        Xdpp_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xdpp));
+        Xdpp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdpp));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xq))
+      if (data.parameters.contains(ModelDataT::Parameters::Xq))
       {
-        Xq_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xq));
+        Xq_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xq));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::Xl))
+      if (data.parameters.contains(ModelDataT::Parameters::Xl))
       {
-        Xl_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::Xl));
+        Xl_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xl));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::S10))
+      if (data.parameters.contains(ModelDataT::Parameters::S10))
       {
-        S10_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::S10));
+        S10_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S10));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::S12))
+      if (data.parameters.contains(ModelDataT::Parameters::S12))
       {
-        S12_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::S12));
+        S12_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S12));
       }
 
-      if (data.parameters.contains(model_data_type::Parameters::mva))
+      if (data.parameters.contains(ModelDataT::Parameters::mva))
       {
-        mva_base_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::mva));
+        mva_base_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::mva));
       }
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* Gensal<ScalarT, IdxT>::getMonitor() const
+    template <typename scalar_type, typename index_type>
+    const Model::VariableMonitorBase* Gensal<scalar_type, index_type>::getMonitor() const
     {
       return monitor_.get();
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT Gensal<ScalarT, IdxT>::toMachineBase(ScalarT value) const
+    template <typename scalar_type, typename index_type>
+    scalar_type Gensal<scalar_type, index_type>::toMachineBase(ScalarT value) const
     {
       return value * va_system_base_ / va_machine_base_;
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT Gensal<ScalarT, IdxT>::toSystemBase(ScalarT value) const
+    template <typename scalar_type, typename index_type>
+    scalar_type Gensal<scalar_type, index_type>::toSystemBase(ScalarT value) const
     {
       return value / toMachineBase(static_cast<ScalarT>(ONE<RealT>));
     }
 
-    template <class ScalarT, typename IdxT>
-    void Gensal<ScalarT, IdxT>::initializeMonitor()
+    template <typename scalar_type, typename index_type>
+    void Gensal<scalar_type, index_type>::initializeMonitor()
     {
-      using Variable = typename model_data_type::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::ir, [this]
                     { return toSystemBase(y_[12]); });
       monitor_->set(Variable::ii, [this]
@@ -181,8 +181,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int Gensal<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename scalar_type, typename index_type>
+    int Gensal<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -191,8 +191,8 @@ namespace GridKit
     /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int Gensal<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int Gensal<scalar_type, index_type>::allocate()
     {
       // Resize component model data
       auto size = static_cast<size_t>(size_);
@@ -232,8 +232,8 @@ namespace GridKit
     /**
      * @brief verify method checks that attached signals are also linked
      */
-    template <class ScalarT, typename IdxT>
-    int Gensal<ScalarT, IdxT>::verify() const
+    template <typename scalar_type, typename index_type>
+    int Gensal<scalar_type, index_type>::verify() const
     {
       static constexpr auto PM  = GensalExternalVariables::PM;
       static constexpr auto EFD = GensalExternalVariables::EFD;
@@ -265,8 +265,8 @@ namespace GridKit
      * Initialization of the generator model
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Gensal<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int Gensal<scalar_type, index_type>::initialize()
     {
       // Network frame terminal values
       ScalarT vr  = Vr();
@@ -336,8 +336,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int Gensal<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int Gensal<scalar_type, index_type>::tagDifferentiable()
     {
       for (IdxT i = 0; i < size_; ++i)
       {
@@ -350,8 +350,8 @@ namespace GridKit
      * @brief Internal residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Gensal<ScalarT, IdxT>::evaluateInternalResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) inline int Gensal<scalar_type, index_type>::evaluateInternalResidual(
         ScalarT* y,
         ScalarT* yp,
         ScalarT* wb,
@@ -421,8 +421,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) inline int Gensal<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) inline int Gensal<scalar_type, index_type>::evaluateBusResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         ScalarT*                  wb,
@@ -443,8 +443,8 @@ namespace GridKit
      * \brief Residual evaluation and contribution to the connected bus
      *
      */
-    template <class ScalarT, typename IdxT>
-    int Gensal<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int Gensal<scalar_type, index_type>::evaluateResidual()
     {
       // Mechanical Power
       ws_[0] = pmech_set_;
@@ -480,24 +480,22 @@ namespace GridKit
     /**
      * @brief Access generator relative speed
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    ScalarT Gensal<ScalarT, IdxT>::getSpeed()
+    template <typename scalar_type, typename index_type>
+    scalar_type Gensal<scalar_type, index_type>::getSpeed()
     {
       return y_[1];
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT Gensal<ScalarT, IdxT>::getTorque()
+    template <typename scalar_type, typename index_type>
+    scalar_type Gensal<scalar_type, index_type>::getTorque()
     {
       return y_[9];
     }
 
-    template <class ScalarT, typename IdxT>
-    void Gensal<ScalarT, IdxT>::setDerivedParams()
+    template <typename scalar_type, typename index_type>
+    void Gensal<scalar_type, index_type>::setDerivedParams()
     {
       SA_ = 0;
       SB_ = 0;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
@@ -8,12 +8,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int GenClassical<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for GenClassical..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -17,10 +17,10 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
-    template <class ScalarT, typename IdxT>
+    template <typename scalar_type, typename index_type>
     class BusBase;
 
-    template <typename RealT, typename IdxT>
+    template <typename real_type, typename index_type>
     struct GenClassicalData;
   } // namespace PhasorDynamics
 } // namespace GridKit
@@ -30,45 +30,47 @@ namespace GridKit
   namespace PhasorDynamics
   {
 
-    template <class ScalarT, typename IdxT>
-    class GenClassical : public Component<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class GenClassical : public Component<scalar_type, index_type>
     {
-      using Component<ScalarT, IdxT>::gridkit_component_id_;
-      using Component<ScalarT, IdxT>::alpha_;
-      using Component<ScalarT, IdxT>::f_;
-      using Component<ScalarT, IdxT>::nnz_;
-      using Component<ScalarT, IdxT>::size_;
-      using Component<ScalarT, IdxT>::tag_;
-      using Component<ScalarT, IdxT>::time_;
-      using Component<ScalarT, IdxT>::y_;
-      using Component<ScalarT, IdxT>::yp_;
-      using Component<ScalarT, IdxT>::wb_;
-      using Component<ScalarT, IdxT>::h_;
-      using Component<ScalarT, IdxT>::J_;
-      using Component<ScalarT, IdxT>::J_rows_buffer_;
-      using Component<ScalarT, IdxT>::J_cols_buffer_;
-      using Component<ScalarT, IdxT>::J_vals_buffer_;
-      using Component<ScalarT, IdxT>::freq_system_base_;
-      using Component<ScalarT, IdxT>::va_system_base_;
-      using Component<ScalarT, IdxT>::variable_indices_;
-      using Component<ScalarT, IdxT>::residual_indices_;
+      using Component<scalar_type, index_type>::gridkit_component_id_;
+      using Component<scalar_type, index_type>::alpha_;
+      using Component<scalar_type, index_type>::f_;
+      using Component<scalar_type, index_type>::nnz_;
+      using Component<scalar_type, index_type>::size_;
+      using Component<scalar_type, index_type>::tag_;
+      using Component<scalar_type, index_type>::time_;
+      using Component<scalar_type, index_type>::y_;
+      using Component<scalar_type, index_type>::yp_;
+      using Component<scalar_type, index_type>::wb_;
+      using Component<scalar_type, index_type>::h_;
+      using Component<scalar_type, index_type>::J_;
+      using Component<scalar_type, index_type>::J_rows_buffer_;
+      using Component<scalar_type, index_type>::J_cols_buffer_;
+      using Component<scalar_type, index_type>::J_vals_buffer_;
+      using Component<scalar_type, index_type>::freq_system_base_;
+      using Component<scalar_type, index_type>::va_system_base_;
+      using Component<scalar_type, index_type>::variable_indices_;
+      using Component<scalar_type, index_type>::residual_indices_;
 
     public:
-      using bus_type = BusBase<ScalarT, IdxT>;
-      using RealT    = typename Component<ScalarT, IdxT>::RealT;
-      using DataT    = GenClassicalData<RealT, IdxT>;
-      using MonitorT = Model::VariableMonitor<GenClassical, GenClassicalData>;
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Component<ScalarT, IdxT>::RealT;
+      using BusT       = BusBase<ScalarT, IdxT>;
+      using ModelDataT = GenClassicalData<RealT, IdxT>;
+      using MonitorT   = Model::VariableMonitor<GenClassical, GenClassicalData>;
 
-      GenClassical(bus_type* bus, int unit_id);
-      GenClassical(bus_type* bus,
-                   int       unit_id,
-                   RealT     p0,
-                   RealT     q0,
-                   RealT     H,
-                   RealT     D,
-                   RealT     Ra,
-                   RealT     Xdp);
-      GenClassical(bus_type* bus, const DataT& data);
+      GenClassical(BusT* bus, int unit_id);
+      GenClassical(BusT* bus,
+                   int   unit_id,
+                   RealT p0,
+                   RealT q0,
+                   RealT H,
+                   RealT D,
+                   RealT Ra,
+                   RealT Xdp);
+      GenClassical(BusT* bus, const ModelDataT& data);
       ~GenClassical();
 
       int setGridKitComponentID(IdxT) override final;
@@ -147,9 +149,9 @@ namespace GridKit
 
     private:
       /* Identification */
-      bus_type* bus_;
-      IdxT      bus_id_{0};
-      int       unit_id_; //< @todo this should be removed
+      BusT* bus_;
+      IdxT  bus_id_{0};
+      int   unit_id_; //< @todo this should be removed
 
       /* Initial terminal conditions */
       RealT p0_{0.0};

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
@@ -51,16 +51,16 @@ namespace GridKit
     /**
      * @brief Contains modeling data for a GenClassical generator model.
      *
-     * @tparam RealT Real parameter data type
-     * @tparam IdxT  Integer parameter data type
+     * @tparam real_type  Real parameter data type
+     * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
      *
      * @todo Decide on naming scheme for model parameters.
      */
-    template <typename RealT, typename IdxT>
-    struct GenClassicalData : public ComponentData<RealT,
-                                                   IdxT,
+    template <typename real_type, typename index_type>
+    struct GenClassicalData : public ComponentData<real_type,
+                                                   index_type,
                                                    GenClassicalParameters,
                                                    GenClassicalPorts,
                                                    GenClassicalMonitorableVariables>

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalDependencyTracking.cpp
@@ -8,12 +8,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation not implemented
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int GenClassical<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for GenClassical..." << std::endl;
       Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -15,12 +15,10 @@ namespace GridKit
     /**
      * @brief Jacobian evaluation experimental
      *
-     * @tparam ScalarT - scalar data type
-     * @tparam IdxT    - matrix index data type
      * @return int - error code, 0 = success
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::evaluateJacobian()
+    template <typename scalar_type, typename index_type>
+    int GenClassical<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for GenClassical..." << std::endl;
       Log::misc() << "Jacobian evaluation is experimental!" << std::endl;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -22,8 +22,8 @@ namespace GridKit
     /**
      * @brief Constructor for a classical generator model
      */
-    template <class ScalarT, typename IdxT>
-    GenClassical<ScalarT, IdxT>::GenClassical(bus_type* bus, int unit_id)
+    template <typename scalar_type, typename index_type>
+    GenClassical<scalar_type, index_type>::GenClassical(BusT* bus, int unit_id)
       : bus_(bus),
         bus_id_(0),
         unit_id_(unit_id),
@@ -42,15 +42,15 @@ namespace GridKit
     /**
      * @brief Constructor for a classical generator model
      */
-    template <class ScalarT, typename IdxT>
-    GenClassical<ScalarT, IdxT>::GenClassical(bus_type* bus,
-                                              int       unit_id,
-                                              RealT     p0,
-                                              RealT     q0,
-                                              RealT     H,
-                                              RealT     D,
-                                              RealT     Ra,
-                                              RealT     Xdp)
+    template <typename scalar_type, typename index_type>
+    GenClassical<scalar_type, index_type>::GenClassical(BusT* bus,
+                                                        int   unit_id,
+                                                        RealT p0,
+                                                        RealT q0,
+                                                        RealT H,
+                                                        RealT D,
+                                                        RealT Ra,
+                                                        RealT Xdp)
       : bus_(bus),
         bus_id_(0),
         unit_id_(unit_id),
@@ -69,50 +69,50 @@ namespace GridKit
     /**
      * @brief Constructor for a classical generator model
      */
-    template <class ScalarT, typename IdxT>
-    GenClassical<ScalarT, IdxT>::GenClassical(bus_type* bus, const DataT& data)
+    template <typename scalar_type, typename index_type>
+    GenClassical<scalar_type, index_type>::GenClassical(BusT* bus, const ModelDataT& data)
       : bus_(bus),
         unit_id_(1),
         monitor_(std::make_unique<MonitorT>(data))
     {
-      if (data.parameters.contains(DataT::Parameters::p0))
+      if (data.parameters.contains(ModelDataT::Parameters::p0))
       {
-        p0_ = std::get<RealT>(data.parameters.at(DataT::Parameters::p0));
+        p0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::p0));
       }
 
-      if (data.parameters.contains(DataT::Parameters::q0))
+      if (data.parameters.contains(ModelDataT::Parameters::q0))
       {
-        q0_ = std::get<RealT>(data.parameters.at(DataT::Parameters::q0));
+        q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::q0));
       }
 
-      if (data.parameters.contains(DataT::Parameters::H))
+      if (data.parameters.contains(ModelDataT::Parameters::H))
       {
-        H_ = std::get<RealT>(data.parameters.at(DataT::Parameters::H));
+        H_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::H));
       }
 
-      if (data.parameters.contains(DataT::Parameters::D))
+      if (data.parameters.contains(ModelDataT::Parameters::D))
       {
-        D_ = std::get<RealT>(data.parameters.at(DataT::Parameters::D));
+        D_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::D));
       }
 
-      if (data.parameters.contains(DataT::Parameters::Ra))
+      if (data.parameters.contains(ModelDataT::Parameters::Ra))
       {
-        Ra_ = std::get<RealT>(data.parameters.at(DataT::Parameters::Ra));
+        Ra_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ra));
       }
 
-      if (data.parameters.contains(DataT::Parameters::Xdp))
+      if (data.parameters.contains(ModelDataT::Parameters::Xdp))
       {
-        Xdp_ = std::get<RealT>(data.parameters.at(DataT::Parameters::Xdp));
+        Xdp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdp));
       }
 
-      if (data.parameters.contains(DataT::Parameters::mva))
+      if (data.parameters.contains(ModelDataT::Parameters::mva))
       {
-        mva_base_ = std::get<RealT>(data.parameters.at(DataT::Parameters::mva));
+        mva_base_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::mva));
       }
 
-      if (data.ports.contains(DataT::Ports::bus))
+      if (data.ports.contains(ModelDataT::Ports::bus))
       {
-        bus_id_ = data.ports.at(DataT::Ports::bus);
+        bus_id_ = data.ports.at(ModelDataT::Ports::bus);
       }
 
       initializeMonitor();
@@ -121,33 +121,33 @@ namespace GridKit
       setDerivedParams();
     }
 
-    template <class ScalarT, typename IdxT>
-    GenClassical<ScalarT, IdxT>::~GenClassical()
+    template <typename scalar_type, typename index_type>
+    GenClassical<scalar_type, index_type>::~GenClassical()
     {
     }
 
-    template <class ScalarT, typename IdxT>
-    const Model::VariableMonitorBase* GenClassical<ScalarT, IdxT>::getMonitor() const
+    template <typename scalar_type, typename index_type>
+    const Model::VariableMonitorBase* GenClassical<scalar_type, index_type>::getMonitor() const
     {
       return monitor_.get();
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT GenClassical<ScalarT, IdxT>::toMachineBase(ScalarT value) const
+    template <typename scalar_type, typename index_type>
+    GenClassical<scalar_type, index_type>::ScalarT GenClassical<scalar_type, index_type>::toMachineBase(ScalarT value) const
     {
       return value * va_system_base_ / va_machine_base_;
     }
 
-    template <class ScalarT, typename IdxT>
-    ScalarT GenClassical<ScalarT, IdxT>::toSystemBase(ScalarT value) const
+    template <typename scalar_type, typename index_type>
+    GenClassical<scalar_type, index_type>::ScalarT GenClassical<scalar_type, index_type>::toSystemBase(ScalarT value) const
     {
       return value / toMachineBase(static_cast<ScalarT>(ONE<RealT>));
     }
 
-    template <class ScalarT, typename IdxT>
-    void GenClassical<ScalarT, IdxT>::initializeMonitor()
+    template <typename scalar_type, typename index_type>
+    void GenClassical<scalar_type, index_type>::initializeMonitor()
     {
-      using Variable = typename DataT::MonitorableVariables;
+      using Variable = typename ModelDataT::MonitorableVariables;
       monitor_->set(Variable::ir, [this]
                     { return toSystemBase(y_[3]); });
       monitor_->set(Variable::ii, [this]
@@ -165,8 +165,8 @@ namespace GridKit
     /**
      * @brief Set the component ID
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::setGridKitComponentID(IdxT component_id)
+    template <typename scalar_type, typename index_type>
+    int GenClassical<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
     {
       gridkit_component_id_ = component_id;
       return 0;
@@ -175,8 +175,8 @@ namespace GridKit
     /**
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::allocate()
+    template <typename scalar_type, typename index_type>
+    int GenClassical<scalar_type, index_type>::allocate()
     {
       // Resize component model data
       auto size = static_cast<size_t>(size_);
@@ -204,8 +204,8 @@ namespace GridKit
     /**
      * Initialization of the generator model
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::initialize()
+    template <typename scalar_type, typename index_type>
+    int GenClassical<scalar_type, index_type>::initialize()
     {
       ScalarT vr    = Vr();
       ScalarT vi    = Vi();
@@ -238,8 +238,8 @@ namespace GridKit
     /**
      * \brief Identify differential variables.
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::tagDifferentiable()
+    template <typename scalar_type, typename index_type>
+    int GenClassical<scalar_type, index_type>::tagDifferentiable()
     {
       for (IdxT i = 0; i < size_; ++i)
       {
@@ -252,8 +252,8 @@ namespace GridKit
      * @brief Internal residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateInternalResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) int GenClassical<scalar_type, index_type>::evaluateInternalResidual(
         ScalarT* y,
         ScalarT* yp,
         ScalarT* wb,
@@ -293,8 +293,8 @@ namespace GridKit
      * @brief Bus residual
      *
      */
-    template <class ScalarT, typename IdxT>
-    __attribute__((always_inline)) int GenClassical<ScalarT, IdxT>::evaluateBusResidual(
+    template <typename scalar_type, typename index_type>
+    __attribute__((always_inline)) int GenClassical<scalar_type, index_type>::evaluateBusResidual(
         ScalarT*                  y,
         [[maybe_unused]] ScalarT* yp,
         [[maybe_unused]] ScalarT* wb,
@@ -312,8 +312,8 @@ namespace GridKit
      * \brief Residual for the generator model.
      *
      */
-    template <class ScalarT, typename IdxT>
-    int GenClassical<ScalarT, IdxT>::evaluateResidual()
+    template <typename scalar_type, typename index_type>
+    int GenClassical<scalar_type, index_type>::evaluateResidual()
     {
       wb_[0] = Vr();
       wb_[1] = Vi();
@@ -327,8 +327,8 @@ namespace GridKit
       return 0;
     }
 
-    template <class ScalarT, typename IdxT>
-    void GenClassical<ScalarT, IdxT>::setDerivedParams()
+    template <typename scalar_type, typename index_type>
+    void GenClassical<scalar_type, index_type>::setDerivedParams()
     {
       G_               = Ra_ / (Ra_ * Ra_ + Xdp_ * Xdp_);
       B_               = -Xdp_ / (Ra_ * Ra_ + Xdp_ * Xdp_);

--- a/GridKit/Model/PhasorDynamics/SystemModel.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModel.hpp
@@ -29,31 +29,33 @@ namespace GridKit
      * @todo Address thread safety for the system model methods.
      *
      */
-    template <class ScalarT, typename IdxT>
-    class SystemModel : public PhasorDynamics::Component<ScalarT, IdxT>
+    template <typename scalar_type, typename index_type>
+    class SystemModel : public PhasorDynamics::Component<scalar_type, index_type>
     {
-      using bus_type       = PhasorDynamics::BusBase<ScalarT, IdxT>;
-      using signal_type    = PhasorDynamics::SignalNode<ScalarT, IdxT>;
-      using component_type = PhasorDynamics::Component<ScalarT, IdxT>;
-      using RealT          = typename Model::Evaluator<ScalarT, IdxT>::RealT;
-      using CsrMatrixT     = typename Model::Evaluator<ScalarT, IdxT>::CsrMatrixT;
-
-      using PhasorDynamics::Component<ScalarT, IdxT>::gridkit_component_id_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::size_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::nnz_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::time_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::alpha_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::y_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::yp_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::tag_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::f_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::J_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::rel_tol_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::abs_tol_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::variable_indices_;
-      using PhasorDynamics::Component<ScalarT, IdxT>::residual_indices_;
+      using PhasorDynamics::Component<scalar_type, index_type>::gridkit_component_id_;
+      using PhasorDynamics::Component<scalar_type, index_type>::size_;
+      using PhasorDynamics::Component<scalar_type, index_type>::nnz_;
+      using PhasorDynamics::Component<scalar_type, index_type>::time_;
+      using PhasorDynamics::Component<scalar_type, index_type>::alpha_;
+      using PhasorDynamics::Component<scalar_type, index_type>::y_;
+      using PhasorDynamics::Component<scalar_type, index_type>::yp_;
+      using PhasorDynamics::Component<scalar_type, index_type>::tag_;
+      using PhasorDynamics::Component<scalar_type, index_type>::f_;
+      using PhasorDynamics::Component<scalar_type, index_type>::J_;
+      using PhasorDynamics::Component<scalar_type, index_type>::rel_tol_;
+      using PhasorDynamics::Component<scalar_type, index_type>::abs_tol_;
+      using PhasorDynamics::Component<scalar_type, index_type>::variable_indices_;
+      using PhasorDynamics::Component<scalar_type, index_type>::residual_indices_;
 
     public:
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Model::Evaluator<ScalarT, IdxT>::RealT;
+      using CsrMatrixT = typename Model::Evaluator<ScalarT, IdxT>::CsrMatrixT;
+      using BusT       = PhasorDynamics::BusBase<ScalarT, IdxT>;
+      using SignalT    = PhasorDynamics::SignalNode<ScalarT, IdxT>;
+      using ComponentT = PhasorDynamics::Component<ScalarT, IdxT>;
+
       /**
        * @brief Constructor for the system model
        */
@@ -955,7 +957,7 @@ namespace GridKit
        * Add bus at the end of the bus array and map bus ID with GridKit's ID for the bus
        *
        */
-      void addBus(bus_type* bus)
+      void addBus(BusT* bus)
       {
         IdxT gridkit_bus_id                = static_cast<IdxT>(buses_.size());
         gridkit_bus_indices_[bus->busID()] = gridkit_bus_id;
@@ -968,7 +970,7 @@ namespace GridKit
        * Add signal at the end of the signals array and map signal ID with GridKit's ID for the signal
        *
        */
-      void addSignal(signal_type* signal)
+      void addSignal(SignalT* signal)
       {
         IdxT gridkit_signal_id                      = static_cast<IdxT>(signals_.size());
         gridkit_signal_indices_[signal->signalId()] = gridkit_signal_id;
@@ -983,7 +985,7 @@ namespace GridKit
        */
       void setSystemBase(RealT freq_system_base, RealT va_system_base)
       {
-        component_type::setSystemBase(freq_system_base, va_system_base);
+        ComponentT::setSystemBase(freq_system_base, va_system_base);
 
         for (auto* component : components_)
         {
@@ -1000,7 +1002,7 @@ namespace GridKit
        * component ID to the disambiguation_string
        *
        */
-      void addComponent(component_type* component)
+      void addComponent(ComponentT* component)
       {
         IdxT gridkit_component_id = static_cast<IdxT>(components_.size());
         component->setGridKitComponentID(gridkit_component_id);
@@ -1016,7 +1018,7 @@ namespace GridKit
        * location, so it can easily be accessed.
        *
        */
-      void addFault(component_type* component)
+      void addFault(ComponentT* component)
       {
         IdxT gridkit_component_id                = static_cast<IdxT>(components_.size());
         IdxT gridkit_fault_id                    = static_cast<IdxT>(gridkit_fault_indices_.size());
@@ -1028,7 +1030,7 @@ namespace GridKit
        * @brief Return pointer to a bus
        *
        */
-      bus_type* getBus(IdxT bus_id)
+      BusT* getBus(IdxT bus_id)
       {
         // Should fail if user-provided bus_id is incorrect
         IdxT gridkit_bus_id = gridkit_bus_indices_.at(bus_id);
@@ -1040,7 +1042,7 @@ namespace GridKit
        * @brief Return pointer to a signal
        *
        */
-      signal_type* getSignal(IdxT signal_id)
+      SignalT* getSignal(IdxT signal_id)
       {
         // Should fail if user-provided signal_id is incorrect
         IdxT gridkit_signal_id = gridkit_signal_indices_.at(signal_id);
@@ -1052,7 +1054,7 @@ namespace GridKit
        * @brief Return pointer to a component
        *
        */
-      component_type* getComponent(IdxT gridkit_component_id)
+      ComponentT* getComponent(IdxT gridkit_component_id)
       {
         // gridkit_component_id_ is set by System model and guarantied to be unique
         return components_[gridkit_component_id];
@@ -1072,9 +1074,9 @@ namespace GridKit
       }
 
     private:
-      std::vector<bus_type*>       buses_;
-      std::vector<signal_type*>    signals_;
-      std::vector<component_type*> components_;
+      std::vector<BusT*>       buses_;
+      std::vector<SignalT*>    signals_;
+      std::vector<ComponentT*> components_;
 
       std::map<IdxT, IdxT> gridkit_bus_indices_;    ///< Map between gridkit_bus_id and bus_id
       std::map<IdxT, IdxT> gridkit_signal_indices_; ///< Map between gridkit_signal_id and signal_id

--- a/GridKit/Model/PhasorDynamics/SystemModelData.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.hpp
@@ -31,9 +31,11 @@ namespace GridKit
     ///
     /// In particular, this structure is modeled after the grid dynamics
     /// case format, which is described within `INPUT_FORMAT.md`
-    template <typename RealT = double, typename IdxT = size_t>
+    template <typename real_type = double, typename index_type = size_t>
     struct SystemModelData
     {
+      using RealT                   = real_type;
+      using IdxT                    = index_type;
       using BranchDataT             = BranchData<RealT, IdxT>;
       using BusDataT                = BusData<RealT, IdxT>;
       using BusToSignalAdapterDataT = BusToSignalAdapterData<RealT, IdxT>;

--- a/GridKit/Model/VariableMonitor.hpp
+++ b/GridKit/Model/VariableMonitor.hpp
@@ -23,7 +23,7 @@ namespace GridKit
 {
   namespace Model
   {
-    template <typename ScalarT>
+    template <typename scalar_type>
     class VariableMonitorController;
 
     namespace VariableMonitorDetail
@@ -165,7 +165,7 @@ namespace GridKit
       ///@}
     };
 
-    template <typename EvalT, template <typename, typename> typename DataT>
+    template <typename eval_type, template <typename, typename> typename model_data_type>
     class VariableMonitor;
 
   } // namespace Model

--- a/GridKit/Model/VariableMonitorController.hpp
+++ b/GridKit/Model/VariableMonitorController.hpp
@@ -18,10 +18,12 @@ namespace GridKit
      * High-level print functions (without parameters) manage printing for all
      * monitors for multiple output sinks.
      */
-    template <typename ScalarT>
+    template <typename scalar_type>
     class VariableMonitorController : public VariableMonitorBase
     {
     public:
+      /// Underlying scalar value type
+      using ScalarT  = scalar_type;
       /// Underlying real value type
       using RealT    = typename GridKit::ScalarTraits<ScalarT>::RealT;
       ///@{
@@ -349,9 +351,11 @@ namespace GridKit
       /**
        * @brief Define sink for a specific output format
        */
-      template <typename FormatT>
+      template <typename format_type>
       struct Sink
       {
+        using FormatT = format_type;
+
         Sink() = delete;
 
         /**

--- a/GridKit/Model/VariableMonitorImpl.hpp
+++ b/GridKit/Model/VariableMonitorImpl.hpp
@@ -8,7 +8,7 @@ namespace GridKit
 {
   namespace Model
   {
-    template <typename ScalarT>
+    template <typename scalar_type>
     class VariableMonitorController;
 
     using magic_enum::enum_count;
@@ -25,21 +25,25 @@ namespace GridKit
      * append likewise on the same line, and the line can be ended by the control
      * monitor.
      */
-    template <typename ScalarT,
-              typename IdxT,
-              template <typename, typename> typename EvalT,
-              template <typename, typename> typename DataT>
-    class VariableMonitor<EvalT<ScalarT, IdxT>, DataT>
+    template <typename scalar_type,
+              typename index_type,
+              template <typename, typename> typename eval_type,
+              template <typename, typename> typename model_data_type>
+    class VariableMonitor<eval_type<scalar_type, index_type>, model_data_type>
       : public VariableMonitorBase
     {
       template <typename>
       friend class VariableMonitorController;
 
     public:
+      /// Underlying scalar value type
+      using ScalarT      = scalar_type;
+      /// Index type
+      using IdxT         = index_type;
       /// Underlying real value type
       using RealT        = typename GridKit::ScalarTraits<ScalarT>::RealT;
       /// Type of (EvalT)Data class expected to have MonitorableVariables enum
-      using ObjData      = DataT<RealT, IdxT>;
+      using ObjData      = model_data_type<RealT, IdxT>;
       /// Enum of valid monitorable variables
       using VariableEnum = typename ObjData::MonitorableVariables;
       ///@{

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -383,7 +383,7 @@ namespace GridKit
         const ScalarT Vr2{30.0};
         const ScalarT Vi2{40.0};
 
-        typename PhasorDynamics::Branch<ScalarT, IdxT>::model_data_type data;
+        typename PhasorDynamics::Branch<ScalarT, IdxT>::ModelDataT data;
         data.ports[PhasorDynamics::BranchPorts::bus1]        = 1;
         data.ports[PhasorDynamics::BranchPorts::bus2]        = 2;
         data.parameters[PhasorDynamics::BranchParameters::R] = R;


### PR DESCRIPTION
## Description
 
 See #366 
 
## Proposed changes
 
Use `snake_case` for template parameters. and `UpperCamelT` for public interface types.
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [N/A?] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.