### PR TITLE
Use ports for PhasorDynamics signal connectivity

### DIFF
--- a/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
@@ -23,11 +23,24 @@ namespace GridKit
       phase, ///< Phase shift angle in radians
     };
 
-    /// Ports for a branch
-    enum class BranchPorts
+    /// Terminals for a branch
+    enum class BranchTerminals : size_t
     {
       bus1, ///< Unique ID of bus 1
       bus2, ///< Unique ID of bus 2
+      SIZE
+    };
+
+    /// Input ports supported for a branch
+    enum class BranchInputPorts : size_t
+    {
+      SIZE
+    };
+
+    /// Output ports supported for a branch
+    enum class BranchOutputPorts : size_t
+    {
+      SIZE
     };
 
     /// Variables able to be monitored for a branch
@@ -57,13 +70,17 @@ namespace GridKit
     struct BranchData : public ComponentData<real_type,
                                              index_type,
                                              BranchParameters,
-                                             BranchPorts,
+                                             BranchTerminals,
+                                             BranchInputPorts,
+                                             BranchOutputPorts,
                                              BranchMonitorableVariables>
     {
       BranchData() = default;
 
       using Parameters           = BranchParameters;
-      using Ports                = BranchPorts;
+      using Terminals            = BranchTerminals;
+      using InputPorts           = BranchInputPorts;
+      using OutputPorts          = BranchOutputPorts;
       using MonitorableVariables = BranchMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
@@ -23,22 +23,22 @@ namespace GridKit
       phase, ///< Phase shift angle in radians
     };
 
-    /// Terminals for a branch
-    enum class BranchTerminals : size_t
+    /// Buses for a branch
+    enum class BranchBuses : size_t
     {
       bus1, ///< Unique ID of bus 1
       bus2, ///< Unique ID of bus 2
       SIZE
     };
 
-    /// Input ports supported for a branch
-    enum class BranchInputPorts : size_t
+    /// Signal inputs supported for a branch
+    enum class BranchSignalInputs : size_t
     {
       SIZE
     };
 
-    /// Output ports supported for a branch
-    enum class BranchOutputPorts : size_t
+    /// Signal outputs supported for a branch
+    enum class BranchSignalOutputs : size_t
     {
       SIZE
     };
@@ -70,17 +70,17 @@ namespace GridKit
     struct BranchData : public ComponentData<real_type,
                                              index_type,
                                              BranchParameters,
-                                             BranchTerminals,
-                                             BranchInputPorts,
-                                             BranchOutputPorts,
+                                             BranchBuses,
+                                             BranchSignalInputs,
+                                             BranchSignalOutputs,
                                              BranchMonitorableVariables>
     {
       BranchData() = default;
 
       using Parameters           = BranchParameters;
-      using Terminals            = BranchTerminals;
-      using InputPorts           = BranchInputPorts;
-      using OutputPorts          = BranchOutputPorts;
+      using Buses                = BranchBuses;
+      using SignalInputs         = BranchSignalInputs;
+      using SignalOutputs        = BranchSignalOutputs;
       using MonitorableVariables = BranchMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -329,7 +329,7 @@ namespace GridKit
     void Branch<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
       using Parameter = typename ModelDataT::Parameters;
-      using Terminal  = typename ModelDataT::Terminals;
+      using Buses     = typename ModelDataT::Buses;
 
       readRealParameter(data, Parameter::R, R_);
       readRealParameter(data, Parameter::X, X_);
@@ -338,14 +338,14 @@ namespace GridKit
       readRealParameter(data, Parameter::tap, tap_);
       readRealParameter(data, Parameter::phase, phase_);
 
-      if (data.terminals.contains(Terminal::bus1))
+      if (data.buses.contains(Buses::bus1))
       {
-        bus1_id_ = data.terminals.at(Terminal::bus1);
+        bus1_id_ = data.buses.at(Buses::bus1);
       }
 
-      if (data.terminals.contains(Terminal::bus2))
+      if (data.buses.contains(Buses::bus2))
       {
-        bus2_id_ = data.terminals.at(Terminal::bus2);
+        bus2_id_ = data.buses.at(Buses::bus2);
       }
     }
 

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -328,21 +328,24 @@ namespace GridKit
     template <typename scalar_type, typename index_type>
     void Branch<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
-      readRealParameter(data, ModelDataT::Parameters::R, R_);
-      readRealParameter(data, ModelDataT::Parameters::X, X_);
-      readRealParameter(data, ModelDataT::Parameters::G, G_);
-      readRealParameter(data, ModelDataT::Parameters::B, B_);
-      readRealParameter(data, ModelDataT::Parameters::tap, tap_);
-      readRealParameter(data, ModelDataT::Parameters::phase, phase_);
+      using Parameter = typename ModelDataT::Parameters;
+      using Terminal  = typename ModelDataT::Terminals;
 
-      if (data.ports.contains(ModelDataT::Ports::bus1))
+      readRealParameter(data, Parameter::R, R_);
+      readRealParameter(data, Parameter::X, X_);
+      readRealParameter(data, Parameter::G, G_);
+      readRealParameter(data, Parameter::B, B_);
+      readRealParameter(data, Parameter::tap, tap_);
+      readRealParameter(data, Parameter::phase, phase_);
+
+      if (data.terminals.contains(Terminal::bus1))
       {
-        bus1_id_ = data.ports.at(ModelDataT::Ports::bus1);
+        bus1_id_ = data.terminals.at(Terminal::bus1);
       }
 
-      if (data.ports.contains(ModelDataT::Ports::bus2))
+      if (data.terminals.contains(Terminal::bus2))
       {
-        bus2_id_ = data.ports.at(ModelDataT::Ports::bus2);
+        bus2_id_ = data.terminals.at(Terminal::bus2);
       }
     }
 

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultData.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultData.hpp
@@ -20,11 +20,24 @@ namespace GridKit
       X,      ///< Short to ground reactance
     };
 
-    /// Ports supported for a bus fault
-    enum class BusFaultPorts
+    /// Terminals supported for a bus fault
+    enum class BusFaultTerminals : size_t
     {
-      bus,            ///< Unique ID of the bus where the fault occurs
+      bus, ///< Unique ID of the bus where the fault occurs
+      SIZE
+    };
+
+    /// Input ports supported for a bus fault
+    enum class BusFaultInputPorts : size_t
+    {
       control_signal, ///< Unique ID of the bus providing a control signal
+      SIZE
+    };
+
+    /// Output ports supported for a bus fault
+    enum class BusFaultOutputPorts : size_t
+    {
+      SIZE
     };
 
     /// Variables able to be monitored for a bus fault
@@ -47,13 +60,17 @@ namespace GridKit
     struct BusFaultData : public ComponentData<real_type,
                                                index_type,
                                                BusFaultParameters,
-                                               BusFaultPorts,
+                                               BusFaultTerminals,
+                                               BusFaultInputPorts,
+                                               BusFaultOutputPorts,
                                                BusFaultMonitorableVariables>
     {
       BusFaultData() = default;
 
       using Parameters           = BusFaultParameters;
-      using Ports                = BusFaultPorts;
+      using Terminals            = BusFaultTerminals;
+      using InputPorts           = BusFaultInputPorts;
+      using OutputPorts          = BusFaultOutputPorts;
       using MonitorableVariables = BusFaultMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultData.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultData.hpp
@@ -20,22 +20,22 @@ namespace GridKit
       X,      ///< Short to ground reactance
     };
 
-    /// Terminals supported for a bus fault
-    enum class BusFaultTerminals : size_t
+    /// Buses supported for a bus fault
+    enum class BusFaultBuses : size_t
     {
       bus, ///< Unique ID of the bus where the fault occurs
       SIZE
     };
 
-    /// Input ports supported for a bus fault
-    enum class BusFaultInputPorts : size_t
+    /// Signal inputs supported for a bus fault
+    enum class BusFaultSignalInputs : size_t
     {
       control_signal, ///< Unique ID of the bus providing a control signal
       SIZE
     };
 
-    /// Output ports supported for a bus fault
-    enum class BusFaultOutputPorts : size_t
+    /// Signal outputs supported for a bus fault
+    enum class BusFaultSignalOutputs : size_t
     {
       SIZE
     };
@@ -60,17 +60,17 @@ namespace GridKit
     struct BusFaultData : public ComponentData<real_type,
                                                index_type,
                                                BusFaultParameters,
-                                               BusFaultTerminals,
-                                               BusFaultInputPorts,
-                                               BusFaultOutputPorts,
+                                               BusFaultBuses,
+                                               BusFaultSignalInputs,
+                                               BusFaultSignalOutputs,
                                                BusFaultMonitorableVariables>
     {
       BusFaultData() = default;
 
       using Parameters           = BusFaultParameters;
-      using Terminals            = BusFaultTerminals;
-      using InputPorts           = BusFaultInputPorts;
-      using OutputPorts          = BusFaultOutputPorts;
+      using Buses                = BusFaultBuses;
+      using SignalInputs         = BusFaultSignalInputs;
+      using SignalOutputs        = BusFaultSignalOutputs;
       using MonitorableVariables = BusFaultMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
@@ -57,24 +57,27 @@ namespace GridKit
       : bus_(bus),
         monitor_(std::make_unique<MonitorT>(data))
     {
-      if (data.parameters.contains(ModelDataT::Parameters::R))
+      using Parameter = typename ModelDataT::Parameters;
+      using Terminal  = typename ModelDataT::Terminals;
+
+      if (data.parameters.contains(Parameter::R))
       {
-        R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
+        R_ = std::get<RealT>(data.parameters.at(Parameter::R));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::X))
+      if (data.parameters.contains(Parameter::X))
       {
-        X_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::X));
+        X_ = std::get<RealT>(data.parameters.at(Parameter::X));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::state0))
+      if (data.parameters.contains(Parameter::state0))
       {
-        status_ = std::get<bool>(data.parameters.at(ModelDataT::Parameters::state0));
+        status_ = std::get<bool>(data.parameters.at(Parameter::state0));
       }
 
-      if (data.ports.contains(ModelDataT::Ports::bus))
+      if (data.terminals.contains(Terminal::bus))
       {
-        bus_id_ = data.ports.at(ModelDataT::Ports::bus);
+        bus_id_ = data.terminals.at(Terminal::bus);
       }
 
       using Variable = typename ModelDataT::MonitorableVariables;

--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultImpl.hpp
@@ -58,7 +58,7 @@ namespace GridKit
         monitor_(std::make_unique<MonitorT>(data))
     {
       using Parameter = typename ModelDataT::Parameters;
-      using Terminal  = typename ModelDataT::Terminals;
+      using Buses     = typename ModelDataT::Buses;
 
       if (data.parameters.contains(Parameter::R))
       {
@@ -75,9 +75,9 @@ namespace GridKit
         status_ = std::get<bool>(data.parameters.at(Parameter::state0));
       }
 
-      if (data.terminals.contains(Terminal::bus))
+      if (data.buses.contains(Buses::bus))
       {
-        bus_id_ = data.terminals.at(Terminal::bus);
+        bus_id_ = data.buses.at(Buses::bus);
       }
 
       using Variable = typename ModelDataT::MonitorableVariables;

--- a/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapterData.hpp
+++ b/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapterData.hpp
@@ -24,15 +24,32 @@ namespace GridKit
     };
 
     /**
-     * @brief BusToSignalAdapter ports
+     * @brief BusToSignalAdapter terminals
      */
-    enum class BusToSignalAdapterPorts
+    enum class BusToSignalAdapterTerminals : size_t
     {
       bus,
-      vr,
-      vi,
+      SIZE
+    };
+
+    /**
+     * @brief BusToSignalAdapter input ports
+     */
+    enum class BusToSignalAdapterInputPorts : size_t
+    {
       ir,
       ii,
+      SIZE
+    };
+
+    /**
+     * @brief BusToSignalAdapter output ports
+     */
+    enum class BusToSignalAdapterOutputPorts : size_t
+    {
+      vr,
+      vi,
+      SIZE
     };
 
     /**
@@ -54,13 +71,17 @@ namespace GridKit
       : public ComponentData<real_type,
                              index_type,
                              BusToSignalAdapterParameters,
-                             BusToSignalAdapterPorts,
+                             BusToSignalAdapterTerminals,
+                             BusToSignalAdapterInputPorts,
+                             BusToSignalAdapterOutputPorts,
                              BusToSignalAdapterMonitorableVariables>
     {
       BusToSignalAdapterData() = default;
 
       using Parameters           = BusToSignalAdapterParameters;
-      using Ports                = BusToSignalAdapterPorts;
+      using Terminals            = BusToSignalAdapterTerminals;
+      using InputPorts           = BusToSignalAdapterInputPorts;
+      using OutputPorts          = BusToSignalAdapterOutputPorts;
       using MonitorableVariables = BusToSignalAdapterMonitorableVariables;
     };
 

--- a/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapterData.hpp
+++ b/GridKit/Model/PhasorDynamics/BusToSignalAdapter/BusToSignalAdapterData.hpp
@@ -24,18 +24,18 @@ namespace GridKit
     };
 
     /**
-     * @brief BusToSignalAdapter terminals
+     * @brief BusToSignalAdapter buses
      */
-    enum class BusToSignalAdapterTerminals : size_t
+    enum class BusToSignalAdapterBuses : size_t
     {
       bus,
       SIZE
     };
 
     /**
-     * @brief BusToSignalAdapter input ports
+     * @brief BusToSignalAdapter signal inputs
      */
-    enum class BusToSignalAdapterInputPorts : size_t
+    enum class BusToSignalAdapterSignalInputs : size_t
     {
       ir,
       ii,
@@ -43,9 +43,9 @@ namespace GridKit
     };
 
     /**
-     * @brief BusToSignalAdapter output ports
+     * @brief BusToSignalAdapter signal outputs
      */
-    enum class BusToSignalAdapterOutputPorts : size_t
+    enum class BusToSignalAdapterSignalOutputs : size_t
     {
       vr,
       vi,
@@ -71,17 +71,17 @@ namespace GridKit
       : public ComponentData<real_type,
                              index_type,
                              BusToSignalAdapterParameters,
-                             BusToSignalAdapterTerminals,
-                             BusToSignalAdapterInputPorts,
-                             BusToSignalAdapterOutputPorts,
+                             BusToSignalAdapterBuses,
+                             BusToSignalAdapterSignalInputs,
+                             BusToSignalAdapterSignalOutputs,
                              BusToSignalAdapterMonitorableVariables>
     {
       BusToSignalAdapterData() = default;
 
       using Parameters           = BusToSignalAdapterParameters;
-      using Terminals            = BusToSignalAdapterTerminals;
-      using InputPorts           = BusToSignalAdapterInputPorts;
-      using OutputPorts          = BusToSignalAdapterOutputPorts;
+      using Buses                = BusToSignalAdapterBuses;
+      using SignalInputs         = BusToSignalAdapterSignalInputs;
+      using SignalOutputs        = BusToSignalAdapterSignalOutputs;
       using MonitorableVariables = BusToSignalAdapterMonitorableVariables;
     };
 

--- a/GridKit/Model/PhasorDynamics/ComponentData.hpp
+++ b/GridKit/Model/PhasorDynamics/ComponentData.hpp
@@ -20,14 +20,14 @@ namespace GridKit
     template <typename real_type,
               typename index_type,
               typename Parameters,
-              typename Terminals,
-              typename InputPorts,
-              typename OutputPorts,
+              typename Buses,
+              typename SignalInputs,
+              typename SignalOutputs,
               typename MonitorableVariables>
       requires std::is_enum_v<Parameters>
-               && std::is_enum_v<Terminals>
-               && std::is_enum_v<InputPorts>
-               && std::is_enum_v<OutputPorts>
+               && std::is_enum_v<Buses>
+               && std::is_enum_v<SignalInputs>
+               && std::is_enum_v<SignalOutputs>
                && std::is_enum_v<MonitorableVariables>
     struct ComponentData
     {
@@ -43,13 +43,13 @@ namespace GridKit
       std::map<Parameters, std::variant<bool, RealT, IdxT>> parameters;
 
       /// Mapping of terminal attachments to bus identifiers
-      std::map<Terminals, IdxT> terminals;
+      std::map<Buses, IdxT> buses;
 
-      /// Mapping of signal input ports to signal identifiers
-      std::map<InputPorts, IdxT> input_ports;
+      /// Mapping of signal inputs to signal identifiers
+      std::map<SignalInputs, IdxT> signal_inputs;
 
-      /// Mapping of signal output ports to signal identifiers
-      std::map<OutputPorts, IdxT> output_ports;
+      /// Mapping of signal outputs to signal identifiers
+      std::map<SignalOutputs, IdxT> signal_outputs;
 
       /// Set of variables being monitored
       std::set<MonitorableVariables> monitored_variables;

--- a/GridKit/Model/PhasorDynamics/ComponentData.hpp
+++ b/GridKit/Model/PhasorDynamics/ComponentData.hpp
@@ -20,10 +20,14 @@ namespace GridKit
     template <typename real_type,
               typename index_type,
               typename Parameters,
-              typename Ports,
+              typename Terminals,
+              typename InputPorts,
+              typename OutputPorts,
               typename MonitorableVariables>
       requires std::is_enum_v<Parameters>
-               && std::is_enum_v<Ports>
+               && std::is_enum_v<Terminals>
+               && std::is_enum_v<InputPorts>
+               && std::is_enum_v<OutputPorts>
                && std::is_enum_v<MonitorableVariables>
     struct ComponentData
     {
@@ -38,8 +42,14 @@ namespace GridKit
       /// Mapping of parameters to parameter values
       std::map<Parameters, std::variant<bool, RealT, IdxT>> parameters;
 
-      /// Mapping of ports to port values
-      std::map<Ports, IdxT> ports;
+      /// Mapping of terminal attachments to bus identifiers
+      std::map<Terminals, IdxT> terminals;
+
+      /// Mapping of signal input ports to signal identifiers
+      std::map<InputPorts, IdxT> input_ports;
+
+      /// Mapping of signal output ports to signal identifiers
+      std::map<OutputPorts, IdxT> output_ports;
 
       /// Set of variables being monitored
       std::set<MonitorableVariables> monitored_variables;

--- a/GridKit/Model/PhasorDynamics/ComponentDataJSONParser.hpp
+++ b/GridKit/Model/PhasorDynamics/ComponentDataJSONParser.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <sstream>
-#include <stdexcept>
+#include <string>
+#include <type_traits>
 
 #include <magic_enum/magic_enum.hpp>
 #include <nlohmann/json.hpp>
@@ -20,12 +21,23 @@ namespace GridKit
     template <typename RealT,
               typename IdxT,
               typename Parameters,
-              typename Ports,
+              typename Terminals,
+              typename InputPorts,
+              typename OutputPorts,
               typename MonitorableVariables>
       requires std::is_enum_v<Parameters>
-               && std::is_enum_v<Ports>
+               && std::is_enum_v<Terminals>
+               && std::is_enum_v<InputPorts>
+               && std::is_enum_v<OutputPorts>
                && std::is_enum_v<MonitorableVariables>
-    void from_json(const json& j, ComponentData<RealT, IdxT, Parameters, Ports, MonitorableVariables>& c)
+    void from_json(const json&                          j,
+                   ComponentData<RealT,
+                                 IdxT,
+                                 Parameters,
+                                 Terminals,
+                                 InputPorts,
+                                 OutputPorts,
+                                 MonitorableVariables>& c)
     {
       j.at("class").get_to(c.device_class);
 
@@ -72,19 +84,37 @@ namespace GridKit
         }
       }
 
+      // WARNING --- TEMPORARY --- : the C++ model data is
+      // intentionally split into terminals, input ports, and output ports.
+      // This backward-compatible flat JSON "ports" parsing SHOULD NOT become
+      // the supported design; it only avoids changing every tracked case in
+      // this PR. The JSON schema should be split once the ingress changes are merged
       for (auto& raw_port : j.at("ports").items())
       {
-        auto key = magic_enum::enum_cast<Ports>(raw_port.key());
-        if (key.has_value())
+        auto terminal = magic_enum::enum_cast<Terminals>(raw_port.key());
+        if (terminal.has_value() && terminal.value() != Terminals::SIZE)
         {
-          raw_port.value().get_to(c.ports[key.value()]);
+          raw_port.value().get_to(c.terminals[terminal.value()]);
+          continue;
         }
-        else
+
+        auto input_port = magic_enum::enum_cast<InputPorts>(raw_port.key());
+        if (input_port.has_value() && input_port.value() != InputPorts::SIZE)
         {
-          Log::error() << "\n\tInvalid port mapping: \"" << raw_port.key()
-                       << "\" has no value." << error_context.str()
-                       << std::endl;
+          raw_port.value().get_to(c.input_ports[input_port.value()]);
+          continue;
         }
+
+        auto output_port = magic_enum::enum_cast<OutputPorts>(raw_port.key());
+        if (output_port.has_value() && output_port.value() != OutputPorts::SIZE)
+        {
+          raw_port.value().get_to(c.output_ports[output_port.value()]);
+          continue;
+        }
+
+        Log::error() << "\n\tInvalid port mapping: \"" << raw_port.key()
+                     << "\" has no value." << error_context.str()
+                     << std::endl;
       }
 
       if (j.contains("mon"))

--- a/GridKit/Model/PhasorDynamics/ComponentDataJSONParser.hpp
+++ b/GridKit/Model/PhasorDynamics/ComponentDataJSONParser.hpp
@@ -21,22 +21,22 @@ namespace GridKit
     template <typename RealT,
               typename IdxT,
               typename Parameters,
-              typename Terminals,
-              typename InputPorts,
-              typename OutputPorts,
+              typename Buses,
+              typename SignalInputs,
+              typename SignalOutputs,
               typename MonitorableVariables>
       requires std::is_enum_v<Parameters>
-               && std::is_enum_v<Terminals>
-               && std::is_enum_v<InputPorts>
-               && std::is_enum_v<OutputPorts>
+               && std::is_enum_v<Buses>
+               && std::is_enum_v<SignalInputs>
+               && std::is_enum_v<SignalOutputs>
                && std::is_enum_v<MonitorableVariables>
     void from_json(const json&                          j,
                    ComponentData<RealT,
                                  IdxT,
                                  Parameters,
-                                 Terminals,
-                                 InputPorts,
-                                 OutputPorts,
+                                 Buses,
+                                 SignalInputs,
+                                 SignalOutputs,
                                  MonitorableVariables>& c)
     {
       j.at("class").get_to(c.device_class);
@@ -85,30 +85,30 @@ namespace GridKit
       }
 
       // WARNING --- TEMPORARY --- : the C++ model data is
-      // intentionally split into terminals, input ports, and output ports.
+      // intentionally split into buses, signal inputs, and signal outputs.
       // This backward-compatible flat JSON "ports" parsing SHOULD NOT become
       // the supported design; it only avoids changing every tracked case in
       // this PR. The JSON schema should be split once the ingress changes are merged
       for (auto& raw_port : j.at("ports").items())
       {
-        auto terminal = magic_enum::enum_cast<Terminals>(raw_port.key());
-        if (terminal.has_value() && terminal.value() != Terminals::SIZE)
+        auto bus = magic_enum::enum_cast<Buses>(raw_port.key());
+        if (bus.has_value() && bus.value() != Buses::SIZE)
         {
-          raw_port.value().get_to(c.terminals[terminal.value()]);
+          raw_port.value().get_to(c.buses[bus.value()]);
           continue;
         }
 
-        auto input_port = magic_enum::enum_cast<InputPorts>(raw_port.key());
-        if (input_port.has_value() && input_port.value() != InputPorts::SIZE)
+        auto signal_input = magic_enum::enum_cast<SignalInputs>(raw_port.key());
+        if (signal_input.has_value() && signal_input.value() != SignalInputs::SIZE)
         {
-          raw_port.value().get_to(c.input_ports[input_port.value()]);
+          raw_port.value().get_to(c.signal_inputs[signal_input.value()]);
           continue;
         }
 
-        auto output_port = magic_enum::enum_cast<OutputPorts>(raw_port.key());
-        if (output_port.has_value() && output_port.value() != OutputPorts::SIZE)
+        auto signal_output = magic_enum::enum_cast<SignalOutputs>(raw_port.key());
+        if (signal_output.has_value() && signal_output.value() != SignalOutputs::SIZE)
         {
-          raw_port.value().get_to(c.output_ports[output_port.value()]);
+          raw_port.value().get_to(c.signal_outputs[signal_output.value()]);
           continue;
         }
 

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
@@ -34,23 +34,23 @@ namespace GridKit
         Ispdlim ///< Speed limit flag indicator
       };
 
-      /// Terminals for a IEEET1 Exciter model
-      enum class Ieeet1Terminals : size_t
+      /// Buses for a IEEET1 Exciter model
+      enum class Ieeet1Buses : size_t
       {
         bus, ///< Unique ID of the terminal bus
         SIZE
       };
 
-      /// Input ports for a IEEET1 Exciter model
-      enum class Ieeet1InputPorts : size_t
+      /// Signal inputs for a IEEET1 Exciter model
+      enum class Ieeet1SignalInputs : size_t
       {
         speed, ///< Unique ID of the generator speed signal
         vs,    ///< Unique ID of the stabilizer output signal (optional)
         SIZE
       };
 
-      /// Output ports for a IEEET1 Exciter model
-      enum class Ieeet1OutputPorts : size_t
+      /// Signal outputs for a IEEET1 Exciter model
+      enum class Ieeet1SignalOutputs : size_t
       {
         efd, ///< Unique ID of the output efd signal
         SIZE
@@ -75,17 +75,17 @@ namespace GridKit
       struct Ieeet1Data : public ComponentData<real_type,
                                                index_type,
                                                Ieeet1Parameters,
-                                               Ieeet1Terminals,
-                                               Ieeet1InputPorts,
-                                               Ieeet1OutputPorts,
+                                               Ieeet1Buses,
+                                               Ieeet1SignalInputs,
+                                               Ieeet1SignalOutputs,
                                                Ieeet1MonitorableVariables>
       {
         Ieeet1Data() = default;
 
         using Parameters           = Ieeet1Parameters;
-        using Terminals            = Ieeet1Terminals;
-        using InputPorts           = Ieeet1InputPorts;
-        using OutputPorts          = Ieeet1OutputPorts;
+        using Buses                = Ieeet1Buses;
+        using SignalInputs         = Ieeet1SignalInputs;
+        using SignalOutputs        = Ieeet1SignalOutputs;
         using MonitorableVariables = Ieeet1MonitorableVariables;
       };
     } // namespace Exciter

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Data.hpp
@@ -34,13 +34,26 @@ namespace GridKit
         Ispdlim ///< Speed limit flag indicator
       };
 
-      /// Ports for a IEEET1 Exciter model
-      enum class Ieeet1Ports
+      /// Terminals for a IEEET1 Exciter model
+      enum class Ieeet1Terminals : size_t
       {
-        bus,   ///< Unique ID of the terminal bus
+        bus, ///< Unique ID of the terminal bus
+        SIZE
+      };
+
+      /// Input ports for a IEEET1 Exciter model
+      enum class Ieeet1InputPorts : size_t
+      {
         speed, ///< Unique ID of the generator speed signal
-        efd,   ///< Unique ID of the output efd signal
         vs,    ///< Unique ID of the stabilizer output signal (optional)
+        SIZE
+      };
+
+      /// Output ports for a IEEET1 Exciter model
+      enum class Ieeet1OutputPorts : size_t
+      {
+        efd, ///< Unique ID of the output efd signal
+        SIZE
       };
 
       /// Variables able to be monitored for a IEEET1 Exciter model
@@ -62,13 +75,17 @@ namespace GridKit
       struct Ieeet1Data : public ComponentData<real_type,
                                                index_type,
                                                Ieeet1Parameters,
-                                               Ieeet1Ports,
+                                               Ieeet1Terminals,
+                                               Ieeet1InputPorts,
+                                               Ieeet1OutputPorts,
                                                Ieeet1MonitorableVariables>
       {
         Ieeet1Data() = default;
 
         using Parameters           = Ieeet1Parameters;
-        using Ports                = Ieeet1Ports;
+        using Terminals            = Ieeet1Terminals;
+        using InputPorts           = Ieeet1InputPorts;
+        using OutputPorts          = Ieeet1OutputPorts;
         using MonitorableVariables = Ieeet1MonitorableVariables;
       };
     } // namespace Exciter

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -358,67 +358,68 @@ namespace GridKit
       template <typename scalar_type, typename index_type>
       void Ieeet1<scalar_type, index_type>::initModelParams(const ModelDataT& data)
       {
+        using Parameter = typename ModelDataT::Parameters;
 
         Tr_ = TR_MINIMUM;
-        if (data.parameters.contains(ModelDataT::Parameters::Tr))
+        if (data.parameters.contains(Parameter::Tr))
         {
-          Tr_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tr));
+          Tr_ = std::get<RealT>(data.parameters.at(Parameter::Tr));
         }
         if (Tr_ < TR_MINIMUM)
         {
           Tr_ = TR_MINIMUM;
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Ka))
+        if (data.parameters.contains(Parameter::Ka))
         {
-          Ka_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ka));
+          Ka_ = std::get<RealT>(data.parameters.at(Parameter::Ka));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Ta))
+        if (data.parameters.contains(Parameter::Ta))
         {
-          Ta_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ta));
+          Ta_ = std::get<RealT>(data.parameters.at(Parameter::Ta));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Ke))
+        if (data.parameters.contains(Parameter::Ke))
         {
-          Ke_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ke));
+          Ke_ = std::get<RealT>(data.parameters.at(Parameter::Ke));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Te))
+        if (data.parameters.contains(Parameter::Te))
         {
-          Te_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Te));
+          Te_ = std::get<RealT>(data.parameters.at(Parameter::Te));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Kf))
+        if (data.parameters.contains(Parameter::Kf))
         {
-          Kf_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Kf));
+          Kf_ = std::get<RealT>(data.parameters.at(Parameter::Kf));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Tf))
+        if (data.parameters.contains(Parameter::Tf))
         {
-          Tf_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tf));
+          Tf_ = std::get<RealT>(data.parameters.at(Parameter::Tf));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Vrmin))
+        if (data.parameters.contains(Parameter::Vrmin))
         {
-          Vrmin_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vrmin));
+          Vrmin_ = std::get<RealT>(data.parameters.at(Parameter::Vrmin));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Vrmax))
+        if (data.parameters.contains(Parameter::Vrmax))
         {
-          Vrmax_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vrmax));
+          Vrmax_ = std::get<RealT>(data.parameters.at(Parameter::Vrmax));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::E1))
+        if (data.parameters.contains(Parameter::E1))
         {
-          E1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::E1));
+          E1_ = std::get<RealT>(data.parameters.at(Parameter::E1));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::E2))
+        if (data.parameters.contains(Parameter::E2))
         {
-          E2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::E2));
+          E2_ = std::get<RealT>(data.parameters.at(Parameter::E2));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Se1))
+        if (data.parameters.contains(Parameter::Se1))
         {
-          Se1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Se1));
+          Se1_ = std::get<RealT>(data.parameters.at(Parameter::Se1));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Se2))
+        if (data.parameters.contains(Parameter::Se2))
         {
-          Se2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Se2));
+          Se2_ = std::get<RealT>(data.parameters.at(Parameter::Se2));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Ispdlim))
+        if (data.parameters.contains(Parameter::Ispdlim))
         {
-          Ispdlim_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ispdlim));
+          Ispdlim_ = std::get<RealT>(data.parameters.at(Parameter::Ispdlim));
         }
 
         // Derived Parameters

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiData.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiData.hpp
@@ -25,12 +25,25 @@ namespace GridKit
         Efdmin  ///< Minimum excitation output
       };
 
