### PR TITLE
Off-nominal branch tap and phase support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Added multi-contingency analysis application.
 - Added `BusToSignalAdapter` component for communicating bus voltages and injection currents.
 - Added cmake-format hooks, including in pre-commit.
+- Added off-nominal tap ratio and phase shift support to the PhasorDynamics `Branch` model.
 
 ## v0.1
 

--- a/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
@@ -8,8 +8,6 @@
  */
 #pragma once
 
-#include <complex>
-
 #include <GridKit/Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
 #include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
@@ -125,12 +123,6 @@ namespace GridKit
       const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
-      struct AdmittanceBlock
-      {
-        RealT G{0.0};
-        RealT B{0.0};
-      };
-
       void                                              initializeParameters(const model_data_type& data);
       void                                              initializeMonitor();
       void                                              setDerivedParams();
@@ -139,15 +131,16 @@ namespace GridKit
       bool                                              readRealParameter(const model_data_type&               data,
                                                                           typename model_data_type::Parameters parameter,
                                                                           RealT&                               target);
-      static void                                       setAdmittanceBlock(AdmittanceBlock& block, const std::complex<RealT>& y);
-      static __attribute__((always_inline)) inline void addAdmittanceContribution(const AdmittanceBlock& y,
-                                                                                  const ScalarT&         Vr,
-                                                                                  const ScalarT&         Vi,
-                                                                                  ScalarT&               Ir,
-                                                                                  ScalarT&               Ii);
-      static __attribute__((always_inline)) inline void evaluateAdmittanceBlock(const AdmittanceBlock& y,
-                                                                                const ScalarT*         wb,
-                                                                                ScalarT*               h);
+      static __attribute__((always_inline)) inline void addAdmittanceContribution(RealT          G,
+                                                                                  RealT          B,
+                                                                                  const ScalarT& Vr,
+                                                                                  const ScalarT& Vi,
+                                                                                  ScalarT&       Ir,
+                                                                                  ScalarT&       Ii);
+      static __attribute__((always_inline)) inline void evaluateAdmittanceBlock(RealT          G,
+                                                                                RealT          B,
+                                                                                const ScalarT* wb,
+                                                                                ScalarT*       h);
 
       ScalarT& Vr1()
       {
@@ -207,10 +200,14 @@ namespace GridKit
       IdxT      bus1_id_{0};
       IdxT      bus2_id_{0};
 
-      AdmittanceBlock y11_;
-      AdmittanceBlock y12_;
-      AdmittanceBlock y21_;
-      AdmittanceBlock y22_;
+      RealT g11_{0.0};
+      RealT b11_{0.0};
+      RealT g12_{0.0};
+      RealT b12_{0.0};
+      RealT g21_{0.0};
+      RealT b21_{0.0};
+      RealT g22_{0.0};
+      RealT b22_{0.0};
 
       int parameter_error_count_{0};
 

--- a/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
@@ -8,6 +8,8 @@
  */
 #pragma once
 
+#include <complex>
+
 #include <GridKit/Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
 #include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
@@ -31,7 +33,7 @@ namespace GridKit
   namespace PhasorDynamics
   {
     /**
-     * @brief Implementation of a pi-model branch between two buses.
+     * @brief Implementation of a line or off-nominal transformer branch between two buses.
      *
      * The model is implemented in Cartesian coordinates. Positive current
      * direction is into the busses.
@@ -65,7 +67,14 @@ namespace GridKit
       using MonitorT        = Model::VariableMonitor<Branch, BranchData>;
 
       Branch(bus_type* bus1, bus_type* bus2);
-      Branch(bus_type* bus1, bus_type* bus2, RealT R, RealT X, RealT G, RealT B);
+      Branch(bus_type* bus1,
+             bus_type* bus2,
+             RealT     R,
+             RealT     X,
+             RealT     G,
+             RealT     B,
+             RealT     tap   = 1.0,
+             RealT     phase = 0.0);
       Branch(bus_type* bus1, bus_type* bus2, const model_data_type& data);
       virtual ~Branch();
 
@@ -75,11 +84,7 @@ namespace GridKit
       virtual int tagDifferentiable() override final;
       virtual int evaluateResidual() override final;
       virtual int evaluateJacobian() override final;
-
-      virtual int verify() const override final
-      {
-        return 0;
-      }
+      virtual int verify() const override final;
 
       void setR(RealT R)
       {
@@ -89,7 +94,6 @@ namespace GridKit
 
       void setX(RealT X)
       {
-        // std::cout << "Setting X ...\n";
         X_ = X;
         setDerivedParams();
       }
@@ -106,12 +110,44 @@ namespace GridKit
         setDerivedParams();
       }
 
+      void setTap(RealT tap)
+      {
+        tap_ = tap;
+        setDerivedParams();
+      }
+
+      void setPhase(RealT phase)
+      {
+        phase_ = phase;
+        setDerivedParams();
+      }
+
       const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
-      void initializeParameters(const model_data_type& data);
-      void initializeMonitor();
-      void setDerivedParams();
+      struct AdmittanceBlock
+      {
+        RealT G{0.0};
+        RealT B{0.0};
+      };
+
+      void                                              initializeParameters(const model_data_type& data);
+      void                                              initializeMonitor();
+      void                                              setDerivedParams();
+      void                                              terminalCurrent1(ScalarT& Ir, ScalarT& Ii);
+      void                                              terminalCurrent2(ScalarT& Ir, ScalarT& Ii);
+      bool                                              readRealParameter(const model_data_type&               data,
+                                                                          typename model_data_type::Parameters parameter,
+                                                                          RealT&                               target);
+      static void                                       setAdmittanceBlock(AdmittanceBlock& block, const std::complex<RealT>& y);
+      static __attribute__((always_inline)) inline void addAdmittanceContribution(const AdmittanceBlock& y,
+                                                                                  const ScalarT&         Vr,
+                                                                                  const ScalarT&         Vi,
+                                                                                  ScalarT&               Ir,
+                                                                                  ScalarT&               Ii);
+      static __attribute__((always_inline)) inline void evaluateAdmittanceBlock(const AdmittanceBlock& y,
+                                                                                const ScalarT*         wb,
+                                                                                ScalarT*               h);
 
       ScalarT& Vr1()
       {
@@ -166,12 +202,17 @@ namespace GridKit
       RealT     X_{0.0};
       RealT     G_{0.0};
       RealT     B_{0.0};
+      RealT     tap_{1.0};
+      RealT     phase_{0.0};
       IdxT      bus1_id_{0};
       IdxT      bus2_id_{0};
 
-      /* Derived parameters */
-      RealT b_;
-      RealT g_;
+      AdmittanceBlock y11_;
+      AdmittanceBlock y12_;
+      AdmittanceBlock y21_;
+      AdmittanceBlock y22_;
+
+      int parameter_error_count_{0};
 
       /// Variable monitor
       std::unique_ptr<MonitorT> monitor_;

--- a/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
@@ -1,7 +1,7 @@
 /**
  * @file BranchData.hpp
  * @author Slaven Peles (peless@ornl.gov)
- * @brief Modeling data for branches (transmission lines)
+ * @brief Modeling data for branches
  *
  */
 #pragma once
@@ -15,10 +15,12 @@ namespace GridKit
     /// Initial parameters for a branch
     enum class BranchParameters
     {
-      R, ///< Line series resistance
-      X, ///< Line series reactance
-      G, ///< Line shunt conductance
-      B, ///< Line shunt charging
+      R,     ///< Line series resistance
+      X,     ///< Line series reactance
+      G,     ///< Total shunt conductance
+      B,     ///< Total shunt susceptance
+      tap,   ///< Off-nominal tap magnitude on bus1 side
+      phase, ///< Phase shift angle in radians
     };
 
     /// Ports for a branch

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -8,7 +8,10 @@
  */
 
 #include <cmath>
-#include <iostream>
+#include <complex>
+#include <variant>
+
+#include <magic_enum/magic_enum.hpp>
 
 #include <GridKit/Model/PhasorDynamics/Branch/Branch.hpp>
 #include <GridKit/Model/PhasorDynamics/Branch/BranchData.hpp>
@@ -20,7 +23,7 @@ namespace GridKit
   namespace PhasorDynamics
   {
     /**
-     * @brief Constructor for a pi-model branch
+     * @brief Constructor for a line or off-nominal transformer branch
      *
      * Model size:
      * - Number of equations = 0
@@ -34,6 +37,8 @@ namespace GridKit
         X_(0.01),
         G_(0.0),
         B_(0.0),
+        tap_(1.0),
+        phase_(0.0),
         bus1_id_(0),
         bus2_id_(0)
     {
@@ -50,8 +55,10 @@ namespace GridKit
      * @param bus2 - pointer to bus-2
      * @param R - line series resistance
      * @param X - line series reactance
-     * @param G - line shunt conductance
-     * @param B - line shunt charging
+     * @param G - total shunt conductance
+     * @param B - total shunt susceptance
+     * @param tap - off-nominal tap magnitude on bus1 side
+     * @param phase - phase shift angle in radians
      */
     template <class ScalarT, typename IdxT>
     Branch<ScalarT, IdxT>::Branch(bus_type* bus1,
@@ -59,16 +66,21 @@ namespace GridKit
                                   RealT     R,
                                   RealT     X,
                                   RealT     G,
-                                  RealT     B)
+                                  RealT     B,
+                                  RealT     tap,
+                                  RealT     phase)
       : bus1_(bus1),
         bus2_(bus2),
         R_(R),
         X_(X),
         G_(G),
         B_(B),
+        tap_(tap),
+        phase_(phase),
         bus1_id_(0),
         bus2_id_(0)
     {
+      size_ = 0;
       setDerivedParams();
     }
 
@@ -94,7 +106,6 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     Branch<ScalarT, IdxT>::~Branch()
     {
-      // std::cout << "Destroy Branch..." << std::endl;
     }
 
     /**
@@ -113,8 +124,6 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int Branch<ScalarT, IdxT>::allocate()
     {
-      // std::cout << "Allocate Branch..." << std::endl;
-
       wb_.resize(2);
       h_.resize(2);
 
@@ -140,6 +149,60 @@ namespace GridKit
       return 0;
     }
 
+    template <class ScalarT, typename IdxT>
+    int Branch<ScalarT, IdxT>::verify() const
+    {
+      int ret = parameter_error_count_;
+
+      auto check = [&](bool condition, const char* message)
+      {
+        if (!condition)
+        {
+          Log::error() << "Branch: " << message << '\n';
+          ret += 1;
+        }
+      };
+
+      check(bus1_ != nullptr, "bus1 pointer is null");
+      check(bus2_ != nullptr, "bus2 pointer is null");
+
+      check(std::isfinite(R_), "R must be finite");
+      check(std::isfinite(X_), "X must be finite");
+      check(std::isfinite(G_), "G must be finite");
+      check(std::isfinite(B_), "B must be finite");
+      check(std::isfinite(tap_), "tap must be finite");
+      check(std::isfinite(phase_), "phase must be finite");
+      check(R_ * R_ + X_ * X_ > RealT{0.0}, "R and X cannot both be zero");
+      check(tap_ > RealT{0.0}, "tap must be positive");
+
+      return ret;
+    }
+
+    template <class ScalarT, typename IdxT>
+    __attribute__((always_inline)) inline void Branch<ScalarT, IdxT>::addAdmittanceContribution(
+        const AdmittanceBlock& y,
+        const ScalarT&         Vr,
+        const ScalarT&         Vi,
+        ScalarT&               Ir,
+        ScalarT&               Ii)
+    {
+      Ir += y.G * Vr - y.B * Vi;
+      Ii += y.B * Vr + y.G * Vi;
+    }
+
+    template <class ScalarT, typename IdxT>
+    __attribute__((always_inline)) inline void Branch<ScalarT, IdxT>::evaluateAdmittanceBlock(
+        const AdmittanceBlock& y,
+        const ScalarT*         wb,
+        ScalarT*               h)
+    {
+      const ScalarT Vr = wb[0];
+      const ScalarT Vi = wb[1];
+
+      h[0] = y.G * Vr - y.B * Vi;
+      h[1] = y.B * Vr + y.G * Vi;
+    }
+
     /**
      * @brief Bus 1 residual contribution from bus 1 variables
      *
@@ -151,12 +214,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      ScalarT Vr1 = wb[0];
-      ScalarT Vi1 = wb[1];
-      ScalarT Ir1 = -(g_ + 0.5 * G_) * Vr1 + (b_ + 0.5 * B_) * Vi1;
-      ScalarT Ii1 = -(b_ + 0.5 * B_) * Vr1 - (g_ + 0.5 * G_) * Vi1;
-      h[0]        = Ir1;
-      h[1]        = Ii1;
+      evaluateAdmittanceBlock(y11_, wb, h);
 
       return 0;
     }
@@ -172,12 +230,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      ScalarT Vr2 = wb[0];
-      ScalarT Vi2 = wb[1];
-      ScalarT Ir1 = g_ * Vr2 - b_ * Vi2;
-      ScalarT Ii1 = b_ * Vr2 + g_ * Vi2;
-      h[0]        = Ir1;
-      h[1]        = Ii1;
+      evaluateAdmittanceBlock(y12_, wb, h);
 
       return 0;
     }
@@ -193,12 +246,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      ScalarT Vr1 = wb[0];
-      ScalarT Vi1 = wb[1];
-      ScalarT Ir2 = g_ * Vr1 - b_ * Vi1;
-      ScalarT Ii2 = b_ * Vr1 + g_ * Vi1;
-      h[0]        = Ir2;
-      h[1]        = Ii2;
+      evaluateAdmittanceBlock(y21_, wb, h);
 
       return 0;
     }
@@ -214,12 +262,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      ScalarT Vr2 = wb[0];
-      ScalarT Vi2 = wb[1];
-      ScalarT Ir2 = -(g_ + 0.5 * G_) * Vr2 + (b_ + 0.5 * B_) * Vi2;
-      ScalarT Ii2 = -(b_ + 0.5 * B_) * Vr2 - (g_ + 0.5 * G_) * Vi2;
-      h[0]        = Ir2;
-      h[1]        = Ii2;
+      evaluateAdmittanceBlock(y22_, wb, h);
 
       return 0;
     }
@@ -231,49 +274,51 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     int Branch<ScalarT, IdxT>::evaluateResidual()
     {
-      wb_[0] = Vr1();
-      wb_[1] = Vi1();
-      evaluateBusResidual11(y_.data(), yp_.data(), wb_.data(), h_.data());
-      Ir1() += h_[0];
-      Ii1() += h_[1];
-      evaluateBusResidual21(y_.data(), yp_.data(), wb_.data(), h_.data());
-      Ir2() += h_[0];
-      Ii2() += h_[1];
+      ScalarT ir1{0.0};
+      ScalarT ii1{0.0};
+      ScalarT ir2{0.0};
+      ScalarT ii2{0.0};
 
-      wb_[0] = Vr2();
-      wb_[1] = Vi2();
-      evaluateBusResidual12(y_.data(), yp_.data(), wb_.data(), h_.data());
-      Ir1() += h_[0];
-      Ii1() += h_[1];
-      evaluateBusResidual22(y_.data(), yp_.data(), wb_.data(), h_.data());
-      Ir2() += h_[0];
-      Ii2() += h_[1];
+      terminalCurrent1(ir1, ii1);
+      terminalCurrent2(ir2, ii2);
+
+      Ir1() += ir1;
+      Ii1() += ii1;
+      Ir2() += ir2;
+      Ii2() += ii2;
 
       return 0;
     }
 
     template <class ScalarT, typename IdxT>
+    void Branch<ScalarT, IdxT>::terminalCurrent1(ScalarT& Ir, ScalarT& Ii)
+    {
+      Ir = ScalarT{0.0};
+      Ii = ScalarT{0.0};
+
+      addAdmittanceContribution(y11_, Vr1(), Vi1(), Ir, Ii);
+      addAdmittanceContribution(y12_, Vr2(), Vi2(), Ir, Ii);
+    }
+
+    template <class ScalarT, typename IdxT>
+    void Branch<ScalarT, IdxT>::terminalCurrent2(ScalarT& Ir, ScalarT& Ii)
+    {
+      Ir = ScalarT{0.0};
+      Ii = ScalarT{0.0};
+
+      addAdmittanceContribution(y21_, Vr1(), Vi1(), Ir, Ii);
+      addAdmittanceContribution(y22_, Vr2(), Vi2(), Ir, Ii);
+    }
+
+    template <class ScalarT, typename IdxT>
     void Branch<ScalarT, IdxT>::initializeParameters(const model_data_type& data)
     {
-      if (data.parameters.contains(model_data_type::Parameters::R))
-      {
-        R_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::R));
-      }
-
-      if (data.parameters.contains(model_data_type::Parameters::X))
-      {
-        X_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::X));
-      }
-
-      if (data.parameters.contains(model_data_type::Parameters::G))
-      {
-        G_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::G));
-      }
-
-      if (data.parameters.contains(model_data_type::Parameters::B))
-      {
-        B_ = std::get<RealT>(data.parameters.at(model_data_type::Parameters::B));
-      }
+      readRealParameter(data, model_data_type::Parameters::R, R_);
+      readRealParameter(data, model_data_type::Parameters::X, X_);
+      readRealParameter(data, model_data_type::Parameters::G, G_);
+      readRealParameter(data, model_data_type::Parameters::B, B_);
+      readRealParameter(data, model_data_type::Parameters::tap, tap_);
+      readRealParameter(data, model_data_type::Parameters::phase, phase_);
 
       if (data.ports.contains(model_data_type::Ports::bus1))
       {
@@ -287,6 +332,35 @@ namespace GridKit
     }
 
     template <class ScalarT, typename IdxT>
+    bool Branch<ScalarT, IdxT>::readRealParameter(const model_data_type&               data,
+                                                  typename model_data_type::Parameters parameter,
+                                                  RealT&                               target)
+    {
+      if (!data.parameters.contains(parameter))
+      {
+        return false;
+      }
+
+      const auto& value = data.parameters.at(parameter);
+      if (const auto* real_value = std::get_if<RealT>(&value))
+      {
+        target = *real_value;
+        return true;
+      }
+
+      if (const auto* integer_value = std::get_if<IdxT>(&value))
+      {
+        target = static_cast<RealT>(*integer_value);
+        return true;
+      }
+
+      Log::error() << "Branch: parameter " << magic_enum::enum_name(parameter)
+                   << " must be numeric\n";
+      parameter_error_count_ += 1;
+      return false;
+    }
+
+    template <class ScalarT, typename IdxT>
     const Model::VariableMonitorBase* Branch<ScalarT, IdxT>::getMonitor() const
     {
       return monitor_.get();
@@ -297,25 +371,65 @@ namespace GridKit
     {
       using Variable = typename model_data_type::MonitorableVariables;
       monitor_->set(Variable::ir1, [this]
-                    { return Ir1(); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent1(Ir, Ii);
+                      return Ir; });
       monitor_->set(Variable::ii1, [this]
-                    { return Ii1(); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent1(Ir, Ii);
+                      return Ii; });
       monitor_->set(Variable::im1, [this]
-                    { return std::sqrt(Ir1() * Ir1() + Ii1() * Ii1()); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent1(Ir, Ii);
+                      return std::sqrt(Ir * Ir + Ii * Ii); });
       monitor_->set(Variable::p1, [this]
-                    { return Vr1() * Ir1() + Vi1() * Ii1(); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent1(Ir, Ii);
+                      return Vr1() * Ir + Vi1() * Ii; });
       monitor_->set(Variable::q1, [this]
-                    { return Vi1() * Ir1() - Vr1() * Ii1(); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent1(Ir, Ii);
+                      return Vi1() * Ir - Vr1() * Ii; });
       monitor_->set(Variable::ir2, [this]
-                    { return Ir2(); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent2(Ir, Ii);
+                      return Ir; });
       monitor_->set(Variable::ii2, [this]
-                    { return Ii2(); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent2(Ir, Ii);
+                      return Ii; });
       monitor_->set(Variable::im2, [this]
-                    { return std::sqrt(Ir2() * Ir2() + Ii2() * Ii2()); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent2(Ir, Ii);
+                      return std::sqrt(Ir * Ir + Ii * Ii); });
       monitor_->set(Variable::p2, [this]
-                    { return Vr2() * Ir2() + Vi2() * Ii2(); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent2(Ir, Ii);
+                      return Vr2() * Ir + Vi2() * Ii; });
       monitor_->set(Variable::q2, [this]
-                    { return Vi2() * Ir2() - Vr2() * Ii2(); });
+                    {
+                      ScalarT Ir;
+                      ScalarT Ii;
+                      terminalCurrent2(Ir, Ii);
+                      return Vi2() * Ir - Vr2() * Ii; });
     }
 
     /**
@@ -325,8 +439,28 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     void Branch<ScalarT, IdxT>::setDerivedParams()
     {
-      b_ = -X_ / (R_ * R_ + X_ * X_);
-      g_ = R_ / (R_ * R_ + X_ * X_);
+      const RealT denom   = R_ * R_ + X_ * X_;
+      const RealT g       = R_ / denom;
+      const RealT b       = -X_ / denom;
+      const RealT inv_tap = RealT{1.0} / tap_;
+
+      const std::complex<RealT> ybr{g, b};
+      const std::complex<RealT> ysh{G_, B_};
+      const std::complex<RealT> rotation{std::cos(phase_), std::sin(phase_)};
+      const std::complex<RealT> ydiag = -(ybr + RealT{0.5} * ysh);
+
+      setAdmittanceBlock(y11_, ydiag * inv_tap * inv_tap);
+      setAdmittanceBlock(y12_, ybr * rotation * inv_tap);
+      setAdmittanceBlock(y21_, ybr * std::conj(rotation) * inv_tap);
+      setAdmittanceBlock(y22_, ydiag);
+    }
+
+    template <class ScalarT, typename IdxT>
+    void Branch<ScalarT, IdxT>::setAdmittanceBlock(AdmittanceBlock&           block,
+                                                   const std::complex<RealT>& y)
+    {
+      block.G = y.real();
+      block.B = y.imag();
     }
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -8,7 +8,6 @@
  */
 
 #include <cmath>
-#include <complex>
 #include <variant>
 
 #include <magic_enum/magic_enum.hpp>
@@ -180,27 +179,29 @@ namespace GridKit
 
     template <class ScalarT, typename IdxT>
     __attribute__((always_inline)) inline void Branch<ScalarT, IdxT>::addAdmittanceContribution(
-        const AdmittanceBlock& y,
-        const ScalarT&         Vr,
-        const ScalarT&         Vi,
-        ScalarT&               Ir,
-        ScalarT&               Ii)
+        RealT          G,
+        RealT          B,
+        const ScalarT& Vr,
+        const ScalarT& Vi,
+        ScalarT&       Ir,
+        ScalarT&       Ii)
     {
-      Ir += y.G * Vr - y.B * Vi;
-      Ii += y.B * Vr + y.G * Vi;
+      Ir += G * Vr - B * Vi;
+      Ii += B * Vr + G * Vi;
     }
 
     template <class ScalarT, typename IdxT>
     __attribute__((always_inline)) inline void Branch<ScalarT, IdxT>::evaluateAdmittanceBlock(
-        const AdmittanceBlock& y,
-        const ScalarT*         wb,
-        ScalarT*               h)
+        RealT          G,
+        RealT          B,
+        const ScalarT* wb,
+        ScalarT*       h)
     {
       const ScalarT Vr = wb[0];
       const ScalarT Vi = wb[1];
 
-      h[0] = y.G * Vr - y.B * Vi;
-      h[1] = y.B * Vr + y.G * Vi;
+      h[0] = G * Vr - B * Vi;
+      h[1] = B * Vr + G * Vi;
     }
 
     /**
@@ -214,7 +215,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      evaluateAdmittanceBlock(y11_, wb, h);
+      evaluateAdmittanceBlock(g11_, b11_, wb, h);
 
       return 0;
     }
@@ -230,7 +231,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      evaluateAdmittanceBlock(y12_, wb, h);
+      evaluateAdmittanceBlock(g12_, b12_, wb, h);
 
       return 0;
     }
@@ -246,7 +247,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      evaluateAdmittanceBlock(y21_, wb, h);
+      evaluateAdmittanceBlock(g21_, b21_, wb, h);
 
       return 0;
     }
@@ -262,7 +263,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      evaluateAdmittanceBlock(y22_, wb, h);
+      evaluateAdmittanceBlock(g22_, b22_, wb, h);
 
       return 0;
     }
@@ -296,8 +297,8 @@ namespace GridKit
       Ir = ScalarT{0.0};
       Ii = ScalarT{0.0};
 
-      addAdmittanceContribution(y11_, Vr1(), Vi1(), Ir, Ii);
-      addAdmittanceContribution(y12_, Vr2(), Vi2(), Ir, Ii);
+      addAdmittanceContribution(g11_, b11_, Vr1(), Vi1(), Ir, Ii);
+      addAdmittanceContribution(g12_, b12_, Vr2(), Vi2(), Ir, Ii);
     }
 
     template <class ScalarT, typename IdxT>
@@ -306,8 +307,8 @@ namespace GridKit
       Ir = ScalarT{0.0};
       Ii = ScalarT{0.0};
 
-      addAdmittanceContribution(y21_, Vr1(), Vi1(), Ir, Ii);
-      addAdmittanceContribution(y22_, Vr2(), Vi2(), Ir, Ii);
+      addAdmittanceContribution(g21_, b21_, Vr1(), Vi1(), Ir, Ii);
+      addAdmittanceContribution(g22_, b22_, Vr2(), Vi2(), Ir, Ii);
     }
 
     template <class ScalarT, typename IdxT>
@@ -439,28 +440,41 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     void Branch<ScalarT, IdxT>::setDerivedParams()
     {
-      const RealT denom   = R_ * R_ + X_ * X_;
-      const RealT g       = R_ / denom;
-      const RealT b       = -X_ / denom;
+      g11_ = RealT{0.0};
+      b11_ = RealT{0.0};
+      g12_ = RealT{0.0};
+      b12_ = RealT{0.0};
+      g21_ = RealT{0.0};
+      b21_ = RealT{0.0};
+      g22_ = RealT{0.0};
+      b22_ = RealT{0.0};
+
+      const RealT denom = R_ * R_ + X_ * X_;
+      if (denom == RealT{0.0} || tap_ == RealT{0.0})
+      {
+        return;
+      }
+
+      const RealT g_br    = R_ / denom;
+      const RealT b_br    = -X_ / denom;
       const RealT inv_tap = RealT{1.0} / tap_;
+      const RealT cos_ph  = std::cos(phase_);
+      const RealT sin_ph  = std::sin(phase_);
 
-      const std::complex<RealT> ybr{g, b};
-      const std::complex<RealT> ysh{G_, B_};
-      const std::complex<RealT> rotation{std::cos(phase_), std::sin(phase_)};
-      const std::complex<RealT> ydiag = -(ybr + RealT{0.5} * ysh);
+      const RealT g_diag = -(g_br + RealT{0.5} * G_);
+      const RealT b_diag = -(b_br + RealT{0.5} * B_);
 
-      setAdmittanceBlock(y11_, ydiag * inv_tap * inv_tap);
-      setAdmittanceBlock(y12_, ybr * rotation * inv_tap);
-      setAdmittanceBlock(y21_, ybr * std::conj(rotation) * inv_tap);
-      setAdmittanceBlock(y22_, ydiag);
-    }
+      g11_ = g_diag * inv_tap * inv_tap;
+      b11_ = b_diag * inv_tap * inv_tap;
 
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::setAdmittanceBlock(AdmittanceBlock&           block,
-                                                   const std::complex<RealT>& y)
-    {
-      block.G = y.real();
-      block.B = y.imag();
+      g12_ = (g_br * cos_ph - b_br * sin_ph) * inv_tap;
+      b12_ = (b_br * cos_ph + g_br * sin_ph) * inv_tap;
+
+      g21_ = (g_br * cos_ph + b_br * sin_ph) * inv_tap;
+      b21_ = (b_br * cos_ph - g_br * sin_ph) * inv_tap;
+
+      g22_ = g_diag;
+      b22_ = b_diag;
     }
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Branch/README.md
+++ b/GridKit/Model/PhasorDynamics/Branch/README.md
@@ -1,144 +1,191 @@
-# Transmission Line Branch Model
+# **Branch Model**
 
-Transmission lines and different types of transformers (traditional, Load
-Tap-Changing transformers (LTC) and Phase Angle Regulators (PARs)) can be
-modeled with a common branch model.
+The Branch model represents a two-terminal phasor-domain $\pi$ branch with an
+optional off-nominal tap magnitude and phase shift on bus 1. Terminal current
+contributions are oriented entering the adjacent buses.
 
-The most common circuit that is used to represent the transmission line model
-is $`\pi`$ circuit as shown in Figure 1. The positive flow direction is into
-buses. Commonly used convention is to define positive direction to be from
-sending to receiving bus. We decide to use this symmetric convention because it
-provides more flexibility for modeling.
+Notes:
+- Setting $\tau = 1$ and $\theta = 0$ gives the ordinary symmetric
+  transmission-line $\pi$ model.
+- $G$ and $B$ are total branch shunt values split equally between terminals.
+- The branch has no solver-owned variables; it contributes current residuals
+  directly to the connected buses.
+
+## Circuit Diagram
+
+An ideal complex tap is placed on the bus-1 side of the branch equivalent. The
+ordinary transmission-line $\pi$ model is recovered with $\tau = 1$ and
+$\theta = 0$.
 
 <div align="center">
-   <img align="center" src="../../../../docs/Figures/branch_phasor_dynamics.png">
+   <img align="center" src="../../../../docs/Figures/transformer-branch.png">
 
-  Figure 1: Transmission line $`\pi`$ equivalent circuit
+  Figure 1: Branch equivalent circuit
 </div>
 
 ## Model Parameters
 
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------| ------
-$R$  | [p.u.] | Branch series resistance  | 
-$X$  | [p.u.] | Branch series reactance  | 
-$G$  | [p.u.] | Branch shunt conductance  | 
-$B$  | [p.u.] | Branch shunt susceptance  | 
+Symbol      | Units   | Description                                      | Typical Value | Note
+------------|---------|--------------------------------------------------|---------------|------
+$R$         | [p.u.]  | Branch series resistance                         |               |
+$X$         | [p.u.]  | Branch series reactance                          |               |
+$G$         | [p.u.]  | Total branch shunt conductance                   | 0             |
+$B$         | [p.u.]  | Total branch shunt susceptance                   | 0             |
+$\tau$      | [p.u.]  | Off-nominal tap magnitude on bus-1 side          | 1             | Parameter name: `tap`
+$\theta$    | [rad]   | Phase-shift angle                                | 0             | Parameter name: `phase`
 
-### Model Derived Parameters
-Note the difference between little-g and big-G, little-b, big-B in these equations.
-``` math
+### Parameter Validation
+
+Invalid Branch parameter sets are rejected by the following checks:
+
+```math
 \begin{aligned}
-  g   &=\dfrac{R}{R^2 + X^2} \\
-  b   &= -\dfrac{X}{R^2 + X^2}\\
+  &R, X, G, B, \tau, \theta \in \mathbb{R}\ \text{and finite} \\
+  &R^2 + X^2 > 0 \\
+  &\tau > 0
 \end{aligned}
 ```
 
+### Model Derived Parameters
+
+The series and shunt admittances are:
+
+```math
+\begin{aligned}
+  Y_{\mathrm{br}} &= \dfrac{1}{R + jX} \\
+  Y_{\mathrm{sh}} &= G + jB
+\end{aligned}
+```
+
+The nominal $\pi$-branch admittance matrix is the sum of the series and shunt
+admittance contributions:
+
+```math
+\begin{aligned}
+  \mathbf{Y}_0
+    &=
+    \begin{bmatrix}
+      -Y_{\mathrm{br}} & Y_{\mathrm{br}} \\
+      Y_{\mathrm{br}}
+      & -Y_{\mathrm{br}}
+    \end{bmatrix}
+    +
+    \dfrac{1}{2}
+    \begin{bmatrix}
+      -Y_{\mathrm{sh}} & 0 \\
+      0 & -Y_{\mathrm{sh}}
+    \end{bmatrix}
+\end{aligned}
+```
+
+The off-nominal transformer transformation uses bus 1 as the tap side:
+
+```math
+\begin{aligned}
+  \mathbf{M}
+    &=
+    \begin{bmatrix}
+      \tau^{-1} & 0 \\
+      0 & e^{j\theta}
+    \end{bmatrix} \\
+  \mathbf{Y} &= \mathbf{M}^{\dagger}\mathbf{Y}_0\mathbf{M}
+\end{aligned}
+```
+
+For the equations below, write each entry as $Y_{mn}=G_{mn}+jB_{mn}$.
 
 ## Model Variables
 
 ### Internal Variables
 
 #### Differential
+
 None.
 
 #### Algebraic
 
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------| ------
-$I_{r1}$  | [p.u.] | Terminal current, real component, bus 1  | Read by bus
-$I_{i1}$  | [p.u.] | Terminal current, imaginary component, bus 1  |  Read by bus
-$I_{r2}$  | [p.u.] | Terminal current, real component, bus 2  | Read by bus
-$I_{i2}$  | [p.u.] | Terminal current, imaginary component, bus 2  |  Read by bus
-
+None.
 
 ### External Variables
 
 #### Differential
+
 None.
 
 #### Algebraic
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------| ------
-$V_{r1}$  | [p.u.] | Terminal voltage, real component, bus 1 | owned by bus object
-$V_{i1}$  | [p.u.] | Terminal voltage, imaginary component, bus 1 | owned by bus object
-$V_{r2}$  | [p.u.] | Terminal voltage, real component, bus 2 | owned by bus object
-$V_{i2}$  | [p.u.] | Terminal voltage, imaginary component, bus 2 | owned by bus object
 
+Symbol      | Units   | Description                             | Note
+------------|---------|-----------------------------------------|------
+$V_{r1}$    | [p.u.]  | Terminal voltage, real component, bus 1 | Owned by bus object
+$V_{i1}$    | [p.u.]  | Terminal voltage, imaginary component, bus 1 | Owned by bus object
+$V_{r2}$    | [p.u.]  | Terminal voltage, real component, bus 2 | Owned by bus object
+$V_{i2}$    | [p.u.]  | Terminal voltage, imaginary component, bus 2 | Owned by bus object
 
 ## Model Equations
 
 ### Differential Equations
+
 None.
 
 ### Algebraic Equations
-``` math
-\begin{aligned}
-      0 &= - I_{r1} -\left(g + \dfrac{G}{2}\right) V_{r1} + \left(b + \dfrac{B}{2}\right) V_{i1} + g V_{r2} - b V_{i2}\\
-      0 &= I_{i1} - \left(b + \dfrac{B}{2}\right) V_{r1} - \left(g + \dfrac{G}{2}\right) V_{i1} + b V_{r2} + g V_{i2}\\
-      0 &= I_{r2} + g V_{r1} - b V_{i1} - \left(g + \dfrac{G}{2}\right) V_{r2} + \left(b + \dfrac{B}{2}\right) V_{i2}\\
-      0 &= I_{i2} + b V_{r1} + g V_{i1} - \left(b + \dfrac{B}{2}\right) V_{r2} - \left(g + \dfrac{G}{2}\right) V_{i2}
-\end{aligned}
-```
 
-# Model Outputs
-
-Real and imaginary current at the branch's two buses
-are model variables of the branch model: $I_{r1}$, $I_{i1}$, $I_{r2}$, 
-and $I_{i2}$.
-Current is oriented leaving the branch (i.e. entering the bus).
-
-Current magnitude $I_{m1}$ and $I_{m2}$ are the phasor magnitude of the current.
-``` math
-\begin{aligned}
-      I_{m1} &= \sqrt{(I_{r1})^2 + (I_{i1})^2} \\
-      I_{m2} &= \sqrt{(I_{r2})^2 + (I_{i2})^2}
-\end{aligned}
-```
-
-Active and reactive power ($P_1$, $Q_1$, $P_2$, and $Q_2$) 
-are the real and imaginary parts of the complex power at each end of the branch,
-where the complex power is defined as $S=VI^{\ast}=(V_r + j V_i)(I_r - jI_i)$
-``` math
-\begin{aligned}
-      P_1 &= V_{r1} I_{r1} + V_{i1} I_{i1}\\
-      Q_1 &= V_{i1} I_{r1} - V_{r1} I_{i1} \\
-      P_2 &= V_{r2} I_{r2} + V_{i2} I_{i2}\\
-      Q_2 &= V_{i2} I_{r2} - V_{r2} I_{i2}
-\end{aligned}
-```
-
-Real and reactive power are oriented leaving the branch (i.e. entering the bus).
-
-# Transformer Branch Model
-
-**Note: Transformer model not yet implemented**
-
-The branch model can be created by adding the ideal transformer in series with
-the $`\pi`$ circuit as shown in Figure 2 where $`\tau`$ is a tap ratio
-magnitude and $`\theta`$ is the phase shift angle and
-$`N = \tau e^{j \theta}`$.
-
-<div align="center">
-   <img align="center" src="../../../../docs/Figures/transformer-branch.png">
-   
-   
-  Figure 2: Branch equivalent circuit
-</div>
-
-
-The branch admitance matrix is then:
+The branch current relation is $0 = -\mathbf{I} + \mathbf{Y}\mathbf{V}$.
 
 ```math
-\mathbf{Y}_{BR}=
-\begin{bmatrix}
- -\left(g + jb + \dfrac{G+jB}{2} \right) \dfrac{1}{\tau^2} & (g + jb)\dfrac{1}{\tau e^{-j\theta}}\\
-                                                           &                                     \\
-     (g + jb)\dfrac{1}{\tau e^{j\theta}}                   & -\left(g + jb + \dfrac{G+jB}{2}\right)
-\end{bmatrix}
+\begin{aligned}
+  I_{r1} &= G_{11} V_{r1} - B_{11} V_{i1}
+         + G_{12} V_{r2} - B_{12} V_{i2} \\
+  I_{i1} &= B_{11} V_{r1} + G_{11} V_{i1}
+         + B_{12} V_{r2} + G_{12} V_{i2} \\
+  I_{r2} &= G_{21} V_{r1} - B_{21} V_{i1}
+         + G_{22} V_{r2} - B_{22} V_{i2} \\
+  I_{i2} &= B_{21} V_{r1} + G_{21} V_{i1}
+         + B_{22} V_{r2} + G_{22} V_{i2}
+\end{aligned}
 ```
 
-### Branch contribution to residuals at adjacent busses
+These current contributions are added to the connected bus residuals with
+positive sign because branch current is oriented entering the bus.
 
-The currents entering adjacent buses are obtained in a similar manner as for
-the $`\pi`$-model.
+## Initialization
+
+The Branch model has no internal state to initialize. During construction or
+parameter updates, the component computes $\mathbf{Y}$ from the current
+parameter values. Initial terminal current and power monitor values are
+evaluated from the connected bus voltages. Parameter verification rejects the
+invalid cases listed above.
+
+## Model Outputs
+
+Output | Units  | Description                                  | Note
+-------|--------|----------------------------------------------|------
+`ir1`  | [p.u.] | Terminal current, real component, bus 1      | Oriented entering bus 1
+`ii1`  | [p.u.] | Terminal current, imaginary component, bus 1 | Oriented entering bus 1
+`im1`  | [p.u.] | Terminal current magnitude, bus 1            |
+`p1`   | [p.u.] | Active power at bus 1 terminal               | Positive entering bus 1
+`q1`   | [p.u.] | Reactive power at bus 1 terminal             | Positive entering bus 1
+`ir2`  | [p.u.] | Terminal current, real component, bus 2      | Oriented entering bus 2
+`ii2`  | [p.u.] | Terminal current, imaginary component, bus 2 | Oriented entering bus 2
+`im2`  | [p.u.] | Terminal current magnitude, bus 2            |
+`p2`   | [p.u.] | Active power at bus 2 terminal               | Positive entering bus 2
+`q2`   | [p.u.] | Reactive power at bus 2 terminal             | Positive entering bus 2
+
+Current magnitudes are:
+
+```math
+\begin{aligned}
+  I_{m1} &= \sqrt{I_{r1}^2 + I_{i1}^2} \\
+  I_{m2} &= \sqrt{I_{r2}^2 + I_{i2}^2}
+\end{aligned}
+```
+
+Complex power at each end is defined as $S=VI^{\ast}$:
+
+```math
+\begin{aligned}
+  P_1 &= V_{r1} I_{r1} + V_{i1} I_{i1} \\
+  Q_1 &= V_{i1} I_{r1} - V_{r1} I_{i1} \\
+  P_2 &= V_{r2} I_{r2} + V_{i2} I_{i2} \\
+  Q_2 &= V_{i2} I_{r2} - V_{r2} I_{i2}
+\end{aligned}
+```

--- a/GridKit/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/GridKit/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -139,7 +139,7 @@ are specified:
 
   Device class         | Description                                          | Ports                            | Initialization parameters   | Variables available to monitor
   ---------------------|------------------------------------------------------|----------------------------------|---------------------------- | -------------------------
-  `Branch`             | a basic algebraic pi model for a line or transformer | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`           | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
+  `Branch`             | algebraic pi model for a line or off-nominal transformer branch | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`, `tap`, `phase` | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
   `Load`               | a basic static impedence load model                  | `bus`                            | `R`, `X` | `p`, `q`
   `Genrou`             | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqop`, `Tqopp`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12`, `mva_base`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`, `speed`
   `Gensal`             | 5th order salient-pole machine model                 | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xl`, `S10`, `S12`, `mva_base`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`, `speed`, `Eqp`, `psidp`, `psiqpp`, `psidpp`, `vd`, `vq`, `te`, `id`, `iq`
@@ -154,6 +154,10 @@ are specified:
 Ports marked with \* are optional and, if missing, will be assumed to be
 connected to a constant value. This list is subject to change.
 
+
+For `Branch`, `tap` and `phase` are optional parameters. If omitted, `tap`
+defaults to `1.0` and `phase` defaults to `0.0` radians. Bus `bus1` is the tap
+side for off-nominal transformer branches.
 
 ## Example File for a 2-Bus System
 

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -1,10 +1,12 @@
+#include <cmath>
+#include <complex>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/Model/PhasorDynamics/Branch/Branch.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
-#include <GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
 
@@ -25,6 +27,7 @@ namespace GridKit
 
       TestOutcome constructor()
       {
+        // Verifies Branch construction through the component interface.
         TestStatus success = true;
 
         auto* bus1 = new PhasorDynamics::Bus<ScalarT, IdxT>(1.0, 0.0);
@@ -47,6 +50,7 @@ namespace GridKit
 
       TestOutcome residual()
       {
+        // Verifies nominal pi-branch current residual contributions.
         TestStatus success = true;
 
         RealT R{2.0}; ///< Branch series resistance
@@ -64,8 +68,14 @@ namespace GridKit
         const ScalarT Ir2{15.0};  ///< Solution: real current entering bus-2
         const ScalarT Ii2{-20.0}; ///< Solution: imaginary current entering bus-2
 
-        PhasorDynamics::BusInfinite<ScalarT, IdxT> bus1(Vr1, Vi1);
-        PhasorDynamics::BusInfinite<ScalarT, IdxT> bus2(Vr2, Vi2);
+        PhasorDynamics::Bus<ScalarT, IdxT> bus1(Vr1, Vi1);
+        PhasorDynamics::Bus<ScalarT, IdxT> bus2(Vr2, Vi2);
+        bus1.allocate();
+        bus1.initialize();
+        bus1.evaluateResidual();
+        bus2.allocate();
+        bus2.initialize();
+        bus2.evaluateResidual();
 
         PhasorDynamics::Branch<ScalarT, IdxT> branch(&bus1, &bus2, R, X, G, B);
         branch.allocate();
@@ -79,8 +89,53 @@ namespace GridKit
         return success.report(__func__);
       }
 
+      TestOutcome offNominalResidual()
+      {
+        // Verifies tap and phase-shift current residual contributions.
+        TestStatus success = true;
+
+        RealT R{2.0};
+        RealT X{4.0};
+        RealT G{0.2};
+        RealT B{1.2};
+        RealT tap{1.25};
+        RealT phase{0.3};
+
+        ScalarT Vr1{10.0};
+        ScalarT Vi1{20.0};
+        ScalarT Vr2{30.0};
+        ScalarT Vi2{40.0};
+
+        const ScalarT Ir1{12.719793434963478};
+        const ScalarT Ii1{-4.047960563981182};
+        const ScalarT Ir2{13.821345956502421};
+        const ScalarT Ii2{-21.182080826645354};
+
+        PhasorDynamics::Bus<ScalarT, IdxT> bus1(Vr1, Vi1);
+        PhasorDynamics::Bus<ScalarT, IdxT> bus2(Vr2, Vi2);
+        bus1.allocate();
+        bus1.initialize();
+        bus1.evaluateResidual();
+        bus2.allocate();
+        bus2.initialize();
+        bus2.evaluateResidual();
+
+        PhasorDynamics::Branch<ScalarT, IdxT> branch(&bus1, &bus2, R, X, G, B, tap, phase);
+        branch.allocate();
+        branch.evaluateResidual();
+
+        const RealT tol{1.0e-12};
+        success *= isEqual(bus1.Ir(), Ir1, tol);
+        success *= isEqual(bus1.Ii(), Ii1, tol);
+        success *= isEqual(bus2.Ir(), Ir2, tol);
+        success *= isEqual(bus2.Ii(), Ii2, tol);
+
+        return success.report(__func__);
+      }
+
       TestOutcome jacobian()
       {
+        // Verifies nominal branch residual derivatives.
         TestStatus success = true;
 
         RealT R{2.0}; ///< Branch series resistance
@@ -93,13 +148,18 @@ namespace GridKit
         DependencyTracking::Variable Vr2{30.0}; ///< Bus-2 real voltage
         DependencyTracking::Variable Vi2{40.0}; ///< Bus-2 imaginary voltage
 
-        Vr1.setVariableNumber(0); ///< Independent variables: first
-        Vi1.setVariableNumber(1); ///< Independent variables: second
-        Vr2.setVariableNumber(2); ///< Independent variables: third
-        Vi2.setVariableNumber(3); ///< Independent variables: fourth
-
-        PhasorDynamics::BusInfinite<DependencyTracking::Variable, IdxT> bus1(Vr1, Vi1);
-        PhasorDynamics::BusInfinite<DependencyTracking::Variable, IdxT> bus2(Vr2, Vi2);
+        PhasorDynamics::Bus<DependencyTracking::Variable, IdxT> bus1(Vr1, Vi1);
+        PhasorDynamics::Bus<DependencyTracking::Variable, IdxT> bus2(Vr2, Vi2);
+        bus1.allocate();
+        bus1.initialize();
+        bus1.evaluateResidual();
+        bus2.allocate();
+        bus2.initialize();
+        bus2.evaluateResidual();
+        bus1.Vr().setVariableNumber(0);
+        bus1.Vi().setVariableNumber(1);
+        bus2.Vr().setVariableNumber(2);
+        bus2.Vi().setVariableNumber(3);
 
         PhasorDynamics::Branch<DependencyTracking::Variable, IdxT> branch(&bus1, &bus2, R, X, G, B);
         branch.allocate();
@@ -120,66 +180,196 @@ namespace GridKit
         return success.report(__func__);
       }
 
-      TestOutcome accessors()
+      TestOutcome offNominalJacobian()
       {
+        // Verifies tap and phase-shift residual derivatives.
         TestStatus success = true;
 
-        const RealT zero{0.0};
+        RealT R{2.0};
+        RealT X{4.0};
+        RealT G{0.2};
+        RealT B{1.2};
+        RealT tap{1.25};
+        RealT phase{0.3};
 
-        RealT R{2.0}; ///< Branch series resistance
-        RealT X{4.0}; ///< Branch series reactance
-        RealT G{0.2}; ///< Branch shunt conductance
-        RealT B{1.2}; ///< Branch shunt charging
+        DependencyTracking::Variable Vr1{10.0};
+        DependencyTracking::Variable Vi1{20.0};
+        DependencyTracking::Variable Vr2{30.0};
+        DependencyTracking::Variable Vi2{40.0};
 
-        ScalarT Vr1{-1.0}; ///< Bus-1 real voltage
-        ScalarT Vi1{-1.0}; ///< Bus-1 imaginary voltage
-        ScalarT Vr2{1.0};  ///< Bus-2 real voltage
-        ScalarT Vi2{1.0};  ///< Bus-2 imaginary voltage
+        PhasorDynamics::Bus<DependencyTracking::Variable, IdxT> bus1(Vr1, Vi1);
+        PhasorDynamics::Bus<DependencyTracking::Variable, IdxT> bus2(Vr2, Vi2);
+        bus1.allocate();
+        bus1.initialize();
+        bus1.evaluateResidual();
+        bus2.allocate();
+        bus2.initialize();
+        bus2.evaluateResidual();
+        bus1.Vr().setVariableNumber(0);
+        bus1.Vi().setVariableNumber(1);
+        bus2.Vr().setVariableNumber(2);
+        bus2.Vi().setVariableNumber(3);
 
-        const ScalarT res_R{1.0};  ///< Solution: real current entering bus-1
-        const ScalarT res_X{0.5};  ///< Solution: imaginary current entering bus-1
-        const ScalarT res_G{3.0};  ///< Solution: real current entering bus-2
-        const ScalarT res_B{-4.0}; ///< Solution: imaginary current entering bus-2
-
-        PhasorDynamics::BusInfinite<ScalarT, IdxT> bus1(Vr1, Vi1);
-        PhasorDynamics::BusInfinite<ScalarT, IdxT> bus2(Vr2, Vi2);
-
-        PhasorDynamics::Branch<ScalarT, IdxT> branch(&bus1,
-                                                     &bus2,
-                                                     zero,
-                                                     zero,
-                                                     zero,
-                                                     zero);
+        PhasorDynamics::Branch<DependencyTracking::Variable, IdxT> branch(&bus1,
+                                                                          &bus2,
+                                                                          R,
+                                                                          X,
+                                                                          G,
+                                                                          B,
+                                                                          tap,
+                                                                          phase);
         branch.allocate();
-
-        // Test setting branch series resistance
-        branch.setR(R);
-        bus1.evaluateResidual(); // <- set Ir1 to zero
         branch.evaluateResidual();
-        success *= isEqual(bus1.Ir(), res_R);
-        branch.setR(zero);
 
-        // Test setting branch series reactance
-        branch.setX(X);
-        bus1.evaluateResidual(); // <- set Ir1 to zero
-        branch.evaluateResidual();
-        success *= isEqual(bus1.Ir(), res_X);
-        branch.setX(zero);
+        std::vector<DependencyTracking::Variable>                residuals{bus1.Ir(), bus1.Ii(), bus2.Ir(), bus2.Ii()};
+        std::vector<DependencyTracking::Variable::DependencyMap> ref = analyticalJacobian(R, X, G, B, tap, phase);
+
+        const RealT tol{1.0e-12};
+        for (size_t i = 0; i < residuals.size(); ++i)
+        {
+          DependencyTracking::Variable                       res           = residuals[i];
+          const DependencyTracking::Variable::DependencyMap& dependencies  = res.getDependencies();
+          success                                                         *= (GridKit::Testing::isEqual(dependencies, ref[i], tol));
+        }
+
         return success.report(__func__);
+      }
 
-        // Test setting branch shunt conductance
-        branch.setG(G);
-        bus1.evaluateResidual(); // <- set Ir1 to zero
-        branch.evaluateResidual();
-        success *= isEqual(bus1.Ir(), res_G);
-        branch.setG(zero);
+      TestOutcome parameterSetters()
+      {
+        // Verifies parameter setters refresh derived admittance values.
+        TestStatus success = true;
 
-        // Test setting branch shunt charging
-        branch.setB(B);
-        bus1.evaluateResidual(); // <- set Ir1 to zero
-        branch.evaluateResidual();
-        success *= isEqual(bus1.Ir(), res_B);
-        branch.setB(zero);
+        const RealT R{2.0};
+        const RealT X{4.0};
+        const RealT G{0.2};
+        const RealT B{1.2};
+        const RealT tap{1.25};
+        const RealT phase{0.3};
+
+        const ScalarT Vr1{10.0};
+        const ScalarT Vi1{20.0};
+        const ScalarT Vr2{30.0};
+        const ScalarT Vi2{40.0};
+
+        PhasorDynamics::Bus<ScalarT, IdxT> ref_bus1(Vr1, Vi1);
+        PhasorDynamics::Bus<ScalarT, IdxT> ref_bus2(Vr2, Vi2);
+        ref_bus1.allocate();
+        ref_bus1.initialize();
+        ref_bus1.evaluateResidual();
+        ref_bus2.allocate();
+        ref_bus2.initialize();
+        ref_bus2.evaluateResidual();
+        PhasorDynamics::Branch<ScalarT, IdxT> ref_branch(&ref_bus1, &ref_bus2, R, X, G, B, tap, phase);
+
+        PhasorDynamics::Bus<ScalarT, IdxT> test_bus1(Vr1, Vi1);
+        PhasorDynamics::Bus<ScalarT, IdxT> test_bus2(Vr2, Vi2);
+        test_bus1.allocate();
+        test_bus1.initialize();
+        test_bus1.evaluateResidual();
+        test_bus2.allocate();
+        test_bus2.initialize();
+        test_bus2.evaluateResidual();
+        PhasorDynamics::Branch<ScalarT, IdxT> test_branch(&test_bus1, &test_bus2, 1.0, 1.0, 0.0, 0.0);
+
+        test_branch.setR(R);
+        test_branch.setX(X);
+        test_branch.setG(G);
+        test_branch.setB(B);
+        test_branch.setTap(tap);
+        test_branch.setPhase(phase);
+
+        ref_branch.evaluateResidual();
+        test_branch.evaluateResidual();
+
+        const RealT tol{1.0e-12};
+        success *= isEqual(test_bus1.Ir(), ref_bus1.Ir(), tol);
+        success *= isEqual(test_bus1.Ii(), ref_bus1.Ii(), tol);
+        success *= isEqual(test_bus2.Ir(), ref_bus2.Ir(), tol);
+        success *= isEqual(test_bus2.Ii(), ref_bus2.Ii(), tol);
+
+        return success.report(__func__);
+      }
+
+      TestOutcome parameterValidation()
+      {
+        // Verifies invalid branch parameters are rejected.
+        TestStatus success = true;
+
+        PhasorDynamics::Bus<ScalarT, IdxT> bus1(1.0, 0.0);
+        PhasorDynamics::Bus<ScalarT, IdxT> bus2(1.0, 0.0);
+
+        PhasorDynamics::Branch<ScalarT, IdxT> valid_branch(&bus1, &bus2, 0.0, 0.1, 0.0, 0.0);
+        success *= (valid_branch.verify() == 0);
+
+        PhasorDynamics::Branch<ScalarT, IdxT> zero_impedance_branch(&bus1, &bus2, 0.0, 0.0, 0.0, 0.0);
+        success *= (zero_impedance_branch.verify() != 0);
+
+        PhasorDynamics::Branch<ScalarT, IdxT> zero_tap_branch(&bus1, &bus2, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0);
+        success *= (zero_tap_branch.verify() != 0);
+
+        PhasorDynamics::Branch<ScalarT, IdxT> negative_tap_branch(&bus1, &bus2, 0.0, 0.1, 0.0, 0.0, -1.0, 0.0);
+        success *= (negative_tap_branch.verify() != 0);
+
+        const RealT                           nan = std::numeric_limits<RealT>::quiet_NaN();
+        PhasorDynamics::Branch<ScalarT, IdxT> nonfinite_branch(&bus1, &bus2, nan, 0.1, 0.0, 0.0);
+        success *= (nonfinite_branch.verify() != 0);
+
+        return success.report(__func__);
+      }
+
+      TestOutcome dataConstructorDefaults()
+      {
+        // Verifies omitted data parameters use tap and phase defaults.
+        TestStatus success = true;
+
+        const RealT R{2.0};
+        const RealT X{4.0};
+        const RealT G{0.2};
+        const RealT B{1.2};
+
+        const ScalarT Vr1{10.0};
+        const ScalarT Vi1{20.0};
+        const ScalarT Vr2{30.0};
+        const ScalarT Vi2{40.0};
+
+        typename PhasorDynamics::Branch<ScalarT, IdxT>::model_data_type data;
+        data.ports[PhasorDynamics::BranchPorts::bus1]        = 1;
+        data.ports[PhasorDynamics::BranchPorts::bus2]        = 2;
+        data.parameters[PhasorDynamics::BranchParameters::R] = R;
+        data.parameters[PhasorDynamics::BranchParameters::X] = X;
+        data.parameters[PhasorDynamics::BranchParameters::G] = G;
+        data.parameters[PhasorDynamics::BranchParameters::B] = B;
+
+        PhasorDynamics::Bus<ScalarT, IdxT> data_bus1(Vr1, Vi1);
+        PhasorDynamics::Bus<ScalarT, IdxT> data_bus2(Vr2, Vi2);
+        data_bus1.allocate();
+        data_bus1.initialize();
+        data_bus1.evaluateResidual();
+        data_bus2.allocate();
+        data_bus2.initialize();
+        data_bus2.evaluateResidual();
+
+        PhasorDynamics::Bus<ScalarT, IdxT> ref_bus1(Vr1, Vi1);
+        PhasorDynamics::Bus<ScalarT, IdxT> ref_bus2(Vr2, Vi2);
+        ref_bus1.allocate();
+        ref_bus1.initialize();
+        ref_bus1.evaluateResidual();
+        ref_bus2.allocate();
+        ref_bus2.initialize();
+        ref_bus2.evaluateResidual();
+
+        PhasorDynamics::Branch<ScalarT, IdxT> data_branch(&data_bus1, &data_bus2, data);
+        PhasorDynamics::Branch<ScalarT, IdxT> ref_branch(&ref_bus1, &ref_bus2, R, X, G, B, 1.0, 0.0);
+
+        data_branch.evaluateResidual();
+        ref_branch.evaluateResidual();
+
+        const RealT tol{1.0e-12};
+        success *= isEqual(data_bus1.Ir(), ref_bus1.Ir(), tol);
+        success *= isEqual(data_bus1.Ii(), ref_bus1.Ii(), tol);
+        success *= isEqual(data_bus2.Ir(), ref_bus2.Ir(), tol);
+        success *= isEqual(data_bus2.Ii(), ref_bus2.Ii(), tol);
 
         return success.report(__func__);
       }
@@ -188,36 +378,30 @@ namespace GridKit
       std::vector<DependencyTracking::Variable::DependencyMap> analyticalJacobian(const RealT R,
                                                                                   const RealT X,
                                                                                   const RealT G,
-                                                                                  const RealT B)
+                                                                                  const RealT B,
+                                                                                  const RealT tap   = 1.0,
+                                                                                  const RealT phase = 0.0)
       {
-        const RealT b = -X / (R * R + X * X);
-        const RealT g = R / (R * R + X * X);
+        const RealT denom   = R * R + X * X;
+        const RealT g       = R / denom;
+        const RealT b       = -X / denom;
+        const RealT inv_tap = RealT{1.0} / tap;
 
-        RealT dIr1_dVr1 = -(g + 0.5 * G);
-        RealT dIr1_dVi1 = (b + 0.5 * B);
-        RealT dIr1_dVr2 = g;
-        RealT dIr1_dVi2 = -b;
+        const std::complex<RealT> ybr{g, b};
+        const std::complex<RealT> ysh{G, B};
+        const std::complex<RealT> rotation{std::cos(phase), std::sin(phase)};
+        const std::complex<RealT> ydiag = -(ybr + RealT{0.5} * ysh);
 
-        RealT dIi1_dVr1 = -(b + 0.5 * B);
-        RealT dIi1_dVi1 = -(g + 0.5 * G);
-        RealT dIi1_dVr2 = b;
-        RealT dIi1_dVi2 = g;
-
-        RealT dIr2_dVr1 = g;
-        RealT dIr2_dVi1 = -b;
-        RealT dIr2_dVr2 = -(g + 0.5 * G);
-        RealT dIr2_dVi2 = (b + 0.5 * B);
-
-        RealT dIi2_dVr1 = b;
-        RealT dIi2_dVi1 = g;
-        RealT dIi2_dVr2 = -(b + 0.5 * B);
-        RealT dIi2_dVi2 = -(g + 0.5 * G);
+        const std::complex<RealT> y11 = ydiag * inv_tap * inv_tap;
+        const std::complex<RealT> y12 = ybr * rotation * inv_tap;
+        const std::complex<RealT> y21 = ybr * std::conj(rotation) * inv_tap;
+        const std::complex<RealT> y22 = ydiag;
 
         std::vector<DependencyTracking::Variable::DependencyMap> dependencies(4);
-        dependencies[0] = {{0, dIr1_dVr1}, {1, dIr1_dVi1}, {2, dIr1_dVr2}, {3, dIr1_dVi2}};
-        dependencies[1] = {{0, dIi1_dVr1}, {1, dIi1_dVi1}, {2, dIi1_dVr2}, {3, dIi1_dVi2}};
-        dependencies[2] = {{0, dIr2_dVr1}, {1, dIr2_dVi1}, {2, dIr2_dVr2}, {3, dIr2_dVi2}};
-        dependencies[3] = {{0, dIi2_dVr1}, {1, dIi2_dVi1}, {2, dIi2_dVr2}, {3, dIi2_dVi2}};
+        dependencies[0] = {{0, y11.real()}, {1, -y11.imag()}, {2, y12.real()}, {3, -y12.imag()}};
+        dependencies[1] = {{0, y11.imag()}, {1, y11.real()}, {2, y12.imag()}, {3, y12.real()}};
+        dependencies[2] = {{0, y21.real()}, {1, -y21.imag()}, {2, y22.real()}, {3, -y22.imag()}};
+        dependencies[3] = {{0, y21.imag()}, {1, y21.real()}, {2, y22.imag()}, {3, y22.real()}};
 
         return dependencies;
       }

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -7,6 +7,7 @@
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/Model/PhasorDynamics/Branch/Branch.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
+#include <GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
 
@@ -181,6 +182,55 @@ namespace GridKit
       }
 
       TestOutcome offNominalJacobian()
+      {
+        TestStatus success = true;
+
+        RealT R{2.0};
+        RealT X{4.0};
+        RealT G{0.2};
+        RealT B{1.2};
+        RealT tap{1.25};
+        RealT phase{0.3};
+
+        DependencyTracking::Variable Vr1{10.0};
+        DependencyTracking::Variable Vi1{20.0};
+        DependencyTracking::Variable Vr2{30.0};
+        DependencyTracking::Variable Vi2{40.0};
+
+        Vr1.setVariableNumber(0);
+        Vi1.setVariableNumber(1);
+        Vr2.setVariableNumber(2);
+        Vi2.setVariableNumber(3);
+
+        PhasorDynamics::BusInfinite<DependencyTracking::Variable, IdxT> bus1(Vr1, Vi1);
+        PhasorDynamics::BusInfinite<DependencyTracking::Variable, IdxT> bus2(Vr2, Vi2);
+
+        PhasorDynamics::Branch<DependencyTracking::Variable, IdxT> branch(&bus1,
+                                                                          &bus2,
+                                                                          R,
+                                                                          X,
+                                                                          G,
+                                                                          B,
+                                                                          tap,
+                                                                          phase);
+        branch.allocate();
+        branch.evaluateResidual();
+
+        std::vector<DependencyTracking::Variable>                residuals{bus1.Ir(), bus1.Ii(), bus2.Ir(), bus2.Ii()};
+        std::vector<DependencyTracking::Variable::DependencyMap> ref = analyticalJacobian(R, X, G, B, tap, phase);
+
+        const RealT tol{1.0e-12};
+        for (size_t i = 0; i < residuals.size(); ++i)
+        {
+          DependencyTracking::Variable                       res           = residuals[i];
+          const DependencyTracking::Variable::DependencyMap& dependencies  = res.getDependencies();
+          success                                                         *= (GridKit::Testing::isEqual(dependencies, ref[i], tol));
+        }
+
+        return success.report(__func__);
+      }
+
+      TestOutcome accessors()
       {
         // Verifies tap and phase-shift residual derivatives.
         TestStatus success = true;

--- a/tests/UnitTests/PhasorDynamics/runBranchTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runBranchTests.cpp
@@ -9,9 +9,13 @@ int main()
   GridKit::Testing::BranchTests<double, size_t> test;
 
   result += test.constructor();
-  result += test.accessors();
+  result += test.parameterValidation();
+  result += test.dataConstructorDefaults();
+  result += test.parameterSetters();
   result += test.residual();
+  result += test.offNominalResidual();
   result += test.jacobian();
+  result += test.offNominalJacobian();
 
   return result.summary();
 }

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -61,7 +61,7 @@ namespace GridKit
                    { "number": 2, "class": "infinite_bus", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "v_base": 115e3 }
                ],
                "devices": [
-                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
+                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0, "tap":1.05, "phase":0.1} },
                    { "class": "Genrou", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
                           "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
                    { "class": "Gensal", "ports": {"bus":1}, "id": "2", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
@@ -114,6 +114,8 @@ namespace GridKit
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::X]) == 0.1;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::G]) == 0.0;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::B]) == 0.0;
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::tap]) == 1.05;
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::phase]) == 0.1;
         success *= result.branch[0].ports[BranchPorts::bus1] == 1;
         success *= result.branch[0].ports[BranchPorts::bus2] == 2;
         success *= result.branch[0].disambiguation_string == "1";
@@ -188,7 +190,7 @@ namespace GridKit
                    { "signal_id": 3, "name": "Excitation Field"}
                ],
                "devices": [
-                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
+                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0, "tap":1.05, "phase":0.1} },
                    { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
                    { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0.0, "Pvmin":1.0, "Dt":0.0}},
                    { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "DV3", "params": {"Tr":0.001, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1.0, "Vrmax":1.0, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlim":0.0}},
@@ -245,6 +247,8 @@ namespace GridKit
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::X]) == 0.1;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::G]) == 0.0;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::B]) == 0.0;
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::tap]) == 1.05;
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::phase]) == 0.1;
         success *= result.branch[0].ports[BranchPorts::bus1] == 1;
         success *= result.branch[0].ports[BranchPorts::bus2] == 2;
         success *= result.branch[0].disambiguation_string == "BR1";


### PR DESCRIPTION
## Description

Adds off-nominal tap magnitude and phase shift support to the PhasorDynamics `Branch` model so branch devices can represent line and transformer-style branches through the same component.

## Proposed changes

- Added `tap` and `phase` branch parameters with defaults of `1.0` and `0.0`.
- Updated branch admittance/residual calculations for off-nominal tap and phase shift behavior.
- Added parser coverage, branch residual/Jacobian unit tests, and documentation for the new parameters.
- 
## Checklist

- [x] All tests pass. (except existing PE test)
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR.

## Further comments

None