### PR TITLE
Cleanup branch unit test

### DIFF
--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -230,61 +230,6 @@ namespace GridKit
         return success.report(__func__);
       }
 
-      TestOutcome accessors()
-      {
-        // Verifies tap and phase-shift residual derivatives.
-        TestStatus success = true;
-
-        RealT R{2.0};
-        RealT X{4.0};
-        RealT G{0.2};
-        RealT B{1.2};
-        RealT tap{1.25};
-        RealT phase{0.3};
-
-        DependencyTracking::Variable Vr1{10.0};
-        DependencyTracking::Variable Vi1{20.0};
-        DependencyTracking::Variable Vr2{30.0};
-        DependencyTracking::Variable Vi2{40.0};
-
-        PhasorDynamics::Bus<DependencyTracking::Variable, IdxT> bus1(Vr1, Vi1);
-        PhasorDynamics::Bus<DependencyTracking::Variable, IdxT> bus2(Vr2, Vi2);
-        bus1.allocate();
-        bus1.initialize();
-        bus1.evaluateResidual();
-        bus2.allocate();
-        bus2.initialize();
-        bus2.evaluateResidual();
-        bus1.Vr().setVariableNumber(0);
-        bus1.Vi().setVariableNumber(1);
-        bus2.Vr().setVariableNumber(2);
-        bus2.Vi().setVariableNumber(3);
-
-        PhasorDynamics::Branch<DependencyTracking::Variable, IdxT> branch(&bus1,
-                                                                          &bus2,
-                                                                          R,
-                                                                          X,
-                                                                          G,
-                                                                          B,
-                                                                          tap,
-                                                                          phase);
-        branch.allocate();
-        branch.evaluateResidual();
-
-        std::vector<DependencyTracking::Variable>                residuals{bus1.Ir(), bus1.Ii(), bus2.Ir(), bus2.Ii()};
-        std::vector<DependencyTracking::Variable::DependencyMap> ref = analyticalJacobian(R, X, G, B, tap, phase);
-
-        const RealT tol{1.0e-12};
-        for (size_t i = 0; i < residuals.size(); ++i)
-        {
-          DependencyTracking::Variable                       res           = residuals[i];
-          const DependencyTracking::Variable::DependencyMap& dependencies  = res.getDependencies();
-          success                                                         *= (GridKit::Testing::isEqual(dependencies, ref[i], tol));
-        }
-
-        return success.report(__func__);
-      }
-
       TestOutcome parameterSetters()
       {
         // Verifies parameter setters refresh derived admittance values.

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -125,11 +125,10 @@ namespace GridKit
         branch.allocate();
         branch.evaluateResidual();
 
-        const RealT tol{1.0e-12};
-        success *= isEqual(bus1.Ir(), Ir1, tol);
-        success *= isEqual(bus1.Ii(), Ii1, tol);
-        success *= isEqual(bus2.Ir(), Ir2, tol);
-        success *= isEqual(bus2.Ii(), Ii2, tol);
+        success *= isEqual(bus1.Ir(), Ir1);
+        success *= isEqual(bus1.Ii(), Ii1);
+        success *= isEqual(bus2.Ir(), Ir2);
+        success *= isEqual(bus2.Ii(), Ii2);
 
         return success.report(__func__);
       }
@@ -219,12 +218,11 @@ namespace GridKit
         std::vector<DependencyTracking::Variable>                residuals{bus1.Ir(), bus1.Ii(), bus2.Ir(), bus2.Ii()};
         std::vector<DependencyTracking::Variable::DependencyMap> ref = analyticalJacobian(R, X, G, B, tap, phase);
 
-        const RealT tol{1.0e-12};
         for (size_t i = 0; i < residuals.size(); ++i)
         {
           DependencyTracking::Variable                       res           = residuals[i];
           const DependencyTracking::Variable::DependencyMap& dependencies  = res.getDependencies();
-          success                                                         *= (GridKit::Testing::isEqual(dependencies, ref[i], tol));
+          success                                                         *= (GridKit::Testing::isEqual(dependencies, ref[i]));
         }
 
         return success.report(__func__);
@@ -277,11 +275,10 @@ namespace GridKit
         ref_branch.evaluateResidual();
         test_branch.evaluateResidual();
 
-        const RealT tol{1.0e-12};
-        success *= isEqual(test_bus1.Ir(), ref_bus1.Ir(), tol);
-        success *= isEqual(test_bus1.Ii(), ref_bus1.Ii(), tol);
-        success *= isEqual(test_bus2.Ir(), ref_bus2.Ir(), tol);
-        success *= isEqual(test_bus2.Ii(), ref_bus2.Ii(), tol);
+        success *= isEqual(test_bus1.Ir(), ref_bus1.Ir());
+        success *= isEqual(test_bus1.Ii(), ref_bus1.Ii());
+        success *= isEqual(test_bus2.Ir(), ref_bus2.Ir());
+        success *= isEqual(test_bus2.Ii(), ref_bus2.Ii());
 
         return success.report(__func__);
       }
@@ -360,11 +357,10 @@ namespace GridKit
         data_branch.evaluateResidual();
         ref_branch.evaluateResidual();
 
-        const RealT tol{1.0e-12};
-        success *= isEqual(data_bus1.Ir(), ref_bus1.Ir(), tol);
-        success *= isEqual(data_bus1.Ii(), ref_bus1.Ii(), tol);
-        success *= isEqual(data_bus2.Ir(), ref_bus2.Ir(), tol);
-        success *= isEqual(data_bus2.Ii(), ref_bus2.Ii(), tol);
+        success *= isEqual(data_bus1.Ir(), ref_bus1.Ir());
+        success *= isEqual(data_bus1.Ii(), ref_bus1.Ii());
+        success *= isEqual(data_bus2.Ir(), ref_bus2.Ir());
+        success *= isEqual(data_bus2.Ii(), ref_bus2.Ii());
 
         return success.report(__func__);
       }


### PR DESCRIPTION
## Description
 
Looks like something went wrong in #417 . The `accessor` method in `BranchTests` is not called from `runBranchTests`, and it somehow contains Jacobian tests.

 ## Proposed changes
 
- Remove `accessor` method. It was replaced with `parameterSetters`.
- [Minor] Remove ad-hoc `tol = 1e-12` The default for `isEqual` should work.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [N/A] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 

