### PR TITLE
Fix phasor_dynamics_systemmodel targets.

### DIFF
--- a/GridKit/Model/PhasorDynamics/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/CMakeLists.txt
@@ -29,30 +29,6 @@ target_link_libraries(
   phasor_dynamics_components_dependency_tracking
   INTERFACE GridKit::phasor_dynamics_core)
 
-gridkit_add_library(
-  phasor_dynamics_systemmodel
-  SOURCES SystemModel.cpp SystemModelData.cpp
-  HEADERS SystemModel.hpp SystemModelData.hpp
-  LINK_LIBRARIES PUBLIC GridKit::phasor_dynamics_core
-  INCLUDE_DIRECTORIES
-    PRIVATE
-    ${GRIDKIT_THIRD_PARTY_DIR}/nlohmann-json/include
-    PRIVATE
-    ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
-
-gridkit_add_library(
-  phasor_dynamics_systemmodel_dependency_tracking
-  SOURCES SystemModelDependencyTracking.cpp
-  HEADERS SystemModel.hpp
-  LINK_LIBRARIES PUBLIC GridKit::phasor_dynamics_core)
-
-target_link_libraries(
-  phasor_dynamics_components
-  INTERFACE GridKit::phasor_dynamics_systemmodel)
-target_link_libraries(
-  phasor_dynamics_components_dependency_tracking
-  INTERFACE GridKit::phasor_dynamics_systemmodel_dependency_tracking)
-
 add_subdirectory(Branch)
 add_subdirectory(Bus)
 add_subdirectory(BusFault)
@@ -69,6 +45,25 @@ add_subdirectory(SignalNode)
 add_library(GridKit::phasor_dynamics_components ALIAS phasor_dynamics_components)
 add_library(GridKit::phasor_dynamics_components_dependency_tracking ALIAS
             phasor_dynamics_components_dependency_tracking)
+
+gridkit_add_library(
+  phasor_dynamics_systemmodel
+  SOURCES SystemModel.cpp SystemModelData.cpp
+  HEADERS SystemModel.hpp SystemModelData.hpp
+  LINK_LIBRARIES PUBLIC GridKit::phasor_dynamics_core
+                 PUBLIC GridKit::phasor_dynamics_components
+  INCLUDE_DIRECTORIES
+    PRIVATE
+    ${GRIDKIT_THIRD_PARTY_DIR}/nlohmann-json/include
+    PRIVATE
+    ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+
+gridkit_add_library(
+  phasor_dynamics_systemmodel_dependency_tracking
+  SOURCES SystemModelDependencyTracking.cpp
+  HEADERS SystemModel.hpp
+  LINK_LIBRARIES PUBLIC GridKit::phasor_dynamics_core
+                 PUBLIC GridKit::phasor_dynamics_components_dependency_tracking)
 
 install(TARGETS phasor_dynamics_components phasor_dynamics_components_dependency_tracking
         EXPORT gridkit-targets)

--- a/GridKit/Model/PhasorDynamics/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/CMakeLists.txt
@@ -50,8 +50,11 @@ gridkit_add_library(
   phasor_dynamics_systemmodel
   SOURCES SystemModel.cpp SystemModelData.cpp
   HEADERS SystemModel.hpp SystemModelData.hpp
-  LINK_LIBRARIES PUBLIC GridKit::phasor_dynamics_core
-                 PUBLIC GridKit::phasor_dynamics_components
+  LINK_LIBRARIES
+    PUBLIC
+    GridKit::phasor_dynamics_core
+    PUBLIC
+    GridKit::phasor_dynamics_components
   INCLUDE_DIRECTORIES
     PRIVATE
     ${GRIDKIT_THIRD_PARTY_DIR}/nlohmann-json/include
@@ -62,8 +65,11 @@ gridkit_add_library(
   phasor_dynamics_systemmodel_dependency_tracking
   SOURCES SystemModelDependencyTracking.cpp
   HEADERS SystemModel.hpp
-  LINK_LIBRARIES PUBLIC GridKit::phasor_dynamics_core
-                 PUBLIC GridKit::phasor_dynamics_components_dependency_tracking)
+  LINK_LIBRARIES
+    PUBLIC
+    GridKit::phasor_dynamics_core
+    PUBLIC
+    GridKit::phasor_dynamics_components_dependency_tracking)
 
 install(TARGETS phasor_dynamics_components phasor_dynamics_components_dependency_tracking
         EXPORT gridkit-targets)

--- a/application/PhasorDynamics/CMakeLists.txt
+++ b/application/PhasorDynamics/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(DynamicSimulation DynamicSimulation.cpp)
 target_link_libraries(
   DynamicSimulation
-  PUBLIC GridKit::phasor_dynamics_components
+  PUBLIC GridKit::phasor_dynamics_systemmodel
          GridKit::solvers_dyn
          GridKit::Utilities
          GridKit::testing)
@@ -13,7 +13,7 @@ target_include_directories(
 add_executable(ContingencyAnalysis ContingencyAnalysis.cpp)
 target_link_libraries(
   ContingencyAnalysis
-  PUBLIC GridKit::phasor_dynamics_components
+  PUBLIC GridKit::phasor_dynamics_systemmodel
          GridKit::solvers_dyn
          GridKit::Utilities
          GridKit::testing)

--- a/examples/Consumer/CMakeLists.txt
+++ b/examples/Consumer/CMakeLists.txt
@@ -18,7 +18,7 @@ if(GRIDKIT_ENABLE_SUNDIALS)
   list(
     APPEND
     GRIDKIT_CONSUMER_TEST_LINK_LIBRARIES
-    GridKit::phasor_dynamics_components
+    GridKit::phasor_dynamics_systemmodel
     GridKit::solvers_dyn)
 else()
   install(

--- a/examples/PhasorDynamics/Small/TenGen/Classical/CMakeLists.txt
+++ b/examples/PhasorDynamics/Small/TenGen/Classical/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(TenGenClassical TenGenClassical.cpp)
 target_link_libraries(
-  TenGenClassical GridKit::phasor_dynamics_components GridKit::solvers_dyn)
+  TenGenClassical GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS TenGenClassical RUNTIME DESTINATION bin)
 
 # Not used for tesing for now.

--- a/examples/PhasorDynamics/Small/TenGen/Genrou/CMakeLists.txt
+++ b/examples/PhasorDynamics/Small/TenGen/Genrou/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(TenGenGenrou TenGenGenrou.cpp)
 target_link_libraries(
-  TenGenGenrou GridKit::phasor_dynamics_components GridKit::solvers_dyn)
+  TenGenGenrou GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS TenGenGenrou RUNTIME DESTINATION bin)
 
 # Not used for tesing for now.

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/CMakeLists.txt
@@ -2,13 +2,13 @@ gridkit_example_current_install_path(_install_path)
 
 add_executable(ThreeBusBasic ThreeBusBasic.cpp)
 target_link_libraries(
-  ThreeBusBasic GridKit::phasor_dynamics_components GridKit::solvers_dyn)
+  ThreeBusBasic GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS ThreeBusBasic RUNTIME DESTINATION ${_install_path})
 
 add_executable(ThreeBusBasicJson ThreeBusBasicJson.cpp)
 target_link_libraries(
   ThreeBusBasicJson
-  GridKit::phasor_dynamics_components
+  GridKit::phasor_dynamics_systemmodel
   GridKit::solvers_dyn
   GridKit::utilities_cli_args
   GridKit::testing)

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/CMakeLists.txt
@@ -7,12 +7,12 @@ gridkit_example_current_install_path(_install_path)
 
 add_executable(ThreeBusClassical ThreeBusClassical.cpp)
 target_link_libraries(
-  ThreeBusClassical GridKit::phasor_dynamics_components GridKit::solvers_dyn)
+  ThreeBusClassical GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS ThreeBusClassical RUNTIME DESTINATION ${_install_path})
 
 add_executable(ThreeBusClassicalJson ThreeBusClassicalJson.cpp)
 target_link_libraries(
-  ThreeBusClassicalJson GridKit::phasor_dynamics_components GridKit::solvers_dyn)
+  ThreeBusClassicalJson GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS ThreeBusClassicalJson RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(ThreeBusClassical.json)
 

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ZipLoad/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ZipLoad/CMakeLists.txt
@@ -2,6 +2,6 @@ gridkit_example_current_install_path(_install_path)
 
 add_executable(ThreeBusZipLoadJson ThreeBusZipLoadJson.cpp)
 target_link_libraries(
-  ThreeBusZipLoadJson GridKit::phasor_dynamics_components GridKit::solvers_dyn)
+  ThreeBusZipLoadJson GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS ThreeBusZipLoadJson RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(ThreeBusZipLoad.json)

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/CMakeLists.txt
@@ -2,12 +2,12 @@ gridkit_example_current_install_path(_install_path)
 
 add_executable(TwoBusBasic TwoBusBasic.cpp)
 target_link_libraries(
-  TwoBusBasic GridKit::phasor_dynamics_components GridKit::solvers_dyn)
+  TwoBusBasic GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS TwoBusBasic RUNTIME DESTINATION ${_install_path})
 
 add_executable(TwoBusBasicJson TwoBusBasicJson.cpp)
 target_link_libraries(
-  TwoBusBasicJson GridKit::phasor_dynamics_components GridKit::solvers_dyn)
+  TwoBusBasicJson GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS TwoBusBasicJson RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusBasic.case.json)
 

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
@@ -2,16 +2,12 @@ gridkit_example_current_install_path(_install_path)
 
 add_executable(TwoBusIeeet1 TwoBusIeeet1.cpp)
 target_link_libraries(
-  TwoBusIeeet1
-  GridKit::phasor_dynamics_systemmodel
-  GridKit::solvers_dyn)
+  TwoBusIeeet1 GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS TwoBusIeeet1 RUNTIME DESTINATION ${_install_path})
 
 add_executable(TwoBusIeeet1Json TwoBusIeeet1Json.cpp)
 target_link_libraries(
-  TwoBusIeeet1Json
-  GridKit::phasor_dynamics_systemmodel
-  GridKit::solvers_dyn)
+  TwoBusIeeet1Json GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS TwoBusIeeet1Json RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusIeeet1.json)
 

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/CMakeLists.txt
@@ -3,16 +3,14 @@ gridkit_example_current_install_path(_install_path)
 add_executable(TwoBusIeeet1 TwoBusIeeet1.cpp)
 target_link_libraries(
   TwoBusIeeet1
-  GridKit::phasor_dynamics_components
-  GridKit::phasor_dynamics_signal
+  GridKit::phasor_dynamics_systemmodel
   GridKit::solvers_dyn)
 install(TARGETS TwoBusIeeet1 RUNTIME DESTINATION ${_install_path})
 
 add_executable(TwoBusIeeet1Json TwoBusIeeet1Json.cpp)
 target_link_libraries(
   TwoBusIeeet1Json
-  GridKit::phasor_dynamics_components
-  GridKit::phasor_dynamics_signal
+  GridKit::phasor_dynamics_systemmodel
   GridKit::solvers_dyn)
 install(TARGETS TwoBusIeeet1Json RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusIeeet1.json)

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
@@ -2,16 +2,12 @@ gridkit_example_current_install_path(_install_path)
 
 add_executable(TwoBusTgov1 TwoBusTgov1.cpp)
 target_link_libraries(
-  TwoBusTgov1
-  GridKit::phasor_dynamics_systemmodel
-  GridKit::solvers_dyn)
+  TwoBusTgov1 GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS TwoBusTgov1 RUNTIME DESTINATION ${_install_path})
 
 add_executable(TwoBusTgov1Json TwoBusTgov1Json.cpp)
 target_link_libraries(
-  TwoBusTgov1Json
-  GridKit::phasor_dynamics_systemmodel
-  GridKit::solvers_dyn)
+  TwoBusTgov1Json GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn)
 install(TARGETS TwoBusTgov1Json RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusTgov1.json)
 

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/CMakeLists.txt
@@ -3,16 +3,14 @@ gridkit_example_current_install_path(_install_path)
 add_executable(TwoBusTgov1 TwoBusTgov1.cpp)
 target_link_libraries(
   TwoBusTgov1
-  GridKit::phasor_dynamics_components
-  GridKit::phasor_dynamics_signal
+  GridKit::phasor_dynamics_systemmodel
   GridKit::solvers_dyn)
 install(TARGETS TwoBusTgov1 RUNTIME DESTINATION ${_install_path})
 
 add_executable(TwoBusTgov1Json TwoBusTgov1Json.cpp)
 target_link_libraries(
   TwoBusTgov1Json
-  GridKit::phasor_dynamics_components
-  GridKit::phasor_dynamics_signal
+  GridKit::phasor_dynamics_systemmodel
   GridKit::solvers_dyn)
 install(TARGETS TwoBusTgov1Json RUNTIME DESTINATION ${_install_path})
 gridkit_example_add_file(TwoBusTgov1.json)

