### PR TITLE
Avoid adding monitor sink when not intended

### DIFF
--- a/application/PhasorDynamics/AnalysisUtilities.hpp
+++ b/application/PhasorDynamics/AnalysisUtilities.hpp
@@ -161,8 +161,11 @@ namespace GridKit
 
       if (model_output_file.empty())
       {
-        // Add study output file to model if one did not already exist
-        data.model_data.monitor_sink.emplace_back(csv, data.output_file);
+        if (!data.output_file.empty())
+        {
+          // Add study output file to model if one did not already exist
+          data.model_data.monitor_sink.emplace_back(csv, data.output_file);
+        }
       }
       else
       {


### PR DESCRIPTION
## Description
 
This fixes a bug in the dynamic simulation app that was adding a console sink to the monitor when no output file is specified.
 
 ## Proposed changes
 
Only add the output file from the solver json file if it is non-empty.
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.