-      /// Ports for the SEXS-PTI exciter model.
-      enum class SexsPtiPorts
+      /// Terminals for the SEXS-PTI exciter model.
+      enum class SexsPtiTerminals : size_t
       {
         bus, ///< Unique ID of the terminal bus
+        SIZE
+      };
+
+      /// Input ports for the SEXS-PTI exciter model.
+      enum class SexsPtiInputPorts : size_t
+      {
+        vs, ///< Unique ID of the optional stabilizer output signal
+        SIZE
+      };
+
+      /// Output ports for the SEXS-PTI exciter model.
+      enum class SexsPtiOutputPorts : size_t
+      {
         efd, ///< Unique ID of the output efd signal
-        vs   ///< Unique ID of the optional stabilizer output signal
+        SIZE
       };
 
       /// Monitorable variables for the SEXS-PTI exciter model.
@@ -43,13 +56,17 @@ namespace GridKit
       struct SexsPtiData : public ComponentData<real_type,
                                                 index_type,
                                                 SexsPtiParameters,
-                                                SexsPtiPorts,
+                                                SexsPtiTerminals,
+                                                SexsPtiInputPorts,
+                                                SexsPtiOutputPorts,
                                                 SexsPtiMonitorableVariables>
       {
         SexsPtiData() = default;
 
         using Parameters           = SexsPtiParameters;
-        using Ports                = SexsPtiPorts;
+        using Terminals            = SexsPtiTerminals;
+        using InputPorts           = SexsPtiInputPorts;
+        using OutputPorts          = SexsPtiOutputPorts;
         using MonitorableVariables = SexsPtiMonitorableVariables;
       };
 

--- a/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiData.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/SEXS-PTI/SexsPtiData.hpp
@@ -25,22 +25,22 @@ namespace GridKit
         Efdmin  ///< Minimum excitation output
       };
 
-      /// Terminals for the SEXS-PTI exciter model.
-      enum class SexsPtiTerminals : size_t
+      /// Buses for the SEXS-PTI exciter model.
+      enum class SexsPtiBuses : size_t
       {
         bus, ///< Unique ID of the terminal bus
         SIZE
       };
 
-      /// Input ports for the SEXS-PTI exciter model.
-      enum class SexsPtiInputPorts : size_t
+      /// Signal inputs for the SEXS-PTI exciter model.
+      enum class SexsPtiSignalInputs : size_t
       {
         vs, ///< Unique ID of the optional stabilizer output signal
         SIZE
       };
 
-      /// Output ports for the SEXS-PTI exciter model.
-      enum class SexsPtiOutputPorts : size_t
+      /// Signal outputs for the SEXS-PTI exciter model.
+      enum class SexsPtiSignalOutputs : size_t
       {
         efd, ///< Unique ID of the output efd signal
         SIZE
@@ -56,17 +56,17 @@ namespace GridKit
       struct SexsPtiData : public ComponentData<real_type,
                                                 index_type,
                                                 SexsPtiParameters,
-                                                SexsPtiTerminals,
-                                                SexsPtiInputPorts,
-                                                SexsPtiOutputPorts,
+                                                SexsPtiBuses,
+                                                SexsPtiSignalInputs,
+                                                SexsPtiSignalOutputs,
                                                 SexsPtiMonitorableVariables>
       {
         SexsPtiData() = default;
 
         using Parameters           = SexsPtiParameters;
-        using Terminals            = SexsPtiTerminals;
-        using InputPorts           = SexsPtiInputPorts;
-        using OutputPorts          = SexsPtiOutputPorts;
+        using Buses                = SexsPtiBuses;
+        using SignalInputs         = SexsPtiSignalInputs;
+        using SignalOutputs        = SexsPtiSignalOutputs;
         using MonitorableVariables = SexsPtiMonitorableVariables;
       };
 

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
@@ -33,13 +33,35 @@ namespace GridKit
       };
 
       /**
-       * @brief Placeholder enum for TGOV1 ports.
+       * @brief Temporary TGOV1 terminal keys.
+       *
+       * NOTE: The TGOV1 bus terminal is accepted only so existing flat JSON
+       * cases continue to parse without case-file churn. TGOV1 does not use
+       * this bus terminal, and it should be removed when the JSON port format
+       * is updated.
        */
-      enum class Tgov1Ports
+      enum class Tgov1Terminals : size_t
       {
         bus,
+        SIZE,
+      };
+
+      /**
+       * @brief TGOV1 input ports.
+       */
+      enum class Tgov1InputPorts : size_t
+      {
         speed,
+        SIZE,
+      };
+
+      /**
+       * @brief TGOV1 output ports.
+       */
+      enum class Tgov1OutputPorts : size_t
+      {
         pmech,
+        SIZE,
       };
 
       /**
@@ -60,13 +82,17 @@ namespace GridKit
       struct Tgov1Data : public ComponentData<real_type,
                                               index_type,
                                               Tgov1Parameters,
-                                              Tgov1Ports,
+                                              Tgov1Terminals,
+                                              Tgov1InputPorts,
+                                              Tgov1OutputPorts,
                                               Tgov1MonitorableVariables>
       {
         Tgov1Data() = default;
 
         using Parameters           = Tgov1Parameters;
-        using Ports                = Tgov1Ports;
+        using Terminals            = Tgov1Terminals;
+        using InputPorts           = Tgov1InputPorts;
+        using OutputPorts          = Tgov1OutputPorts;
         using MonitorableVariables = Tgov1MonitorableVariables;
       };
 

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
@@ -33,32 +33,32 @@ namespace GridKit
       };
 
       /**
-       * @brief Temporary TGOV1 terminal keys.
+       * @brief Temporary TGOV1 bus keys.
        *
-       * NOTE: The TGOV1 bus terminal is accepted only so existing flat JSON
+       * NOTE: The TGOV1 bus key is accepted only so existing flat JSON
        * cases continue to parse without case-file churn. TGOV1 does not use
-       * this bus terminal, and it should be removed when the JSON port format
+       * this bus key, and it should be removed when the JSON port format
        * is updated.
        */
-      enum class Tgov1Terminals : size_t
+      enum class Tgov1Buses : size_t
       {
         bus,
         SIZE,
       };
 
       /**
-       * @brief TGOV1 input ports.
+       * @brief TGOV1 signal inputs.
        */
-      enum class Tgov1InputPorts : size_t
+      enum class Tgov1SignalInputs : size_t
       {
         speed,
         SIZE,
       };
 
       /**
-       * @brief TGOV1 output ports.
+       * @brief TGOV1 signal outputs.
        */
-      enum class Tgov1OutputPorts : size_t
+      enum class Tgov1SignalOutputs : size_t
       {
         pmech,
         SIZE,
@@ -82,17 +82,17 @@ namespace GridKit
       struct Tgov1Data : public ComponentData<real_type,
                                               index_type,
                                               Tgov1Parameters,
-                                              Tgov1Terminals,
-                                              Tgov1InputPorts,
-                                              Tgov1OutputPorts,
+                                              Tgov1Buses,
+                                              Tgov1SignalInputs,
+                                              Tgov1SignalOutputs,
                                               Tgov1MonitorableVariables>
       {
         Tgov1Data() = default;
 
         using Parameters           = Tgov1Parameters;
-        using Terminals            = Tgov1Terminals;
-        using InputPorts           = Tgov1InputPorts;
-        using OutputPorts          = Tgov1OutputPorts;
+        using Buses                = Tgov1Buses;
+        using SignalInputs         = Tgov1SignalInputs;
+        using SignalOutputs        = Tgov1SignalOutputs;
         using MonitorableVariables = Tgov1MonitorableVariables;
       };
 

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -87,44 +87,46 @@ namespace GridKit
       template <typename scalar_type, typename index_type>
       void Tgov1<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
       {
-        if (data.parameters.contains(ModelDataT::Parameters::Trate))
+        using Parameter = typename ModelDataT::Parameters;
+
+        if (data.parameters.contains(Parameter::Trate))
         {
-          Trate_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Trate));
+          Trate_ = std::get<RealT>(data.parameters.at(Parameter::Trate));
         }
 
-        if (data.parameters.contains(ModelDataT::Parameters::R))
+        if (data.parameters.contains(Parameter::R))
         {
-          R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
+          R_ = std::get<RealT>(data.parameters.at(Parameter::R));
         }
 
-        if (data.parameters.contains(ModelDataT::Parameters::Pvmin))
+        if (data.parameters.contains(Parameter::Pvmin))
         {
-          Pvmin_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Pvmin));
+          Pvmin_ = std::get<RealT>(data.parameters.at(Parameter::Pvmin));
         }
 
-        if (data.parameters.contains(ModelDataT::Parameters::Pvmax))
+        if (data.parameters.contains(Parameter::Pvmax))
         {
-          Pvmax_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Pvmax));
+          Pvmax_ = std::get<RealT>(data.parameters.at(Parameter::Pvmax));
         }
 
-        if (data.parameters.contains(ModelDataT::Parameters::T1))
+        if (data.parameters.contains(Parameter::T1))
         {
-          T1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T1));
+          T1_ = std::get<RealT>(data.parameters.at(Parameter::T1));
         }
 
-        if (data.parameters.contains(ModelDataT::Parameters::T2))
+        if (data.parameters.contains(Parameter::T2))
         {
-          T2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T2));
+          T2_ = std::get<RealT>(data.parameters.at(Parameter::T2));
         }
 
-        if (data.parameters.contains(ModelDataT::Parameters::T3))
+        if (data.parameters.contains(Parameter::T3))
         {
-          T3_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T3));
+          T3_ = std::get<RealT>(data.parameters.at(Parameter::T3));
         }
 
-        if (data.parameters.contains(ModelDataT::Parameters::Dt))
+        if (data.parameters.contains(Parameter::Dt))
         {
-          Dt_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Dt));
+          Dt_ = std::get<RealT>(data.parameters.at(Parameter::Dt));
         }
       }
 

--- a/GridKit/Model/PhasorDynamics/Load/LoadZ/LoadZData.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadZ/LoadZData.hpp
@@ -19,10 +19,23 @@ namespace GridKit
       X, ///< Load reactance
     };
 
-    /// Ports for a load
-    enum class LoadZPorts
+    /// Terminals for a load
+    enum class LoadZTerminals : size_t
     {
       bus, ///< Unique ID of the bus to which the load is connected
+      SIZE
+    };
+
+    /// Input ports supported for a load
+    enum class LoadZInputPorts : size_t
+    {
+      SIZE
+    };
+
+    /// Output ports supported for a load
+    enum class LoadZOutputPorts : size_t
+    {
+      SIZE
     };
 
     /// Variables able to be monitored for a load
@@ -44,13 +57,17 @@ namespace GridKit
     struct LoadZData : public ComponentData<real_type,
                                             index_type,
                                             LoadZParameters,
-                                            LoadZPorts,
+                                            LoadZTerminals,
+                                            LoadZInputPorts,
+                                            LoadZOutputPorts,
                                             LoadZMonitorableVariables>
     {
       LoadZData() = default;
 
       using Parameters           = LoadZParameters;
-      using Ports                = LoadZPorts;
+      using Terminals            = LoadZTerminals;
+      using InputPorts           = LoadZInputPorts;
+      using OutputPorts          = LoadZOutputPorts;
       using MonitorableVariables = LoadZMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Load/LoadZ/LoadZData.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadZ/LoadZData.hpp
@@ -19,21 +19,21 @@ namespace GridKit
       X, ///< Load reactance
     };
 
-    /// Terminals for a load
-    enum class LoadZTerminals : size_t
+    /// Buses for a load
+    enum class LoadZBuses : size_t
     {
       bus, ///< Unique ID of the bus to which the load is connected
       SIZE
     };
 
-    /// Input ports supported for a load
-    enum class LoadZInputPorts : size_t
+    /// Signal inputs supported for a load
+    enum class LoadZSignalInputs : size_t
     {
       SIZE
     };
 
-    /// Output ports supported for a load
-    enum class LoadZOutputPorts : size_t
+    /// Signal outputs supported for a load
+    enum class LoadZSignalOutputs : size_t
     {
       SIZE
     };
@@ -57,17 +57,17 @@ namespace GridKit
     struct LoadZData : public ComponentData<real_type,
                                             index_type,
                                             LoadZParameters,
-                                            LoadZTerminals,
-                                            LoadZInputPorts,
-                                            LoadZOutputPorts,
+                                            LoadZBuses,
+                                            LoadZSignalInputs,
+                                            LoadZSignalOutputs,
                                             LoadZMonitorableVariables>
     {
       LoadZData() = default;
 
       using Parameters           = LoadZParameters;
-      using Terminals            = LoadZTerminals;
-      using InputPorts           = LoadZInputPorts;
-      using OutputPorts          = LoadZOutputPorts;
+      using Buses                = LoadZBuses;
+      using SignalInputs         = LoadZSignalInputs;
+      using SignalOutputs        = LoadZSignalOutputs;
       using MonitorableVariables = LoadZMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Load/LoadZ/LoadZImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadZ/LoadZImpl.hpp
@@ -46,14 +46,15 @@ namespace GridKit
       : bus_(bus),
         monitor_(std::make_unique<MonitorT>(data))
     {
-      if (data.parameters.contains(ModelDataT::Parameters::R))
+      using Parameter = typename ModelDataT::Parameters;
+      if (data.parameters.contains(Parameter::R))
       {
-        R_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::R));
+        R_ = std::get<RealT>(data.parameters.at(Parameter::R));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::X))
+      if (data.parameters.contains(Parameter::X))
       {
-        X_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::X));
+        X_ = std::get<RealT>(data.parameters.at(Parameter::X));
       }
 
       size_ = 2;

--- a/GridKit/Model/PhasorDynamics/Load/LoadZIP/LoadZIPData.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadZIP/LoadZIPData.hpp
@@ -17,10 +17,23 @@ namespace GridKit
       alphaP, ///< Fraction of load represented as constant power
     };
 
-    /// Ports for a loadZIP
-    enum class LoadZIPPorts
+    /// Terminals for a loadZIP
+    enum class LoadZIPTerminals : size_t
     {
       bus, ///< Unique ID of the bus to which the loadZIP is connected
+      SIZE
+    };
+
+    /// Input ports supported for a loadZIP
+    enum class LoadZIPInputPorts : size_t
+    {
+      SIZE
+    };
+
+    /// Output ports supported for a loadZIP
+    enum class LoadZIPOutputPorts : size_t
+    {
+      SIZE
     };
 
     /// Variables able to be monitored for a loadZIP
@@ -45,13 +58,17 @@ namespace GridKit
     struct LoadZIPData : public ComponentData<real_type,
                                               index_type,
                                               LoadZIPParameters,
-                                              LoadZIPPorts,
+                                              LoadZIPTerminals,
+                                              LoadZIPInputPorts,
+                                              LoadZIPOutputPorts,
                                               LoadZIPMonitorableVariables>
     {
       LoadZIPData() = default;
 
       using Parameters           = LoadZIPParameters;
-      using Ports                = LoadZIPPorts;
+      using Terminals            = LoadZIPTerminals;
+      using InputPorts           = LoadZIPInputPorts;
+      using OutputPorts          = LoadZIPOutputPorts;
       using MonitorableVariables = LoadZIPMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Load/LoadZIP/LoadZIPData.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadZIP/LoadZIPData.hpp
@@ -17,21 +17,21 @@ namespace GridKit
       alphaP, ///< Fraction of load represented as constant power
     };
 
-    /// Terminals for a loadZIP
-    enum class LoadZIPTerminals : size_t
+    /// Buses for a loadZIP
+    enum class LoadZIPBuses : size_t
     {
       bus, ///< Unique ID of the bus to which the loadZIP is connected
       SIZE
     };
 
-    /// Input ports supported for a loadZIP
-    enum class LoadZIPInputPorts : size_t
+    /// Signal inputs supported for a loadZIP
+    enum class LoadZIPSignalInputs : size_t
     {
       SIZE
     };
 
-    /// Output ports supported for a loadZIP
-    enum class LoadZIPOutputPorts : size_t
+    /// Signal outputs supported for a loadZIP
+    enum class LoadZIPSignalOutputs : size_t
     {
       SIZE
     };
@@ -58,17 +58,17 @@ namespace GridKit
     struct LoadZIPData : public ComponentData<real_type,
                                               index_type,
                                               LoadZIPParameters,
-                                              LoadZIPTerminals,
-                                              LoadZIPInputPorts,
-                                              LoadZIPOutputPorts,
+                                              LoadZIPBuses,
+                                              LoadZIPSignalInputs,
+                                              LoadZIPSignalOutputs,
                                               LoadZIPMonitorableVariables>
     {
       LoadZIPData() = default;
 
       using Parameters           = LoadZIPParameters;
-      using Terminals            = LoadZIPTerminals;
-      using InputPorts           = LoadZIPInputPorts;
-      using OutputPorts          = LoadZIPOutputPorts;
+      using Buses                = LoadZIPBuses;
+      using SignalInputs         = LoadZIPSignalInputs;
+      using SignalOutputs        = LoadZIPSignalOutputs;
       using MonitorableVariables = LoadZIPMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Load/LoadZIP/LoadZIPImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Load/LoadZIP/LoadZIPImpl.hpp
@@ -58,29 +58,30 @@ namespace GridKit
     template <typename scalar_type, typename index_type>
     void LoadZIP<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
-      if (data.parameters.contains(ModelDataT::Parameters::Pnom))
+      using Parameter = typename ModelDataT::Parameters;
+      if (data.parameters.contains(Parameter::Pnom))
       {
-        Pnom_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Pnom));
+        Pnom_ = std::get<RealT>(data.parameters.at(Parameter::Pnom));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Qnom))
+      if (data.parameters.contains(Parameter::Qnom))
       {
-        Qnom_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Qnom));
+        Qnom_ = std::get<RealT>(data.parameters.at(Parameter::Qnom));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Vnom))
+      if (data.parameters.contains(Parameter::Vnom))
       {
-        Vnom_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vnom));
+        Vnom_ = std::get<RealT>(data.parameters.at(Parameter::Vnom));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::alphaI))
+      if (data.parameters.contains(Parameter::alphaI))
       {
-        alphaI_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::alphaI));
+        alphaI_ = std::get<RealT>(data.parameters.at(Parameter::alphaI));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::alphaP))
+      if (data.parameters.contains(Parameter::alphaP))
       {
-        alphaP_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::alphaP));
+        alphaP_ = std::get<RealT>(data.parameters.at(Parameter::alphaP));
       }
 
       setDerivedParams();

--- a/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceData.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceData.hpp
@@ -12,10 +12,21 @@ namespace GridKit
       Si
     };
 
-    enum class ConstantSignalSourcePorts
+    enum class ConstantSignalSourceTerminals : size_t
+    {
+      SIZE
+    };
+
+    enum class ConstantSignalSourceInputPorts : size_t
+    {
+      SIZE
+    };
+
+    enum class ConstantSignalSourceOutputPorts : size_t
     {
       sr,
-      si
+      si,
+      SIZE
     };
 
     enum class ConstantSignalSourceMonitorableVariables
@@ -27,13 +38,17 @@ namespace GridKit
     struct ConstantSignalSourceData : public ComponentData<real_type,
                                                            index_type,
                                                            ConstantSignalSourceParameters,
-                                                           ConstantSignalSourcePorts,
+                                                           ConstantSignalSourceTerminals,
+                                                           ConstantSignalSourceInputPorts,
+                                                           ConstantSignalSourceOutputPorts,
                                                            ConstantSignalSourceMonitorableVariables>
     {
       ConstantSignalSourceData() = default;
 
       using Parameters           = ConstantSignalSourceParameters;
-      using Ports                = ConstantSignalSourcePorts;
+      using Terminals            = ConstantSignalSourceTerminals;
+      using InputPorts           = ConstantSignalSourceInputPorts;
+      using OutputPorts          = ConstantSignalSourceOutputPorts;
       using MonitorableVariables = ConstantSignalSourceMonitorableVariables;
     };
 

--- a/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceData.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceData.hpp
@@ -12,17 +12,17 @@ namespace GridKit
       Si
     };
 
-    enum class ConstantSignalSourceTerminals : size_t
+    enum class ConstantSignalSourceBuses : size_t
     {
       SIZE
     };
 
-    enum class ConstantSignalSourceInputPorts : size_t
+    enum class ConstantSignalSourceSignalInputs : size_t
     {
       SIZE
     };
 
-    enum class ConstantSignalSourceOutputPorts : size_t
+    enum class ConstantSignalSourceSignalOutputs : size_t
     {
       sr,
       si,
@@ -38,17 +38,17 @@ namespace GridKit
     struct ConstantSignalSourceData : public ComponentData<real_type,
                                                            index_type,
                                                            ConstantSignalSourceParameters,
-                                                           ConstantSignalSourceTerminals,
-                                                           ConstantSignalSourceInputPorts,
-                                                           ConstantSignalSourceOutputPorts,
+                                                           ConstantSignalSourceBuses,
+                                                           ConstantSignalSourceSignalInputs,
+                                                           ConstantSignalSourceSignalOutputs,
                                                            ConstantSignalSourceMonitorableVariables>
     {
       ConstantSignalSourceData() = default;
 
       using Parameters           = ConstantSignalSourceParameters;
-      using Terminals            = ConstantSignalSourceTerminals;
-      using InputPorts           = ConstantSignalSourceInputPorts;
-      using OutputPorts          = ConstantSignalSourceOutputPorts;
+      using Buses                = ConstantSignalSourceBuses;
+      using SignalInputs         = ConstantSignalSourceSignalInputs;
+      using SignalOutputs        = ConstantSignalSourceSignalOutputs;
       using MonitorableVariables = ConstantSignalSourceMonitorableVariables;
     };
 

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestData.hpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestData.hpp
@@ -40,12 +40,29 @@ namespace GridKit
       };
 
       /**
-       * @brief Port keys for IEEEST Stabilizer model.
+       * @brief Terminal keys for IEEEST Stabilizer model.
        */
