### PR TITLE
Use relative errors by default when comparing output files

### DIFF
--- a/GridKit/Testing/AggregateErrors.hpp
+++ b/GridKit/Testing/AggregateErrors.hpp
@@ -21,31 +21,45 @@ namespace GridKit
      */
     struct TemporalNormAggregate
     {
+      /// Name of variable
       std::string label;
-      double      max{0.0};
-      double      max_time{0.0};
+      /// L-inf norm
+      double      max_value{0.0};
+      /// Time at which max value occurred
+      double      max_value_time{0.0};
+      /// L2 norm
       double      L2{0.0};
 
-      void push(double err, double time)
+      /**
+       * @brief Add a new value for the variable to be aggregated
+       */
+      void push(double val, double time)
       {
-        if (err > max)
+        if (val > max_value)
         {
-          max      = err;
-          max_time = time;
+          max_value      = val;
+          max_value_time = time;
         }
-        L2 += err * err;
+        L2 += val * val;
       }
 
+      /**
+       * @brief Finalize the calculation(s)
+       */
       void wrap()
       {
         L2 = std::sqrt(L2);
       }
 
+      /**
+       * @brief Scale by a reference value (only if the current value is above
+       * the given threshold (used internally for relative errors)
+       */
       void scale(const TemporalNormAggregate& ref, double threshold)
       {
-        if (ref.max > threshold)
+        if (ref.max_value > threshold)
         {
-          max /= ref.max;
+          max_value /= ref.max_value;
         }
         if (ref.L2 > threshold)
         {
@@ -53,12 +67,15 @@ namespace GridKit
         }
       }
 
+      /**
+       * @brief Pretty-print label and values to output stream
+       */
       std::ostream& display(
           std::ostream& os = std::cout, const std::string& indent = "  ") const
       {
         os << indent << label << ":\n"
            << indent << indent << "max     : "
-           << std::format("{:.6e} (at time {:.3e})", max, max_time)
+           << std::format("{:.6e} (at time {:.3e})", max_value, max_value_time)
            << '\n'
            << indent << indent << "L2-norm : "
            << std::format("{:.6e}", L2) << '\n';
@@ -66,11 +83,23 @@ namespace GridKit
       }
     };
 