--- a/tests/UnitTests/PhasorDynamics/CMakeLists.txt
+++ b/tests/UnitTests/PhasorDynamics/CMakeLists.txt
@@ -90,8 +90,8 @@ add_executable(test_phasor_exciter_sexspti runExciterSexsPtiTests.cpp)
 target_link_libraries(
   test_phasor_exciter_sexspti
   GridKit::definitions
-  GridKit::phasor_dynamics_components
-  GridKit::phasor_dynamics_components_dependency_tracking
+  GridKit::phasor_dynamics_systemmodel
+  GridKit::phasor_dynamics_systemmodel_dependency_tracking
   GridKit::testing)
 
 add_executable(test_phasor_stabilizer_ieeest runStabilizerIeeestTests.cpp)
@@ -117,8 +117,8 @@ add_executable(test_phasor_system runSystemTests.cpp)
 target_link_libraries(
   test_phasor_system
   GridKit::definitions
-  GridKit::phasor_dynamics_components
-  GridKit::phasor_dynamics_components_dependency_tracking
+  GridKit::phasor_dynamics_systemmodel
+  GridKit::phasor_dynamics_systemmodel_dependency_tracking
   GridKit::testing)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ThreeBusBasicBad.json
                ${CMAKE_CURRENT_BINARY_DIR}/ThreeBusBasicBad.json COPYONLY)