-      enum class IeeestPorts
+      enum class IeeestTerminals : size_t
       {
-        input,  ///< Unique ID of the stabilizer input signal
+        SIZE
+      };
+
+      /**
+       * @brief Input port keys for IEEEST Stabilizer model.
+       */
+      enum class IeeestInputPorts : size_t
+      {
+        input, ///< Unique ID of the stabilizer input signal
+        SIZE
+      };
+
+      /**
+       * @brief Output port keys for IEEEST Stabilizer model.
+       */
+      enum class IeeestOutputPorts : size_t
+      {
         output, ///< Unique ID of the stabilizer output signal
+        SIZE
       };
 
       /**
@@ -66,13 +83,17 @@ namespace GridKit
       struct IeeestData : public ComponentData<real_type,
                                                index_type,
                                                IeeestParameters,
-                                               IeeestPorts,
+                                               IeeestTerminals,
+                                               IeeestInputPorts,
+                                               IeeestOutputPorts,
                                                IeeestMonitorableVariables>
       {
         IeeestData() = default;
 
         using Parameters           = IeeestParameters;
-        using Ports                = IeeestPorts;
+        using Terminals            = IeeestTerminals;
+        using InputPorts           = IeeestInputPorts;
+        using OutputPorts          = IeeestOutputPorts;
         using MonitorableVariables = IeeestMonitorableVariables;
       };
 

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestData.hpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestData.hpp
@@ -40,26 +40,26 @@ namespace GridKit
       };
 
       /**
-       * @brief Terminal keys for IEEEST Stabilizer model.
+       * @brief Bus keys for IEEEST Stabilizer model.
        */
-      enum class IeeestTerminals : size_t
+      enum class IeeestBuses : size_t
       {
         SIZE
       };
 
       /**
-       * @brief Input port keys for IEEEST Stabilizer model.
+       * @brief Signal input keys for IEEEST Stabilizer model.
        */
-      enum class IeeestInputPorts : size_t
+      enum class IeeestSignalInputs : size_t
       {
         input, ///< Unique ID of the stabilizer input signal
         SIZE
       };
 
       /**
-       * @brief Output port keys for IEEEST Stabilizer model.
+       * @brief Signal output keys for IEEEST Stabilizer model.
        */
-      enum class IeeestOutputPorts : size_t
+      enum class IeeestSignalOutputs : size_t
       {
         output, ///< Unique ID of the stabilizer output signal
         SIZE
@@ -83,17 +83,17 @@ namespace GridKit
       struct IeeestData : public ComponentData<real_type,
                                                index_type,
                                                IeeestParameters,
-                                               IeeestTerminals,
-                                               IeeestInputPorts,
-                                               IeeestOutputPorts,
+                                               IeeestBuses,
+                                               IeeestSignalInputs,
+                                               IeeestSignalOutputs,
                                                IeeestMonitorableVariables>
       {
         IeeestData() = default;
 
         using Parameters           = IeeestParameters;
-        using Terminals            = IeeestTerminals;
-        using InputPorts           = IeeestInputPorts;
-        using OutputPorts          = IeeestOutputPorts;
+        using Buses                = IeeestBuses;
+        using SignalInputs         = IeeestSignalInputs;
+        using SignalOutputs        = IeeestSignalOutputs;
         using MonitorableVariables = IeeestMonitorableVariables;
       };
 

--- a/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestImpl.hpp
@@ -46,77 +46,78 @@ namespace GridKit
       template <typename scalar_type, typename index_type>
       void Ieeest<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
       {
-        if (data.parameters.contains(ModelDataT::Parameters::A1))
+        using Parameter = typename ModelDataT::Parameters;
+        if (data.parameters.contains(Parameter::A1))
         {
-          A1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A1));
+          A1_ = std::get<RealT>(data.parameters.at(Parameter::A1));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::A2))
+        if (data.parameters.contains(Parameter::A2))
         {
-          A2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A2));
+          A2_ = std::get<RealT>(data.parameters.at(Parameter::A2));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::A3))
+        if (data.parameters.contains(Parameter::A3))
         {
-          A3_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A3));
+          A3_ = std::get<RealT>(data.parameters.at(Parameter::A3));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::A4))
+        if (data.parameters.contains(Parameter::A4))
         {
-          A4_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A4));
+          A4_ = std::get<RealT>(data.parameters.at(Parameter::A4));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::A5))
+        if (data.parameters.contains(Parameter::A5))
         {
-          A5_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A5));
+          A5_ = std::get<RealT>(data.parameters.at(Parameter::A5));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::A6))
+        if (data.parameters.contains(Parameter::A6))
         {
-          A6_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::A6));
+          A6_ = std::get<RealT>(data.parameters.at(Parameter::A6));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::T1))
+        if (data.parameters.contains(Parameter::T1))
         {
-          T1_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T1));
+          T1_ = std::get<RealT>(data.parameters.at(Parameter::T1));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::T2))
+        if (data.parameters.contains(Parameter::T2))
         {
-          T2_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T2));
+          T2_ = std::get<RealT>(data.parameters.at(Parameter::T2));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::T3))
+        if (data.parameters.contains(Parameter::T3))
         {
-          T3_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T3));
+          T3_ = std::get<RealT>(data.parameters.at(Parameter::T3));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::T4))
+        if (data.parameters.contains(Parameter::T4))
         {
-          T4_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T4));
+          T4_ = std::get<RealT>(data.parameters.at(Parameter::T4));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::T5))
+        if (data.parameters.contains(Parameter::T5))
         {
-          T5_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T5));
+          T5_ = std::get<RealT>(data.parameters.at(Parameter::T5));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::T6))
+        if (data.parameters.contains(Parameter::T6))
         {
-          T6_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::T6));
+          T6_ = std::get<RealT>(data.parameters.at(Parameter::T6));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Ks))
+        if (data.parameters.contains(Parameter::Ks))
         {
-          Ks_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ks));
+          Ks_ = std::get<RealT>(data.parameters.at(Parameter::Ks));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Lsmin))
+        if (data.parameters.contains(Parameter::Lsmin))
         {
-          Lsmin_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Lsmin));
+          Lsmin_ = std::get<RealT>(data.parameters.at(Parameter::Lsmin));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Lsmax))
+        if (data.parameters.contains(Parameter::Lsmax))
         {
-          Lsmax_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Lsmax));
+          Lsmax_ = std::get<RealT>(data.parameters.at(Parameter::Lsmax));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Vcl))
+        if (data.parameters.contains(Parameter::Vcl))
         {
-          Vcl_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vcl));
+          Vcl_ = std::get<RealT>(data.parameters.at(Parameter::Vcl));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Vcu))
+        if (data.parameters.contains(Parameter::Vcu))
         {
-          Vcu_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Vcu));
+          Vcu_ = std::get<RealT>(data.parameters.at(Parameter::Vcu));
         }
-        if (data.parameters.contains(ModelDataT::Parameters::Tdelay))
+        if (data.parameters.contains(Parameter::Tdelay))
         {
-          Tdelay_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdelay));
+          Tdelay_ = std::get<RealT>(data.parameters.at(Parameter::Tdelay));
         }
 
         a0_ = 1;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/GenrouData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/GenrouData.hpp
@@ -36,23 +36,23 @@ namespace GridKit
       mva,   ///< MVA base of the genrou model
     };
 
-    /// Terminals for a Genrou generator model
-    enum class GenrouTerminals : size_t
+    /// Buses for a Genrou generator model
+    enum class GenrouBuses : size_t
     {
       bus, ///< Unique ID of the connecting bus
       SIZE
     };
 
-    /// Input ports for a Genrou generator model
-    enum class GenrouInputPorts : size_t
+    /// Signal inputs for a Genrou generator model
+    enum class GenrouSignalInputs : size_t
     {
       pmech, ///< Unique ID of the signal providing mechanical power
       efd,   ///< Unique ID of the signal providing exciter field signal
       SIZE
     };
 
-    /// Output ports for a Genrou generator model
-    enum class GenrouOutputPorts : size_t
+    /// Signal outputs for a Genrou generator model
+    enum class GenrouSignalOutputs : size_t
     {
       speed, ///< Unique ID of the signal receiving speed deviation
       SIZE
@@ -82,17 +82,17 @@ namespace GridKit
     struct GenrouData : public ComponentData<real_type,
                                              index_type,
                                              GenrouParameters,
-                                             GenrouTerminals,
-                                             GenrouInputPorts,
-                                             GenrouOutputPorts,
+                                             GenrouBuses,
+                                             GenrouSignalInputs,
+                                             GenrouSignalOutputs,
                                              GenrouMonitorableVariables>
     {
       GenrouData() = default;
 
       using Parameters           = GenrouParameters;
-      using Terminals            = GenrouTerminals;
-      using InputPorts           = GenrouInputPorts;
-      using OutputPorts          = GenrouOutputPorts;
+      using Buses                = GenrouBuses;
+      using SignalInputs         = GenrouSignalInputs;
+      using SignalOutputs        = GenrouSignalOutputs;
       using MonitorableVariables = GenrouMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/GenrouData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/GenrouData.hpp
@@ -36,13 +36,26 @@ namespace GridKit
       mva,   ///< MVA base of the genrou model
     };
 
-    /// Ports for a Genrou generator model
-    enum class GenrouPorts
+    /// Terminals for a Genrou generator model
+    enum class GenrouTerminals : size_t
     {
-      bus,   ///< Unique ID of the connecting bus
-      pmech, ///< Unique ID of the bus providing the exciter signal
-      speed, ///< Unique ID of the bus providing the governor signal
-      efd,   ///< Unique ID of the bus providing exciter field signal
+      bus, ///< Unique ID of the connecting bus
+      SIZE
+    };
+
+    /// Input ports for a Genrou generator model
+    enum class GenrouInputPorts : size_t
+    {
+      pmech, ///< Unique ID of the signal providing mechanical power
+      efd,   ///< Unique ID of the signal providing exciter field signal
+      SIZE
+    };
+
+    /// Output ports for a Genrou generator model
+    enum class GenrouOutputPorts : size_t
+    {
+      speed, ///< Unique ID of the signal receiving speed deviation
+      SIZE
     };
 
     /// Variables able to be monitored for a Genrou generator model
@@ -69,13 +82,17 @@ namespace GridKit
     struct GenrouData : public ComponentData<real_type,
                                              index_type,
                                              GenrouParameters,
-                                             GenrouPorts,
+                                             GenrouTerminals,
+                                             GenrouInputPorts,
+                                             GenrouOutputPorts,
                                              GenrouMonitorableVariables>
     {
       GenrouData() = default;
 
       using Parameters           = GenrouParameters;
-      using Ports                = GenrouPorts;
+      using Terminals            = GenrouTerminals;
+      using InputPorts           = GenrouInputPorts;
+      using OutputPorts          = GenrouOutputPorts;
       using MonitorableVariables = GenrouMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/GenrouImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/GenrouImpl.hpp
@@ -164,7 +164,7 @@ namespace GridKit
     void Genrou<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
       using Parameter = typename ModelDataT::Parameters;
-      using Terminal  = typename ModelDataT::Terminals;
+      using Buses     = typename ModelDataT::Buses;
       if (data.parameters.contains(Parameter::p0))
       {
         p0_ = std::get<RealT>(data.parameters.at(Parameter::p0));
@@ -260,9 +260,9 @@ namespace GridKit
         mva_base_ = std::get<RealT>(data.parameters.at(Parameter::mva));
       }
 
-      if (data.terminals.contains(Terminal::bus))
+      if (data.buses.contains(Buses::bus))
       {
-        bus_id_ = data.terminals.at(Terminal::bus);
+        bus_id_ = data.buses.at(Buses::bus);
       }
     }
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/GenrouImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/GenrouImpl.hpp
@@ -163,104 +163,106 @@ namespace GridKit
     template <typename scalar_type, typename index_type>
     void Genrou<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
-      if (data.parameters.contains(ModelDataT::Parameters::p0))
+      using Parameter = typename ModelDataT::Parameters;
+      using Terminal  = typename ModelDataT::Terminals;
+      if (data.parameters.contains(Parameter::p0))
       {
-        p0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::p0));
+        p0_ = std::get<RealT>(data.parameters.at(Parameter::p0));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::q0))
+      if (data.parameters.contains(Parameter::q0))
       {
-        q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::q0));
+        q0_ = std::get<RealT>(data.parameters.at(Parameter::q0));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::H))
+      if (data.parameters.contains(Parameter::H))
       {
-        H_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::H));
+        H_ = std::get<RealT>(data.parameters.at(Parameter::H));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::D))
+      if (data.parameters.contains(Parameter::D))
       {
-        D_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::D));
+        D_ = std::get<RealT>(data.parameters.at(Parameter::D));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Ra))
+      if (data.parameters.contains(Parameter::Ra))
       {
-        Ra_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ra));
+        Ra_ = std::get<RealT>(data.parameters.at(Parameter::Ra));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Tdop))
+      if (data.parameters.contains(Parameter::Tdop))
       {
-        Tdop_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdop));
+        Tdop_ = std::get<RealT>(data.parameters.at(Parameter::Tdop));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Tdopp))
+      if (data.parameters.contains(Parameter::Tdopp))
       {
-        Tdopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdopp));
+        Tdopp_ = std::get<RealT>(data.parameters.at(Parameter::Tdopp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Tqopp))
+      if (data.parameters.contains(Parameter::Tqopp))
       {
-        Tqopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tqopp));
+        Tqopp_ = std::get<RealT>(data.parameters.at(Parameter::Tqopp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Tqop))
+      if (data.parameters.contains(Parameter::Tqop))
       {
-        Tqop_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tqop));
+        Tqop_ = std::get<RealT>(data.parameters.at(Parameter::Tqop));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xd))
+      if (data.parameters.contains(Parameter::Xd))
       {
-        Xd_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xd));
+        Xd_ = std::get<RealT>(data.parameters.at(Parameter::Xd));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xdp))
+      if (data.parameters.contains(Parameter::Xdp))
       {
-        Xdp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdp));
+        Xdp_ = std::get<RealT>(data.parameters.at(Parameter::Xdp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xdpp))
+      if (data.parameters.contains(Parameter::Xdpp))
       {
-        Xdpp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdpp));
+        Xdpp_ = std::get<RealT>(data.parameters.at(Parameter::Xdpp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xq))
+      if (data.parameters.contains(Parameter::Xq))
       {
-        Xq_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xq));
+        Xq_ = std::get<RealT>(data.parameters.at(Parameter::Xq));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xqp))
+      if (data.parameters.contains(Parameter::Xqp))
       {
-        Xqp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xqp));
+        Xqp_ = std::get<RealT>(data.parameters.at(Parameter::Xqp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xqpp))
+      if (data.parameters.contains(Parameter::Xqpp))
       {
-        Xqpp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xqpp));
+        Xqpp_ = std::get<RealT>(data.parameters.at(Parameter::Xqpp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xl))
+      if (data.parameters.contains(Parameter::Xl))
       {
-        Xl_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xl));
+        Xl_ = std::get<RealT>(data.parameters.at(Parameter::Xl));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::S10))
+      if (data.parameters.contains(Parameter::S10))
       {
-        S10_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S10));
+        S10_ = std::get<RealT>(data.parameters.at(Parameter::S10));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::S12))
+      if (data.parameters.contains(Parameter::S12))
       {
-        S12_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S12));
+        S12_ = std::get<RealT>(data.parameters.at(Parameter::S12));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::mva))
+      if (data.parameters.contains(Parameter::mva))
       {
-        mva_base_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::mva));
+        mva_base_ = std::get<RealT>(data.parameters.at(Parameter::mva));
       }
 
-      if (data.ports.contains(ModelDataT::Ports::bus))
+      if (data.terminals.contains(Terminal::bus))
       {
-        bus_id_ = data.ports.at(ModelDataT::Ports::bus);
+        bus_id_ = data.terminals.at(Terminal::bus);
       }
     }
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSAL/GensalData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSAL/GensalData.hpp
@@ -33,13 +33,26 @@ namespace GridKit
       mva,   ///< MVA base of the gensal model
     };
 
-    /// Ports for a Gensal generator model
-    enum class GensalPorts
+    /// Terminals for a Gensal generator model
+    enum class GensalTerminals : size_t
     {
-      bus,   ///< Unique ID of the connecting bus
+      bus, ///< Unique ID of the connecting bus
+      SIZE
+    };
+
+    /// Input ports for a Gensal generator model
+    enum class GensalInputPorts : size_t
+    {
       pmech, ///< Unique ID of the signal providing mechanical power
-      speed, ///< Unique ID of the signal receiving speed deviation
       efd,   ///< Unique ID of the signal providing exciter field voltage
+      SIZE
+    };
+
+    /// Output ports for a Gensal generator model
+    enum class GensalOutputPorts : size_t
+    {
+      speed, ///< Unique ID of the signal receiving speed deviation
+      SIZE
     };
 
     /// Variables able to be monitored for a Gensal generator model
@@ -75,13 +88,17 @@ namespace GridKit
     struct GensalData : public ComponentData<real_type,
                                              index_type,
                                              GensalParameters,
-                                             GensalPorts,
+                                             GensalTerminals,
+                                             GensalInputPorts,
+                                             GensalOutputPorts,
                                              GensalMonitorableVariables>
     {
       GensalData() = default;
 
       using Parameters           = GensalParameters;
-      using Ports                = GensalPorts;
+      using Terminals            = GensalTerminals;
+      using InputPorts           = GensalInputPorts;
+      using OutputPorts          = GensalOutputPorts;
       using MonitorableVariables = GensalMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSAL/GensalData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSAL/GensalData.hpp
@@ -33,23 +33,23 @@ namespace GridKit
       mva,   ///< MVA base of the gensal model
     };
 
-    /// Terminals for a Gensal generator model
-    enum class GensalTerminals : size_t
+    /// Buses for a Gensal generator model
+    enum class GensalBuses : size_t
     {
       bus, ///< Unique ID of the connecting bus
       SIZE
     };
 
-    /// Input ports for a Gensal generator model
-    enum class GensalInputPorts : size_t
+    /// Signal inputs for a Gensal generator model
+    enum class GensalSignalInputs : size_t
     {
       pmech, ///< Unique ID of the signal providing mechanical power
       efd,   ///< Unique ID of the signal providing exciter field voltage
       SIZE
     };
 
-    /// Output ports for a Gensal generator model
-    enum class GensalOutputPorts : size_t
+    /// Signal outputs for a Gensal generator model
+    enum class GensalSignalOutputs : size_t
     {
       speed, ///< Unique ID of the signal receiving speed deviation
       SIZE
@@ -88,17 +88,17 @@ namespace GridKit
     struct GensalData : public ComponentData<real_type,
                                              index_type,
                                              GensalParameters,
-                                             GensalTerminals,
-                                             GensalInputPorts,
-                                             GensalOutputPorts,
+                                             GensalBuses,
+                                             GensalSignalInputs,
+                                             GensalSignalOutputs,
                                              GensalMonitorableVariables>
     {
       GensalData() = default;
 
       using Parameters           = GensalParameters;
-      using Terminals            = GensalTerminals;
-      using InputPorts           = GensalInputPorts;
-      using OutputPorts          = GensalOutputPorts;
+      using Buses                = GensalBuses;
+      using SignalInputs         = GensalSignalInputs;
+      using SignalOutputs        = GensalSignalOutputs;
       using MonitorableVariables = GensalMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSAL/GensalImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSAL/GensalImpl.hpp
@@ -41,84 +41,85 @@ namespace GridKit
     template <typename scalar_type, typename index_type>
     void Gensal<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
-      if (data.parameters.contains(ModelDataT::Parameters::p0))
+      using Parameter = typename ModelDataT::Parameters;
+      if (data.parameters.contains(Parameter::p0))
       {
-        p0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::p0));
+        p0_ = std::get<RealT>(data.parameters.at(Parameter::p0));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::q0))
+      if (data.parameters.contains(Parameter::q0))
       {
-        q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::q0));
+        q0_ = std::get<RealT>(data.parameters.at(Parameter::q0));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::H))
+      if (data.parameters.contains(Parameter::H))
       {
-        H_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::H));
+        H_ = std::get<RealT>(data.parameters.at(Parameter::H));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::D))
+      if (data.parameters.contains(Parameter::D))
       {
-        D_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::D));
+        D_ = std::get<RealT>(data.parameters.at(Parameter::D));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Ra))
+      if (data.parameters.contains(Parameter::Ra))
       {
-        Ra_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ra));
+        Ra_ = std::get<RealT>(data.parameters.at(Parameter::Ra));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Tdop))
+      if (data.parameters.contains(Parameter::Tdop))
       {
-        Tdop_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdop));
+        Tdop_ = std::get<RealT>(data.parameters.at(Parameter::Tdop));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Tdopp))
+      if (data.parameters.contains(Parameter::Tdopp))
       {
-        Tdopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tdopp));
+        Tdopp_ = std::get<RealT>(data.parameters.at(Parameter::Tdopp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Tqopp))
+      if (data.parameters.contains(Parameter::Tqopp))
       {
-        Tqopp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Tqopp));
+        Tqopp_ = std::get<RealT>(data.parameters.at(Parameter::Tqopp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xd))
+      if (data.parameters.contains(Parameter::Xd))
       {
-        Xd_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xd));
+        Xd_ = std::get<RealT>(data.parameters.at(Parameter::Xd));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xdp))
+      if (data.parameters.contains(Parameter::Xdp))
       {
-        Xdp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdp));
+        Xdp_ = std::get<RealT>(data.parameters.at(Parameter::Xdp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xdpp))
+      if (data.parameters.contains(Parameter::Xdpp))
       {
-        Xdpp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdpp));
+        Xdpp_ = std::get<RealT>(data.parameters.at(Parameter::Xdpp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xq))
+      if (data.parameters.contains(Parameter::Xq))
       {
-        Xq_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xq));
+        Xq_ = std::get<RealT>(data.parameters.at(Parameter::Xq));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xl))
+      if (data.parameters.contains(Parameter::Xl))
       {
-        Xl_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xl));
+        Xl_ = std::get<RealT>(data.parameters.at(Parameter::Xl));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::S10))
+      if (data.parameters.contains(Parameter::S10))
       {
-        S10_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S10));
+        S10_ = std::get<RealT>(data.parameters.at(Parameter::S10));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::S12))
+      if (data.parameters.contains(Parameter::S12))
       {
-        S12_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::S12));
+        S12_ = std::get<RealT>(data.parameters.at(Parameter::S12));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::mva))
+      if (data.parameters.contains(Parameter::mva))
       {
-        mva_base_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::mva));
+        mva_base_ = std::get<RealT>(data.parameters.at(Parameter::mva));
       }
     }
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
@@ -24,28 +24,28 @@ namespace GridKit
       mva  ///< MVA Base of the generator
     };
 
-    /// Terminals supported for a classical generator model
-    enum class GenClassicalTerminals : size_t
+    /// Buses supported for a classical generator model
+    enum class GenClassicalBuses : size_t
     {
       bus, ///< Unique ID of the connecting bus
       SIZE
     };
 
-    /// Input ports supported for a classical generator model
+    /// Signal inputs supported for a classical generator model
     ///
-    /// @warning GenClassical signal support is incomplete. These legacy port
+    /// @warning GenClassical signal support is incomplete. These legacy signal
     /// names are not wired by SystemModel today; the intended refactor is to
     /// align this model with Genrou/Gensal by supporting `pmech`, `speed`, and
-    /// `efd` ports through ComponentSignals.
-    enum class GenClassicalInputPorts : size_t
+    /// `efd` signals through ComponentSignals.
+    enum class GenClassicalSignalInputs : size_t
     {
       exciter_signal,  ///< Unique ID of the bus providing the exciter signal
       governor_signal, ///< Unique ID of the bus providing the governor signal
       SIZE
     };
 
-    /// Output ports supported for a classical generator model
-    enum class GenClassicalOutputPorts : size_t
+    /// Signal outputs supported for a classical generator model
+    enum class GenClassicalSignalOutputs : size_t
     {
       SIZE
     };
@@ -75,17 +75,17 @@ namespace GridKit
     struct GenClassicalData : public ComponentData<real_type,
                                                    index_type,
                                                    GenClassicalParameters,
-                                                   GenClassicalTerminals,
-                                                   GenClassicalInputPorts,
-                                                   GenClassicalOutputPorts,
+                                                   GenClassicalBuses,
+                                                   GenClassicalSignalInputs,
+                                                   GenClassicalSignalOutputs,
                                                    GenClassicalMonitorableVariables>
     {
       GenClassicalData() = default;
 
       using Parameters           = GenClassicalParameters;
-      using Terminals            = GenClassicalTerminals;
-      using InputPorts           = GenClassicalInputPorts;
-      using OutputPorts          = GenClassicalOutputPorts;
+      using Buses                = GenClassicalBuses;
+      using SignalInputs         = GenClassicalSignalInputs;
+      using SignalOutputs        = GenClassicalSignalOutputs;
       using MonitorableVariables = GenClassicalMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
@@ -24,17 +24,30 @@ namespace GridKit
       mva  ///< MVA Base of the generator
     };
 
-    /// Ports supported for a classical generator model
+    /// Terminals supported for a classical generator model
+    enum class GenClassicalTerminals : size_t
+    {
+      bus, ///< Unique ID of the connecting bus
+      SIZE
+    };
+
+    /// Input ports supported for a classical generator model
     ///
     /// @warning GenClassical signal support is incomplete. These legacy port
     /// names are not wired by SystemModel today; the intended refactor is to
     /// align this model with Genrou/Gensal by supporting `pmech`, `speed`, and
     /// `efd` ports through ComponentSignals.
-    enum class GenClassicalPorts
+    enum class GenClassicalInputPorts : size_t
     {
-      bus,             ///< Unique ID of the connecting bus
       exciter_signal,  ///< Unique ID of the bus providing the exciter signal
       governor_signal, ///< Unique ID of the bus providing the governor signal
+      SIZE
+    };
+
+    /// Output ports supported for a classical generator model
+    enum class GenClassicalOutputPorts : size_t
+    {
+      SIZE
     };
 
     /// Variables able to be monitored for a classical generator model
@@ -62,13 +75,17 @@ namespace GridKit
     struct GenClassicalData : public ComponentData<real_type,
                                                    index_type,
                                                    GenClassicalParameters,