+    /**
+     * @brief A set of aggregate norms (represented with TemporalNormAggregate)
+     * for the error in each variable plus one for the total (combined) error
+     *
+     * @note The "total_error" aggregate is based on the L-infinity norm of the
+     * local error of variables at a given time step.
+     */
     struct ErrorSet
     {
+      /// Aggregate of the combined error value at each time step
       TemporalNormAggregate              total_error{"Total"};
+      /// Aggregate error for each variable
       std::vector<TemporalNormAggregate> var_errors{};
 
+      /**
+       * @brief Construct with variable labels
+       */
       template <typename C>
       explicit ErrorSet(const C& labels)
         : var_errors(std::size(labels))
@@ -85,6 +114,9 @@ namespace GridKit
       {
       }
 
+      /**
+       * @brief Finalize the calculations
+       */
       virtual void wrap()
       {
         for (auto& agg : var_errors)
@@ -94,8 +126,15 @@ namespace GridKit
         total_error.wrap();
       }
 
+      /**
+       * @brief Take the error between the two output parameters for each
+       * variable and add to the aggregate
+       */
       virtual void push(const OutputAtTime&, const OutputAtTime&) = 0;
 
+      /**
+       * @brief Pretty-print the set of errors for each variable and total
+       */
       std::ostream& display(std::ostream& os = std::cout) const
       {
         std::string indent{"  "};
@@ -118,13 +157,6 @@ namespace GridKit
     struct RelativeError;
     struct AbsoluteError;
 
-    /**
-     * @brief A set of TemporalNormAggregate for the error in each variable plus
-     * a TemporalNormAggregate representing total (combined) error
-     *
-     * @note The "total_error" aggregate is based on the L-infinity norm of the local
-     * error of variables at a given time step.
-     */
     template <typename error_type = RelativeError>
     struct ErrorSetImpl;
 

--- a/GridKit/Testing/AggregateErrors.hpp
+++ b/GridKit/Testing/AggregateErrors.hpp
@@ -2,6 +2,8 @@
 
 #include <cmath>
 #include <format>
+#include <limits>
+#include <memory>
 #include <vector>
 
 #include <GridKit/Testing/OutputAtTime.hpp>
@@ -11,29 +13,44 @@ namespace GridKit
   namespace Testing
   {
 
+    inline constexpr double DEFAULT_ABS_ERROR_THRESHOLD =
+        std::numeric_limits<double>::epsilon();
+
     /**
-     * @brief Aggregate error data for a single variable
+     * @brief Aggregate norm data for a single variable over time
      */
-    struct ErrorAggregate
+    struct TemporalNormAggregate
     {
       std::string label;
-      double      max_error{0.0};
-      double      max_error_time{0.0};
-      double      error_norm_L2{0.0};
+      double      max{0.0};
+      double      max_time{0.0};
+      double      L2{0.0};
 
       void push(double err, double time)
       {
-        if (err > max_error)
+        if (err > max)
         {
-          max_error      = err;
-          max_error_time = time;
+          max      = err;
+          max_time = time;
         }
-        error_norm_L2 += err * err;
+        L2 += err * err;
       }
 
       void wrap()
       {
-        error_norm_L2 = std::sqrt(error_norm_L2);
+        L2 = std::sqrt(L2);
+      }
+
+      void scale(const TemporalNormAggregate& ref, double threshold)
+      {
+        if (ref.max > threshold)
+        {
+          max /= ref.max;
+        }
+        if (ref.L2 > threshold)
+        {
+          L2 /= ref.L2;
+        }
       }
 
       std::ostream& display(
@@ -41,66 +58,151 @@ namespace GridKit
       {
         os << indent << label << ":\n"
            << indent << indent << "max     : "
-           << std::format("{:.6e} (at time {:.3e})", max_error, max_error_time)
+           << std::format("{:.6e} (at time {:.3e})", max, max_time)
            << '\n'
            << indent << indent << "L2-norm : "
-           << std::format("{:.6e}", error_norm_L2) << '\n';
+           << std::format("{:.6e}", L2) << '\n';
         return os;
       }
     };
 
-    /**
-     * @brief A set of ErrorAggregate for each variable plus a total (combined)
-     * ErrorAggregate
-     *
-     * @note The "total" aggregate is based on the L-infinity norm of the local
-     * error of variables at a given time step.
-     */
     struct ErrorSet
     {
-      ErrorAggregate              total{"Total"};
-      std::vector<ErrorAggregate> vars{};
+      TemporalNormAggregate              total_error{"Total"};
+      std::vector<TemporalNormAggregate> var_errors{};
 
       template <typename C>
       explicit ErrorSet(const C& labels)
-        : vars(std::size(labels))
+        : var_errors(std::size(labels))
       {
         for (std::size_t i = 0; i < std::size(labels); ++i)
         {
-          vars[i].label = labels[i];
+          var_errors[i].label = labels[i];
         }
       }
 
-      void push(const OutputAtTime& err)
+      virtual ~ErrorSet()
       {
-        for (std::size_t i = 0; i < vars.size(); ++i)
-        {
-          vars[i].push(std::abs(err.data[i]), err.t);
-        }
-        total.push(lInfNorm(err), err.t);
       }
 
-      void wrap()
+      virtual void wrap()
       {
-        for (auto& agg : vars)
+        for (auto& agg : var_errors)
         {
           agg.wrap();
         }
-        total.wrap();
+        total_error.wrap();
       }
+
+      virtual void push(const OutputAtTime&, const OutputAtTime&) = 0;
 
       std::ostream& display(std::ostream& os = std::cout) const
       {
         std::string indent{"  "};
         os << "Error Set:\n";
-        for (const auto& var : vars)
+        for (const auto& var : var_errors)
         {
           var.display(os, indent);
         }
-        total.display(os, indent);
+        total_error.display(os, indent);
         return os;
       }
     };
+
+    enum class ErrorType
+    {
+      RELATIVE,
+      ABSOLUTE
+    };
+
+    struct RelativeError;
+    struct AbsoluteError;
+
+    /**
+     * @brief A set of TemporalNormAggregate for the error in each variable plus
+     * a TemporalNormAggregate representing total (combined) error
+     *
+     * @note The "total_error" aggregate is based on the L-infinity norm of the local
+     * error of variables at a given time step.
+     */
+    template <typename error_type = RelativeError>
+    struct ErrorSetImpl;
+
+    template <>
+    struct ErrorSetImpl<RelativeError> : ErrorSet
+    {
+      template <typename C>
+      explicit ErrorSetImpl(
+          const C& labels,
+          double   abs_threshold = DEFAULT_ABS_ERROR_THRESHOLD)
+        : ErrorSet(labels),
+          abs_threshold_(abs_threshold),
+          ref_norms_(std::size(labels))
+      {
+      }
+
+      void push(const OutputAtTime& test, const OutputAtTime& ref) override
+      {
+        auto err = test - ref;
+        for (std::size_t i = 0; i < var_errors.size(); ++i)
+        {
+          var_errors[i].push(std::abs(err.data[i]), err.t);
+          ref_norms_[i].push(std::abs(ref.data[i]), ref.t);
+        }
+        total_error.push(lInfNorm(err), err.t);
+        ref_total_norm_.push(lInfNorm(ref), ref.t);
+      }
+
+      void wrap() override
+      {
+        ErrorSet::wrap();
+        for (std::size_t i = 0; i < var_errors.size(); ++i)
+        {
+          ref_norms_[i].wrap();
+          var_errors[i].scale(ref_norms_[i], abs_threshold_);
+        }
+        ref_total_norm_.wrap();
+        total_error.scale(ref_total_norm_, abs_threshold_);
+      }
+
+    private:
+      double                             abs_threshold_{};
+      TemporalNormAggregate              ref_total_norm_{};
+      std::vector<TemporalNormAggregate> ref_norms_{};
+    };
+
+    template <>
+    struct ErrorSetImpl<AbsoluteError> : ErrorSet
+    {
+      using ErrorSet::ErrorSet;
+
+      void push(const OutputAtTime& test, const OutputAtTime& ref) override
+      {
+        auto err = test - ref;
+        for (std::size_t i = 0; i < var_errors.size(); ++i)
+        {
+          var_errors[i].push(std::abs(err.data[i]), err.t);
+        }
+        total_error.push(lInfNorm(err), err.t);
+      }
+    };
+
+    template <typename C>
+    std::unique_ptr<ErrorSet> makeErrorSet(
+        ErrorType type,
+        const C&  labels,
+        double    abs_threshold = DEFAULT_ABS_ERROR_THRESHOLD)
+    {
+      switch (type)
+      {
+      case ErrorType::RELATIVE:
+        return std::make_unique<ErrorSetImpl<RelativeError>>(labels, abs_threshold);
+      case ErrorType::ABSOLUTE:
+        return std::make_unique<ErrorSetImpl<AbsoluteError>>(labels);
+      default:
+        throw std::runtime_error("Invalid error type");
+      }
+    }
 
   } // namespace Testing
 } // namespace GridKit

--- a/GridKit/Testing/CSV.cpp
+++ b/GridKit/Testing/CSV.cpp
@@ -35,50 +35,54 @@ namespace GridKit
       return ifs;
     }
 
-    ErrorSet compareCSV(const std::string& f_a, const std::string& f_b)
+    std::unique_ptr<ErrorSet> compareCSV(const std::string& f_test,
+                                         const std::string& f_ref,
+                                         ErrorType          error_type,
+                                         double             abs_threshold)
     {
       // Open files and read labels
-      auto ifs_a = checkOpenFile(f_a);
-      auto ifs_b = checkOpenFile(f_b);
+      auto ifs_test = checkOpenFile(f_test);
+      auto ifs_ref  = checkOpenFile(f_ref);
 
-      std::string line_a;
-      std::getline(ifs_a, line_a);
-      auto labels_a = Tokenizer<>(line_a, ',')();
+      std::string line_test;
+      std::getline(ifs_test, line_test);
+      auto labels_a = Tokenizer<>(line_test, ',')();
 
-      std::string line_b;
-      std::getline(ifs_b, line_b);
-      auto labels_b = Tokenizer<>(line_b, ',')();
+      std::string line_ref;
+      std::getline(ifs_ref, line_ref);
+      auto labels_b = Tokenizer<>(line_ref, ',')();
 
       if (labels_a.size() != labels_b.size())
       {
-        Log::error() << "Files \"" << f_a << "\" and \"" << f_b
+        Log::error() << "Files \"" << f_test << "\" and \"" << f_ref
                      << "\" have different number of variables." << std::endl;
       }
 
       // Create error set
-      auto err = ErrorSet(std::span{next(begin(labels_a)), end(labels_a)});
+      auto var_labels = std::span{next(begin(labels_a)), end(labels_a)};
+      auto err        = makeErrorSet(error_type, var_labels, abs_threshold);
 
-      while (ifs_a && ifs_b)
+      while (ifs_test && ifs_ref)
       {
-        std::getline(ifs_a, line_a);
-        std::getline(ifs_b, line_b);
-        if (!(ifs_a && ifs_b))
+        std::getline(ifs_test, line_test);
+        std::getline(ifs_ref, line_ref);
+        if (!(ifs_test && ifs_ref))
         {
-          if (ifs_a || ifs_b)
+          if (ifs_test || ifs_ref)
           {
-            Log::error() << "Files \"" << f_a << "\" and \"" << f_b
+            Log::error() << "Files \"" << f_test << "\" and \"" << f_ref
                          << "\" have different lengths." << std::endl;
           }
           break;
         }
 
-        OutputAtTime d_a(Tokenizer<double>(line_b, ',')());
-        OutputAtTime d_b(Tokenizer<double>(line_a, ',')());
+        OutputAtTime d_test(Tokenizer<double>(line_test, ',')());
+        OutputAtTime d_ref(Tokenizer<double>(line_ref, ',')());
 
-        err.push(d_a - d_b);
+        err->push(d_test, d_ref);
       }
 
-      err.wrap();
+      err->wrap();
 
       return err;
     }

--- a/GridKit/Testing/CSV.hpp
+++ b/GridKit/Testing/CSV.hpp
@@ -20,7 +20,11 @@ namespace GridKit
      *
      * @note This assumes a "time" variable is always in the first column.
      */
-    ErrorSet compareCSV(const std::string& f_a, const std::string& f_b);
+    std::unique_ptr<ErrorSet> compareCSV(
+        const std::string& test_file,
+        const std::string& reference_file,
+        ErrorType          error_type    = ErrorType::RELATIVE,
+        double             abs_threshold = DEFAULT_ABS_ERROR_THRESHOLD);
 
   } // namespace Testing
 } // namespace GridKit

