### PR TITLE
Add option to suppress algebraic errors in IDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - Added the ability to print matrices to matrix market files for later analysis.
 - Added input format specifications.
 - Improved IDA interface.
-- Added IDA option to suppress algebraic variables in local error tests.
 - SUNDIALS interface updates.
 - Refactored and reorganized examples.
 - Updated variable names and function signatures to follow conventions.
@@ -65,6 +64,7 @@
 - Added off-nominal tap ratio and phase shift support to the PhasorDynamics `Branch` model.
 - Added portable Vector class to GridKit
 - Added support for running IDA with fixed time steps
+- Added IDA option to suppress algebraic variables in local error tests.
 
 ## v0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added the ability to print matrices to matrix market files for later analysis.
 - Added input format specifications.
 - Improved IDA interface.
+- Added IDA option to suppress algebraic variables in local error tests.
 - SUNDIALS interface updates.
 - Refactored and reorganized examples.
 - Updated variable names and function signatures to follow conventions.

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -92,7 +92,7 @@ namespace AnalysisManager
       retval = IDASetId(solver_, tag_);
       checkOutput(retval, "IDASetId");
 
-      setIDAOptions(solver_, time_step_, rel_tol_, abs_tol_override_, max_steps_);
+      setIDAOptions(solver_, time_step_, rel_tol_, abs_tol_override_, max_steps_, suppress_alg_);
 
       // Set up linear solver
       return this->configureLinearSolver();
@@ -535,7 +535,12 @@ namespace AnalysisManager
       retval = IDAInitB(solver_, backwardID_, this->adjointResidual, tf, yyB_, ypB_);
       checkOutput(retval, "IDAInitB");
 
-      setIDAOptions(IDAGetAdjIDABmem(solver_, backwardID_), backward_time_step_, backward_rel_tol_, backward_abs_tol_override_, backward_max_steps_);
+      setIDAOptions(IDAGetAdjIDABmem(solver_, backwardID_),
+                    backward_time_step_,
+                    backward_rel_tol_,
+                    backward_abs_tol_override_,
+                    backward_max_steps_,
+                    backward_suppress_alg_);
 
       retval = IDASetUserDataB(solver_, backwardID_, model_);
       checkOutput(retval, "IDASetUserDataB");
@@ -1169,6 +1174,35 @@ namespace AnalysisManager
     }
 
     /**
+     * @brief Set whether IDA suppresses local error tests on algebraic variables
+     *
+     * @param suppress If true, algebraic variables are excluded from IDA's
+     *        local error test
+     * @tparam ScalarT Scalar data type
+     * @tparam IdxT Index data type
+     */
+    template <class ScalarT, typename IdxT>
+    void Ida<ScalarT, IdxT>::setSuppressAlgebraicErrors(bool suppress)
+    {
+      suppress_alg_ = suppress;
+    }
+
+    /**
+     * @brief Set whether IDA suppresses local error tests on algebraic
+     *        variables for the backward simulation
+     *
+     * @param suppress If true, algebraic variables are excluded from IDA's
+     *        local error test
+     * @tparam ScalarT Scalar data type
+     * @tparam IdxT Index data type
+     */
+    template <class ScalarT, typename IdxT>
+    void Ida<ScalarT, IdxT>::setBackwardSuppressAlgebraicErrors(bool suppress)
+    {
+      backward_suppress_alg_ = suppress;
+    }
+
+    /**
      * @brief Set the maximum number of steps
      *
      * @param max_steps The maximum number of steps
@@ -1204,6 +1238,8 @@ namespace AnalysisManager
      *        absolute tolerance for the nonlinear solver rather than the
      *        model's default absolute tolerance
      * @param max_steps The maximum number of steps
+     * @param suppress_alg If true, algebraic variables are excluded from IDA's
+     *        local error test
      * @tparam ScalarT Scalar data type
      * @tparam IdxT Index data type
      */
@@ -1212,7 +1248,8 @@ namespace AnalysisManager
                                            ScalarT time_step,
                                            ScalarT rel_tol,
                                            ScalarT abs_tol_override,
