### PR TITLE
`ConstantSignalSource` component and example with `BusToSignalAdapter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Added off-nominal tap ratio and phase shift support to the PhasorDynamics `Branch` model.
 - Added portable Vector class to GridKit
 - Added support for running IDA with fixed time steps
+- Added `ConstantSignalSource` component as first use case for `BusToSignalAdapter`.
 - Added IDA option to suppress algebraic variables in local error tests.
 - Removed `COO_Matrix` class.
 

--- a/GridKit/Model/PhasorDynamics/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/CMakeLists.txt
@@ -37,6 +37,7 @@ add_subdirectory(Exciter)
 add_subdirectory(Governor)
 add_subdirectory(Load)
 add_subdirectory(SignalNode)
+add_subdirectory(SignalSource)
 add_subdirectory(Stabilizer)
 add_subdirectory(SynchronousMachine)
 

--- a/GridKit/Model/PhasorDynamics/ComponentLibrary.hpp
+++ b/GridKit/Model/PhasorDynamics/ComponentLibrary.hpp
@@ -11,6 +11,7 @@
 #include <GridKit/Model/PhasorDynamics/Load/LoadZ/LoadZ.hpp>
 #include <GridKit/Model/PhasorDynamics/Load/LoadZIP/LoadZIP.hpp>
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
+#include <GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSource.hpp>
 #include <GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/Ieeest.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/Genrou.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/Gensal.hpp>

--- a/GridKit/Model/PhasorDynamics/SignalSource/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/SignalSource/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(_install_headers ConstantSignalSource.hpp ConstantSignalSourceData.hpp)
+
+gridkit_add_library(
+  phasor_dynamics_signalsource
+  SOURCES ConstantSignalSource.cpp
+  HEADERS ${_install_headers}
+  LINK_LIBRARIES GridKit::phasor_dynamics_core GridKit::phasor_dynamics_signal)
+
+gridkit_add_library(
+  phasor_dynamics_signalsource_dependency_tracking
+  SOURCES ConstantSignalSourceDependencyTracking.cpp
+  LINK_LIBRARIES GridKit::phasor_dynamics_core GridKit::phasor_dynamics_signal_dependency_tracking)
+
+# Link to interface target for all components
+target_link_libraries(
+  phasor_dynamics_components
+  INTERFACE GridKit::phasor_dynamics_signalsource)
+target_link_libraries(
+  phasor_dynamics_components_dependency_tracking
+  INTERFACE GridKit::phasor_dynamics_signalsource_dependency_tracking)

--- a/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSource.cpp
+++ b/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSource.cpp
@@ -1,0 +1,13 @@
+
+#include "ConstantSignalSourceImpl.hpp"
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    // Available template instantiations
+    template class ConstantSignalSource<double, long int>;
+    template class ConstantSignalSource<double, size_t>;
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSource.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSource.hpp
@@ -7,9 +7,11 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    // Forward declaration
     template <typename real_type, typename index_type>
     struct ConstantSignalSourceData;
 
+    /// Internal variables for ConstantSignalSource
     enum class ConstantSignalSourceInternalVariables : size_t
     {
       SREAL,
@@ -17,11 +19,18 @@ namespace GridKit
       MAXIMUM,
     };
 
+    /// No external variables for ConstantSignalSource
     enum class ConstantSignalSourceExternalVariables : size_t
     {
       MAXIMUM,
     };
 
+    /**
+     * @brief Constant signal source component
+     *
+     * This class emits a constant complex value on two output signals (real and
+     * imaginary).
+     */
     template <typename scalar_type, typename index_type>
     class ConstantSignalSource : public Component<scalar_type, index_type>
     {
@@ -43,9 +52,11 @@ namespace GridKit
       int verify() const override final;
       int initialize() override final;
       int tagDifferentiable() override final;
+      int setAbsoluteTolerance(RealT) override final;
       int evaluateResidual() override final;
       int evaluateJacobian() override final;
 
+      /// Get the `ComponentSignals` from this component
       auto getSignals()
           -> ComponentSignals<ScalarT,
                               IdxT,
@@ -56,12 +67,16 @@ namespace GridKit
       }
 
     private:
-      ScalarT s_real_;
-      ScalarT s_imag_;
+      /// Real part of source value
+      ScalarT s_real_{0.0};
+      /// Imaginary part of source value
+      ScalarT s_imag_{0.0};
 
+      // Placeholders for variable indices
       IdxT sr_index_{INVALID_INDEX<IdxT>};
       IdxT si_index_{INVALID_INDEX<IdxT>};
 
+      /// Component signals
       ComponentSignals<ScalarT, IdxT, ConstantSignalSourceInternalVariables, ConstantSignalSourceExternalVariables> signals_;
 
       // Parameter initialization function

--- a/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSource.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSource.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <GridKit/Model/PhasorDynamics/Component.hpp>
+#include <GridKit/Model/PhasorDynamics/ComponentSignals.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    template <typename real_type, typename index_type>
+    struct ConstantSignalSourceData;
+
+    enum class ConstantSignalSourceInternalVariables : size_t
+    {
+      SREAL,
+      SIMAG,
+      MAXIMUM,
+    };
+
+    enum class ConstantSignalSourceExternalVariables : size_t
+    {
+      MAXIMUM,
+    };
+
+    template <typename scalar_type, typename index_type>
+    class ConstantSignalSource : public Component<scalar_type, index_type>
+    {
+      using Component<scalar_type, index_type>::gridkit_component_id_;
+      using Component<scalar_type, index_type>::size_;
+
+    public:
+      using ScalarT    = scalar_type;
+      using IdxT       = index_type;
+      using RealT      = typename Component<ScalarT, IdxT>::RealT;
+      using ModelDataT = ConstantSignalSourceData<RealT, IdxT>;
+
+      ConstantSignalSource();
+      ConstantSignalSource(const ModelDataT& data);
+      ~ConstantSignalSource();
+
+      int setGridKitComponentID(IdxT) override final;
+      int allocate() override final;
+      int verify() const override final;
+      int initialize() override final;
+      int tagDifferentiable() override final;
+      int evaluateResidual() override final;
+      int evaluateJacobian() override final;
+
+      auto getSignals()
+          -> ComponentSignals<ScalarT,
+                              IdxT,
+                              ConstantSignalSourceInternalVariables,
+                              ConstantSignalSourceExternalVariables>&
+      {
+        return signals_;
+      }
+
+    private:
+      ScalarT s_real_;
+      ScalarT s_imag_;
+
+      IdxT sr_index_{INVALID_INDEX<IdxT>};
+      IdxT si_index_{INVALID_INDEX<IdxT>};
+
+      ComponentSignals<ScalarT, IdxT, ConstantSignalSourceInternalVariables, ConstantSignalSourceExternalVariables> signals_;
+
+      // Parameter initialization function
+      void initializeParameters(const ModelDataT& data);
+    };
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceData.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceData.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <GridKit/Model/PhasorDynamics/ComponentData.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    enum class ConstantSignalSourceParameters
+    {
+      Sr,
+      Si
+    };
+
+    enum class ConstantSignalSourcePorts
+    {
+      sr,
+      si
+    };
+
+    enum class ConstantSignalSourceMonitorableVariables
+    {
+      NONE,
+    };
+
+    template <typename real_type, typename index_type>
+    struct ConstantSignalSourceData : public ComponentData<real_type,
+                                                           index_type,
+                                                           ConstantSignalSourceParameters,
+                                                           ConstantSignalSourcePorts,
+                                                           ConstantSignalSourceMonitorableVariables>
+    {
+      ConstantSignalSourceData() = default;
+
+      using Parameters           = ConstantSignalSourceParameters;
+      using Ports                = ConstantSignalSourcePorts;
+      using MonitorableVariables = ConstantSignalSourceMonitorableVariables;
+    };
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceDependencyTracking.cpp
@@ -1,0 +1,13 @@
+
+#include "ConstantSignalSourceImpl.hpp"
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    // Available template instantiations
+    template class ConstantSignalSource<DependencyTracking::Variable, long int>;
+    template class ConstantSignalSource<DependencyTracking::Variable, size_t>;
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceImpl.hpp
@@ -9,12 +9,18 @@ namespace GridKit
   {
     using Log = ::GridKit::Utilities::Logger;
 
+    /**
+     * @brief Default construct with zero value
+     */
     template <typename scalar_type, typename index_type>
     ConstantSignalSource<scalar_type, index_type>::ConstantSignalSource()
     {
       size_ = 0;
     }
 
+    /**
+     * @brief Construct with values from input data
+     */
     template <typename scalar_type, typename index_type>
     ConstantSignalSource<scalar_type, index_type>::ConstantSignalSource(const ModelDataT& data)
     {
@@ -27,6 +33,9 @@ namespace GridKit
     {
     }
 
+    /**
+     * @brief Set value from input data
+     */
     template <typename scalar_type, typename index_type>
     void ConstantSignalSource<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
@@ -41,6 +50,9 @@ namespace GridKit
       }
     }
 
+    /**
+     * @brief Set the component ID
+     */
     template <typename scalar_type, typename index_type>
     int ConstantSignalSource<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
     {
@@ -48,6 +60,9 @@ namespace GridKit
       return 0;
     }
 
+    /**
+     * @brief Link up assigned signal nodes
+     */
     template <typename scalar_type, typename index_type>
     int ConstantSignalSource<scalar_type, index_type>::allocate()
     {
@@ -80,6 +95,12 @@ namespace GridKit
 
     template <typename scalar_type, typename index_type>
     int ConstantSignalSource<scalar_type, index_type>::tagDifferentiable()
+    {
+      return 0;
+    }
+
+    template <class scalar_type, typename index_type>
+    int ConstantSignalSource<scalar_type, index_type>::setAbsoluteTolerance(RealT)
     {
       return 0;
     }

--- a/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceImpl.hpp
@@ -1,0 +1,100 @@
+
+#include <GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSource.hpp>
+#include <GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceData.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    using Log = ::GridKit::Utilities::Logger;
+
+    template <typename scalar_type, typename index_type>
+    ConstantSignalSource<scalar_type, index_type>::ConstantSignalSource()
+    {
+      size_ = 0;
+    }
+
+    template <typename scalar_type, typename index_type>
+    ConstantSignalSource<scalar_type, index_type>::ConstantSignalSource(const ModelDataT& data)
+    {
+      initializeParameters(data);
+      size_ = 0;
+    }
+
+    template <typename scalar_type, typename index_type>
+    ConstantSignalSource<scalar_type, index_type>::~ConstantSignalSource()
+    {
+    }
+
+    template <typename scalar_type, typename index_type>
+    void ConstantSignalSource<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
+    {
+      using Parameters = ModelDataT::Parameters;
+      if (data.parameters.contains(Parameters::Sr))
+      {
+        s_real_ = std::get<RealT>(data.parameters.at(Parameters::Sr));
+      }
+      if (data.parameters.contains(Parameters::Si))
+      {
+        s_imag_ = std::get<RealT>(data.parameters.at(Parameters::Si));
+      }
+    }
+
+    template <typename scalar_type, typename index_type>
+    int ConstantSignalSource<scalar_type, index_type>::setGridKitComponentID(IdxT component_id)
+    {
+      gridkit_component_id_ = component_id;
+      return 0;
+    }
+
+    template <typename scalar_type, typename index_type>
+    int ConstantSignalSource<scalar_type, index_type>::allocate()
+    {
+      static constexpr auto SREAL = ConstantSignalSourceInternalVariables::SREAL;
+      static constexpr auto SIMAG = ConstantSignalSourceInternalVariables::SIMAG;
+
+      if (signals_.template isAssigned<SREAL>())
+      {
+        signals_.template getSignalNode<SREAL>()->set(&s_real_, &sr_index_);
+      }
+      if (signals_.template isAssigned<SIMAG>())
+      {
+        signals_.template getSignalNode<SIMAG>()->set(&s_imag_, &si_index_);
+      }
+
+      return 0;
+    }
+
+    template <typename scalar_type, typename index_type>
+    int ConstantSignalSource<scalar_type, index_type>::verify() const
+    {
+      return 0;
+    }
+
+    template <typename scalar_type, typename index_type>
+    int ConstantSignalSource<scalar_type, index_type>::initialize()
+    {
+      return 0;
+    }
+
+    template <typename scalar_type, typename index_type>
+    int ConstantSignalSource<scalar_type, index_type>::tagDifferentiable()
+    {
+      return 0;
+    }
+
+    template <typename scalar_type, typename index_type>
+    int ConstantSignalSource<scalar_type, index_type>::evaluateResidual()
+    {
+      return 0;
+    }
+
+    template <typename scalar_type, typename index_type>
+    int ConstantSignalSource<scalar_type, index_type>::evaluateJacobian()
+    {
+      return 0;
+    }
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SignalSource/README.md
+++ b/GridKit/Model/PhasorDynamics/SignalSource/README.md
@@ -1,0 +1,20 @@
+# Constant signal source
+
+This component emits a constant complex value on two output ports (real and
+imaginary).
+
+## Model Parameters
+
+The complex-value parameter is intentionally ambiguous, because it may be
+applied in different contexts (for different input variables).
+
+Symbol      | Units   | Description                     | Note
+------------|---------|---------------------------------| ------
+$Sr$  | unspecified | Real component  |
+$Si$  | unspecified | Imaginary component  | 
+
+## Output ports
+- `sr` ($S_r$)
+- `si` ($S_i$)
+
+Constant parameters are made available to signal nodes.

--- a/GridKit/Model/PhasorDynamics/SystemModelData.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.hpp
@@ -98,8 +98,8 @@ namespace GridKit
       std::vector<GenrouDataT>             genrou;          ///< GENROU instances within the model
       std::vector<GensalDataT>             gensal;          ///< GENSAL instances within the model
       std::vector<GenClassicalDataT>       genclassical;    ///< Classical generator instances within the model
-      std::vector<LoadZDataT>              loadz;        ///< LoadZ instances within the model
-      std::vector<LoadZIPDataT>            loadzip;      ///< LoadZIP instances within the model
+      std::vector<LoadZDataT>              loadz;           ///< LoadZ instances within the model
+      std::vector<LoadZIPDataT>            loadzip;         ///< LoadZIP instances within the model
       std::vector<Tgov1DataT>              gov;             ///< Governors within the model
       std::vector<Ieeet1DataT>             exciter;         ///< Exciters within the model
       std::vector<SexsPtiDataT>            sexspti;         ///< SEXS-PTI exciters within the model

--- a/GridKit/Model/PhasorDynamics/SystemModelData.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.hpp
@@ -16,6 +16,7 @@
 #include <GridKit/Model/PhasorDynamics/Load/LoadZ/LoadZData.hpp>
 #include <GridKit/Model/PhasorDynamics/Load/LoadZIP/LoadZIPData.hpp>
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNodeData.hpp>
+#include <GridKit/Model/PhasorDynamics/SignalSource/ConstantSignalSourceData.hpp>
 #include <GridKit/Model/PhasorDynamics/Stabilizer/IEEEST/IeeestData.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/GenrouData.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/GensalData.hpp>
@@ -49,6 +50,7 @@ namespace GridKit
       using GenClassicalDataT       = GenClassicalData<RealT, IdxT>;
       using LoadZDataT              = LoadZData<RealT, IdxT>;
       using LoadZIPDataT            = LoadZIPData<RealT, IdxT>;
+      using ConstantSourceT         = ConstantSignalSourceData<RealT, IdxT>;
       using SignalDataT             = SignalNodeData<RealT, IdxT>;
       using MonitorSinkSpec         = Model::VariableMonitorBase::SinkSpec;
 
@@ -89,20 +91,21 @@ namespace GridKit
       /// - Convert string to enum
       /// - Associate component type to its corresponding enum
       /// - Consolidate components to allow writing to them using the enum as the argument
-      std::vector<BusDataT>                bus;          ///< Buses within the model
-      std::vector<BusToSignalAdapterDataT> adapter;      ///< bus-to-signal adapters within the model
-      std::vector<BranchDataT>             branch;       ///< Branches within the model
-      std::vector<BusFaultDataT>           bus_fault;    ///< Bus faults within the model
-      std::vector<GenrouDataT>             genrou;       ///< GENROU instances within the model
-      std::vector<GensalDataT>             gensal;       ///< GENSAL instances within the model
-      std::vector<GenClassicalDataT>       genclassical; ///< Classical generator instances within the model
+      std::vector<BusDataT>                bus;             ///< Buses within the model
+      std::vector<BusToSignalAdapterDataT> adapter;         ///< bus-to-signal adapters within the model
+      std::vector<BranchDataT>             branch;          ///< Branches within the model
+      std::vector<BusFaultDataT>           bus_fault;       ///< Bus faults within the model
+      std::vector<GenrouDataT>             genrou;          ///< GENROU instances within the model
+      std::vector<GensalDataT>             gensal;          ///< GENSAL instances within the model
+      std::vector<GenClassicalDataT>       genclassical;    ///< Classical generator instances within the model
       std::vector<LoadZDataT>              loadz;        ///< LoadZ instances within the model
       std::vector<LoadZIPDataT>            loadzip;      ///< LoadZIP instances within the model
-      std::vector<Tgov1DataT>              gov;          ///< Governors within the model
-      std::vector<Ieeet1DataT>             exciter;      ///< Exciters within the model
-      std::vector<SexsPtiDataT>            sexspti;      ///< SEXS-PTI exciters within the model
-      std::vector<IeeestDataT>             stabilizer;   ///< Stabilizers within the model
-      std::vector<SignalDataT>             signal;       ///< Signal nodes
+      std::vector<Tgov1DataT>              gov;             ///< Governors within the model
+      std::vector<Ieeet1DataT>             exciter;         ///< Exciters within the model
+      std::vector<SexsPtiDataT>            sexspti;         ///< SEXS-PTI exciters within the model
+      std::vector<IeeestDataT>             stabilizer;      ///< Stabilizers within the model
+      std::vector<ConstantSourceT>         constant_source; ///< Constant signal sources within the model
+      std::vector<SignalDataT>             signal;          ///< Signal nodes
 
       /// Monitor sink specs
       std::vector<MonitorSinkSpec> monitor_sink;

--- a/GridKit/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
@@ -160,6 +160,12 @@ namespace GridKit
           raw_component.get_to(stabilizer);
           sm.stabilizer.push_back(stabilizer);
         }
+        else if (kind == "ConstantSignalSource")
+        {
+          typename SystemModelData<RealT, IdxT>::ConstantSourceT source;
+          raw_component.get_to(source);
+          sm.constant_source.push_back(source);
+        }
         else if (kind == "BusFault")
         {
           typename SystemModelData<RealT, IdxT>::BusFaultDataT bus_fault;

--- a/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
@@ -342,6 +342,28 @@ namespace GridKit
         addComponent(stabilizer);
       }
 
+      // Add constant signal sources
+      for (const auto& srcdata : data.constant_source)
+      {
+        auto* source = new ConstantSignalSource<ScalarT, IdxT>(srcdata);
+
+        using Ports = ConstantSignalSourcePorts;
+        if (srcdata.ports.contains(Ports::sr))
+        {
+          IdxT           sr    = srcdata.ports.at(Ports::sr);
+          constexpr auto SREAL = ConstantSignalSourceInternalVariables::SREAL;
+          source->getSignals().template assignSignalNode<SREAL>(getSignal(sr));
+        }
+        if (srcdata.ports.contains(Ports::si))
+        {
+          IdxT           si    = srcdata.ports.at(Ports::si);
+          constexpr auto SIMAG = ConstantSignalSourceInternalVariables::SIMAG;
+          source->getSignals().template assignSignalNode<SIMAG>(getSignal(si));
+        }
+
+        addComponent(source);
+      }
+
       // Add faults
       for (const auto& faultdata : data.bus_fault)
       {

--- a/examples/PhasorDynamics/Tiny/ThreeBus/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Basic)
 add_subdirectory(Classical)
+add_subdirectory(ConstantSource)
 add_subdirectory(ZipLoad)

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/CMakeLists.txt
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/CMakeLists.txt
@@ -1,0 +1,7 @@
+gridkit_example_add_file(ThreeBusConstantSource.case.json)
+gridkit_example_add_file(ThreeBusConstantSource.solver.json)
+
+add_test(
+  NAME ThreeBusConstantSource_pdsim
+  COMMAND DynamicSimulation ThreeBusConstantSource.solver.json
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.case.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.case.json
@@ -1,0 +1,165 @@
+{
+    "header": {
+        "format_version": 0,
+        "format_revision": 1,
+        "case_name": "ThreeBusConstantSource",
+        "case_description": "3-bus test case with constant signal sources",
+        "case_comments": "None",
+        "freq_base": 60.0,
+        "va_base": 100e6
+    },
+    "buses": [
+        {
+            "number": 1,
+            "class": "infinite_bus",
+            "name": "1",
+            "init": {
+                "Vr": 1.06,
+                "Vi": 0.0
+            },
+            "v_base": 138000.0,
+            "mon": [
+                "Vm"
+            ]
+        },
+        {
+            "number": 2,
+            "class": "bus",
+            "name": "2",
+            "init": {
+                "Vr": 1.0599558398065716,
+                "Vi": -0.009675621941024773
+            },
+            "v_base": 138000.0,
+            "mon": [
+                "Vm"
+            ]
+        },
+        {
+            "number": 3,
+            "class": "bus",
+            "name": "3",
+            "init": {
+                "Vr": 0.9610827543495831,
+                "Vi": -0.13122476630506485
+            },
+            "v_base": 138000.0,
+            "mon": [
+                "Vm"
+            ]
+        }
+    ],
+    "signals": [
+        { "signal_id": 1, "name": "ir1"},
+        { "signal_id": 2, "name": "ir2"}
+    ],
+    "devices": [
+        {
+            "class": "Branch",
+            "ports": {
+                "bus1": 1,
+                "bus2": 2
+            },
+            "id": "BR_0_1",
+            "params": {
+                "R": 0.05,
+                "X": 0.21,
+                "G": 0.0,
+                "B": 0.1
+            }
+        },
+        {
+            "class": "Branch",
+            "ports": {
+                "bus1": 1,
+                "bus2": 3
+            },
+            "id": "BR_0_2",
+            "params": {
+                "R": 0.06,
+                "X": 0.15,
+                "G": 0.0,
+                "B": 0.12
+            }
+        },
+        {
+            "class": "Branch",
+            "ports": {
+                "bus1": 2,
+                "bus2": 3
+            },
+            "id": "BR_1_2",
+            "params": {
+                "R": 0.08,
+                "X": 0.27,
+                "G": 0.0,
+                "B": 0.45
+            }
+        },
+        {
+            "class": "Load",
+            "ports": {
+                "bus": 3
+            },
+            "id": "load_2_0",
+            "params": {
+                "R": 0.4447197839297772,
+                "X": 0.20330047265361242
+            }
+        },
+        {
+            "class": "BusFault",
+            "ports": {
+                "bus": 3
+            },
+            "id": "bus_fault_2",
+            "params": {
+                "R": 0.0,
+                "X": 1e-5,
+                "state0": false
+            }
+        },
+        {
+            "class": "Genrou",
+            "ports": {
+                "bus": 2
+            },
+            "id": "genrou_2_1",
+            "params": {
+                "p0": 0.5,
+                "q0": -0.07588,
+                "H": 2.7,
+                "D": 0.0,
+                "Ra": 0.0,
+                "Tdop": 7.0,
+                "Tdopp": 0.04,
+                "Tqopp": 0.05,
+                "Tqop": 0.75,
+                "Xd": 1.9,
+                "Xdp": 0.17,
+                "Xdpp": 0.15,
+                "Xq": 0.4,
+                "Xqp": 0.35,
+                "Xqpp": 0.15,
+                "Xl": 0.14999,
+                "S10": 0.0,
+                "S12": 0.0
+            },
+            "mon": [
+                "speed"
+            ]
+        },
+        {
+            "class": "BusToSignalAdapter",
+            "ports": {"bus":1, "ir":1, "ii":2},
+            "id": "adapt3",
+            "params": []
+        },
+        {
+            "class": "ConstantSignalSource",
+            "ports": {"sr":1, "si":2},
+            "id": "const_source_1",
+            "params": []
+        }
+    ]
+}

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.solver.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.solver.json
@@ -1,0 +1,9 @@
+{
+    "system_model_file": "ThreeBusConstantSource.case.json",
+    "dt":   0.00416666666666,
+    "tmax":  10,
+    "events": [
+        {"time": 1, "type": "fault_on", "element_id": 0},
+        {"time": 1.1, "type": "fault_off", "element_id": 0}
+    ]
+}


### PR DESCRIPTION
## Description
 
Introduce new component model as a simple example of sending currents to buses via the bus signal adapter
 
 ## Proposed changes
 
`ConstantSignalSource` takes complex parameter and makes it available on output signal nodes (real and imag).
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [p] There are unit tests for the new code.
- [x] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [X] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.