### PR TITLE
Get rid of complex numbers and structs for params

### DIFF
--- a/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
@@ -8,8 +8,6 @@
  */
 #pragma once
 
-#include <complex>
-
 #include <GridKit/Model/PhasorDynamics/Branch/BranchData.hpp>
 #include <GridKit/Model/PhasorDynamics/Component.hpp>
 #include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
@@ -139,7 +137,6 @@ namespace GridKit
       bool                                              readRealParameter(const model_data_type&               data,
                                                                           typename model_data_type::Parameters parameter,
                                                                           RealT&                               target);
-      static void                                       setAdmittanceBlock(AdmittanceBlock& block, const std::complex<RealT>& y);
       static __attribute__((always_inline)) inline void addAdmittanceContribution(const AdmittanceBlock& y,
                                                                                   const ScalarT&         Vr,
                                                                                   const ScalarT&         Vi,

--- a/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
@@ -123,12 +123,6 @@ namespace GridKit
       const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
-      struct AdmittanceBlock
-      {
-        RealT G{0.0};
-        RealT B{0.0};
-      };
-
       void                                              initializeParameters(const model_data_type& data);
       void                                              initializeMonitor();
       void                                              setDerivedParams();
@@ -137,14 +131,16 @@ namespace GridKit
       bool                                              readRealParameter(const model_data_type&               data,
                                                                           typename model_data_type::Parameters parameter,
                                                                           RealT&                               target);
-      static __attribute__((always_inline)) inline void addAdmittanceContribution(const AdmittanceBlock& y,
-                                                                                  const ScalarT&         Vr,
-                                                                                  const ScalarT&         Vi,
-                                                                                  ScalarT&               Ir,
-                                                                                  ScalarT&               Ii);
-      static __attribute__((always_inline)) inline void evaluateAdmittanceBlock(const AdmittanceBlock& y,
-                                                                                const ScalarT*         wb,
-                                                                                ScalarT*               h);
+      static __attribute__((always_inline)) inline void addAdmittanceContribution(RealT          G,
+                                                                                  RealT          B,
+                                                                                  const ScalarT& Vr,
+                                                                                  const ScalarT& Vi,
+                                                                                  ScalarT&       Ir,
+                                                                                  ScalarT&       Ii);
+      static __attribute__((always_inline)) inline void evaluateAdmittanceBlock(RealT          G,
+                                                                                RealT          B,
+                                                                                const ScalarT* wb,
+                                                                                ScalarT*       h);
 
       ScalarT& Vr1()
       {
@@ -204,10 +200,14 @@ namespace GridKit
       IdxT      bus1_id_{0};
       IdxT      bus2_id_{0};
 
-      AdmittanceBlock y11_;
-      AdmittanceBlock y12_;
-      AdmittanceBlock y21_;
-      AdmittanceBlock y22_;
+      RealT g11_{0.0};
+      RealT b11_{0.0};
+      RealT g12_{0.0};
+      RealT b12_{0.0};
+      RealT g21_{0.0};
+      RealT b21_{0.0};
+      RealT g22_{0.0};
+      RealT b22_{0.0};
 
       int parameter_error_count_{0};
 

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -179,27 +179,29 @@ namespace GridKit
 
     template <class ScalarT, typename IdxT>
     __attribute__((always_inline)) inline void Branch<ScalarT, IdxT>::addAdmittanceContribution(
-        const AdmittanceBlock& y,
-        const ScalarT&         Vr,
-        const ScalarT&         Vi,
-        ScalarT&               Ir,
-        ScalarT&               Ii)
+        RealT          G,
+        RealT          B,
+        const ScalarT& Vr,
+        const ScalarT& Vi,
+        ScalarT&       Ir,
+        ScalarT&       Ii)
     {
-      Ir += y.G * Vr - y.B * Vi;
-      Ii += y.B * Vr + y.G * Vi;
+      Ir += G * Vr - B * Vi;
+      Ii += B * Vr + G * Vi;
     }
 
     template <class ScalarT, typename IdxT>
     __attribute__((always_inline)) inline void Branch<ScalarT, IdxT>::evaluateAdmittanceBlock(
-        const AdmittanceBlock& y,
-        const ScalarT*         wb,
-        ScalarT*               h)
+        RealT          G,
+        RealT          B,
+        const ScalarT* wb,
+        ScalarT*       h)
     {
       const ScalarT Vr = wb[0];
       const ScalarT Vi = wb[1];
 
-      h[0] = y.G * Vr - y.B * Vi;
-      h[1] = y.B * Vr + y.G * Vi;
+      h[0] = G * Vr - B * Vi;
+      h[1] = B * Vr + G * Vi;
     }
 
     /**
@@ -213,7 +215,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      evaluateAdmittanceBlock(y11_, wb, h);
+      evaluateAdmittanceBlock(g11_, b11_, wb, h);
 
       return 0;
     }
@@ -229,7 +231,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      evaluateAdmittanceBlock(y12_, wb, h);
+      evaluateAdmittanceBlock(g12_, b12_, wb, h);
 
       return 0;
     }
@@ -245,7 +247,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      evaluateAdmittanceBlock(y21_, wb, h);
+      evaluateAdmittanceBlock(g21_, b21_, wb, h);
 
       return 0;
     }
@@ -261,7 +263,7 @@ namespace GridKit
         ScalarT*                  wb,
         ScalarT*                  h)
     {
-      evaluateAdmittanceBlock(y22_, wb, h);
+      evaluateAdmittanceBlock(g22_, b22_, wb, h);
 
       return 0;
     }
@@ -295,8 +297,8 @@ namespace GridKit
       Ir = ScalarT{0.0};
       Ii = ScalarT{0.0};
 
-      addAdmittanceContribution(y11_, Vr1(), Vi1(), Ir, Ii);
-      addAdmittanceContribution(y12_, Vr2(), Vi2(), Ir, Ii);
+      addAdmittanceContribution(g11_, b11_, Vr1(), Vi1(), Ir, Ii);
+      addAdmittanceContribution(g12_, b12_, Vr2(), Vi2(), Ir, Ii);
     }
 
     template <class ScalarT, typename IdxT>
@@ -305,8 +307,8 @@ namespace GridKit
       Ir = ScalarT{0.0};
       Ii = ScalarT{0.0};
 
-      addAdmittanceContribution(y21_, Vr1(), Vi1(), Ir, Ii);
-      addAdmittanceContribution(y22_, Vr2(), Vi2(), Ir, Ii);
+      addAdmittanceContribution(g21_, b21_, Vr1(), Vi1(), Ir, Ii);
+      addAdmittanceContribution(g22_, b22_, Vr2(), Vi2(), Ir, Ii);
     }
 
     template <class ScalarT, typename IdxT>
@@ -438,10 +440,14 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     void Branch<ScalarT, IdxT>::setDerivedParams()
     {
-      y11_ = {};
-      y12_ = {};
-      y21_ = {};
-      y22_ = {};
+      g11_ = RealT{0.0};
+      b11_ = RealT{0.0};
+      g12_ = RealT{0.0};
+      b12_ = RealT{0.0};
+      g21_ = RealT{0.0};
+      b21_ = RealT{0.0};
+      g22_ = RealT{0.0};
+      b22_ = RealT{0.0};
 
       const RealT denom = R_ * R_ + X_ * X_;
       if (denom == RealT{0.0} || tap_ == RealT{0.0})
@@ -458,17 +464,17 @@ namespace GridKit
       const RealT g_diag = -(g_br + RealT{0.5} * G_);
       const RealT b_diag = -(b_br + RealT{0.5} * B_);
 
-      y11_.G = g_diag * inv_tap * inv_tap;
-      y11_.B = b_diag * inv_tap * inv_tap;
+      g11_ = g_diag * inv_tap * inv_tap;
+      b11_ = b_diag * inv_tap * inv_tap;
 
-      y12_.G = (g_br * cos_ph - b_br * sin_ph) * inv_tap;
-      y12_.B = (b_br * cos_ph + g_br * sin_ph) * inv_tap;
+      g12_ = (g_br * cos_ph - b_br * sin_ph) * inv_tap;
+      b12_ = (b_br * cos_ph + g_br * sin_ph) * inv_tap;
 
-      y21_.G = (g_br * cos_ph + b_br * sin_ph) * inv_tap;
-      y21_.B = (b_br * cos_ph - g_br * sin_ph) * inv_tap;
+      g21_ = (g_br * cos_ph + b_br * sin_ph) * inv_tap;
+      b21_ = (b_br * cos_ph - g_br * sin_ph) * inv_tap;
 
-      y22_.G = g_diag;
-      y22_.B = b_diag;
+      g22_ = g_diag;
+      b22_ = b_diag;
     }
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -439,7 +439,17 @@ namespace GridKit
     template <class ScalarT, typename IdxT>
     void Branch<ScalarT, IdxT>::setDerivedParams()
     {
-      const RealT denom   = R_ * R_ + X_ * X_;
+      y11_ = {};
+      y12_ = {};
+      y21_ = {};
+      y22_ = {};
+
+      const RealT denom = R_ * R_ + X_ * X_;
+      if (denom == RealT{0.0} || tap_ == RealT{0.0})
+      {
+        return;
+      }
+
       const RealT g       = R_ / denom;
       const RealT b       = -X_ / denom;
       const RealT inv_tap = RealT{1.0} / tap_;

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -8,7 +8,6 @@
  */
 
 #include <cmath>