-                                                   GenClassicalPorts,
+                                                   GenClassicalTerminals,
+                                                   GenClassicalInputPorts,
+                                                   GenClassicalOutputPorts,
                                                    GenClassicalMonitorableVariables>
     {
       GenClassicalData() = default;
 
       using Parameters           = GenClassicalParameters;
-      using Ports                = GenClassicalPorts;
+      using Terminals            = GenClassicalTerminals;
+      using InputPorts           = GenClassicalInputPorts;
+      using OutputPorts          = GenClassicalOutputPorts;
       using MonitorableVariables = GenClassicalMonitorableVariables;
     };
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -71,44 +71,46 @@ namespace GridKit
       : bus_(bus),
         monitor_(std::make_unique<MonitorT>(data))
     {
-      if (data.parameters.contains(ModelDataT::Parameters::p0))
+      using Parameter = typename ModelDataT::Parameters;
+      using Terminal  = typename ModelDataT::Terminals;
+      if (data.parameters.contains(Parameter::p0))
       {
-        p0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::p0));
+        p0_ = std::get<RealT>(data.parameters.at(Parameter::p0));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::q0))
+      if (data.parameters.contains(Parameter::q0))
       {
-        q0_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::q0));
+        q0_ = std::get<RealT>(data.parameters.at(Parameter::q0));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::H))
+      if (data.parameters.contains(Parameter::H))
       {
-        H_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::H));
+        H_ = std::get<RealT>(data.parameters.at(Parameter::H));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::D))
+      if (data.parameters.contains(Parameter::D))
       {
-        D_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::D));
+        D_ = std::get<RealT>(data.parameters.at(Parameter::D));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Ra))
+      if (data.parameters.contains(Parameter::Ra))
       {
-        Ra_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Ra));
+        Ra_ = std::get<RealT>(data.parameters.at(Parameter::Ra));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::Xdp))
+      if (data.parameters.contains(Parameter::Xdp))
       {
-        Xdp_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::Xdp));
+        Xdp_ = std::get<RealT>(data.parameters.at(Parameter::Xdp));
       }
 
-      if (data.parameters.contains(ModelDataT::Parameters::mva))
+      if (data.parameters.contains(Parameter::mva))
       {
-        mva_base_ = std::get<RealT>(data.parameters.at(ModelDataT::Parameters::mva));
+        mva_base_ = std::get<RealT>(data.parameters.at(Parameter::mva));
       }
 
