### PR TITLE
`GRIDKIT_ENABLE_THREADS` to use std::async in `ContingencyAnalyis`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ option(GridKit_ENABLE_UBSAN "Enable the undefined behavior sanitizer" OFF)
 # Enable OpenMP
 option(GridKit_ENABLE_OPENMP "Enable OpenMP" OFF)
 
+# Enable Threads
+option(GridKit_ENABLE_THREADS "Enable THreads" OFF)
+
 # This allows use of "GRIDKIT_*" versions of the above options
 list(
   APPEND
@@ -138,6 +141,10 @@ endif()
 
 if(GRIDKIT_ENABLE_OPENMP)
   find_package(OpenMP REQUIRED)
+endif()
+
+if(GRIDKIT_ENABLE_THREADS)
+  find_package(Threads REQUIRED)
 endif()
 
 # Macro that adds libraries

--- a/GridKit/Definitions.hpp.in
+++ b/GridKit/Definitions.hpp.in
@@ -1,7 +1,9 @@
 #pragma once
 
 #cmakedefine GRIDKIT_ENABLE_ENZYME
+#cmakedefine GRIDKIT_ENABLE_OPENMP
 #cmakedefine GRIDKIT_ENABLE_SUNDIALS_SPARSE
+#cmakedefine GRIDKIT_ENABLE_THREADS
 
 #define GRIDKIT_VERSION "@GridKit_VERSION@"
 

--- a/application/PhasorDynamics/CMakeLists.txt
+++ b/application/PhasorDynamics/CMakeLists.txt
@@ -26,6 +26,10 @@ if(GRIDKIT_ENABLE_OPENMP)
   target_link_libraries(ContingencyAnalysis PUBLIC OpenMP::OpenMP_CXX)
 endif()
 
+if(GRIDKIT_ENABLE_THREADS)
+  target_link_libraries(ContingencyAnalysis PUBLIC Threads::Threads)
+endif()
+
 install(
   TARGETS DynamicSimulation
   EXPORT gridkit-targets

--- a/application/PhasorDynamics/ContingencyAnalysis.cpp
+++ b/application/PhasorDynamics/ContingencyAnalysis.cpp
@@ -159,16 +159,16 @@ int main(int argc, const char* argv[])
 
   auto faults   = study_data.model_data.bus_fault;
   auto stat_vec = std::vector<TestStatus>(faults.size(), true);
- 
+
   // Use std::async if threads are available (so far, std::async has out-performed OpenMP)
   // Otherwise, use OpenMP if available
   // Fall back to serial if neither threads or OpenMP are available
 #ifdef GRIDKIT_ENABLE_THREADS
   runStudyAsync(study_data, stat_vec);
 #else
-#ifdef _OPENMP 
+#ifdef _OPENMP
   runStudyOpenMP(study_data, stat_vec);
-#else 
+#else
   runStudySerial(study_data, stat_vec);
 #endif // _OPENMP
 #endif // GRIDKIT_ENABLE_THREADS

--- a/application/PhasorDynamics/ContingencyAnalysis.cpp
+++ b/application/PhasorDynamics/ContingencyAnalysis.cpp
@@ -163,15 +163,13 @@ int main(int argc, const char* argv[])
   // Use std::async if threads are available (so far, std::async has out-performed OpenMP)
   // Otherwise, use OpenMP if available
   // Fall back to serial if neither threads or OpenMP are available
-#ifdef GRIDKIT_ENABLE_THREADS
+#if defined(GRIDKIT_ENABLE_THREADS)
   runStudyAsync(study_data, stat_vec);
-#else
-#ifdef _OPENMP
+#elif defined(_OPENMP)
   runStudyOpenMP(study_data, stat_vec);
 #else
   runStudySerial(study_data, stat_vec);
-#endif // _OPENMP
-#endif // GRIDKIT_ENABLE_THREADS
+#endif
 
   const auto stop = Clock::now();
   const auto dur  = std::chrono::duration<double>(stop - start);

--- a/application/PhasorDynamics/ContingencyAnalysis.cpp
+++ b/application/PhasorDynamics/ContingencyAnalysis.cpp
@@ -115,6 +115,7 @@ void runStudySerial(const StudyData& study_data, std::vector<TestStatus>& stat_v
   }
 }
 
+#ifdef GRIDKIT_ENABLE_THREADS
 void runStudyAsync(const StudyData& study_data, std::vector<TestStatus>& stat_vec)
 {
   auto n_faults = study_data.model_data.bus_fault.size();
@@ -133,6 +134,7 @@ void runStudyAsync(const StudyData& study_data, std::vector<TestStatus>& stat_ve
     stat_vec[i] = stat;
   }
 }
+#endif
 
 #ifdef _OPENMP
 void runStudyOpenMP(const StudyData& study_data, std::vector<TestStatus>& stat_vec)
@@ -157,13 +159,19 @@ int main(int argc, const char* argv[])
 
   auto faults   = study_data.model_data.bus_fault;
   auto stat_vec = std::vector<TestStatus>(faults.size(), true);
-
-  // runStudySerial(study_data, stat_vec);
-#ifdef _OPENMP
-  runStudyOpenMP(study_data, stat_vec);
-#else
+ 
+  // Use std::async if threads are available (so far, std::async has out-performed OpenMP)
+  // Otherwise, use OpenMP if available
+  // Fall back to serial if neither threads or OpenMP are available
+#ifdef GRIDKIT_ENABLE_THREADS
   runStudyAsync(study_data, stat_vec);
-#endif
+#else
+#ifdef _OPENMP 
+  runStudyOpenMP(study_data, stat_vec);
+#else 
+  runStudySerial(study_data, stat_vec);
+#endif // _OPENMP
+#endif // GRIDKIT_ENABLE_THREADS
 
   const auto stop = Clock::now();
   const auto dur  = std::chrono::duration<double>(stop - start);


### PR DESCRIPTION
## Description
 
`std::async` requires `Threads`. This fixes a bug where trying to run `ContingencyAnalyis` on a platform that does not provide `Threads` by default (e.g. OLCF Andes) fails. 

```
ld: CMakeFiles/ContingencyAnalysis.dir/ContingencyAnalysis.cpp.o: in function `std::thread::_M_thread_deps_never_run()':
/autofs/nccs-svm1_sw/andes/gcc/14.2.0/bin/../lib/gcc/x86_64-pc-linux-gnu/14.2.0/../../../../include/c++/14.2.0/bits/std_thread.h:154:(.text._ZNSt6thread24_M_thread_deps_never_runEv[_ZNSt6thread24_M_thread_deps_never_runEv]+0x2): undefined reference to `pthread_create'
ld: /autofs/nccs-svm1_sw/andes/gcc/14.2.0/bin/../lib/gcc/x86_64-pc-linux-gnu/14.2.0/../../../../include/c++/14.2.0/bits/std_thread.h:155:(.text._ZNSt6thread24_M_thread_deps_never_runEv[_ZNSt6thread24_M_thread_deps_never_runEv]+0x8): undefined reference to `pthread_join'
```
 
 ## Proposed changes
 - Added `GRIDKIT_ENABLE_THREADS`
 - Added corresponding CMake `find_package` and `target_link_library` for `Threads`.
 - Added guards for `ContingencyAnalysis` `runStudyAsync`
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments

This requires the user to set `GRIDKIT_ENABLE_THREADS=On` when needed. The previous default behavior was to use `std::async` when `GRIDKIT_ENABLE_OPENMP=Off`. We now default to the serial implementation.
cc @lukelowry 