-#include <complex>
 #include <variant>
 
 #include <magic_enum/magic_enum.hpp>
@@ -450,27 +449,26 @@ namespace GridKit
         return;
       }
 
-      const RealT g       = R_ / denom;
-      const RealT b       = -X_ / denom;
+      const RealT g_br    = R_ / denom;
+      const RealT b_br    = -X_ / denom;
       const RealT inv_tap = RealT{1.0} / tap_;
+      const RealT cos_ph  = std::cos(phase_);
+      const RealT sin_ph  = std::sin(phase_);
 
-      const std::complex<RealT> ybr{g, b};
-      const std::complex<RealT> ysh{G_, B_};
-      const std::complex<RealT> rotation{std::cos(phase_), std::sin(phase_)};
-      const std::complex<RealT> ydiag = -(ybr + RealT{0.5} * ysh);
+      const RealT g_diag = -(g_br + RealT{0.5} * G_);
+      const RealT b_diag = -(b_br + RealT{0.5} * B_);
 
-      setAdmittanceBlock(y11_, ydiag * inv_tap * inv_tap);
-      setAdmittanceBlock(y12_, ybr * rotation * inv_tap);
-      setAdmittanceBlock(y21_, ybr * std::conj(rotation) * inv_tap);
-      setAdmittanceBlock(y22_, ydiag);
-    }
+      y11_.G = g_diag * inv_tap * inv_tap;
+      y11_.B = b_diag * inv_tap * inv_tap;
 