-      if (data.ports.contains(ModelDataT::Ports::bus))
+      if (data.terminals.contains(Terminal::bus))
       {
-        bus_id_ = data.ports.at(ModelDataT::Ports::bus);
+        bus_id_ = data.terminals.at(Terminal::bus);
       }
 
       initializeMonitor();

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -72,7 +72,7 @@ namespace GridKit
         monitor_(std::make_unique<MonitorT>(data))
     {
       using Parameter = typename ModelDataT::Parameters;
-      using Terminal  = typename ModelDataT::Terminals;
+      using Buses     = typename ModelDataT::Buses;
       if (data.parameters.contains(Parameter::p0))
       {
         p0_ = std::get<RealT>(data.parameters.at(Parameter::p0));
@@ -108,9 +108,9 @@ namespace GridKit
         mva_base_ = std::get<RealT>(data.parameters.at(Parameter::mva));
       }
 
-      if (data.terminals.contains(Terminal::bus))
+      if (data.buses.contains(Buses::bus))
       {
-        bus_id_ = data.terminals.at(Terminal::bus);
+        bus_id_ = data.buses.at(Buses::bus);
       }
 
       initializeMonitor();

--- a/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
@@ -346,16 +346,16 @@ namespace GridKit
       {
         auto* source = new ConstantSignalSource<ScalarT, IdxT>(srcdata);
 
-        using Ports = ConstantSignalSourcePorts;
-        if (srcdata.ports.contains(Ports::sr))
+        using OutputPorts = ConstantSignalSourceOutputPorts;
+        if (srcdata.output_ports.contains(OutputPorts::sr))
         {
-          IdxT           sr    = srcdata.ports.at(Ports::sr);
+          IdxT           sr    = srcdata.output_ports.at(OutputPorts::sr);
           constexpr auto SREAL = ConstantSignalSourceInternalVariables::SREAL;
           source->getSignals().template assignSignalNode<SREAL>(getSignal(sr));
         }
-        if (srcdata.ports.contains(Ports::si))
+        if (srcdata.output_ports.contains(OutputPorts::si))
         {
-          IdxT           si    = srcdata.ports.at(Ports::si);
+          IdxT           si    = srcdata.output_ports.at(OutputPorts::si);
           constexpr auto SIMAG = ConstantSignalSourceInternalVariables::SIMAG;
           source->getSignals().template assignSignalNode<SIMAG>(getSignal(si));
         }

--- a/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
@@ -66,39 +66,38 @@ namespace GridKit
       // Add bus-to-signal adapters
       for (const auto& adapterdata : data.adapter)
       {
-        using AdapterPorts = BusToSignalAdapterPorts;
-        IdxT bus_index     = 0;
-        if (adapterdata.ports.contains(AdapterPorts::bus))
+        IdxT bus_index = 0;
+        if (adapterdata.terminals.contains(BusToSignalAdapterTerminals::bus))
         {
-          bus_index = adapterdata.ports.at(AdapterPorts::bus);
+          bus_index = adapterdata.terminals.at(BusToSignalAdapterTerminals::bus);
         }
 
         auto* adapter = new BusToSignalAdapter<ScalarT, IdxT>(getBus(bus_index));
 
-        if (adapterdata.ports.contains(AdapterPorts::vr))
+        if (adapterdata.output_ports.contains(BusToSignalAdapterOutputPorts::vr))
         {
-          IdxT           vr    = adapterdata.ports.at(AdapterPorts::vr);
+          IdxT           vr    = adapterdata.output_ports.at(BusToSignalAdapterOutputPorts::vr);
           constexpr auto VREAL = BusToSignalAdapterInternalVariables::VREAL;
           adapter->getSignals().template assignSignalNode<VREAL>(getSignal(vr));
         }
 
-        if (adapterdata.ports.contains(AdapterPorts::vi))
+        if (adapterdata.output_ports.contains(BusToSignalAdapterOutputPorts::vi))
         {
-          IdxT           vi    = adapterdata.ports.at(AdapterPorts::vi);
+          IdxT           vi    = adapterdata.output_ports.at(BusToSignalAdapterOutputPorts::vi);
           constexpr auto VIMAG = BusToSignalAdapterInternalVariables::VIMAG;
           adapter->getSignals().template assignSignalNode<VIMAG>(getSignal(vi));
         }
 
-        if (adapterdata.ports.contains(AdapterPorts::ir))
+        if (adapterdata.input_ports.contains(BusToSignalAdapterInputPorts::ir))
         {
-          IdxT           ir    = adapterdata.ports.at(AdapterPorts::ir);
+          IdxT           ir    = adapterdata.input_ports.at(BusToSignalAdapterInputPorts::ir);
           constexpr auto IREAL = BusToSignalAdapterExternalVariables::IREAL;
           adapter->getSignals().template attachSignalNode<IREAL>(getSignal(ir));
         }
 
-        if (adapterdata.ports.contains(AdapterPorts::ii))
+        if (adapterdata.input_ports.contains(BusToSignalAdapterInputPorts::ii))
         {
-          IdxT           ii    = adapterdata.ports.at(AdapterPorts::ii);
+          IdxT           ii    = adapterdata.input_ports.at(BusToSignalAdapterInputPorts::ii);
           constexpr auto IIMAG = BusToSignalAdapterExternalVariables::IIMAG;
           adapter->getSignals().template attachSignalNode<IIMAG>(getSignal(ii));
         }
@@ -110,15 +109,15 @@ namespace GridKit
       for (const auto& branchdata : data.branch)
       {
         IdxT bus1_index = 0;
-        if (branchdata.ports.contains(BranchPorts::bus1))
+        if (branchdata.terminals.contains(BranchTerminals::bus1))
         {
-          bus1_index = branchdata.ports.at(BranchPorts::bus1);
+          bus1_index = branchdata.terminals.at(BranchTerminals::bus1);
         }
 
         IdxT bus2_index = 0;
-        if (branchdata.ports.contains(BranchPorts::bus2))
+        if (branchdata.terminals.contains(BranchTerminals::bus2))
         {
-          bus2_index = branchdata.ports.at(BranchPorts::bus2);
+          bus2_index = branchdata.terminals.at(BranchTerminals::bus2);
         }
 
         auto* branch = new Branch<ScalarT, IdxT>(
@@ -131,9 +130,9 @@ namespace GridKit
       for (const auto& loaddata : data.loadz)
       {
         IdxT bus_index = 0;
-        if (loaddata.ports.contains(LoadZPorts::bus))
+        if (loaddata.terminals.contains(LoadZTerminals::bus))
         {
-          bus_index = loaddata.ports.at(LoadZPorts::bus);
+          bus_index = loaddata.terminals.at(LoadZTerminals::bus);
         }
         auto* load = new LoadZ<ScalarT, IdxT>(getBus(bus_index), loaddata);
         addComponent(load);
@@ -144,9 +143,9 @@ namespace GridKit
       for (const auto& loadzipdata : data.loadzip)
       {
         IdxT bus_index = 0;
-        if (loadzipdata.ports.contains(LoadZIPPorts::bus))
+        if (loadzipdata.terminals.contains(LoadZIPTerminals::bus))
         {
-          bus_index = loadzipdata.ports.at(LoadZIPPorts::bus);
+          bus_index = loadzipdata.terminals.at(LoadZIPTerminals::bus);
         }
         auto* loadzip = new LoadZIP<ScalarT, IdxT>(getBus(bus_index), loadzipdata);
         addComponent(loadzip);
@@ -156,9 +155,9 @@ namespace GridKit
       for (const auto& gendata : data.genrou)
       {
         IdxT bus_index = 0;
-        if (gendata.ports.contains(GenrouPorts::bus))
+        if (gendata.terminals.contains(GenrouTerminals::bus))
         {
-          bus_index = gendata.ports.at(GenrouPorts::bus);
+          bus_index = gendata.terminals.at(GenrouTerminals::bus);
         }
 
         auto* gen = new Genrou<ScalarT, IdxT>(getBus(bus_index), gendata);
@@ -166,23 +165,23 @@ namespace GridKit
         /// @todo Genrou (and likely other components) would need to name multiple
         /// signal inlets and outlets. For now we have only speed out and mechanical
         /// power in.
-        if (gendata.ports.contains(GenrouPorts::speed))
+        if (gendata.output_ports.contains(GenrouOutputPorts::speed))
         {
-          IdxT           speed = gendata.ports.at(GenrouPorts::speed);
+          IdxT           speed = gendata.output_ports.at(GenrouOutputPorts::speed);
           constexpr auto OMEGA = GenrouInternalVariables::OMEGA;
           gen->getSignals().template assignSignalNode<OMEGA>(getSignal(speed));
         }
 
-        if (gendata.ports.contains(GenrouPorts::pmech))
+        if (gendata.input_ports.contains(GenrouInputPorts::pmech))
         {
-          IdxT           pmech = gendata.ports.at(GenrouPorts::pmech);
+          IdxT           pmech = gendata.input_ports.at(GenrouInputPorts::pmech);
           constexpr auto PM    = GenrouExternalVariables::PM;
           gen->getSignals().template attachSignalNode<PM>(getSignal(pmech));
         }
 
-        if (gendata.ports.contains(GenrouPorts::efd))
+        if (gendata.input_ports.contains(GenrouInputPorts::efd))
         {
-          IdxT           efd = gendata.ports.at(GenrouPorts::efd);
+          IdxT           efd = gendata.input_ports.at(GenrouInputPorts::efd);
           constexpr auto EFD = GenrouExternalVariables::EFD;
           gen->getSignals().template attachSignalNode<EFD>(getSignal(efd));
         }
@@ -194,30 +193,30 @@ namespace GridKit
       for (const auto& gendata : data.gensal)
       {
         IdxT bus_index = 0;
-        if (gendata.ports.contains(GensalPorts::bus))
+        if (gendata.terminals.contains(GensalTerminals::bus))
         {
-          bus_index = gendata.ports.at(GensalPorts::bus);
+          bus_index = gendata.terminals.at(GensalTerminals::bus);
         }
 
         auto* gen = new Gensal<ScalarT, IdxT>(getBus(bus_index), gendata);
 
-        if (gendata.ports.contains(GensalPorts::speed))
+        if (gendata.output_ports.contains(GensalOutputPorts::speed))
         {
-          IdxT           speed = gendata.ports.at(GensalPorts::speed);
+          IdxT           speed = gendata.output_ports.at(GensalOutputPorts::speed);
           constexpr auto OMEGA = GensalInternalVariables::OMEGA;
           gen->getSignals().template assignSignalNode<OMEGA>(getSignal(speed));
         }
 
-        if (gendata.ports.contains(GensalPorts::pmech))
+        if (gendata.input_ports.contains(GensalInputPorts::pmech))
         {
-          IdxT           pmech = gendata.ports.at(GensalPorts::pmech);
+          IdxT           pmech = gendata.input_ports.at(GensalInputPorts::pmech);
           constexpr auto PM    = GensalExternalVariables::PM;
           gen->getSignals().template attachSignalNode<PM>(getSignal(pmech));
         }
 
-        if (gendata.ports.contains(GensalPorts::efd))
+        if (gendata.input_ports.contains(GensalInputPorts::efd))
         {
-          IdxT           efd = gendata.ports.at(GensalPorts::efd);
+          IdxT           efd = gendata.input_ports.at(GensalInputPorts::efd);
           constexpr auto EFD = GensalExternalVariables::EFD;
           gen->getSignals().template attachSignalNode<EFD>(getSignal(efd));
         }
@@ -229,9 +228,9 @@ namespace GridKit
       for (const auto& gendata : data.genclassical)
       {
         IdxT bus_index = 0;
-        if (gendata.ports.contains(GenClassicalPorts::bus))
+        if (gendata.terminals.contains(GenClassicalTerminals::bus))
         {
-          bus_index = gendata.ports.at(GenClassicalPorts::bus);
+          bus_index = gendata.terminals.at(GenClassicalTerminals::bus);
         }
         auto* gen = new GenClassical<ScalarT, IdxT>(getBus(bus_index), gendata);
         addComponent(gen);
@@ -242,16 +241,16 @@ namespace GridKit
       {
         auto* gov = new Tgov1<ScalarT, IdxT>(govdata);
 
-        if (govdata.ports.contains(Tgov1Ports::speed))
+        if (govdata.input_ports.contains(Tgov1InputPorts::speed))
         {
-          IdxT           speed      = govdata.ports.at(Tgov1Ports::speed);
+          IdxT           speed      = govdata.input_ports.at(Tgov1InputPorts::speed);
           constexpr auto DELTAOMEGA = Tgov1ExternalVariables::DELTAOMEGA;
           gov->getSignals().template attachSignalNode<DELTAOMEGA>(getSignal(speed));
         }
 
-        if (govdata.ports.contains(Tgov1Ports::pmech))
+        if (govdata.output_ports.contains(Tgov1OutputPorts::pmech))
         {
-          IdxT           pmech = govdata.ports.at(Tgov1Ports::pmech);
+          IdxT           pmech = govdata.output_ports.at(Tgov1OutputPorts::pmech);
           constexpr auto PM    = Tgov1InternalVariables::PM;
           gov->getSignals().template assignSignalNode<PM>(getSignal(pmech));
         }
@@ -262,30 +261,30 @@ namespace GridKit
       for (const auto& excitedata : data.exciter)
       {
         IdxT bus_index = 0;
-        if (excitedata.ports.contains(Ieeet1Ports::bus))
+        if (excitedata.terminals.contains(Ieeet1Terminals::bus))
         {
-          bus_index = excitedata.ports.at(Ieeet1Ports::bus);
+          bus_index = excitedata.terminals.at(Ieeet1Terminals::bus);
         }
 
         auto* exciter = new Ieeet1<ScalarT, IdxT>(getBus(bus_index), excitedata);
 
-        if (excitedata.ports.contains(Ieeet1Ports::speed))
+        if (excitedata.input_ports.contains(Ieeet1InputPorts::speed))
         {
-          IdxT           speed = excitedata.ports.at(Ieeet1Ports::speed);
+          IdxT           speed = excitedata.input_ports.at(Ieeet1InputPorts::speed);
           constexpr auto OMEGA = Ieeet1ExternalVariables::OMEGA;
           exciter->getSignals().template attachSignalNode<OMEGA>(getSignal(speed));
         }
 
-        if (excitedata.ports.contains(Ieeet1Ports::efd))
+        if (excitedata.output_ports.contains(Ieeet1OutputPorts::efd))
         {
-          IdxT           efd = excitedata.ports.at(Ieeet1Ports::efd);
+          IdxT           efd = excitedata.output_ports.at(Ieeet1OutputPorts::efd);
           constexpr auto EFD = Ieeet1InternalVariables::EFD;
           exciter->getSignals().template assignSignalNode<EFD>(getSignal(efd));
         }
 
-        if (excitedata.ports.contains(Ieeet1Ports::vs))
+        if (excitedata.input_ports.contains(Ieeet1InputPorts::vs))
         {
-          IdxT           vs = excitedata.ports.at(Ieeet1Ports::vs);
+          IdxT           vs = excitedata.input_ports.at(Ieeet1InputPorts::vs);
           constexpr auto VS = Ieeet1ExternalVariables::VS;
           exciter->getSignals().template attachSignalNode<VS>(getSignal(vs));
         }
@@ -296,23 +295,23 @@ namespace GridKit
       for (const auto& excitedata : data.sexspti)
       {
         IdxT bus_index = 0;
-        if (excitedata.ports.contains(SexsPtiPorts::bus))
+        if (excitedata.terminals.contains(SexsPtiTerminals::bus))
         {
-          bus_index = excitedata.ports.at(SexsPtiPorts::bus);
+          bus_index = excitedata.terminals.at(SexsPtiTerminals::bus);
         }
 
         auto* exciter = new SexsPti<ScalarT, IdxT>(getBus(bus_index), excitedata);
 
-        if (excitedata.ports.contains(SexsPtiPorts::efd))
+        if (excitedata.output_ports.contains(SexsPtiOutputPorts::efd))
         {
-          IdxT           efd = excitedata.ports.at(SexsPtiPorts::efd);
+          IdxT           efd = excitedata.output_ports.at(SexsPtiOutputPorts::efd);
           constexpr auto EFD = SexsPtiInternalVariables::EFD;
           exciter->getSignals().template assignSignalNode<EFD>(getSignal(efd));
         }
 
-        if (excitedata.ports.contains(SexsPtiPorts::vs))
+        if (excitedata.input_ports.contains(SexsPtiInputPorts::vs))
         {
-          IdxT           vs = excitedata.ports.at(SexsPtiPorts::vs);
+          IdxT           vs = excitedata.input_ports.at(SexsPtiInputPorts::vs);
           constexpr auto VS = SexsPtiExternalVariables::VS;
           exciter->getSignals().template attachSignalNode<VS>(getSignal(vs));
         }
@@ -325,16 +324,16 @@ namespace GridKit
       {
         auto* stabilizer = new Ieeest<ScalarT, IdxT>(stabdata);
 
-        if (stabdata.ports.contains(IeeestPorts::input))
+        if (stabdata.input_ports.contains(IeeestInputPorts::input))
         {
-          IdxT           input = stabdata.ports.at(IeeestPorts::input);
+          IdxT           input = stabdata.input_ports.at(IeeestInputPorts::input);
           constexpr auto U     = IeeestExternalVariables::U;
           stabilizer->getSignals().template attachSignalNode<U>(getSignal(input));
         }
 
-        if (stabdata.ports.contains(IeeestPorts::output))
+        if (stabdata.output_ports.contains(IeeestOutputPorts::output))
         {
-          IdxT           output = stabdata.ports.at(IeeestPorts::output);
+          IdxT           output = stabdata.output_ports.at(IeeestOutputPorts::output);
           constexpr auto VSS    = IeeestInternalVariables::VSS;
           stabilizer->getSignals().template assignSignalNode<VSS>(getSignal(output));
         }
@@ -368,9 +367,9 @@ namespace GridKit
       for (const auto& faultdata : data.bus_fault)
       {
         IdxT bus_index = 0;
-        if (faultdata.ports.contains(BusFaultPorts::bus))
+        if (faultdata.terminals.contains(BusFaultTerminals::bus))
         {
-          bus_index = faultdata.ports.at(BusFaultPorts::bus);
+          bus_index = faultdata.terminals.at(BusFaultTerminals::bus);
         }
         auto* fault = new BusFault<ScalarT, IdxT>(getBus(bus_index), faultdata);
         addFault(fault);

--- a/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
@@ -67,37 +67,37 @@ namespace GridKit
       for (const auto& adapterdata : data.adapter)
       {
         IdxT bus_index = 0;
-        if (adapterdata.terminals.contains(BusToSignalAdapterTerminals::bus))
+        if (adapterdata.buses.contains(BusToSignalAdapterBuses::bus))
         {
-          bus_index = adapterdata.terminals.at(BusToSignalAdapterTerminals::bus);
+          bus_index = adapterdata.buses.at(BusToSignalAdapterBuses::bus);
         }
 
         auto* adapter = new BusToSignalAdapter<ScalarT, IdxT>(getBus(bus_index));
 
-        if (adapterdata.output_ports.contains(BusToSignalAdapterOutputPorts::vr))
+        if (adapterdata.signal_outputs.contains(BusToSignalAdapterSignalOutputs::vr))
         {
-          IdxT           vr    = adapterdata.output_ports.at(BusToSignalAdapterOutputPorts::vr);
+          IdxT           vr    = adapterdata.signal_outputs.at(BusToSignalAdapterSignalOutputs::vr);
           constexpr auto VREAL = BusToSignalAdapterInternalVariables::VREAL;
           adapter->getSignals().template assignSignalNode<VREAL>(getSignal(vr));
         }
 
-        if (adapterdata.output_ports.contains(BusToSignalAdapterOutputPorts::vi))
+        if (adapterdata.signal_outputs.contains(BusToSignalAdapterSignalOutputs::vi))
         {
-          IdxT           vi    = adapterdata.output_ports.at(BusToSignalAdapterOutputPorts::vi);
+          IdxT           vi    = adapterdata.signal_outputs.at(BusToSignalAdapterSignalOutputs::vi);
           constexpr auto VIMAG = BusToSignalAdapterInternalVariables::VIMAG;
           adapter->getSignals().template assignSignalNode<VIMAG>(getSignal(vi));
         }
 
-        if (adapterdata.input_ports.contains(BusToSignalAdapterInputPorts::ir))
+        if (adapterdata.signal_inputs.contains(BusToSignalAdapterSignalInputs::ir))
         {
-          IdxT           ir    = adapterdata.input_ports.at(BusToSignalAdapterInputPorts::ir);
+          IdxT           ir    = adapterdata.signal_inputs.at(BusToSignalAdapterSignalInputs::ir);
           constexpr auto IREAL = BusToSignalAdapterExternalVariables::IREAL;
           adapter->getSignals().template attachSignalNode<IREAL>(getSignal(ir));
         }
 
-        if (adapterdata.input_ports.contains(BusToSignalAdapterInputPorts::ii))
+        if (adapterdata.signal_inputs.contains(BusToSignalAdapterSignalInputs::ii))
         {
-          IdxT           ii    = adapterdata.input_ports.at(BusToSignalAdapterInputPorts::ii);
+          IdxT           ii    = adapterdata.signal_inputs.at(BusToSignalAdapterSignalInputs::ii);
           constexpr auto IIMAG = BusToSignalAdapterExternalVariables::IIMAG;
           adapter->getSignals().template attachSignalNode<IIMAG>(getSignal(ii));
         }
@@ -109,15 +109,15 @@ namespace GridKit
       for (const auto& branchdata : data.branch)
       {
         IdxT bus1_index = 0;
-        if (branchdata.terminals.contains(BranchTerminals::bus1))
+        if (branchdata.buses.contains(BranchBuses::bus1))
         {
-          bus1_index = branchdata.terminals.at(BranchTerminals::bus1);
+          bus1_index = branchdata.buses.at(BranchBuses::bus1);
         }
 
         IdxT bus2_index = 0;
-        if (branchdata.terminals.contains(BranchTerminals::bus2))
+        if (branchdata.buses.contains(BranchBuses::bus2))
         {
-          bus2_index = branchdata.terminals.at(BranchTerminals::bus2);
+          bus2_index = branchdata.buses.at(BranchBuses::bus2);
         }
 
         auto* branch = new Branch<ScalarT, IdxT>(
@@ -130,9 +130,9 @@ namespace GridKit
       for (const auto& loaddata : data.loadz)
       {
         IdxT bus_index = 0;
-        if (loaddata.terminals.contains(LoadZTerminals::bus))
+        if (loaddata.buses.contains(LoadZBuses::bus))
         {
-          bus_index = loaddata.terminals.at(LoadZTerminals::bus);
+          bus_index = loaddata.buses.at(LoadZBuses::bus);
         }
         auto* load = new LoadZ<ScalarT, IdxT>(getBus(bus_index), loaddata);
         addComponent(load);
@@ -143,9 +143,9 @@ namespace GridKit
       for (const auto& loadzipdata : data.loadzip)
       {
         IdxT bus_index = 0;
-        if (loadzipdata.terminals.contains(LoadZIPTerminals::bus))
+        if (loadzipdata.buses.contains(LoadZIPBuses::bus))
         {
-          bus_index = loadzipdata.terminals.at(LoadZIPTerminals::bus);
+          bus_index = loadzipdata.buses.at(LoadZIPBuses::bus);
         }
         auto* loadzip = new LoadZIP<ScalarT, IdxT>(getBus(bus_index), loadzipdata);
         addComponent(loadzip);
@@ -155,9 +155,9 @@ namespace GridKit
       for (const auto& gendata : data.genrou)
       {
         IdxT bus_index = 0;
-        if (gendata.terminals.contains(GenrouTerminals::bus))
+        if (gendata.buses.contains(GenrouBuses::bus))
         {
-          bus_index = gendata.terminals.at(GenrouTerminals::bus);
+          bus_index = gendata.buses.at(GenrouBuses::bus);
         }
 
         auto* gen = new Genrou<ScalarT, IdxT>(getBus(bus_index), gendata);
@@ -165,23 +165,23 @@ namespace GridKit
         /// @todo Genrou (and likely other components) would need to name multiple
         /// signal inlets and outlets. For now we have only speed out and mechanical
         /// power in.
-        if (gendata.output_ports.contains(GenrouOutputPorts::speed))
+        if (gendata.signal_outputs.contains(GenrouSignalOutputs::speed))
         {
-          IdxT           speed = gendata.output_ports.at(GenrouOutputPorts::speed);
+          IdxT           speed = gendata.signal_outputs.at(GenrouSignalOutputs::speed);
           constexpr auto OMEGA = GenrouInternalVariables::OMEGA;
           gen->getSignals().template assignSignalNode<OMEGA>(getSignal(speed));
         }
 
-        if (gendata.input_ports.contains(GenrouInputPorts::pmech))
+        if (gendata.signal_inputs.contains(GenrouSignalInputs::pmech))
         {
-          IdxT           pmech = gendata.input_ports.at(GenrouInputPorts::pmech);
+          IdxT           pmech = gendata.signal_inputs.at(GenrouSignalInputs::pmech);
           constexpr auto PM    = GenrouExternalVariables::PM;
           gen->getSignals().template attachSignalNode<PM>(getSignal(pmech));
         }
 
-        if (gendata.input_ports.contains(GenrouInputPorts::efd))
+        if (gendata.signal_inputs.contains(GenrouSignalInputs::efd))
         {
-          IdxT           efd = gendata.input_ports.at(GenrouInputPorts::efd);
+          IdxT           efd = gendata.signal_inputs.at(GenrouSignalInputs::efd);
           constexpr auto EFD = GenrouExternalVariables::EFD;
           gen->getSignals().template attachSignalNode<EFD>(getSignal(efd));
         }
@@ -193,30 +193,30 @@ namespace GridKit
       for (const auto& gendata : data.gensal)
       {
         IdxT bus_index = 0;
-        if (gendata.terminals.contains(GensalTerminals::bus))
+        if (gendata.buses.contains(GensalBuses::bus))
         {
-          bus_index = gendata.terminals.at(GensalTerminals::bus);
+          bus_index = gendata.buses.at(GensalBuses::bus);
         }
 
         auto* gen = new Gensal<ScalarT, IdxT>(getBus(bus_index), gendata);
 
-        if (gendata.output_ports.contains(GensalOutputPorts::speed))
+        if (gendata.signal_outputs.contains(GensalSignalOutputs::speed))
         {
-          IdxT           speed = gendata.output_ports.at(GensalOutputPorts::speed);
+          IdxT           speed = gendata.signal_outputs.at(GensalSignalOutputs::speed);
           constexpr auto OMEGA = GensalInternalVariables::OMEGA;
           gen->getSignals().template assignSignalNode<OMEGA>(getSignal(speed));
         }
 
-        if (gendata.input_ports.contains(GensalInputPorts::pmech))
+        if (gendata.signal_inputs.contains(GensalSignalInputs::pmech))
         {
-          IdxT           pmech = gendata.input_ports.at(GensalInputPorts::pmech);
+          IdxT           pmech = gendata.signal_inputs.at(GensalSignalInputs::pmech);
           constexpr auto PM    = GensalExternalVariables::PM;
           gen->getSignals().template attachSignalNode<PM>(getSignal(pmech));
         }
 
-        if (gendata.input_ports.contains(GensalInputPorts::efd))
+        if (gendata.signal_inputs.contains(GensalSignalInputs::efd))
         {
-          IdxT           efd = gendata.input_ports.at(GensalInputPorts::efd);
+          IdxT           efd = gendata.signal_inputs.at(GensalSignalInputs::efd);
           constexpr auto EFD = GensalExternalVariables::EFD;
           gen->getSignals().template attachSignalNode<EFD>(getSignal(efd));
         }
@@ -228,9 +228,9 @@ namespace GridKit
       for (const auto& gendata : data.genclassical)
       {
         IdxT bus_index = 0;
-        if (gendata.terminals.contains(GenClassicalTerminals::bus))
+        if (gendata.buses.contains(GenClassicalBuses::bus))
         {
-          bus_index = gendata.terminals.at(GenClassicalTerminals::bus);
+          bus_index = gendata.buses.at(GenClassicalBuses::bus);
         }
         auto* gen = new GenClassical<ScalarT, IdxT>(getBus(bus_index), gendata);
         addComponent(gen);
@@ -241,16 +241,16 @@ namespace GridKit
       {
         auto* gov = new Tgov1<ScalarT, IdxT>(govdata);
 
-        if (govdata.input_ports.contains(Tgov1InputPorts::speed))
+        if (govdata.signal_inputs.contains(Tgov1SignalInputs::speed))
         {
-          IdxT           speed      = govdata.input_ports.at(Tgov1InputPorts::speed);
+          IdxT           speed      = govdata.signal_inputs.at(Tgov1SignalInputs::speed);
           constexpr auto DELTAOMEGA = Tgov1ExternalVariables::DELTAOMEGA;
           gov->getSignals().template attachSignalNode<DELTAOMEGA>(getSignal(speed));
         }
 
-        if (govdata.output_ports.contains(Tgov1OutputPorts::pmech))
+        if (govdata.signal_outputs.contains(Tgov1SignalOutputs::pmech))
         {
-          IdxT           pmech = govdata.output_ports.at(Tgov1OutputPorts::pmech);
+          IdxT           pmech = govdata.signal_outputs.at(Tgov1SignalOutputs::pmech);
           constexpr auto PM    = Tgov1InternalVariables::PM;
           gov->getSignals().template assignSignalNode<PM>(getSignal(pmech));
         }
@@ -261,30 +261,30 @@ namespace GridKit
       for (const auto& excitedata : data.exciter)
       {
         IdxT bus_index = 0;
-        if (excitedata.terminals.contains(Ieeet1Terminals::bus))
+        if (excitedata.buses.contains(Ieeet1Buses::bus))
         {
-          bus_index = excitedata.terminals.at(Ieeet1Terminals::bus);
+          bus_index = excitedata.buses.at(Ieeet1Buses::bus);
         }
 
         auto* exciter = new Ieeet1<ScalarT, IdxT>(getBus(bus_index), excitedata);
 
-        if (excitedata.input_ports.contains(Ieeet1InputPorts::speed))
+        if (excitedata.signal_inputs.contains(Ieeet1SignalInputs::speed))
         {
-          IdxT           speed = excitedata.input_ports.at(Ieeet1InputPorts::speed);
+          IdxT           speed = excitedata.signal_inputs.at(Ieeet1SignalInputs::speed);
           constexpr auto OMEGA = Ieeet1ExternalVariables::OMEGA;
           exciter->getSignals().template attachSignalNode<OMEGA>(getSignal(speed));
         }
 
-        if (excitedata.output_ports.contains(Ieeet1OutputPorts::efd))
+        if (excitedata.signal_outputs.contains(Ieeet1SignalOutputs::efd))
         {
-          IdxT           efd = excitedata.output_ports.at(Ieeet1OutputPorts::efd);
+          IdxT           efd = excitedata.signal_outputs.at(Ieeet1SignalOutputs::efd);
           constexpr auto EFD = Ieeet1InternalVariables::EFD;
           exciter->getSignals().template assignSignalNode<EFD>(getSignal(efd));
         }
 
-        if (excitedata.input_ports.contains(Ieeet1InputPorts::vs))
+        if (excitedata.signal_inputs.contains(Ieeet1SignalInputs::vs))
         {
-          IdxT           vs = excitedata.input_ports.at(Ieeet1InputPorts::vs);
+          IdxT           vs = excitedata.signal_inputs.at(Ieeet1SignalInputs::vs);
           constexpr auto VS = Ieeet1ExternalVariables::VS;
           exciter->getSignals().template attachSignalNode<VS>(getSignal(vs));
         }
@@ -295,23 +295,23 @@ namespace GridKit
       for (const auto& excitedata : data.sexspti)
       {
         IdxT bus_index = 0;
-        if (excitedata.terminals.contains(SexsPtiTerminals::bus))
+        if (excitedata.buses.contains(SexsPtiBuses::bus))
         {
-          bus_index = excitedata.terminals.at(SexsPtiTerminals::bus);
+          bus_index = excitedata.buses.at(SexsPtiBuses::bus);
         }
 
         auto* exciter = new SexsPti<ScalarT, IdxT>(getBus(bus_index), excitedata);
 
-        if (excitedata.output_ports.contains(SexsPtiOutputPorts::efd))
+        if (excitedata.signal_outputs.contains(SexsPtiSignalOutputs::efd))
         {
-          IdxT           efd = excitedata.output_ports.at(SexsPtiOutputPorts::efd);
+          IdxT           efd = excitedata.signal_outputs.at(SexsPtiSignalOutputs::efd);
           constexpr auto EFD = SexsPtiInternalVariables::EFD;
           exciter->getSignals().template assignSignalNode<EFD>(getSignal(efd));
         }
 
-        if (excitedata.input_ports.contains(SexsPtiInputPorts::vs))
+        if (excitedata.signal_inputs.contains(SexsPtiSignalInputs::vs))
         {
-          IdxT           vs = excitedata.input_ports.at(SexsPtiInputPorts::vs);
+          IdxT           vs = excitedata.signal_inputs.at(SexsPtiSignalInputs::vs);
           constexpr auto VS = SexsPtiExternalVariables::VS;
           exciter->getSignals().template attachSignalNode<VS>(getSignal(vs));
         }
@@ -324,16 +324,16 @@ namespace GridKit
       {
         auto* stabilizer = new Ieeest<ScalarT, IdxT>(stabdata);
 
-        if (stabdata.input_ports.contains(IeeestInputPorts::input))
+        if (stabdata.signal_inputs.contains(IeeestSignalInputs::input))
         {
-          IdxT           input = stabdata.input_ports.at(IeeestInputPorts::input);
+          IdxT           input = stabdata.signal_inputs.at(IeeestSignalInputs::input);
           constexpr auto U     = IeeestExternalVariables::U;
           stabilizer->getSignals().template attachSignalNode<U>(getSignal(input));
         }
 
-        if (stabdata.output_ports.contains(IeeestOutputPorts::output))
+        if (stabdata.signal_outputs.contains(IeeestSignalOutputs::output))
         {
-          IdxT           output = stabdata.output_ports.at(IeeestOutputPorts::output);
+          IdxT           output = stabdata.signal_outputs.at(IeeestSignalOutputs::output);
           constexpr auto VSS    = IeeestInternalVariables::VSS;
           stabilizer->getSignals().template assignSignalNode<VSS>(getSignal(output));
         }
@@ -346,16 +346,16 @@ namespace GridKit
       {
         auto* source = new ConstantSignalSource<ScalarT, IdxT>(srcdata);
 
-        using OutputPorts = ConstantSignalSourceOutputPorts;
-        if (srcdata.output_ports.contains(OutputPorts::sr))
+        using SignalOutputs = ConstantSignalSourceSignalOutputs;
+        if (srcdata.signal_outputs.contains(SignalOutputs::sr))
         {
-          IdxT           sr    = srcdata.output_ports.at(OutputPorts::sr);
+          IdxT           sr    = srcdata.signal_outputs.at(SignalOutputs::sr);
           constexpr auto SREAL = ConstantSignalSourceInternalVariables::SREAL;
           source->getSignals().template assignSignalNode<SREAL>(getSignal(sr));
         }
-        if (srcdata.output_ports.contains(OutputPorts::si))
+        if (srcdata.signal_outputs.contains(SignalOutputs::si))
         {
-          IdxT           si    = srcdata.output_ports.at(OutputPorts::si);
+          IdxT           si    = srcdata.signal_outputs.at(SignalOutputs::si);
           constexpr auto SIMAG = ConstantSignalSourceInternalVariables::SIMAG;
           source->getSignals().template assignSignalNode<SIMAG>(getSignal(si));
         }
@@ -367,9 +367,9 @@ namespace GridKit
       for (const auto& faultdata : data.bus_fault)
       {
         IdxT bus_index = 0;
-        if (faultdata.terminals.contains(BusFaultTerminals::bus))
+        if (faultdata.buses.contains(BusFaultBuses::bus))
         {
-          bus_index = faultdata.terminals.at(BusFaultTerminals::bus);
+          bus_index = faultdata.buses.at(BusFaultBuses::bus);
         }
         auto* fault = new BusFault<ScalarT, IdxT>(getBus(bus_index), faultdata);
         addFault(fault);

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.cpp
@@ -110,34 +110,34 @@ int main()
   data.branch.resize(3);
 
   // Branch 0-1
-  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
-  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R]  = 0.05;
-  data.branch[0].parameters[BranchParameters::X]  = 0.21;
-  data.branch[0].parameters[BranchParameters::G]  = 0.;
-  data.branch[0].parameters[BranchParameters::B]  = 0.1;
+  data.branch[0].buses[BranchBuses::bus1]        = data.bus[0].bus_id;
+  data.branch[0].buses[BranchBuses::bus2]        = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R] = 0.05;
+  data.branch[0].parameters[BranchParameters::X] = 0.21;
+  data.branch[0].parameters[BranchParameters::G] = 0.;
+  data.branch[0].parameters[BranchParameters::B] = 0.1;
 
   // Branch 0-2
-  data.branch[1].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
-  data.branch[1].terminals[BranchTerminals::bus2] = data.bus[2].bus_id;
-  data.branch[1].parameters[BranchParameters::R]  = 0.06;
-  data.branch[1].parameters[BranchParameters::X]  = 0.15;
-  data.branch[1].parameters[BranchParameters::G]  = 0.;
-  data.branch[1].parameters[BranchParameters::B]  = 0.12;
+  data.branch[1].buses[BranchBuses::bus1]        = data.bus[0].bus_id;
+  data.branch[1].buses[BranchBuses::bus2]        = data.bus[2].bus_id;
+  data.branch[1].parameters[BranchParameters::R] = 0.06;
+  data.branch[1].parameters[BranchParameters::X] = 0.15;
+  data.branch[1].parameters[BranchParameters::G] = 0.;
+  data.branch[1].parameters[BranchParameters::B] = 0.12;
 
   // Branch 1-2
-  data.branch[2].terminals[BranchTerminals::bus1] = data.bus[1].bus_id;
-  data.branch[2].terminals[BranchTerminals::bus2] = data.bus[2].bus_id;
-  data.branch[2].parameters[BranchParameters::R]  = 0.08;
-  data.branch[2].parameters[BranchParameters::X]  = 0.27;
-  data.branch[2].parameters[BranchParameters::G]  = 0.;
-  data.branch[2].parameters[BranchParameters::B]  = 0.45;
+  data.branch[2].buses[BranchBuses::bus1]        = data.bus[1].bus_id;
+  data.branch[2].buses[BranchBuses::bus2]        = data.bus[2].bus_id;
+  data.branch[2].parameters[BranchParameters::R] = 0.08;
+  data.branch[2].parameters[BranchParameters::X] = 0.27;
+  data.branch[2].parameters[BranchParameters::G] = 0.;
+  data.branch[2].parameters[BranchParameters::B] = 0.45;
 
   // Set generator data
   data.genrou.resize(2);
 
   // Generator on bus 1
-  data.genrou[0].terminals[GenrouTerminals::bus]     = 1;
+  data.genrou[0].buses[GenrouBuses::bus]             = 1;
   data.genrou[0].parameters[GenrouParameters::p0]    = 0.5;
   data.genrou[0].parameters[GenrouParameters::q0]    = -0.07588;
   data.genrou[0].parameters[GenrouParameters::H]     = 2.7;
@@ -158,7 +158,7 @@ int main()
   data.genrou[0].parameters[GenrouParameters::S12]   = 0.;
 
   // Generator on bus 2
-  data.genrou[1].terminals[GenrouTerminals::bus]     = 2;
+  data.genrou[1].buses[GenrouBuses::bus]             = 2;
   data.genrou[1].parameters[GenrouParameters::p0]    = 0.25;
   data.genrou[1].parameters[GenrouParameters::q0]    = 0.26587;
   data.genrou[1].parameters[GenrouParameters::H]     = 1.6;
@@ -182,14 +182,14 @@ int main()
   data.loadz.resize(1);
 
   // Load on bus 2
-  data.loadz[0].terminals[LoadZTerminals::bus] = 2;
+  data.loadz[0].buses[LoadZBuses::bus]         = 2;
   data.loadz[0].parameters[LoadZParameters::R] = 0.4447197839297772;
   data.loadz[0].parameters[LoadZParameters::X] = 0.20330047265361242;
 
   // Set fault data
   data.bus_fault.resize(1);
 
-  data.bus_fault[0].terminals[BusFaultTerminals::bus]      = 2;
+  data.bus_fault[0].buses[BusFaultBuses::bus]              = 2;
   data.bus_fault[0].parameters[BusFaultParameters::R]      = 0.0;
   data.bus_fault[0].parameters[BusFaultParameters::X]      = 1e-5;
   data.bus_fault[0].parameters[BusFaultParameters::state0] = false;

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.cpp
@@ -110,34 +110,34 @@ int main()
   data.branch.resize(3);
 
   // Branch 0-1
-  data.branch[0].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-  data.branch[0].ports[BranchPorts::bus2]        = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R] = 0.05;
-  data.branch[0].parameters[BranchParameters::X] = 0.21;
-  data.branch[0].parameters[BranchParameters::G] = 0.;
-  data.branch[0].parameters[BranchParameters::B] = 0.1;
+  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
+  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R]  = 0.05;
+  data.branch[0].parameters[BranchParameters::X]  = 0.21;
+  data.branch[0].parameters[BranchParameters::G]  = 0.;
+  data.branch[0].parameters[BranchParameters::B]  = 0.1;
 
   // Branch 0-2
-  data.branch[1].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-  data.branch[1].ports[BranchPorts::bus2]        = data.bus[2].bus_id;
-  data.branch[1].parameters[BranchParameters::R] = 0.06;
-  data.branch[1].parameters[BranchParameters::X] = 0.15;
-  data.branch[1].parameters[BranchParameters::G] = 0.;
-  data.branch[1].parameters[BranchParameters::B] = 0.12;
+  data.branch[1].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
+  data.branch[1].terminals[BranchTerminals::bus2] = data.bus[2].bus_id;
+  data.branch[1].parameters[BranchParameters::R]  = 0.06;
+  data.branch[1].parameters[BranchParameters::X]  = 0.15;
+  data.branch[1].parameters[BranchParameters::G]  = 0.;
+  data.branch[1].parameters[BranchParameters::B]  = 0.12;
 
   // Branch 1-2
-  data.branch[2].ports[BranchPorts::bus1]        = data.bus[1].bus_id;
-  data.branch[2].ports[BranchPorts::bus2]        = data.bus[2].bus_id;
-  data.branch[2].parameters[BranchParameters::R] = 0.08;
-  data.branch[2].parameters[BranchParameters::X] = 0.27;
-  data.branch[2].parameters[BranchParameters::G] = 0.;
-  data.branch[2].parameters[BranchParameters::B] = 0.45;
+  data.branch[2].terminals[BranchTerminals::bus1] = data.bus[1].bus_id;
+  data.branch[2].terminals[BranchTerminals::bus2] = data.bus[2].bus_id;
+  data.branch[2].parameters[BranchParameters::R]  = 0.08;
+  data.branch[2].parameters[BranchParameters::X]  = 0.27;
+  data.branch[2].parameters[BranchParameters::G]  = 0.;
+  data.branch[2].parameters[BranchParameters::B]  = 0.45;
 
   // Set generator data
   data.genrou.resize(2);
 
   // Generator on bus 1
-  data.genrou[0].ports[GenrouPorts::bus]             = 1;
+  data.genrou[0].terminals[GenrouTerminals::bus]     = 1;
   data.genrou[0].parameters[GenrouParameters::p0]    = 0.5;
   data.genrou[0].parameters[GenrouParameters::q0]    = -0.07588;
   data.genrou[0].parameters[GenrouParameters::H]     = 2.7;
@@ -158,7 +158,7 @@ int main()
   data.genrou[0].parameters[GenrouParameters::S12]   = 0.;
 
   // Generator on bus 2
-  data.genrou[1].ports[GenrouPorts::bus]             = 2;
+  data.genrou[1].terminals[GenrouTerminals::bus]     = 2;
   data.genrou[1].parameters[GenrouParameters::p0]    = 0.25;
   data.genrou[1].parameters[GenrouParameters::q0]    = 0.26587;
   data.genrou[1].parameters[GenrouParameters::H]     = 1.6;
@@ -182,14 +182,14 @@ int main()
   data.loadz.resize(1);
 
   // Load on bus 2
-  data.loadz[0].ports[LoadZPorts::bus]         = 2;
+  data.loadz[0].terminals[LoadZTerminals::bus] = 2;
   data.loadz[0].parameters[LoadZParameters::R] = 0.4447197839297772;
   data.loadz[0].parameters[LoadZParameters::X] = 0.20330047265361242;
 
   // Set fault data
   data.bus_fault.resize(1);
 
-  data.bus_fault[0].ports[BusFaultPorts::bus]              = 2;
+  data.bus_fault[0].terminals[BusFaultTerminals::bus]      = 2;
   data.bus_fault[0].parameters[BusFaultParameters::R]      = 0.0;
   data.bus_fault[0].parameters[BusFaultParameters::X]      = 1e-5;
   data.bus_fault[0].parameters[BusFaultParameters::state0] = false;

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
@@ -111,34 +111,34 @@ int main()
   data.branch.resize(3);
 
   // Branch 0-1
-  data.branch[0].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-  data.branch[0].ports[BranchPorts::bus2]        = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R] = 0.05;
-  data.branch[0].parameters[BranchParameters::X] = 0.21;
-  data.branch[0].parameters[BranchParameters::G] = 0.0;
-  data.branch[0].parameters[BranchParameters::B] = 0.1;
+  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
+  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R]  = 0.05;
+  data.branch[0].parameters[BranchParameters::X]  = 0.21;
+  data.branch[0].parameters[BranchParameters::G]  = 0.0;
+  data.branch[0].parameters[BranchParameters::B]  = 0.1;
 
   // Branch 0-2
-  data.branch[1].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-  data.branch[1].ports[BranchPorts::bus2]        = data.bus[2].bus_id;
-  data.branch[1].parameters[BranchParameters::R] = 0.06;
-  data.branch[1].parameters[BranchParameters::X] = 0.15;
-  data.branch[1].parameters[BranchParameters::G] = 0.0;
-  data.branch[1].parameters[BranchParameters::B] = 0.12;
+  data.branch[1].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
+  data.branch[1].terminals[BranchTerminals::bus2] = data.bus[2].bus_id;
+  data.branch[1].parameters[BranchParameters::R]  = 0.06;
+  data.branch[1].parameters[BranchParameters::X]  = 0.15;
+  data.branch[1].parameters[BranchParameters::G]  = 0.0;
+  data.branch[1].parameters[BranchParameters::B]  = 0.12;
 
   // Branch 1-2
-  data.branch[2].ports[BranchPorts::bus1]        = data.bus[1].bus_id;
-  data.branch[2].ports[BranchPorts::bus2]        = data.bus[2].bus_id;
-  data.branch[2].parameters[BranchParameters::R] = 0.08;
-  data.branch[2].parameters[BranchParameters::X] = 0.27;
-  data.branch[2].parameters[BranchParameters::G] = 0.0;
-  data.branch[2].parameters[BranchParameters::B] = 0.45;
+  data.branch[2].terminals[BranchTerminals::bus1] = data.bus[1].bus_id;
+  data.branch[2].terminals[BranchTerminals::bus2] = data.bus[2].bus_id;
+  data.branch[2].parameters[BranchParameters::R]  = 0.08;
+  data.branch[2].parameters[BranchParameters::X]  = 0.27;
+  data.branch[2].parameters[BranchParameters::G]  = 0.0;
+  data.branch[2].parameters[BranchParameters::B]  = 0.45;
 
   // Set generator data
   data.genclassical.resize(2);
 
   // Generator on bus 1
-  data.genclassical[0].ports[GenClassicalPorts::bus]           = data.bus[1].bus_id;
+  data.genclassical[0].terminals[GenClassicalTerminals::bus]   = data.bus[1].bus_id;
   data.genclassical[0].parameters[GenClassicalParameters::p0]  = 0.5;
   data.genclassical[0].parameters[GenClassicalParameters::q0]  = -0.07588;
   data.genclassical[0].parameters[GenClassicalParameters::H]   = 2.7;
@@ -147,7 +147,7 @@ int main()
   data.genclassical[0].parameters[GenClassicalParameters::Xdp] = 0.17;
 
   // Generator on bus 2
-  data.genclassical[1].ports[GenClassicalPorts::bus]           = data.bus[2].bus_id;
+  data.genclassical[1].terminals[GenClassicalTerminals::bus]   = data.bus[2].bus_id;
   data.genclassical[1].parameters[GenClassicalParameters::p0]  = 0.25;
   data.genclassical[1].parameters[GenClassicalParameters::q0]  = 0.26587;
   data.genclassical[1].parameters[GenClassicalParameters::H]   = 1.6;
@@ -159,14 +159,14 @@ int main()
   data.loadz.resize(1);
 
   // Load on bus 2
-  data.loadz[0].ports[LoadZPorts::bus]         = 2;
+  data.loadz[0].terminals[LoadZTerminals::bus] = 2;
   data.loadz[0].parameters[LoadZParameters::R] = 0.4447197839297772;
   data.loadz[0].parameters[LoadZParameters::X] = 0.20330047265361242;
 
   // Set fault data
   data.bus_fault.resize(1);
 
-  data.bus_fault[0].ports[BusFaultPorts::bus]              = 2;
+  data.bus_fault[0].terminals[BusFaultTerminals::bus]      = 2;
   data.bus_fault[0].parameters[BusFaultParameters::R]      = 0.0;
   data.bus_fault[0].parameters[BusFaultParameters::X]      = 1e-5;
   data.bus_fault[0].parameters[BusFaultParameters::state0] = false;

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
@@ -111,34 +111,34 @@ int main()
   data.branch.resize(3);
 
   // Branch 0-1
-  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
-  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R]  = 0.05;
-  data.branch[0].parameters[BranchParameters::X]  = 0.21;
-  data.branch[0].parameters[BranchParameters::G]  = 0.0;
-  data.branch[0].parameters[BranchParameters::B]  = 0.1;
+  data.branch[0].buses[BranchBuses::bus1]        = data.bus[0].bus_id;
+  data.branch[0].buses[BranchBuses::bus2]        = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R] = 0.05;
+  data.branch[0].parameters[BranchParameters::X] = 0.21;
+  data.branch[0].parameters[BranchParameters::G] = 0.0;
+  data.branch[0].parameters[BranchParameters::B] = 0.1;
 
   // Branch 0-2
-  data.branch[1].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
-  data.branch[1].terminals[BranchTerminals::bus2] = data.bus[2].bus_id;
-  data.branch[1].parameters[BranchParameters::R]  = 0.06;
-  data.branch[1].parameters[BranchParameters::X]  = 0.15;
-  data.branch[1].parameters[BranchParameters::G]  = 0.0;
-  data.branch[1].parameters[BranchParameters::B]  = 0.12;
+  data.branch[1].buses[BranchBuses::bus1]        = data.bus[0].bus_id;
+  data.branch[1].buses[BranchBuses::bus2]        = data.bus[2].bus_id;
+  data.branch[1].parameters[BranchParameters::R] = 0.06;
+  data.branch[1].parameters[BranchParameters::X] = 0.15;
+  data.branch[1].parameters[BranchParameters::G] = 0.0;
+  data.branch[1].parameters[BranchParameters::B] = 0.12;
 
   // Branch 1-2
-  data.branch[2].terminals[BranchTerminals::bus1] = data.bus[1].bus_id;
-  data.branch[2].terminals[BranchTerminals::bus2] = data.bus[2].bus_id;
-  data.branch[2].parameters[BranchParameters::R]  = 0.08;
-  data.branch[2].parameters[BranchParameters::X]  = 0.27;
-  data.branch[2].parameters[BranchParameters::G]  = 0.0;
-  data.branch[2].parameters[BranchParameters::B]  = 0.45;
+  data.branch[2].buses[BranchBuses::bus1]        = data.bus[1].bus_id;
+  data.branch[2].buses[BranchBuses::bus2]        = data.bus[2].bus_id;
+  data.branch[2].parameters[BranchParameters::R] = 0.08;
+  data.branch[2].parameters[BranchParameters::X] = 0.27;
+  data.branch[2].parameters[BranchParameters::G] = 0.0;
+  data.branch[2].parameters[BranchParameters::B] = 0.45;
 
   // Set generator data
   data.genclassical.resize(2);
 
   // Generator on bus 1
-  data.genclassical[0].terminals[GenClassicalTerminals::bus]   = data.bus[1].bus_id;
+  data.genclassical[0].buses[GenClassicalBuses::bus]           = data.bus[1].bus_id;
   data.genclassical[0].parameters[GenClassicalParameters::p0]  = 0.5;
   data.genclassical[0].parameters[GenClassicalParameters::q0]  = -0.07588;
   data.genclassical[0].parameters[GenClassicalParameters::H]   = 2.7;
@@ -147,7 +147,7 @@ int main()
   data.genclassical[0].parameters[GenClassicalParameters::Xdp] = 0.17;
 
   // Generator on bus 2
-  data.genclassical[1].terminals[GenClassicalTerminals::bus]   = data.bus[2].bus_id;
+  data.genclassical[1].buses[GenClassicalBuses::bus]           = data.bus[2].bus_id;
   data.genclassical[1].parameters[GenClassicalParameters::p0]  = 0.25;
   data.genclassical[1].parameters[GenClassicalParameters::q0]  = 0.26587;
   data.genclassical[1].parameters[GenClassicalParameters::H]   = 1.6;
@@ -159,14 +159,14 @@ int main()
   data.loadz.resize(1);
 
   // Load on bus 2
-  data.loadz[0].terminals[LoadZTerminals::bus] = 2;
+  data.loadz[0].buses[LoadZBuses::bus]         = 2;
   data.loadz[0].parameters[LoadZParameters::R] = 0.4447197839297772;
   data.loadz[0].parameters[LoadZParameters::X] = 0.20330047265361242;
 
   // Set fault data
   data.bus_fault.resize(1);
 
-  data.bus_fault[0].terminals[BusFaultTerminals::bus]      = 2;
+  data.bus_fault[0].buses[BusFaultBuses::bus]              = 2;
   data.bus_fault[0].parameters[BusFaultParameters::R]      = 0.0;
   data.bus_fault[0].parameters[BusFaultParameters::X]      = 1e-5;
   data.bus_fault[0].parameters[BusFaultParameters::state0] = false;

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.cpp
@@ -54,12 +54,12 @@ int main()
   // Set branch data
   data.branch.resize(1);
 
-  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
-  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R]  = 0.0;
-  data.branch[0].parameters[BranchParameters::X]  = 0.1;
-  data.branch[0].parameters[BranchParameters::G]  = 0.0;
-  data.branch[0].parameters[BranchParameters::B]  = 0.0;
+  data.branch[0].buses[BranchBuses::bus1]        = data.bus[0].bus_id;
+  data.branch[0].buses[BranchBuses::bus2]        = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R] = 0.0;
+  data.branch[0].parameters[BranchParameters::X] = 0.1;
+  data.branch[0].parameters[BranchParameters::G] = 0.0;
+  data.branch[0].parameters[BranchParameters::B] = 0.0;
 
   // Set generator data
   data.genrou.resize(1);

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.cpp
@@ -54,12 +54,12 @@ int main()
   // Set branch data
   data.branch.resize(1);
 
-  data.branch[0].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-  data.branch[0].ports[BranchPorts::bus2]        = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R] = 0.0;
-  data.branch[0].parameters[BranchParameters::X] = 0.1;
-  data.branch[0].parameters[BranchParameters::G] = 0.0;
-  data.branch[0].parameters[BranchParameters::B] = 0.0;
+  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
+  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R]  = 0.0;
+  data.branch[0].parameters[BranchParameters::X]  = 0.1;
+  data.branch[0].parameters[BranchParameters::G]  = 0.0;
+  data.branch[0].parameters[BranchParameters::B]  = 0.0;
 
   // Set generator data
   data.genrou.resize(1);

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.cpp
@@ -65,12 +65,12 @@ int main()
   // Set branch data
   data.branch.resize(1);
 
-  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
-  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R]  = 0.0;
-  data.branch[0].parameters[BranchParameters::X]  = 0.1;
-  data.branch[0].parameters[BranchParameters::G]  = 0.0;
-  data.branch[0].parameters[BranchParameters::B]  = 0.0;
+  data.branch[0].buses[BranchBuses::bus1]        = data.bus[0].bus_id;
+  data.branch[0].buses[BranchBuses::bus2]        = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R] = 0.0;
+  data.branch[0].parameters[BranchParameters::X] = 0.1;
+  data.branch[0].parameters[BranchParameters::G] = 0.0;
+  data.branch[0].parameters[BranchParameters::B] = 0.0;
 
   // Add faults
   data.bus_fault.resize(1);
@@ -82,48 +82,48 @@ int main()
   // Set generator data
   data.genrou.resize(1);
 
-  data.genrou[0].output_ports[GenrouOutputPorts::speed] = 0;
-  data.genrou[0].input_ports[GenrouInputPorts::pmech]   = 1;
-  data.genrou[0].input_ports[GenrouInputPorts::efd]     = 2;
-  data.genrou[0].parameters[GenrouParameters::p0]       = 1.;
-  data.genrou[0].parameters[GenrouParameters::q0]       = 0.05013;
-  data.genrou[0].parameters[GenrouParameters::H]        = 3.;
-  data.genrou[0].parameters[GenrouParameters::D]        = 0.;
-  data.genrou[0].parameters[GenrouParameters::Ra]       = 0.;
-  data.genrou[0].parameters[GenrouParameters::Tdop]     = 7.;
-  data.genrou[0].parameters[GenrouParameters::Tdopp]    = .04;
-  data.genrou[0].parameters[GenrouParameters::Tqopp]    = .05;
-  data.genrou[0].parameters[GenrouParameters::Tqop]     = .75;
-  data.genrou[0].parameters[GenrouParameters::Xd]       = 2.1;
-  data.genrou[0].parameters[GenrouParameters::Xdp]      = 0.2;
-  data.genrou[0].parameters[GenrouParameters::Xdpp]     = 0.18;
-  data.genrou[0].parameters[GenrouParameters::Xq]       = 0.5;
-  data.genrou[0].parameters[GenrouParameters::Xqp]      = 0.5;
-  data.genrou[0].parameters[GenrouParameters::Xqpp]     = 0.18;
-  data.genrou[0].parameters[GenrouParameters::Xl]       = 0.15;
-  data.genrou[0].parameters[GenrouParameters::S10]      = 0.;
-  data.genrou[0].parameters[GenrouParameters::S12]      = 0.;
-  data.genrou[0].parameters[GenrouParameters::mva]      = 100.0;
+  data.genrou[0].signal_outputs[GenrouSignalOutputs::speed] = 0;
+  data.genrou[0].signal_inputs[GenrouSignalInputs::pmech]   = 1;
+  data.genrou[0].signal_inputs[GenrouSignalInputs::efd]     = 2;
+  data.genrou[0].parameters[GenrouParameters::p0]           = 1.;
+  data.genrou[0].parameters[GenrouParameters::q0]           = 0.05013;
+  data.genrou[0].parameters[GenrouParameters::H]            = 3.;
+  data.genrou[0].parameters[GenrouParameters::D]            = 0.;
+  data.genrou[0].parameters[GenrouParameters::Ra]           = 0.;
+  data.genrou[0].parameters[GenrouParameters::Tdop]         = 7.;
+  data.genrou[0].parameters[GenrouParameters::Tdopp]        = .04;
+  data.genrou[0].parameters[GenrouParameters::Tqopp]        = .05;
+  data.genrou[0].parameters[GenrouParameters::Tqop]         = .75;
+  data.genrou[0].parameters[GenrouParameters::Xd]           = 2.1;
+  data.genrou[0].parameters[GenrouParameters::Xdp]          = 0.2;
+  data.genrou[0].parameters[GenrouParameters::Xdpp]         = 0.18;
+  data.genrou[0].parameters[GenrouParameters::Xq]           = 0.5;
+  data.genrou[0].parameters[GenrouParameters::Xqp]          = 0.5;
+  data.genrou[0].parameters[GenrouParameters::Xqpp]         = 0.18;
+  data.genrou[0].parameters[GenrouParameters::Xl]           = 0.15;
+  data.genrou[0].parameters[GenrouParameters::S10]          = 0.;
+  data.genrou[0].parameters[GenrouParameters::S12]          = 0.;
+  data.genrou[0].parameters[GenrouParameters::mva]          = 100.0;
 
   // Governor
   data.gov.resize(1);
 
-  data.gov[0].input_ports[Tgov1InputPorts::speed]   = 0;
-  data.gov[0].output_ports[Tgov1OutputPorts::pmech] = 1;
-  data.gov[0].parameters[Tgov1Parameters::Trate]    = 100.0;
-  data.gov[0].parameters[Tgov1Parameters::R]        = 0.05;
-  data.gov[0].parameters[Tgov1Parameters::Pvmin]    = 0.0;
-  data.gov[0].parameters[Tgov1Parameters::Pvmax]    = 1.0;
-  data.gov[0].parameters[Tgov1Parameters::T1]       = 0.5;
-  data.gov[0].parameters[Tgov1Parameters::T2]       = 2.5;
-  data.gov[0].parameters[Tgov1Parameters::T3]       = 7.5;
-  data.gov[0].parameters[Tgov1Parameters::Dt]       = 0.0;
+  data.gov[0].signal_inputs[Tgov1SignalInputs::speed]   = 0;
+  data.gov[0].signal_outputs[Tgov1SignalOutputs::pmech] = 1;
+  data.gov[0].parameters[Tgov1Parameters::Trate]        = 100.0;
+  data.gov[0].parameters[Tgov1Parameters::R]            = 0.05;
+  data.gov[0].parameters[Tgov1Parameters::Pvmin]        = 0.0;
+  data.gov[0].parameters[Tgov1Parameters::Pvmax]        = 1.0;
+  data.gov[0].parameters[Tgov1Parameters::T1]           = 0.5;
+  data.gov[0].parameters[Tgov1Parameters::T2]           = 2.5;
+  data.gov[0].parameters[Tgov1Parameters::T3]           = 7.5;
+  data.gov[0].parameters[Tgov1Parameters::Dt]           = 0.0;
 
   // Exciter
   data.exciter.resize(1);
 
-  data.exciter[0].ports[Ieeet1Ports::speed]                      = 0;
-  data.exciter[0].ports[Ieeet1Ports::efd]                        = 2;
+  data.exciter[0].signal_inputs[Ieeet1SignalInputs::speed]       = 0;
+  data.exciter[0].signal_outputs[Ieeet1SignalOutputs::efd]       = 2;
   data.exciter[0].parameters[Exciter::Ieeet1Parameters::Tr]      = 0.0;
   data.exciter[0].parameters[Exciter::Ieeet1Parameters::Ka]      = 50.;
   data.exciter[0].parameters[Exciter::Ieeet1Parameters::Ta]      = 0.04;

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.cpp
@@ -65,12 +65,12 @@ int main()
   // Set branch data
   data.branch.resize(1);
 
-  data.branch[0].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-  data.branch[0].ports[BranchPorts::bus2]        = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R] = 0.0;
-  data.branch[0].parameters[BranchParameters::X] = 0.1;
-  data.branch[0].parameters[BranchParameters::G] = 0.0;
-  data.branch[0].parameters[BranchParameters::B] = 0.0;
+  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
+  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R]  = 0.0;
+  data.branch[0].parameters[BranchParameters::X]  = 0.1;
+  data.branch[0].parameters[BranchParameters::G]  = 0.0;
+  data.branch[0].parameters[BranchParameters::B]  = 0.0;
 
   // Add faults
   data.bus_fault.resize(1);
@@ -82,42 +82,42 @@ int main()
   // Set generator data
   data.genrou.resize(1);
 
-  data.genrou[0].ports[GenrouPorts::speed]           = 0;
-  data.genrou[0].ports[GenrouPorts::pmech]           = 1;
-  data.genrou[0].ports[GenrouPorts::efd]             = 2;
-  data.genrou[0].parameters[GenrouParameters::p0]    = 1.;
-  data.genrou[0].parameters[GenrouParameters::q0]    = 0.05013;
-  data.genrou[0].parameters[GenrouParameters::H]     = 3.;
-  data.genrou[0].parameters[GenrouParameters::D]     = 0.;
-  data.genrou[0].parameters[GenrouParameters::Ra]    = 0.;
-  data.genrou[0].parameters[GenrouParameters::Tdop]  = 7.;
-  data.genrou[0].parameters[GenrouParameters::Tdopp] = .04;
-  data.genrou[0].parameters[GenrouParameters::Tqopp] = .05;
-  data.genrou[0].parameters[GenrouParameters::Tqop]  = .75;
-  data.genrou[0].parameters[GenrouParameters::Xd]    = 2.1;
-  data.genrou[0].parameters[GenrouParameters::Xdp]   = 0.2;
-  data.genrou[0].parameters[GenrouParameters::Xdpp]  = 0.18;
-  data.genrou[0].parameters[GenrouParameters::Xq]    = 0.5;
-  data.genrou[0].parameters[GenrouParameters::Xqp]   = 0.5;
-  data.genrou[0].parameters[GenrouParameters::Xqpp]  = 0.18;
-  data.genrou[0].parameters[GenrouParameters::Xl]    = 0.15;
-  data.genrou[0].parameters[GenrouParameters::S10]   = 0.;
-  data.genrou[0].parameters[GenrouParameters::S12]   = 0.;
-  data.genrou[0].parameters[GenrouParameters::mva]   = 100.0;
+  data.genrou[0].output_ports[GenrouOutputPorts::speed] = 0;
+  data.genrou[0].input_ports[GenrouInputPorts::pmech]   = 1;
+  data.genrou[0].input_ports[GenrouInputPorts::efd]     = 2;
+  data.genrou[0].parameters[GenrouParameters::p0]       = 1.;
+  data.genrou[0].parameters[GenrouParameters::q0]       = 0.05013;
+  data.genrou[0].parameters[GenrouParameters::H]        = 3.;
+  data.genrou[0].parameters[GenrouParameters::D]        = 0.;
+  data.genrou[0].parameters[GenrouParameters::Ra]       = 0.;
+  data.genrou[0].parameters[GenrouParameters::Tdop]     = 7.;
+  data.genrou[0].parameters[GenrouParameters::Tdopp]    = .04;
+  data.genrou[0].parameters[GenrouParameters::Tqopp]    = .05;
+  data.genrou[0].parameters[GenrouParameters::Tqop]     = .75;
+  data.genrou[0].parameters[GenrouParameters::Xd]       = 2.1;
+  data.genrou[0].parameters[GenrouParameters::Xdp]      = 0.2;
+  data.genrou[0].parameters[GenrouParameters::Xdpp]     = 0.18;
+  data.genrou[0].parameters[GenrouParameters::Xq]       = 0.5;
+  data.genrou[0].parameters[GenrouParameters::Xqp]      = 0.5;
+  data.genrou[0].parameters[GenrouParameters::Xqpp]     = 0.18;
+  data.genrou[0].parameters[GenrouParameters::Xl]       = 0.15;
+  data.genrou[0].parameters[GenrouParameters::S10]      = 0.;
+  data.genrou[0].parameters[GenrouParameters::S12]      = 0.;
+  data.genrou[0].parameters[GenrouParameters::mva]      = 100.0;
 
   // Governor
   data.gov.resize(1);
 
-  data.gov[0].ports[Tgov1Ports::speed]           = 0;
-  data.gov[0].ports[Tgov1Ports::pmech]           = 1;
-  data.gov[0].parameters[Tgov1Parameters::Trate] = 100.0;
-  data.gov[0].parameters[Tgov1Parameters::R]     = 0.05;
-  data.gov[0].parameters[Tgov1Parameters::Pvmin] = 0.0;
-  data.gov[0].parameters[Tgov1Parameters::Pvmax] = 1.0;
-  data.gov[0].parameters[Tgov1Parameters::T1]    = 0.5;
-  data.gov[0].parameters[Tgov1Parameters::T2]    = 2.5;
-  data.gov[0].parameters[Tgov1Parameters::T3]    = 7.5;
-  data.gov[0].parameters[Tgov1Parameters::Dt]    = 0.0;
+  data.gov[0].input_ports[Tgov1InputPorts::speed]   = 0;
+  data.gov[0].output_ports[Tgov1OutputPorts::pmech] = 1;
+  data.gov[0].parameters[Tgov1Parameters::Trate]    = 100.0;
+  data.gov[0].parameters[Tgov1Parameters::R]        = 0.05;
+  data.gov[0].parameters[Tgov1Parameters::Pvmin]    = 0.0;
+  data.gov[0].parameters[Tgov1Parameters::Pvmax]    = 1.0;
+  data.gov[0].parameters[Tgov1Parameters::T1]       = 0.5;
+  data.gov[0].parameters[Tgov1Parameters::T2]       = 2.5;
+  data.gov[0].parameters[Tgov1Parameters::T3]       = 7.5;
+  data.gov[0].parameters[Tgov1Parameters::Dt]       = 0.0;
 
   // Exciter
   data.exciter.resize(1);

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
@@ -64,12 +64,12 @@ int main()
   // Set branch data
   data.branch.resize(1);
 
-  data.branch[0].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-  data.branch[0].ports[BranchPorts::bus2]        = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R] = 0.0;
-  data.branch[0].parameters[BranchParameters::X] = 0.1;
-  data.branch[0].parameters[BranchParameters::G] = 0.0;
-  data.branch[0].parameters[BranchParameters::B] = 0.0;
+  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
+  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R]  = 0.0;
+  data.branch[0].parameters[BranchParameters::X]  = 0.1;
+  data.branch[0].parameters[BranchParameters::G]  = 0.0;
+  data.branch[0].parameters[BranchParameters::B]  = 0.0;
 
   // Add faults
   data.bus_fault.resize(1);
@@ -81,41 +81,41 @@ int main()
   // Set generator data
   data.genrou.resize(1);
 
-  data.genrou[0].ports[GenrouPorts::pmech]           = 1;
-  data.genrou[0].ports[GenrouPorts::speed]           = 0;
-  data.genrou[0].parameters[GenrouParameters::p0]    = 1.;
-  data.genrou[0].parameters[GenrouParameters::q0]    = 0.05013;
-  data.genrou[0].parameters[GenrouParameters::H]     = 3.;
-  data.genrou[0].parameters[GenrouParameters::D]     = 0.;
-  data.genrou[0].parameters[GenrouParameters::Ra]    = 0.;
-  data.genrou[0].parameters[GenrouParameters::Tdop]  = 7.;
-  data.genrou[0].parameters[GenrouParameters::Tdopp] = .04;
-  data.genrou[0].parameters[GenrouParameters::Tqopp] = .05;
-  data.genrou[0].parameters[GenrouParameters::Tqop]  = .75;
-  data.genrou[0].parameters[GenrouParameters::Xd]    = 2.1;
-  data.genrou[0].parameters[GenrouParameters::Xdp]   = 0.2;
-  data.genrou[0].parameters[GenrouParameters::Xdpp]  = 0.18;
-  data.genrou[0].parameters[GenrouParameters::Xq]    = 0.5;
-  data.genrou[0].parameters[GenrouParameters::Xqp]   = 0.5;
-  data.genrou[0].parameters[GenrouParameters::Xqpp]  = 0.18;
-  data.genrou[0].parameters[GenrouParameters::Xl]    = 0.15;
-  data.genrou[0].parameters[GenrouParameters::S10]   = 0.;
-  data.genrou[0].parameters[GenrouParameters::S12]   = 0.;
-  data.genrou[0].parameters[GenrouParameters::mva]   = 100.0;
+  data.genrou[0].input_ports[GenrouInputPorts::pmech]   = 1;
+  data.genrou[0].output_ports[GenrouOutputPorts::speed] = 0;
+  data.genrou[0].parameters[GenrouParameters::p0]       = 1.;
+  data.genrou[0].parameters[GenrouParameters::q0]       = 0.05013;
+  data.genrou[0].parameters[GenrouParameters::H]        = 3.;
+  data.genrou[0].parameters[GenrouParameters::D]        = 0.;
+  data.genrou[0].parameters[GenrouParameters::Ra]       = 0.;
+  data.genrou[0].parameters[GenrouParameters::Tdop]     = 7.;
+  data.genrou[0].parameters[GenrouParameters::Tdopp]    = .04;
+  data.genrou[0].parameters[GenrouParameters::Tqopp]    = .05;
+  data.genrou[0].parameters[GenrouParameters::Tqop]     = .75;
+  data.genrou[0].parameters[GenrouParameters::Xd]       = 2.1;
+  data.genrou[0].parameters[GenrouParameters::Xdp]      = 0.2;
+  data.genrou[0].parameters[GenrouParameters::Xdpp]     = 0.18;
+  data.genrou[0].parameters[GenrouParameters::Xq]       = 0.5;
+  data.genrou[0].parameters[GenrouParameters::Xqp]      = 0.5;
+  data.genrou[0].parameters[GenrouParameters::Xqpp]     = 0.18;
+  data.genrou[0].parameters[GenrouParameters::Xl]       = 0.15;
+  data.genrou[0].parameters[GenrouParameters::S10]      = 0.;
+  data.genrou[0].parameters[GenrouParameters::S12]      = 0.;
+  data.genrou[0].parameters[GenrouParameters::mva]      = 100.0;
 
   // Set governor data (Default PW values)
   data.gov.resize(1);
 
-  data.gov[0].ports[Tgov1Ports::speed]           = 0;
-  data.gov[0].ports[Tgov1Ports::pmech]           = 1;
-  data.gov[0].parameters[Tgov1Parameters::Trate] = 100.0;
-  data.gov[0].parameters[Tgov1Parameters::R]     = 0.05;
-  data.gov[0].parameters[Tgov1Parameters::Pvmin] = 0.0;
-  data.gov[0].parameters[Tgov1Parameters::Pvmax] = 1.0;
-  data.gov[0].parameters[Tgov1Parameters::T1]    = 0.5;
-  data.gov[0].parameters[Tgov1Parameters::T2]    = 2.5;
-  data.gov[0].parameters[Tgov1Parameters::T3]    = 7.5;
-  data.gov[0].parameters[Tgov1Parameters::Dt]    = 0.0;
+  data.gov[0].input_ports[Tgov1InputPorts::speed]   = 0;
+  data.gov[0].output_ports[Tgov1OutputPorts::pmech] = 1;
+  data.gov[0].parameters[Tgov1Parameters::Trate]    = 100.0;
+  data.gov[0].parameters[Tgov1Parameters::R]        = 0.05;
+  data.gov[0].parameters[Tgov1Parameters::Pvmin]    = 0.0;
+  data.gov[0].parameters[Tgov1Parameters::Pvmax]    = 1.0;
+  data.gov[0].parameters[Tgov1Parameters::T1]       = 0.5;
+  data.gov[0].parameters[Tgov1Parameters::T2]       = 2.5;
+  data.gov[0].parameters[Tgov1Parameters::T3]       = 7.5;
+  data.gov[0].parameters[Tgov1Parameters::Dt]       = 0.0;
 
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
@@ -64,12 +64,12 @@ int main()
   // Set branch data
   data.branch.resize(1);
 
-  data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
-  data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
-  data.branch[0].parameters[BranchParameters::R]  = 0.0;
-  data.branch[0].parameters[BranchParameters::X]  = 0.1;
-  data.branch[0].parameters[BranchParameters::G]  = 0.0;
-  data.branch[0].parameters[BranchParameters::B]  = 0.0;
+  data.branch[0].buses[BranchBuses::bus1]        = data.bus[0].bus_id;
+  data.branch[0].buses[BranchBuses::bus2]        = data.bus[1].bus_id;
+  data.branch[0].parameters[BranchParameters::R] = 0.0;
+  data.branch[0].parameters[BranchParameters::X] = 0.1;
+  data.branch[0].parameters[BranchParameters::G] = 0.0;
+  data.branch[0].parameters[BranchParameters::B] = 0.0;
 
   // Add faults
   data.bus_fault.resize(1);
@@ -81,41 +81,41 @@ int main()
   // Set generator data
   data.genrou.resize(1);
 
-  data.genrou[0].input_ports[GenrouInputPorts::pmech]   = 1;
-  data.genrou[0].output_ports[GenrouOutputPorts::speed] = 0;
-  data.genrou[0].parameters[GenrouParameters::p0]       = 1.;
-  data.genrou[0].parameters[GenrouParameters::q0]       = 0.05013;
-  data.genrou[0].parameters[GenrouParameters::H]        = 3.;
-  data.genrou[0].parameters[GenrouParameters::D]        = 0.;
-  data.genrou[0].parameters[GenrouParameters::Ra]       = 0.;
-  data.genrou[0].parameters[GenrouParameters::Tdop]     = 7.;
-  data.genrou[0].parameters[GenrouParameters::Tdopp]    = .04;
-  data.genrou[0].parameters[GenrouParameters::Tqopp]    = .05;
-  data.genrou[0].parameters[GenrouParameters::Tqop]     = .75;
-  data.genrou[0].parameters[GenrouParameters::Xd]       = 2.1;
-  data.genrou[0].parameters[GenrouParameters::Xdp]      = 0.2;
-  data.genrou[0].parameters[GenrouParameters::Xdpp]     = 0.18;
-  data.genrou[0].parameters[GenrouParameters::Xq]       = 0.5;
-  data.genrou[0].parameters[GenrouParameters::Xqp]      = 0.5;
-  data.genrou[0].parameters[GenrouParameters::Xqpp]     = 0.18;
-  data.genrou[0].parameters[GenrouParameters::Xl]       = 0.15;
-  data.genrou[0].parameters[GenrouParameters::S10]      = 0.;
-  data.genrou[0].parameters[GenrouParameters::S12]      = 0.;
-  data.genrou[0].parameters[GenrouParameters::mva]      = 100.0;
+  data.genrou[0].signal_inputs[GenrouSignalInputs::pmech]   = 1;
+  data.genrou[0].signal_outputs[GenrouSignalOutputs::speed] = 0;
+  data.genrou[0].parameters[GenrouParameters::p0]           = 1.;
+  data.genrou[0].parameters[GenrouParameters::q0]           = 0.05013;
+  data.genrou[0].parameters[GenrouParameters::H]            = 3.;
+  data.genrou[0].parameters[GenrouParameters::D]            = 0.;
+  data.genrou[0].parameters[GenrouParameters::Ra]           = 0.;
+  data.genrou[0].parameters[GenrouParameters::Tdop]         = 7.;
+  data.genrou[0].parameters[GenrouParameters::Tdopp]        = .04;
+  data.genrou[0].parameters[GenrouParameters::Tqopp]        = .05;
+  data.genrou[0].parameters[GenrouParameters::Tqop]         = .75;
+  data.genrou[0].parameters[GenrouParameters::Xd]           = 2.1;
+  data.genrou[0].parameters[GenrouParameters::Xdp]          = 0.2;
+  data.genrou[0].parameters[GenrouParameters::Xdpp]         = 0.18;
+  data.genrou[0].parameters[GenrouParameters::Xq]           = 0.5;
+  data.genrou[0].parameters[GenrouParameters::Xqp]          = 0.5;
+  data.genrou[0].parameters[GenrouParameters::Xqpp]         = 0.18;
+  data.genrou[0].parameters[GenrouParameters::Xl]           = 0.15;
+  data.genrou[0].parameters[GenrouParameters::S10]          = 0.;
+  data.genrou[0].parameters[GenrouParameters::S12]          = 0.;
+  data.genrou[0].parameters[GenrouParameters::mva]          = 100.0;
 
   // Set governor data (Default PW values)
   data.gov.resize(1);
 
-  data.gov[0].input_ports[Tgov1InputPorts::speed]   = 0;
-  data.gov[0].output_ports[Tgov1OutputPorts::pmech] = 1;
-  data.gov[0].parameters[Tgov1Parameters::Trate]    = 100.0;
-  data.gov[0].parameters[Tgov1Parameters::R]        = 0.05;
-  data.gov[0].parameters[Tgov1Parameters::Pvmin]    = 0.0;
-  data.gov[0].parameters[Tgov1Parameters::Pvmax]    = 1.0;
-  data.gov[0].parameters[Tgov1Parameters::T1]       = 0.5;
-  data.gov[0].parameters[Tgov1Parameters::T2]       = 2.5;
-  data.gov[0].parameters[Tgov1Parameters::T3]       = 7.5;
-  data.gov[0].parameters[Tgov1Parameters::Dt]       = 0.0;
+  data.gov[0].signal_inputs[Tgov1SignalInputs::speed]   = 0;
+  data.gov[0].signal_outputs[Tgov1SignalOutputs::pmech] = 1;
+  data.gov[0].parameters[Tgov1Parameters::Trate]        = 100.0;
+  data.gov[0].parameters[Tgov1Parameters::R]            = 0.05;
+  data.gov[0].parameters[Tgov1Parameters::Pvmin]        = 0.0;
+  data.gov[0].parameters[Tgov1Parameters::Pvmax]        = 1.0;
+  data.gov[0].parameters[Tgov1Parameters::T1]           = 0.5;
+  data.gov[0].parameters[Tgov1Parameters::T2]           = 2.5;
+  data.gov[0].parameters[Tgov1Parameters::T3]           = 7.5;
+  data.gov[0].parameters[Tgov1Parameters::Dt]           = 0.0;
 
   SystemModel<scalar_type, index_type> sys(data);
   sys.allocate();

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -325,13 +325,17 @@ namespace GridKit
         const ScalarT Vr2{30.0};
         const ScalarT Vi2{40.0};
 
-        typename PhasorDynamics::Branch<ScalarT, IdxT>::ModelDataT data;
-        data.ports[PhasorDynamics::BranchPorts::bus1]        = 1;
-        data.ports[PhasorDynamics::BranchPorts::bus2]        = 2;
-        data.parameters[PhasorDynamics::BranchParameters::R] = R;
-        data.parameters[PhasorDynamics::BranchParameters::X] = X;
-        data.parameters[PhasorDynamics::BranchParameters::G] = G;
-        data.parameters[PhasorDynamics::BranchParameters::B] = B;
+        using Data      = typename PhasorDynamics::Branch<ScalarT, IdxT>::ModelDataT;
+        using Parameter = typename Data::Parameters;
+        using Terminal  = typename Data::Terminals;
+
+        Data data;
+        data.terminals[Terminal::bus1] = 1;
+        data.terminals[Terminal::bus2] = 2;
+        data.parameters[Parameter::R]  = R;
+        data.parameters[Parameter::X]  = X;
+        data.parameters[Parameter::G]  = G;
+        data.parameters[Parameter::B]  = B;
 
         PhasorDynamics::Bus<ScalarT, IdxT> data_bus1(Vr1, Vi1);
         PhasorDynamics::Bus<ScalarT, IdxT> data_bus2(Vr2, Vi2);

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -327,15 +327,15 @@ namespace GridKit
 
         using Data      = typename PhasorDynamics::Branch<ScalarT, IdxT>::ModelDataT;
         using Parameter = typename Data::Parameters;
-        using Terminal  = typename Data::Terminals;
+        using Buses     = typename Data::Buses;
 
         Data data;
-        data.terminals[Terminal::bus1] = 1;
-        data.terminals[Terminal::bus2] = 2;
-        data.parameters[Parameter::R]  = R;
-        data.parameters[Parameter::X]  = X;
-        data.parameters[Parameter::G]  = G;
-        data.parameters[Parameter::B]  = B;
+        data.buses[Buses::bus1]       = 1;
+        data.buses[Buses::bus2]       = 2;
+        data.parameters[Parameter::R] = R;
+        data.parameters[Parameter::X] = X;
+        data.parameters[Parameter::G] = G;
+        data.parameters[Parameter::B] = B;
 
         PhasorDynamics::Bus<ScalarT, IdxT> data_bus1(Vr1, Vi1);
         PhasorDynamics::Bus<ScalarT, IdxT> data_bus2(Vr2, Vi2);

--- a/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
@@ -189,17 +189,20 @@ namespace GridKit
 
       TestOutcome parameterValidation()
       {
+        using Data      = PhasorDynamics::Exciter::SexsPtiData<RealT, IdxT>;
+        using Parameter = typename Data::Parameters;
+
         TestStatus success = true;
 
         PhasorDynamics::Bus<ScalarT, IdxT> bus(1.0, 0.0);
 
         auto missing = makeTestData();
-        missing.parameters.erase(PhasorDynamics::Exciter::SexsPtiParameters::K);
+        missing.parameters.erase(Parameter::K);
         PhasorDynamics::Exciter::SexsPti<ScalarT, IdxT> missing_model(&bus, missing);
         success *= (missing_model.verify() > 0);
 
-        auto invalid                                                       = makeTestData();
-        invalid.parameters[PhasorDynamics::Exciter::SexsPtiParameters::Tb] = 0.0;
+        auto invalid                      = makeTestData();
+        invalid.parameters[Parameter::Tb] = 0.0;
         PhasorDynamics::Exciter::SexsPti<ScalarT, IdxT> invalid_model(&bus, invalid);
         success *= (invalid_model.verify() > 0);
 
@@ -210,6 +213,9 @@ namespace GridKit
       {
         using namespace PhasorDynamics;
         using namespace PhasorDynamics::Exciter;
+        using Data       = SexsPtiData<RealT, IdxT>;
+        using OutputPort = typename Data::OutputPorts;
+        using Terminal   = typename Data::Terminals;
 
         TestStatus success = true;
 
@@ -224,9 +230,9 @@ namespace GridKit
         data.signal[0].signal_id = 3;
         data.signal[0].name      = "EFD";
 
-        auto exciter                     = makeTestData();
-        exciter.ports[SexsPtiPorts::bus] = 1;
-        exciter.ports[SexsPtiPorts::efd] = 3;
+        auto exciter                          = makeTestData();
+        exciter.terminals[Terminal::bus]      = 1;
+        exciter.output_ports[OutputPort::efd] = 3;
         data.sexspti.push_back(exciter);
 
         SystemModel<ScalarT, IdxT> system(data);
@@ -236,7 +242,7 @@ namespace GridKit
         success *= (system.size() == 5);
 
         auto missing_efd = data;
-        missing_efd.sexspti[0].ports.erase(SexsPtiPorts::efd);
+        missing_efd.sexspti[0].output_ports.erase(OutputPort::efd);
         SystemModel<ScalarT, IdxT> missing_efd_system(missing_efd);
         success *= (missing_efd_system.verify() > 0);
 
@@ -247,6 +253,10 @@ namespace GridKit
       {
         using namespace PhasorDynamics;
         using namespace PhasorDynamics::Exciter;
+        using Data       = SexsPtiData<RealT, IdxT>;
+        using InputPort  = typename Data::InputPorts;
+        using OutputPort = typename Data::OutputPorts;
+        using Terminal   = typename Data::Terminals;
 
         TestStatus success = true;
 
@@ -263,17 +273,17 @@ namespace GridKit
         data.signal[1].signal_id = 20;
         data.signal[1].name      = "consumer_efd";
 
-        auto consumer                     = makeTestData();
-        consumer.disambiguation_string    = "consumer";
-        consumer.ports[SexsPtiPorts::bus] = 1;
-        consumer.ports[SexsPtiPorts::efd] = 20;
-        consumer.ports[SexsPtiPorts::vs]  = 10;
+        auto consumer                          = makeTestData();
+        consumer.disambiguation_string         = "consumer";
+        consumer.terminals[Terminal::bus]      = 1;
+        consumer.output_ports[OutputPort::efd] = 20;
+        consumer.input_ports[InputPort::vs]    = 10;
         data.sexspti.push_back(consumer);
 
-        auto source                     = makeTestData();
-        source.disambiguation_string    = "source";
-        source.ports[SexsPtiPorts::bus] = 1;
-        source.ports[SexsPtiPorts::efd] = 10;
+        auto source                          = makeTestData();
+        source.disambiguation_string         = "source";
+        source.terminals[Terminal::bus]      = 1;
+        source.output_ports[OutputPort::efd] = 10;
         data.sexspti.push_back(source);
 
         SystemModel<ScalarT, IdxT> system(data);

--- a/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
@@ -213,9 +213,9 @@ namespace GridKit
       {
         using namespace PhasorDynamics;
         using namespace PhasorDynamics::Exciter;
-        using Data       = SexsPtiData<RealT, IdxT>;
-        using OutputPort = typename Data::OutputPorts;
-        using Terminal   = typename Data::Terminals;
+        using Data         = SexsPtiData<RealT, IdxT>;
+        using SignalOutput = typename Data::SignalOutputs;
+        using Buses        = typename Data::Buses;
 
         TestStatus success = true;
 
@@ -230,9 +230,9 @@ namespace GridKit
         data.signal[0].signal_id = 3;
         data.signal[0].name      = "EFD";
 
-        auto exciter                          = makeTestData();
-        exciter.terminals[Terminal::bus]      = 1;
-        exciter.output_ports[OutputPort::efd] = 3;
+        auto exciter                              = makeTestData();
+        exciter.buses[Buses::bus]                 = 1;
+        exciter.signal_outputs[SignalOutput::efd] = 3;
         data.sexspti.push_back(exciter);
 
         SystemModel<ScalarT, IdxT> system(data);
@@ -242,7 +242,7 @@ namespace GridKit
         success *= (system.size() == 5);
 
         auto missing_efd = data;
-        missing_efd.sexspti[0].output_ports.erase(OutputPort::efd);
+        missing_efd.sexspti[0].signal_outputs.erase(SignalOutput::efd);
         SystemModel<ScalarT, IdxT> missing_efd_system(missing_efd);
         success *= (missing_efd_system.verify() > 0);
 
@@ -253,10 +253,10 @@ namespace GridKit
       {
         using namespace PhasorDynamics;
         using namespace PhasorDynamics::Exciter;
-        using Data       = SexsPtiData<RealT, IdxT>;
-        using InputPort  = typename Data::InputPorts;
-        using OutputPort = typename Data::OutputPorts;
-        using Terminal   = typename Data::Terminals;
+        using Data         = SexsPtiData<RealT, IdxT>;
+        using SignalInput  = typename Data::SignalInputs;
+        using SignalOutput = typename Data::SignalOutputs;
+        using Buses        = typename Data::Buses;
 
         TestStatus success = true;
 
@@ -273,17 +273,17 @@ namespace GridKit
         data.signal[1].signal_id = 20;
         data.signal[1].name      = "consumer_efd";
 
-        auto consumer                          = makeTestData();
-        consumer.disambiguation_string         = "consumer";
-        consumer.terminals[Terminal::bus]      = 1;
-        consumer.output_ports[OutputPort::efd] = 20;
-        consumer.input_ports[InputPort::vs]    = 10;
+        auto consumer                              = makeTestData();
+        consumer.disambiguation_string             = "consumer";
+        consumer.buses[Buses::bus]                 = 1;
+        consumer.signal_outputs[SignalOutput::efd] = 20;
+        consumer.signal_inputs[SignalInput::vs]    = 10;
         data.sexspti.push_back(consumer);
 
-        auto source                          = makeTestData();
-        source.disambiguation_string         = "source";
-        source.terminals[Terminal::bus]      = 1;
-        source.output_ports[OutputPort::efd] = 10;
+        auto source                              = makeTestData();
+        source.disambiguation_string             = "source";
+        source.buses[Buses::bus]                 = 1;
+        source.signal_outputs[SignalOutput::efd] = 10;
         data.sexspti.push_back(source);
 
         SystemModel<ScalarT, IdxT> system(data);

--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -38,12 +38,12 @@ namespace GridKit
       static GenClassicalDataT makeGenClassicalData()
       {
         using Parameter = typename GenClassicalDataT::Parameters;
-        using Port      = typename GenClassicalDataT::Ports;
+        using Terminal  = typename GenClassicalDataT::Terminals;
 
         GenClassicalDataT data;
         data.device_class               = "GenClassical";
         data.disambiguation_string      = "1";
-        data.ports[Port::bus]           = 1;
+        data.terminals[Terminal::bus]   = 1;
         data.parameters[Parameter::p0]  = RealT{1.0};
         data.parameters[Parameter::q0]  = RealT{0.0};
         data.parameters[Parameter::H]   = RealT{0.5};

--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -38,12 +38,12 @@ namespace GridKit
       static GenClassicalDataT makeGenClassicalData()
       {
         using Parameter = typename GenClassicalDataT::Parameters;
-        using Terminal  = typename GenClassicalDataT::Terminals;
+        using Buses     = typename GenClassicalDataT::Buses;
 
         GenClassicalDataT data;
         data.device_class               = "GenClassical";
         data.disambiguation_string      = "1";
-        data.terminals[Terminal::bus]   = 1;
+        data.buses[Buses::bus]          = 1;
         data.parameters[Parameter::p0]  = RealT{1.0};
         data.parameters[Parameter::q0]  = RealT{0.0};
         data.parameters[Parameter::H]   = RealT{0.5};

--- a/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
@@ -29,12 +29,12 @@ namespace GridKit
       static GenrouDataT makeGenrouData()
       {
         using Parameter = typename GenrouDataT::Parameters;
-        using Port      = typename GenrouDataT::Ports;
+        using Terminal  = typename GenrouDataT::Terminals;
 
         GenrouDataT data;
         data.device_class                 = "Genrou";
         data.disambiguation_string        = "1";
-        data.ports[Port::bus]             = 1;
+        data.terminals[Terminal::bus]     = 1;
         data.parameters[Parameter::p0]    = RealT{1.0};
         data.parameters[Parameter::q0]    = RealT{0.05013};
         data.parameters[Parameter::H]     = RealT{3.0};

--- a/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenrouTests.hpp
@@ -29,12 +29,12 @@ namespace GridKit
       static GenrouDataT makeGenrouData()
       {
         using Parameter = typename GenrouDataT::Parameters;
-        using Terminal  = typename GenrouDataT::Terminals;
+        using Buses     = typename GenrouDataT::Buses;
 
         GenrouDataT data;
         data.device_class                 = "Genrou";
         data.disambiguation_string        = "1";
-        data.terminals[Terminal::bus]     = 1;
+        data.buses[Buses::bus]            = 1;
         data.parameters[Parameter::p0]    = RealT{1.0};
         data.parameters[Parameter::q0]    = RealT{0.05013};
         data.parameters[Parameter::H]     = RealT{3.0};

--- a/tests/UnitTests/PhasorDynamics/GensalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GensalTests.hpp
@@ -30,12 +30,12 @@ namespace GridKit
       static GensalDataT makeGensalData()
       {
         using Parameter = typename GensalDataT::Parameters;
-        using Port      = typename GensalDataT::Ports;
+        using Terminal  = typename GensalDataT::Terminals;
 
         GensalDataT data;
         data.device_class                 = "Gensal";
         data.disambiguation_string        = "1";
-        data.ports[Port::bus]             = 1;
+        data.terminals[Terminal::bus]     = 1;
         data.parameters[Parameter::p0]    = RealT{1.0};
         data.parameters[Parameter::q0]    = RealT{0.05013};
         data.parameters[Parameter::H]     = RealT{3.0};

--- a/tests/UnitTests/PhasorDynamics/GensalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GensalTests.hpp
@@ -30,12 +30,12 @@ namespace GridKit
       static GensalDataT makeGensalData()
       {
         using Parameter = typename GensalDataT::Parameters;
-        using Terminal  = typename GensalDataT::Terminals;
+        using Buses     = typename GensalDataT::Buses;
 
         GensalDataT data;
         data.device_class                 = "Gensal";
         data.disambiguation_string        = "1";
-        data.terminals[Terminal::bus]     = 1;
+        data.buses[Buses::bus]            = 1;
         data.parameters[Parameter::p0]    = RealT{1.0};
         data.parameters[Parameter::q0]    = RealT{0.05013};
         data.parameters[Parameter::H]     = RealT{3.0};

--- a/tests/UnitTests/PhasorDynamics/GovernorTgov1Tests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GovernorTgov1Tests.hpp
@@ -63,9 +63,10 @@ namespace GridKit
       {
         TestStatus success = true;
 
-        using BusType          = PhasorDynamics::BusData<ScalarT, IdxT>::BusType;
-        using GenrouParameters = PhasorDynamics::GenrouData<ScalarT, IdxT>::Parameters;
-        using GenrouPorts      = PhasorDynamics::GenrouData<ScalarT, IdxT>::Ports;
+        using BusType     = PhasorDynamics::BusData<ScalarT, IdxT>::BusType;
+        using GenrouDataT = PhasorDynamics::GenrouData<ScalarT, IdxT>;
+        using Parameter   = typename GenrouDataT::Parameters;
+        using Terminal    = typename GenrouDataT::Terminals;
 
         PhasorDynamics::BusData<ScalarT, IdxT> busdata;
         busdata.bus_id   = 0;
@@ -74,26 +75,26 @@ namespace GridKit
         busdata.Vi0      = 0.0;
 
         PhasorDynamics::GenrouData<ScalarT, IdxT> gendata;
-        gendata.ports[GenrouPorts::bus] = 0;
+        gendata.terminals[Terminal::bus] = 0;
 
-        gendata.parameters[GenrouParameters::p0]    = 1.;
-        gendata.parameters[GenrouParameters::q0]    = 0.05013;
-        gendata.parameters[GenrouParameters::H]     = 3.;
-        gendata.parameters[GenrouParameters::D]     = 0.;
-        gendata.parameters[GenrouParameters::Ra]    = 0.;
-        gendata.parameters[GenrouParameters::Tdop]  = 7.;
-        gendata.parameters[GenrouParameters::Tdopp] = .04;
-        gendata.parameters[GenrouParameters::Tqopp] = .05;
-        gendata.parameters[GenrouParameters::Tqop]  = .75;
-        gendata.parameters[GenrouParameters::Xd]    = 2.1;
-        gendata.parameters[GenrouParameters::Xdp]   = 0.2;
-        gendata.parameters[GenrouParameters::Xdpp]  = 0.18;
-        gendata.parameters[GenrouParameters::Xq]    = 0.5;
-        gendata.parameters[GenrouParameters::Xqp]   = 0.5;
-        gendata.parameters[GenrouParameters::Xqpp]  = 0.18;
-        gendata.parameters[GenrouParameters::Xl]    = 0.15;
-        gendata.parameters[GenrouParameters::S10]   = 0.;
-        gendata.parameters[GenrouParameters::S12]   = 0.;
+        gendata.parameters[Parameter::p0]    = 1.;
+        gendata.parameters[Parameter::q0]    = 0.05013;
+        gendata.parameters[Parameter::H]     = 3.;
+        gendata.parameters[Parameter::D]     = 0.;
+        gendata.parameters[Parameter::Ra]    = 0.;
+        gendata.parameters[Parameter::Tdop]  = 7.;
+        gendata.parameters[Parameter::Tdopp] = .04;
+        gendata.parameters[Parameter::Tqopp] = .05;
+        gendata.parameters[Parameter::Tqop]  = .75;
+        gendata.parameters[Parameter::Xd]    = 2.1;
+        gendata.parameters[Parameter::Xdp]   = 0.2;
+        gendata.parameters[Parameter::Xdpp]  = 0.18;
+        gendata.parameters[Parameter::Xq]    = 0.5;
+        gendata.parameters[Parameter::Xqp]   = 0.5;
+        gendata.parameters[Parameter::Xqpp]  = 0.18;
+        gendata.parameters[Parameter::Xl]    = 0.15;
+        gendata.parameters[Parameter::S10]   = 0.;
+        gendata.parameters[Parameter::S12]   = 0.;
 
         PhasorDynamics::Bus<ScalarT, IdxT>             bus(busdata);
         PhasorDynamics::SignalNode<ScalarT, IdxT>      pmech;
@@ -159,9 +160,10 @@ namespace GridKit
       {
         TestStatus success = true;
 
-        using BusType          = typename PhasorDynamics::BusData<ScalarT, IdxT>::BusType;
-        using GenrouParameters = typename PhasorDynamics::GenrouData<ScalarT, IdxT>::Parameters;
-        using GenrouPorts      = typename PhasorDynamics::GenrouData<ScalarT, IdxT>::Ports;
+        using BusType     = typename PhasorDynamics::BusData<ScalarT, IdxT>::BusType;
+        using GenrouDataT = PhasorDynamics::GenrouData<ScalarT, IdxT>;
+        using Parameter   = typename GenrouDataT::Parameters;
+        using Terminal    = typename GenrouDataT::Terminals;
 
         PhasorDynamics::BusData<ScalarT, IdxT> busdata;
         busdata.bus_id   = 0;
@@ -170,26 +172,26 @@ namespace GridKit
         busdata.Vi0      = 0.0;
 
         PhasorDynamics::GenrouData<ScalarT, IdxT> gendata;
-        gendata.ports[GenrouPorts::bus] = 0;
+        gendata.terminals[Terminal::bus] = 0;
 
-        gendata.parameters[GenrouParameters::p0]    = 1.;
-        gendata.parameters[GenrouParameters::q0]    = 0.05013;
-        gendata.parameters[GenrouParameters::H]     = 3.;
-        gendata.parameters[GenrouParameters::D]     = 0.;
-        gendata.parameters[GenrouParameters::Ra]    = 0.;
-        gendata.parameters[GenrouParameters::Tdop]  = 7.;
-        gendata.parameters[GenrouParameters::Tdopp] = .04;
-        gendata.parameters[GenrouParameters::Tqopp] = .05;
-        gendata.parameters[GenrouParameters::Tqop]  = .75;
-        gendata.parameters[GenrouParameters::Xd]    = 2.1;
-        gendata.parameters[GenrouParameters::Xdp]   = 0.2;
-        gendata.parameters[GenrouParameters::Xdpp]  = 0.18;
-        gendata.parameters[GenrouParameters::Xq]    = 0.5;
-        gendata.parameters[GenrouParameters::Xqp]   = 0.5;
-        gendata.parameters[GenrouParameters::Xqpp]  = 0.18;
-        gendata.parameters[GenrouParameters::Xl]    = 0.15;
-        gendata.parameters[GenrouParameters::S10]   = 0.;
-        gendata.parameters[GenrouParameters::S12]   = 0.;
+        gendata.parameters[Parameter::p0]    = 1.;
+        gendata.parameters[Parameter::q0]    = 0.05013;
+        gendata.parameters[Parameter::H]     = 3.;
+        gendata.parameters[Parameter::D]     = 0.;
+        gendata.parameters[Parameter::Ra]    = 0.;
+        gendata.parameters[Parameter::Tdop]  = 7.;
+        gendata.parameters[Parameter::Tdopp] = .04;
+        gendata.parameters[Parameter::Tqopp] = .05;
+        gendata.parameters[Parameter::Tqop]  = .75;
+        gendata.parameters[Parameter::Xd]    = 2.1;
+        gendata.parameters[Parameter::Xdp]   = 0.2;
+        gendata.parameters[Parameter::Xdpp]  = 0.18;
+        gendata.parameters[Parameter::Xq]    = 0.5;
+        gendata.parameters[Parameter::Xqp]   = 0.5;
+        gendata.parameters[Parameter::Xqpp]  = 0.18;
+        gendata.parameters[Parameter::Xl]    = 0.15;
+        gendata.parameters[Parameter::S10]   = 0.;
+        gendata.parameters[Parameter::S12]   = 0.;
 
         PhasorDynamics::Bus<ScalarT, IdxT>             bus(busdata);
         PhasorDynamics::SignalNode<ScalarT, IdxT>      pmech;
@@ -239,9 +241,10 @@ namespace GridKit
       {
         TestStatus success = true;
 
-        using BusType          = PhasorDynamics::BusData<ScalarT, IdxT>::BusType;
-        using GenrouParameters = PhasorDynamics::GenrouData<ScalarT, IdxT>::Parameters;
-        using GenrouPorts      = PhasorDynamics::GenrouData<ScalarT, IdxT>::Ports;
+        using BusType     = PhasorDynamics::BusData<ScalarT, IdxT>::BusType;
+        using GenrouDataT = PhasorDynamics::GenrouData<ScalarT, IdxT>;
+        using Parameter   = typename GenrouDataT::Parameters;
+        using Terminal    = typename GenrouDataT::Terminals;
 
         PhasorDynamics::BusData<ScalarT, IdxT> busdata;
         busdata.bus_id   = 0;
@@ -250,26 +253,26 @@ namespace GridKit
         busdata.Vi0      = 0.0;
 
         PhasorDynamics::GenrouData<ScalarT, IdxT> gendata;
-        gendata.ports[GenrouPorts::bus] = 0;
+        gendata.terminals[Terminal::bus] = 0;
 
-        gendata.parameters[GenrouParameters::p0]    = 1.;
-        gendata.parameters[GenrouParameters::q0]    = 0.05013;
-        gendata.parameters[GenrouParameters::H]     = 3.;
-        gendata.parameters[GenrouParameters::D]     = 0.;
-        gendata.parameters[GenrouParameters::Ra]    = 0.;
-        gendata.parameters[GenrouParameters::Tdop]  = 7.;
-        gendata.parameters[GenrouParameters::Tdopp] = .04;
-        gendata.parameters[GenrouParameters::Tqopp] = .05;
-        gendata.parameters[GenrouParameters::Tqop]  = .75;
-        gendata.parameters[GenrouParameters::Xd]    = 2.1;
-        gendata.parameters[GenrouParameters::Xdp]   = 0.2;
-        gendata.parameters[GenrouParameters::Xdpp]  = 0.18;
-        gendata.parameters[GenrouParameters::Xq]    = 0.5;
-        gendata.parameters[GenrouParameters::Xqp]   = 0.5;
-        gendata.parameters[GenrouParameters::Xqpp]  = 0.18;
-        gendata.parameters[GenrouParameters::Xl]    = 0.15;
-        gendata.parameters[GenrouParameters::S10]   = 0.;
-        gendata.parameters[GenrouParameters::S12]   = 0.;
+        gendata.parameters[Parameter::p0]    = 1.;
+        gendata.parameters[Parameter::q0]    = 0.05013;
+        gendata.parameters[Parameter::H]     = 3.;
+        gendata.parameters[Parameter::D]     = 0.;
+        gendata.parameters[Parameter::Ra]    = 0.;
+        gendata.parameters[Parameter::Tdop]  = 7.;
+        gendata.parameters[Parameter::Tdopp] = .04;
+        gendata.parameters[Parameter::Tqopp] = .05;
+        gendata.parameters[Parameter::Tqop]  = .75;
+        gendata.parameters[Parameter::Xd]    = 2.1;
+        gendata.parameters[Parameter::Xdp]   = 0.2;
+        gendata.parameters[Parameter::Xdpp]  = 0.18;
+        gendata.parameters[Parameter::Xq]    = 0.5;
+        gendata.parameters[Parameter::Xqp]   = 0.5;
+        gendata.parameters[Parameter::Xqpp]  = 0.18;
+        gendata.parameters[Parameter::Xl]    = 0.15;
+        gendata.parameters[Parameter::S10]   = 0.;
+        gendata.parameters[Parameter::S12]   = 0.;
 
         /// Jacobian via DependencyTracking
         std::vector<DependencyTracking::Variable::DependencyMap> dependency_tracking_jacobian = DependencyTrackingJacobian(busdata, gendata);

--- a/tests/UnitTests/PhasorDynamics/GovernorTgov1Tests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GovernorTgov1Tests.hpp
@@ -66,7 +66,7 @@ namespace GridKit
         using BusType     = PhasorDynamics::BusData<ScalarT, IdxT>::BusType;
         using GenrouDataT = PhasorDynamics::GenrouData<ScalarT, IdxT>;
         using Parameter   = typename GenrouDataT::Parameters;
-        using Terminal    = typename GenrouDataT::Terminals;
+        using Buses       = typename GenrouDataT::Buses;
 
         PhasorDynamics::BusData<ScalarT, IdxT> busdata;
         busdata.bus_id   = 0;
@@ -75,7 +75,7 @@ namespace GridKit
         busdata.Vi0      = 0.0;
 
         PhasorDynamics::GenrouData<ScalarT, IdxT> gendata;
-        gendata.terminals[Terminal::bus] = 0;
+        gendata.buses[Buses::bus] = 0;
 
         gendata.parameters[Parameter::p0]    = 1.;
         gendata.parameters[Parameter::q0]    = 0.05013;
@@ -163,7 +163,7 @@ namespace GridKit
         using BusType     = typename PhasorDynamics::BusData<ScalarT, IdxT>::BusType;
         using GenrouDataT = PhasorDynamics::GenrouData<ScalarT, IdxT>;
         using Parameter   = typename GenrouDataT::Parameters;
-        using Terminal    = typename GenrouDataT::Terminals;
+        using Buses       = typename GenrouDataT::Buses;
 
         PhasorDynamics::BusData<ScalarT, IdxT> busdata;
         busdata.bus_id   = 0;
@@ -172,7 +172,7 @@ namespace GridKit
         busdata.Vi0      = 0.0;
 
         PhasorDynamics::GenrouData<ScalarT, IdxT> gendata;
-        gendata.terminals[Terminal::bus] = 0;
+        gendata.buses[Buses::bus] = 0;
 
         gendata.parameters[Parameter::p0]    = 1.;
         gendata.parameters[Parameter::q0]    = 0.05013;
@@ -244,7 +244,7 @@ namespace GridKit
         using BusType     = PhasorDynamics::BusData<ScalarT, IdxT>::BusType;
         using GenrouDataT = PhasorDynamics::GenrouData<ScalarT, IdxT>;
         using Parameter   = typename GenrouDataT::Parameters;
-        using Terminal    = typename GenrouDataT::Terminals;
+        using Buses       = typename GenrouDataT::Buses;
 
         PhasorDynamics::BusData<ScalarT, IdxT> busdata;
         busdata.bus_id   = 0;
@@ -253,7 +253,7 @@ namespace GridKit
         busdata.Vi0      = 0.0;
 
         PhasorDynamics::GenrouData<ScalarT, IdxT> gendata;
-        gendata.terminals[Terminal::bus] = 0;
+        gendata.buses[Buses::bus] = 0;
 
         gendata.parameters[Parameter::p0]    = 1.;
         gendata.parameters[Parameter::q0]    = 0.05013;

--- a/tests/UnitTests/PhasorDynamics/SystemTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/SystemTests.hpp
@@ -21,8 +21,8 @@ namespace GridKit
 {
   namespace Testing
   {
+    using GridKit::PhasorDynamics::BranchBuses;
     using GridKit::PhasorDynamics::BranchParameters;
-    using GridKit::PhasorDynamics::BranchTerminals;
 
     template <class ScalarT, typename IdxT>
     class SystemTests
@@ -75,12 +75,12 @@ namespace GridKit
         data.branch.resize(1);
 
         // Branch 0-1
-        data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
-        data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
-        data.branch[0].parameters[BranchParameters::R]  = 2.0;
-        data.branch[0].parameters[BranchParameters::X]  = 4.0;
-        data.branch[0].parameters[BranchParameters::G]  = 0.2;
-        data.branch[0].parameters[BranchParameters::B]  = 1.2;
+        data.branch[0].buses[BranchBuses::bus1]        = data.bus[0].bus_id;
+        data.branch[0].buses[BranchBuses::bus2]        = data.bus[1].bus_id;
+        data.branch[0].parameters[BranchParameters::R] = 2.0;
+        data.branch[0].parameters[BranchParameters::X] = 4.0;
+        data.branch[0].parameters[BranchParameters::G] = 0.2;
+        data.branch[0].parameters[BranchParameters::B] = 1.2;
 
         // Create an empty system model
         system = new PhasorDynamics::SystemModel<ScalarT, IdxT>(data);
@@ -198,12 +198,12 @@ namespace GridKit
         data.branch.resize(1);
 
         // Branch 0-1
-        data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
-        data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
-        data.branch[0].parameters[BranchParameters::R]  = 2.0;
-        data.branch[0].parameters[BranchParameters::X]  = 4.0;
-        data.branch[0].parameters[BranchParameters::G]  = 0.2;
-        data.branch[0].parameters[BranchParameters::B]  = 1.2;
+        data.branch[0].buses[BranchBuses::bus1]        = data.bus[0].bus_id;
+        data.branch[0].buses[BranchBuses::bus2]        = data.bus[1].bus_id;
+        data.branch[0].parameters[BranchParameters::R] = 2.0;
+        data.branch[0].parameters[BranchParameters::X] = 4.0;
+        data.branch[0].parameters[BranchParameters::G] = 0.2;
+        data.branch[0].parameters[BranchParameters::B] = 1.2;
 
         // Jacobian via DependencyTracking
         std::vector<DependencyTracking::Variable::DependencyMap> dependency_tracking_jacobian = DependencyTrackingJacobian(data);

--- a/tests/UnitTests/PhasorDynamics/SystemTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/SystemTests.hpp
@@ -22,7 +22,7 @@ namespace GridKit
   namespace Testing
   {
     using GridKit::PhasorDynamics::BranchParameters;
-    using GridKit::PhasorDynamics::BranchPorts;
+    using GridKit::PhasorDynamics::BranchTerminals;
 
     template <class ScalarT, typename IdxT>
     class SystemTests
@@ -75,12 +75,12 @@ namespace GridKit
         data.branch.resize(1);
 
         // Branch 0-1
-        data.branch[0].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-        data.branch[0].ports[BranchPorts::bus2]        = data.bus[1].bus_id;
-        data.branch[0].parameters[BranchParameters::R] = 2.0;
-        data.branch[0].parameters[BranchParameters::X] = 4.0;
-        data.branch[0].parameters[BranchParameters::G] = 0.2;
-        data.branch[0].parameters[BranchParameters::B] = 1.2;
+        data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
+        data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
+        data.branch[0].parameters[BranchParameters::R]  = 2.0;
+        data.branch[0].parameters[BranchParameters::X]  = 4.0;
+        data.branch[0].parameters[BranchParameters::G]  = 0.2;
+        data.branch[0].parameters[BranchParameters::B]  = 1.2;
 
         // Create an empty system model
         system = new PhasorDynamics::SystemModel<ScalarT, IdxT>(data);
@@ -198,12 +198,12 @@ namespace GridKit
         data.branch.resize(1);
 
         // Branch 0-1
-        data.branch[0].ports[BranchPorts::bus1]        = data.bus[0].bus_id;
-        data.branch[0].ports[BranchPorts::bus2]        = data.bus[1].bus_id;
-        data.branch[0].parameters[BranchParameters::R] = 2.0;
-        data.branch[0].parameters[BranchParameters::X] = 4.0;
-        data.branch[0].parameters[BranchParameters::G] = 0.2;
-        data.branch[0].parameters[BranchParameters::B] = 1.2;
+        data.branch[0].terminals[BranchTerminals::bus1] = data.bus[0].bus_id;
+        data.branch[0].terminals[BranchTerminals::bus2] = data.bus[1].bus_id;
+        data.branch[0].parameters[BranchParameters::R]  = 2.0;
+        data.branch[0].parameters[BranchParameters::X]  = 4.0;
+        data.branch[0].parameters[BranchParameters::G]  = 0.2;
+        data.branch[0].parameters[BranchParameters::B]  = 1.2;
 
         // Jacobian via DependencyTracking
         std::vector<DependencyTracking::Variable::DependencyMap> dependency_tracking_jacobian = DependencyTrackingJacobian(data);

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -116,8 +116,8 @@ namespace GridKit
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::B]) == 0.0;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::tap]) == 1.05;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::phase]) == 0.1;
-        success *= result.branch[0].terminals[BranchTerminals::bus1] == 1;
-        success *= result.branch[0].terminals[BranchTerminals::bus2] == 2;
+        success *= result.branch[0].buses[BranchBuses::bus1] == 1;
+        success *= result.branch[0].buses[BranchBuses::bus2] == 2;
         success *= result.branch[0].disambiguation_string == "1";
         success *= result.branch[0].monitored_variables.empty();
 
@@ -139,7 +139,7 @@ namespace GridKit
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xl]) == 0.15;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S10]) == 0.0;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S12]) == 0.0;
-        success *= result.genrou[0].terminals[GenrouTerminals::bus] == 1;
+        success *= result.genrou[0].buses[GenrouBuses::bus] == 1;
         success *= result.genrou[0].disambiguation_string == "1";
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::delta);
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::omega);
@@ -148,7 +148,7 @@ namespace GridKit
         success *= std::get<RealT>(result.gensal[0].parameters[GensalParameters::q0]) == 0.05013;
         success *= std::get<RealT>(result.gensal[0].parameters[GensalParameters::Xd]) == 2.1;
         success *= std::get<RealT>(result.gensal[0].parameters[GensalParameters::Xq]) == 0.5;
-        success *= result.gensal[0].terminals[GensalTerminals::bus] == 1;
+        success *= result.gensal[0].buses[GensalBuses::bus] == 1;
         success *= result.gensal[0].disambiguation_string == "2";
         success *= result.gensal[0].monitored_variables.contains(GensalMonitorableVariables::delta);
         success *= result.gensal[0].monitored_variables.contains(GensalMonitorableVariables::omega);
@@ -156,7 +156,7 @@ namespace GridKit
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::R]) == 0.0;
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::X]) == 1e-3;
         success *= !std::get<bool>(result.bus_fault[0].parameters[BusFaultParameters::state0]);
-        success *= result.bus_fault[0].terminals[BusFaultTerminals::bus] == 1;
+        success *= result.bus_fault[0].buses[BusFaultBuses::bus] == 1;
         success *= result.bus_fault[0].disambiguation_string == "1";
         success *= result.bus_fault[0].monitored_variables.empty();
 
@@ -249,8 +249,8 @@ namespace GridKit
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::B]) == 0.0;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::tap]) == 1.05;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::phase]) == 0.1;
-        success *= result.branch[0].terminals[BranchTerminals::bus1] == 1;
-        success *= result.branch[0].terminals[BranchTerminals::bus2] == 2;
+        success *= result.branch[0].buses[BranchBuses::bus1] == 1;
+        success *= result.branch[0].buses[BranchBuses::bus2] == 2;
         success *= result.branch[0].disambiguation_string == "BR1";
         success *= result.branch[0].monitored_variables.empty();
 
@@ -272,10 +272,10 @@ namespace GridKit
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xl]) == 0.15;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S10]) == 0.0;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S12]) == 0.0;
-        success *= result.genrou[0].terminals[GenrouTerminals::bus] == 1;
-        success *= result.genrou[0].output_ports[GenrouOutputPorts::speed] == 1;
-        success *= result.genrou[0].input_ports[GenrouInputPorts::pmech] == 2;
-        success *= result.genrou[0].input_ports[GenrouInputPorts::efd] == 3;
+        success *= result.genrou[0].buses[GenrouBuses::bus] == 1;
+        success *= result.genrou[0].signal_outputs[GenrouSignalOutputs::speed] == 1;
+        success *= result.genrou[0].signal_inputs[GenrouSignalInputs::pmech] == 2;
+        success *= result.genrou[0].signal_inputs[GenrouSignalInputs::efd] == 3;
         success *= result.genrou[0].disambiguation_string == "DV1";
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::delta);
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::omega);
@@ -287,9 +287,9 @@ namespace GridKit
         success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Pvmax]) == 0;
         success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Pvmin]) == 1;
         success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Dt]) == 0;