--- a/application/PhasorDynamics/AnalysisUtilities.hpp
+++ b/application/PhasorDynamics/AnalysisUtilities.hpp
@@ -62,6 +62,10 @@ namespace GridKit
       fs::path                 reference_file;
       /// Error tolerance (between output file and reference file)
       double                   error_tol;
+      /// Type of total error (relative or absolute)
+      Testing::ErrorType       error_type;
+      /// Smallest value at which to scale for relative error
+      double                   abs_err_threshold;
       /// Instance of model data
       SystemModelData<>        model_data;
     };
@@ -107,6 +111,25 @@ namespace GridKit
       }
 
       c.error_tol = j.value("error_tolerance", 1.0e-4);
+
+      using ErrorType = Testing::ErrorType;
+      if (j.contains("error_type"))
+      {
+        auto type_str  = j.at("error_type").get<std::string>();
+        auto type_wrap = enum_cast<ErrorType>(type_str, case_insensitive);
+        if (!type_wrap.has_value())
+        {
+          Log::error() << "Invalid error type \"" << type_str << "\"; "
+                       << "must be either \"relative\" or \"absolute\"";
+        }
+        c.error_type = type_wrap.value();
+      }
+      else
+      {
+        c.error_type = ErrorType::RELATIVE;
+      }
+
+      c.abs_err_threshold = j.value("abs_err_threshold", Testing::DEFAULT_ABS_ERROR_THRESHOLD);
     }
 
     /**
@@ -223,16 +246,19 @@ namespace GridKit
       const auto& ref_file = study_data.reference_file;
       if (!out_file.empty() && !ref_file.empty())
       {
-        auto errorSet = Testing::compareCSV(out_file, ref_file);
+        auto errorSet = Testing::compareCSV(out_file,
+                                            ref_file,
+                                            study_data.error_type,
+                                            study_data.abs_err_threshold);
 
         // Print the errors
         if (print_results)
         {
-          errorSet.display();
+          errorSet->display();
         }
 
         // Check against specified tolerance
-        status *= errorSet.total.max_error < study_data.error_tol;
+        status *= errorSet->total_error.max < study_data.error_tol;
 
         if (print_results)
         {

--- a/application/PhasorDynamics/AnalysisUtilities.hpp
+++ b/application/PhasorDynamics/AnalysisUtilities.hpp
@@ -258,7 +258,7 @@ namespace GridKit
         }
 
         // Check against specified tolerance
-        status *= errorSet->total_error.max < study_data.error_tol;
+        status *= errorSet->total_error.max_value < study_data.error_tol;
 
         if (print_results)
         {

--- a/application/PhasorDynamics/README.md
+++ b/application/PhasorDynamics/README.md
@@ -5,12 +5,14 @@
    Name               | Value
  ---------------------|-------------------------------------------------------
   `system_model_file` | Path to the system model file[^1]
-  `dt`                | A floating point value for time step size
-  `tmax`              | A floating point value for max time
+  `dt`                | A floating-point value for time step size
+  `tmax`              | A floating-point value for max time
   `events`            | An array of event groups (see [Events](#events) below)
-  `output_file`       | Path to output (CSV) file
-  `reference_file`    | A string containing the name of the case
-  `error_tolerance`   | A string containing the name of the case
+  `output_file`       | Path to output (CSV) file (optional)
+  `reference_file`    | A string containing the name of the case (optional)
+  `error_type`        | One of { "relative" (default), "absolute" }
+  `error_tolerance`   | A floating-point value for highest allowable total error (default: 1.0e-4)
+  `abs_err_threshold` | A floating-point value for the smallest value at which to scale relative error (default: machine epsilon for double-precision)
 
 [^1]: See system model [case format](../../GridKit/Model/PhasorDynamics/INPUT_FORMAT.md)
 

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.solver.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.solver.json
@@ -8,5 +8,6 @@
     ],
     "output_file": "ThreeBus_six_cycle_fault_bus1.csv",
     "reference_file": "ThreeBusBasic.ref.csv",
+    "error_type": "absolute",
     "error_tolerance":  1e-4
 }

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
@@ -116,7 +116,7 @@ int main(int argc, const char* argv[])
 
     auto error_allowed = args["tolerance"].as<real_type>();
 
-    status *= errorSet->total_error.max < error_allowed;
+    status *= errorSet->total_error.max_value < error_allowed;
 
     status.report();
   }

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
@@ -112,11 +112,11 @@ int main(int argc, const char* argv[])
     auto errorSet = GridKit::Testing::compareCSV(out_file, ref_file);
 
     // Print the errors
-    errorSet.display();
+    errorSet->display();
 
     auto error_allowed = args["tolerance"].as<real_type>();
 
-    status *= errorSet.total.max_error < error_allowed;
+    status *= errorSet->total_error.max < error_allowed;
 
     status.report();
   }


### PR DESCRIPTION
## Description
 
Enable relative and absolute errors (for CSV comparison) and use relative by default.
 
 _Closes #368_
 
 ## Proposed changes
 
This enables aggregating absolute errors or relative errors. Optional parameters are added to the JSON solver input file. Scaling relative errors depends on the optional parameter "abs_err_threshold" below which the errors will switch to absolute (so we don't divide by zero).
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.