-                                           IdxT    max_steps)
+                                           IdxT    max_steps,
+                                           bool    suppress_alg)
     {
       int retval = 0;
       retval     = IDASetMinStep(mem, time_step);
@@ -1221,6 +1258,8 @@ namespace AnalysisManager
       checkOutput(retval, "IDASetMaxStep");
       retval = IDASetMaxNumSteps(mem, static_cast<long int>(max_steps));
       checkOutput(retval, "IDASetMaxNumSteps");
+      retval = IDASetSuppressAlg(mem, suppress_alg ? SUNTRUE : SUNFALSE);
+      checkOutput(retval, "IDASetSuppressAlg");
 
       if (time_step == 0)
       {

--- a/GridKit/Solver/Dynamic/Ida.hpp
+++ b/GridKit/Solver/Dynamic/Ida.hpp
@@ -140,6 +140,8 @@ namespace AnalysisManager
                                   ScalarT abs_tol_override = 0);
       void setBackwardQuadratureTolerance(ScalarT rel_tol,
                                           ScalarT abs_tol_override = 0);
+      void setSuppressAlgebraicErrors(bool suppress);
+      void setBackwardSuppressAlgebraicErrors(bool suppress);
       void setMaxSteps(IdxT maxSteps) override;
       void setBackwardMaxSteps(IdxT maxSteps);
 
@@ -217,11 +219,13 @@ namespace AnalysisManager
       RealT rel_tol_{DEFAULT_REL_TOL};
       RealT abs_tol_override_{};
       IdxT  max_steps_{};
+      bool  suppress_alg_{false};
 
       RealT backward_time_step_{};
       RealT backward_rel_tol_{DEFAULT_REL_TOL};
       RealT backward_abs_tol_override_{};
       IdxT  backward_max_steps_{};
+      bool  backward_suppress_alg_{false};
 
       RealT quadrature_rel_tol_{0.1 * DEFAULT_REL_TOL};
       RealT quadrature_abs_tol_override_{};
@@ -243,7 +247,8 @@ namespace AnalysisManager
                          ScalarT time_step,
                          ScalarT rel_tol,
                          ScalarT abs_tol_override,
-                         IdxT    max_steps);
+                         IdxT    max_steps,
+                         bool    suppress_alg);
       void setTolerance(void*   mem,
                         ScalarT rel_tol,
                         ScalarT abs_tol_override,

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <GridKit/Model/Evaluator.hpp>
 #include <GridKit/Solver/Dynamic/Ida.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
@@ -272,6 +274,46 @@ namespace GridKit
       std::vector<ScalarT> param_up_;
       std::vector<ScalarT> param_lo_;
     };
+
+    template <class ScalarT, typename IdxT>
+    class AlgebraicErrorControlEvaluator : public NullEvaluator<ScalarT, IdxT>
+    {
+    public:
+      using RealT = typename NullEvaluator<ScalarT, IdxT>::RealT;
+
+      int initialize() override
+      {
+        this->y_       = {0, 0};
+        this->yp_      = {0, 0};
+        this->tag_     = {true, false};
+        this->abs_tol_ = {0, 0};
+        this->f_       = {0, 0};
+        this->g_       = {0};
+        t_             = 0;
+        return 0;
+      }
+
+      IdxT size() override
+      {
+        return 2;
+      }
+
+      int evaluateResidual() override
+      {
+        static constexpr RealT OMEGA = 100.0;
+        this->f_[0]                  = this->yp_[0];
+        this->f_[1]                  = this->y_[1] - std::sin(OMEGA * t_);
+        return 0;
+      }
+
+      void updateTime(RealT t, [[maybe_unused]] RealT a) override
+      {
+        t_ = t;
+      }
+
+    private:
+      RealT t_{};
+    };
   } // namespace Model
 
   namespace Testing
@@ -321,6 +363,34 @@ namespace GridKit
         auto stats = ida.getStats();
 
         success *= (stats.num_steps_ == n_steps);
+
+        return success.report(__func__);
+      }
+
+      TestOutcome suppressAlgebraicErrors()
+      {
+        TestStatus success = true;
+
+        const auto countSteps = [](bool suppress_alg)
+        {
+          Model::AlgebraicErrorControlEvaluator<ScalarT, IdxT> model;
+
+          Ida<ScalarT, IdxT> ida(&model);
+          ida.setSuppressAlgebraicErrors(suppress_alg);
+          ida.setTolerance(1.0e-6);
+          ida.setMaxSteps(10000);
+          ida.configureSimulation();
+
+          ida.initializeSimulation(0.0, false);
+          ida.runSimulation(1.0);
+
+          return ida.getStats().num_steps_;
+        };
+
+        const auto unsuppressed_steps = countSteps(false);
+        const auto suppressed_steps   = countSteps(true);
+
+        success *= (suppressed_steps < unsuppressed_steps);
 
         return success.report(__func__);
       }

--- a/tests/UnitTests/Solver/Dynamic/runIdaTests.cpp
+++ b/tests/UnitTests/Solver/Dynamic/runIdaTests.cpp
@@ -10,6 +10,7 @@ int main()
 
   result += test.callback();
   result += test.fixedStep();
+  result += test.suppressAlgebraicErrors();
 
   return result.summary();
 }


### PR DESCRIPTION
## Description
 
Allows algebraic errors to be ignored from IDA's local error test.
 
 Closes #455
 
 Mentions @lukelowry 
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 