-        success *= result.gov[0].terminals[Governor::Tgov1Terminals::bus] == 1;
-        success *= result.gov[0].input_ports[Governor::Tgov1InputPorts::speed] == 1;
-        success *= result.gov[0].output_ports[Governor::Tgov1OutputPorts::pmech] == 2;
+        success *= result.gov[0].buses[Governor::Tgov1Buses::bus] == 1;
+        success *= result.gov[0].signal_inputs[Governor::Tgov1SignalInputs::speed] == 1;
+        success *= result.gov[0].signal_outputs[Governor::Tgov1SignalOutputs::pmech] == 2;
         success *= result.gov[0].disambiguation_string == "DV2";
 
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Tr]) == 0.0;
@@ -306,9 +306,9 @@ namespace GridKit
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Se1]) == 0.04;
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Se2]) == 0.33;
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Ispdlim]) == 0.0;
-        success *= result.exciter[0].terminals[Exciter::Ieeet1Terminals::bus] == 1;
-        success *= result.exciter[0].input_ports[Exciter::Ieeet1InputPorts::speed] == 1;
-        success *= result.exciter[0].output_ports[Exciter::Ieeet1OutputPorts::efd] == 3;
+        success *= result.exciter[0].buses[Exciter::Ieeet1Buses::bus] == 1;
+        success *= result.exciter[0].signal_inputs[Exciter::Ieeet1SignalInputs::speed] == 1;
+        success *= result.exciter[0].signal_outputs[Exciter::Ieeet1SignalOutputs::efd] == 3;
         success *= result.exciter[0].disambiguation_string == "DV3";
 
         success *= std::get<RealT>(result.sexspti[0].parameters[Exciter::SexsPtiParameters::Ta]) == 0.1;