@@ -126,8 +126,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ThreeBusBasicBad.json
 add_executable(test_phasor_system_single_component runSystemSingleComponentTests.cpp)
 target_link_libraries(
   test_phasor_system_single_component
-  GridKit::phasor_dynamics_components
-  GridKit::phasor_dynamics_components_dependency_tracking
+  GridKit::phasor_dynamics_systemmodel
+  GridKit::phasor_dynamics_systemmodel_dependency_tracking
   GridKit::testing)
 
 add_test(NAME PhasorDynamicsBusTest COMMAND test_phasor_bus)

--- a/tests/UnitTests/Utilities/CMakeLists.txt
+++ b/tests/UnitTests/Utilities/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(test_case_format runCaseFormatTests.cpp)
 target_link_libraries(
   test_case_format
-  PRIVATE GridKit::phasor_dynamics_components GridKit::testing)
+  PRIVATE GridKit::phasor_dynamics_systemmodel GridKit::testing)
 target_include_directories(
   test_case_format
   PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/nlohmann-json/single_include


### PR DESCRIPTION
## Description
 
This fixes a bug where PhasorDynamics components symbols are not found when building the `phasor_dynamics_systemmodel` target. (This shows up on macOS, but not on Linux. I thought I had tested #437 on macOS, but evidently not).
 
 ## Proposed changes
 
- Construct the `phasor_dynamics_systemmodel` targets after component models have been constructed.
- Replace the `phasor_dynamics_components` target with `phasor_dynamics_systemmodel` where appropriate.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [N/A] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