-    template <class ScalarT, typename IdxT>
-    void Branch<ScalarT, IdxT>::setAdmittanceBlock(AdmittanceBlock&           block,
-                                                   const std::complex<RealT>& y)
-    {
-      block.G = y.real();
-      block.B = y.imag();
+      y12_.G = (g_br * cos_ph - b_br * sin_ph) * inv_tap;
+      y12_.B = (b_br * cos_ph + g_br * sin_ph) * inv_tap;
+
+      y21_.G = (g_br * cos_ph + b_br * sin_ph) * inv_tap;
+      y21_.B = (b_br * cos_ph - g_br * sin_ph) * inv_tap;
+
+      y22_.G = g_diag;
+      y22_.B = b_diag;
     }
 
   } // namespace PhasorDynamics

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -182,6 +182,55 @@ namespace GridKit
 
       TestOutcome offNominalJacobian()
       {
+        TestStatus success = true;
+
+        RealT R{2.0};
+        RealT X{4.0};
+        RealT G{0.2};
+        RealT B{1.2};
+        RealT tap{1.25};
+        RealT phase{0.3};
+
+        DependencyTracking::Variable Vr1{10.0};
+        DependencyTracking::Variable Vi1{20.0};
+        DependencyTracking::Variable Vr2{30.0};
+        DependencyTracking::Variable Vi2{40.0};
+
+        Vr1.setVariableNumber(0);
+        Vi1.setVariableNumber(1);
+        Vr2.setVariableNumber(2);
+        Vi2.setVariableNumber(3);
+
+        PhasorDynamics::BusInfinite<DependencyTracking::Variable, IdxT> bus1(Vr1, Vi1);
+        PhasorDynamics::BusInfinite<DependencyTracking::Variable, IdxT> bus2(Vr2, Vi2);
+
+        PhasorDynamics::Branch<DependencyTracking::Variable, IdxT> branch(&bus1,
+                                                                          &bus2,
+                                                                          R,
+                                                                          X,
+                                                                          G,
+                                                                          B,
+                                                                          tap,
+                                                                          phase);
+        branch.allocate();
+        branch.evaluateResidual();
+
+        std::vector<DependencyTracking::Variable>                residuals{bus1.Ir(), bus1.Ii(), bus2.Ir(), bus2.Ii()};
+        std::vector<DependencyTracking::Variable::DependencyMap> ref = analyticalJacobian(R, X, G, B, tap, phase);
+
+        const RealT tol{1.0e-12};
+        for (size_t i = 0; i < residuals.size(); ++i)
+        {
+          DependencyTracking::Variable                       res           = residuals[i];
+          const DependencyTracking::Variable::DependencyMap& dependencies  = res.getDependencies();
+          success                                                         *= (GridKit::Testing::isEqual(dependencies, ref[i], tol));
+        }
+
+        return success.report(__func__);
+      }
+
+      TestOutcome accessors()
+      {
         // Verifies tap and phase-shift residual derivatives.
         TestStatus success = true;
 

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -7,6 +7,7 @@
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/Model/PhasorDynamics/Branch/Branch.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
+#include <GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
 


### PR DESCRIPTION
## Description
 
Modifies `lukel/branch-xfmr-dev` branch to eliminate complex operations and use of `struct`s to group parameters.
 
 ## Proposed changes
 
This is needed to keep model portable to GPU.
 
 ## Checklist
 
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- N/A I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
 