@@ -317,14 +317,14 @@ namespace GridKit
         success *= std::get<RealT>(result.sexspti[0].parameters[Exciter::SexsPtiParameters::K]) == 10.0;
         success *= std::get<RealT>(result.sexspti[0].parameters[Exciter::SexsPtiParameters::Efdmax]) == 5.0;
         success *= std::get<RealT>(result.sexspti[0].parameters[Exciter::SexsPtiParameters::Efdmin]) == -5.0;
-        success *= result.sexspti[0].terminals[Exciter::SexsPtiTerminals::bus] == 1;
-        success *= result.sexspti[0].output_ports[Exciter::SexsPtiOutputPorts::efd] == 3;
+        success *= result.sexspti[0].buses[Exciter::SexsPtiBuses::bus] == 1;
+        success *= result.sexspti[0].signal_outputs[Exciter::SexsPtiSignalOutputs::efd] == 3;
         success *= result.sexspti[0].disambiguation_string == "DV4";
 
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::R]) == 0.0;
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::X]) == 1e-3;
         success *= !std::get<bool>(result.bus_fault[0].parameters[BusFaultParameters::state0]);
-        success *= result.bus_fault[0].terminals[BusFaultTerminals::bus] == 1;
+        success *= result.bus_fault[0].buses[BusFaultBuses::bus] == 1;
         success *= result.bus_fault[0].disambiguation_string == "1";
         success *= result.bus_fault[0].monitored_variables.empty();
 

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -116,8 +116,8 @@ namespace GridKit
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::B]) == 0.0;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::tap]) == 1.05;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::phase]) == 0.1;
-        success *= result.branch[0].ports[BranchPorts::bus1] == 1;
-        success *= result.branch[0].ports[BranchPorts::bus2] == 2;
+        success *= result.branch[0].terminals[BranchTerminals::bus1] == 1;
+        success *= result.branch[0].terminals[BranchTerminals::bus2] == 2;
         success *= result.branch[0].disambiguation_string == "1";
         success *= result.branch[0].monitored_variables.empty();
 
@@ -139,7 +139,7 @@ namespace GridKit
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xl]) == 0.15;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S10]) == 0.0;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S12]) == 0.0;
-        success *= result.genrou[0].ports[GenrouPorts::bus] == 1;
+        success *= result.genrou[0].terminals[GenrouTerminals::bus] == 1;
         success *= result.genrou[0].disambiguation_string == "1";
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::delta);
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::omega);
@@ -148,7 +148,7 @@ namespace GridKit
         success *= std::get<RealT>(result.gensal[0].parameters[GensalParameters::q0]) == 0.05013;
         success *= std::get<RealT>(result.gensal[0].parameters[GensalParameters::Xd]) == 2.1;
         success *= std::get<RealT>(result.gensal[0].parameters[GensalParameters::Xq]) == 0.5;
-        success *= result.gensal[0].ports[GensalPorts::bus] == 1;
+        success *= result.gensal[0].terminals[GensalTerminals::bus] == 1;
         success *= result.gensal[0].disambiguation_string == "2";
         success *= result.gensal[0].monitored_variables.contains(GensalMonitorableVariables::delta);
         success *= result.gensal[0].monitored_variables.contains(GensalMonitorableVariables::omega);
@@ -156,7 +156,7 @@ namespace GridKit
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::R]) == 0.0;
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::X]) == 1e-3;
         success *= !std::get<bool>(result.bus_fault[0].parameters[BusFaultParameters::state0]);
-        success *= result.bus_fault[0].ports[BusFaultPorts::bus] == 1;
+        success *= result.bus_fault[0].terminals[BusFaultTerminals::bus] == 1;
         success *= result.bus_fault[0].disambiguation_string == "1";
         success *= result.bus_fault[0].monitored_variables.empty();
 
@@ -249,8 +249,8 @@ namespace GridKit
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::B]) == 0.0;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::tap]) == 1.05;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::phase]) == 0.1;
-        success *= result.branch[0].ports[BranchPorts::bus1] == 1;
-        success *= result.branch[0].ports[BranchPorts::bus2] == 2;
+        success *= result.branch[0].terminals[BranchTerminals::bus1] == 1;
+        success *= result.branch[0].terminals[BranchTerminals::bus2] == 2;
         success *= result.branch[0].disambiguation_string == "BR1";
         success *= result.branch[0].monitored_variables.empty();
 
@@ -272,10 +272,10 @@ namespace GridKit
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::Xl]) == 0.15;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S10]) == 0.0;
         success *= std::get<RealT>(result.genrou[0].parameters[GenrouParameters::S12]) == 0.0;
-        success *= result.genrou[0].ports[GenrouPorts::bus] == 1;
-        success *= result.genrou[0].ports[GenrouPorts::speed] == 1;
-        success *= result.genrou[0].ports[GenrouPorts::pmech] == 2;
-        success *= result.genrou[0].ports[GenrouPorts::efd] == 3;
+        success *= result.genrou[0].terminals[GenrouTerminals::bus] == 1;
+        success *= result.genrou[0].output_ports[GenrouOutputPorts::speed] == 1;
+        success *= result.genrou[0].input_ports[GenrouInputPorts::pmech] == 2;
+        success *= result.genrou[0].input_ports[GenrouInputPorts::efd] == 3;
         success *= result.genrou[0].disambiguation_string == "DV1";
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::delta);
         success *= result.genrou[0].monitored_variables.contains(GenrouMonitorableVariables::omega);
@@ -287,9 +287,9 @@ namespace GridKit
         success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Pvmax]) == 0;
         success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Pvmin]) == 1;
         success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Dt]) == 0;
-        success *= result.gov[0].ports[Governor::Tgov1Ports::bus] == 1;
-        success *= result.gov[0].ports[Governor::Tgov1Ports::speed] == 1;
-        success *= result.gov[0].ports[Governor::Tgov1Ports::pmech] == 2;
+        success *= result.gov[0].terminals[Governor::Tgov1Terminals::bus] == 1;
+        success *= result.gov[0].input_ports[Governor::Tgov1InputPorts::speed] == 1;
+        success *= result.gov[0].output_ports[Governor::Tgov1OutputPorts::pmech] == 2;
         success *= result.gov[0].disambiguation_string == "DV2";
 
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Tr]) == 0.0;
@@ -306,9 +306,9 @@ namespace GridKit
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Se1]) == 0.04;
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Se2]) == 0.33;
         success *= std::get<RealT>(result.exciter[0].parameters[Exciter::Ieeet1Parameters::Ispdlim]) == 0.0;
-        success *= result.exciter[0].ports[Exciter::Ieeet1Ports::bus] == 1;
-        success *= result.exciter[0].ports[Exciter::Ieeet1Ports::speed] == 1;
-        success *= result.exciter[0].ports[Exciter::Ieeet1Ports::efd] == 3;
+        success *= result.exciter[0].terminals[Exciter::Ieeet1Terminals::bus] == 1;
+        success *= result.exciter[0].input_ports[Exciter::Ieeet1InputPorts::speed] == 1;
+        success *= result.exciter[0].output_ports[Exciter::Ieeet1OutputPorts::efd] == 3;
         success *= result.exciter[0].disambiguation_string == "DV3";
 
         success *= std::get<RealT>(result.sexspti[0].parameters[Exciter::SexsPtiParameters::Ta]) == 0.1;
@@ -317,14 +317,14 @@ namespace GridKit
         success *= std::get<RealT>(result.sexspti[0].parameters[Exciter::SexsPtiParameters::K]) == 10.0;
         success *= std::get<RealT>(result.sexspti[0].parameters[Exciter::SexsPtiParameters::Efdmax]) == 5.0;
         success *= std::get<RealT>(result.sexspti[0].parameters[Exciter::SexsPtiParameters::Efdmin]) == -5.0;
-        success *= result.sexspti[0].ports[Exciter::SexsPtiPorts::bus] == 1;
-        success *= result.sexspti[0].ports[Exciter::SexsPtiPorts::efd] == 3;
+        success *= result.sexspti[0].terminals[Exciter::SexsPtiTerminals::bus] == 1;
+        success *= result.sexspti[0].output_ports[Exciter::SexsPtiOutputPorts::efd] == 3;
         success *= result.sexspti[0].disambiguation_string == "DV4";
 
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::R]) == 0.0;
         success *= std::get<RealT>(result.bus_fault[0].parameters[BusFaultParameters::X]) == 1e-3;
         success *= !std::get<bool>(result.bus_fault[0].parameters[BusFaultParameters::state0]);
-        success *= result.bus_fault[0].ports[BusFaultPorts::bus] == 1;
+        success *= result.bus_fault[0].terminals[BusFaultTerminals::bus] == 1;
         success *= result.bus_fault[0].disambiguation_string == "1";
         success *= result.bus_fault[0].monitored_variables.empty();
 


### PR DESCRIPTION
## Description

This PR updates PhasorDynamics component wiring so signal nodes are associated with input/output ports instead of internal/external variable enums.

Closes #407

@PhilipFackler, what are your thoughts? Managed to do it with no `*.case.json` changes, which lets us do the INPUT_FORMAT changes and documentation with a few changes in code once we get to it

## Proposed changes

- Split component connection data into terminals, input ports, and output ports.
- Keep the existing flat JSON `"ports"` format, but parse entries into the new internal maps.
- Update `ComponentSignals`, `SystemModel`, components, examples, and tests to use port enums for signal wiring.
- Remove the old variable-enum signal helpers.

## Checklist

- [x] All tests pass for the focused coverage.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [ ] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR.

## Further comments

I organized the commits so we can roll back if the scope is too big, but it was mechanical and straightforward after the main changes were in. 