### PR TITLE
Add new solver options to phasor dynamics application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - Add new `LinearSolver` interface for linear solvers.
 - Added new `Rosenbrock` integrator.
 - Clarified naming conventions for macros.
+- Added `dt_fixed`, `rel_tol`, and `abs_tol` options to phasor dynamics solver JSON files and renamed the `dt` option to `dt_monitor`.
 
 ## v0.1
 

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -270,8 +270,8 @@ namespace AnalysisManager
         return 1;
       }
 
-      const RealT n_est    = (tf - t_init_) / dt_monitor;
-      const RealT epsilon  = std::numeric_limits<RealT>::epsilon()
+      const RealT n_est   = (tf - t_init_) / dt_monitor;
+      const RealT epsilon = std::numeric_limits<RealT>::epsilon()
                             * std::max({std::abs(t_init_), std::abs(tf), RealT(1.0)})
                             / dt_monitor;
       return static_cast<int>(std::ceil(n_est - epsilon));

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -270,9 +270,11 @@ namespace AnalysisManager
         return 1;
       }
 
-      const RealT duration = tf - t_init_;
-      const RealT epsilon  = std::numeric_limits<RealT>::epsilon() * std::max(duration, RealT(1.0));
-      return static_cast<int>(std::ceil((duration - epsilon) / dt_monitor));
+      const RealT n_est    = (tf - t_init_) / dt_monitor;
+      const RealT epsilon  = std::numeric_limits<RealT>::epsilon()
+                            * std::max({std::abs(t_init_), std::abs(tf), RealT(1.0)})
+                            / dt_monitor;
+      return static_cast<int>(std::ceil(n_est - epsilon));
     }
 
     /**

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -1,8 +1,11 @@
 
 #include "Ida.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <sstream>
 
 #include <idas/idas.h>
@@ -215,21 +218,6 @@ namespace AnalysisManager
     }
 
     /**
-     * @brief Set integration time
-     *
-     * @tparam ScalarT
-     * @tparam IdxT
-     */
-    template <class ScalarT, typename IdxT>
-    int Ida<ScalarT, IdxT>::setIntegrationTime(RealT t_init, RealT t_final, int nout)
-    {
-      t_init_  = t_init;
-      t_final_ = t_final;
-      nout_    = nout;
-      return 0;
-    }
-
-    /**
      * @brief Initialize the simulation
      *
      * @tparam ScalarT
@@ -268,40 +256,64 @@ namespace AnalysisManager
     }
 
     /**
-     * @brief Run the IDA solver on the given model and produce a solution at
-     * the given final time.
+     * @brief Compute the number of monitor targets needed to reach `tf`.
      *
-     * @tparam ScalarT Scalar data type
-     * @tparam IdxT Matrix and vector index data type
-     * @param tf The final simulation time.
-     * @param nout The number of integration segmentstimes.
-     * @param step_callback An optional callback which, if provided, will be
-     * called after each time the IDA solver has been invoked with the value
-     * of `t` that IDA has calculated the last step at. The provided model will
-     * be updated with the latest values of `y` and `yp` before the callback is
-     * invoked.
-     * @return int zero if successful, error code otherwise.
-     *
-     * @note The actual time of the final IDA solution should be somewhat
-     * close to `tf`, however due to rounding error the precise final time may
-     * be before or after `tf`.
-     *
-     * @todo Consider adding initial time as the function argument, as well.
+     * When `dt_monitor` is nonpositive, only the final time is targeted. When
+     * the final interval is epsilon-sized, it is folded into the previous
+     * monitor step.
      */
     template <class ScalarT, typename IdxT>
-    int Ida<ScalarT, IdxT>::runSimulation(RealT tf, int nout, const std::optional<std::function<void(RealT)>> step_callback)
+    int Ida<ScalarT, IdxT>::getMonitorStepCount(RealT tf, RealT dt_monitor) const
     {
-      int   retval = 0;
-      int   iout   = 0;
-      RealT tret;
-      RealT dt   = (tf - t_init_) / static_cast<RealT>(nout);
-      RealT tout = t_init_ + dt;
-
-      // In loop, call IDASolve, print results, and test for error.
-      //  Break out of loop when NOUT preset output times have been reached.
-      // printOutput(0.0);
-      while (nout > iout)
+      if (dt_monitor <= 0.0)
       {
+        return 1;
+      }
+
+      const RealT duration = tf - t_init_;
+      const RealT epsilon  = std::numeric_limits<RealT>::epsilon() * std::max(duration, RealT(1.0));
+      return static_cast<int>(std::ceil((duration - epsilon) / dt_monitor));
+    }
+
+    /**
+     * @brief Return the requested monitor target time for a one-based step.
+     *
+     * The final monitor target is pinned exactly to `tf` to avoid roundoff in
+     * repeated time-step arithmetic.
+     */
+    template <class ScalarT, typename IdxT>
+    typename Ida<ScalarT, IdxT>::RealT Ida<ScalarT, IdxT>::getMonitorTime(RealT tf, RealT dt_monitor, int step, int nsteps) const
+    {
+      return step == nsteps ? tf : std::fma((RealT) step, dt_monitor, t_init_);
+    }
+
+    /**
+     * @brief Copy the current IDA solution vectors into the model and set time.
+     */
+    template <class ScalarT, typename IdxT>
+    void Ida<ScalarT, IdxT>::updateModelState(RealT t)
+    {
+      copyVec(yy_, model_->y());
+      copyVec(yp_, model_->yp());
+      model_->updateTime(t, 0.0);
+    }
+
+    /**
+     * @brief Run the IDA solver and optionally produce monitor output every `dt_monitor`.
+     *
+     * When `dt_monitor` is zero, the simulation runs directly to the final
+     * time. The final time is always solved and monitored.
+     */
+    template <class ScalarT, typename IdxT>
+    int Ida<ScalarT, IdxT>::runSimulation(RealT tf, RealT dt_monitor, const std::optional<std::function<void(RealT)>> step_callback)
+    {
+      int retval = 0;
+      int nsteps = getMonitorStepCount(tf, dt_monitor);
+
+      for (int i = 1; i <= nsteps; i++)
+      {
+        const RealT tout = getMonitorTime(tf, dt_monitor, i, nsteps);
+        RealT tret;
         retval = IDASolve(solver_, tout, &tret, yy_, yp_, IDA_NORMAL);
         checkOutput(retval, "IDASolve");
 
@@ -310,9 +322,7 @@ namespace AnalysisManager
           // The callback may try to observe upated values in the model, so we
           // should update them here (At this point, the model's values are one
           // internal integrator step out of date)
-          copyVec(yy_, model_->y());
-          copyVec(yp_, model_->yp());
-          model_->updateTime(tret, 0.0);
+          updateModelState(tret);
 
           if (model_->monitoring())
           {
@@ -323,24 +333,10 @@ namespace AnalysisManager
             (*step_callback)(tret);
           }
         }
-
-        if (retval == IDA_SUCCESS)
-        {
-          ++iout;
-          tout += dt;
-        }
       }
 
-      // Final copy out. No guarantee last residual evaluation is final step.
-      copyVec(yy_, model_->y());
-      copyVec(yp_, model_->yp());
-      model_->updateTime(tf, 0.0);
-      // if (model_->monitoring())
-      // {
-      //   model_->printMonitoredVariables();
-      // }
+      updateModelState(tf);
 
-      // std::cout << "\n";
       return retval;
     }
 
@@ -415,43 +411,35 @@ namespace AnalysisManager
     }
 
     /**
-     * @brief Run simulation with quadrature
+     * @brief Run simulation with optional quadrature output every `dt_monitor`.
      *
-     * @tparam ScalarT
-     * @tparam IdxT
+     * When `dt_monitor` is zero, the simulation runs directly to the final
+     * time. The final time is always solved.
      */
     template <class ScalarT, typename IdxT>
-    int Ida<ScalarT, IdxT>::runSimulationQuadrature(RealT tf, int nout)
+    int Ida<ScalarT, IdxT>::runSimulationQuadrature(RealT tf, RealT dt_monitor)
     {
-      int   retval = 0;
-      RealT tret;
+      int retval = 0;
+      int nsteps = getMonitorStepCount(tf, dt_monitor);
 
-      // std::cout << "Forward integration for initial value problem ... \n";
-
-      RealT dt   = tf / static_cast<RealT>(nout);
-      RealT tout = dt;
-      // printOutput(0.0);
-      // printSpecial(0.0, yy_);
-      for (int i = 0; i < nout; ++i)
+      for (int i = 1; i <= nsteps; i++)
       {
+        const RealT tout = getMonitorTime(tf, dt_monitor, i, nsteps);
+        RealT       tret;
         retval = IDASolve(solver_, tout, &tret, yy_, yp_, IDA_NORMAL);
         checkOutput(retval, "IDASolve");
-        // printSpecial(tout, yy_);
-        // printOutput(tout);
-
-        if (retval == IDA_SUCCESS)
-        {
-          tout += dt;
-        }
 
         retval = IDAGetQuad(solver_, &tret, q_);
         checkOutput(retval, "IDAGetQuad");
+
+        updateModelState(tret);
+        if (model_->monitoring())
+        {
+          model_->printMonitoredVariables();
+        }
       }
 
-      // Final copy out. No gaurentee last residual evaluation is final step.
-      copyVec(yy_, model_->y());
-      copyVec(yp_, model_->yp());
-      model_->updateTime(tf, 0.0);
+      updateModelState(tf);
 
       return retval;
     }
@@ -609,40 +597,36 @@ namespace AnalysisManager
     }
 
     /**
-     * @brief Run forward simulation
+     * @brief Run forward simulation for adjoint analysis with optional output every `dt_monitor`.
      *
-     * @tparam ScalarT
-     * @tparam IdxT
+     * When `dt_monitor` is zero, the simulation runs directly to the final
+     * time. The final time is always solved.
      */
     template <class ScalarT, typename IdxT>
-    int Ida<ScalarT, IdxT>::runForwardSimulation(RealT tf, int nout)
+    int Ida<ScalarT, IdxT>::runForwardSimulation(RealT tf, RealT dt_monitor)
     {
-      int   retval = 0;
-      int   ncheck;
-      RealT time;
+      int retval = 0;
+      int ncheck;
+      int nsteps = getMonitorStepCount(tf, dt_monitor);
 
-      // std::cout << "Forward integration for adjoint analysis ... \n";
-
-      RealT dt   = tf / static_cast<RealT>(nout);
-      RealT tout = dt;
-      for (int i = 0; i < nout; ++i)
+      for (int i = 1; i <= nsteps; i++)
       {
-        retval = IDASolveF(solver_, tout, &time, yy_, yp_, IDA_NORMAL, &ncheck);
+        const RealT tout = getMonitorTime(tf, dt_monitor, i, nsteps);
+        RealT       tret;
+        retval = IDASolveF(solver_, tout, &tret, yy_, yp_, IDA_NORMAL, &ncheck);
         checkOutput(retval, "IDASolveF");
 
-        if (retval == IDA_SUCCESS)
-        {
-          tout += dt;
-        }
+        retval = IDAGetQuad(solver_, &tret, q_);
+        checkOutput(retval, "IDAGetQuad");
 
-        retval = IDAGetQuad(solver_, &time, q_);
-        checkOutput(retval, "IDASolve");
+        updateModelState(tret);
+        if (model_->monitoring())
+        {
+          model_->printMonitoredVariables();
+        }
       }
 
-      // Final copy out. No gaurentee last residual evaluation is final step.
-      copyVec(yy_, model_->y());
-      copyVec(yp_, model_->yp());
-      model_->updateTime(tf, 0.0);
+      updateModelState(tf);
 
       return retval;
     }

--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -313,7 +313,7 @@ namespace AnalysisManager
       for (int i = 1; i <= nsteps; i++)
       {
         const RealT tout = getMonitorTime(tf, dt_monitor, i, nsteps);
-        RealT tret;
+        RealT       tret;
         retval = IDASolve(solver_, tout, &tret, yy_, yp_, IDA_NORMAL);
         checkOutput(retval, "IDASolve");
 

--- a/GridKit/Solver/Dynamic/Ida.hpp
+++ b/GridKit/Solver/Dynamic/Ida.hpp
@@ -60,22 +60,21 @@ namespace AnalysisManager
 #endif
       int configureLinearSolverDense();
       int getDefaultInitialCondition();
-      int setIntegrationTime(RealT t_init, RealT t_final, int nout);
       int initializeSimulation(RealT t0, bool findConsistent = true);
 
-      int runSimulation(RealT tf, int nout = 1, std::optional<std::function<void(RealT)>> step_callback = {});
+      int runSimulation(RealT tf, RealT dt_monitor = 0, std::optional<std::function<void(RealT)>> step_callback = {});
       int deleteSimulation();
 
       int configureQuadrature();
       int initializeQuadrature();
-      int runSimulationQuadrature(RealT tf, int nout = 1);
+      int runSimulationQuadrature(RealT tf, RealT dt_monitor = 0);
       int deleteQuadrature();
 
       int configureAdjoint();
       int configureLinearSolverBackward();
       int initializeAdjoint(IdxT steps = 100);
       int initializeBackwardSimulation(RealT tf);
-      int runForwardSimulation(RealT tf, int nout = 1);
+      int runForwardSimulation(RealT tf, RealT dt_monitor = 0);
       int runBackwardSimulation(RealT t0);
       int deleteAdjoint();
       int deleteBackwardSimulation();
@@ -97,16 +96,6 @@ namespace AnalysisManager
       RealT getInitialTime()
       {
         return t_init_;
-      }
-
-      RealT getFinalTime()
-      {
-        return t_final_;
-      }
-
-      int getNumberOutputTimes()
-      {
-        return nout_;
       }
 
       const RealT* getIntegral() const
@@ -189,6 +178,10 @@ namespace AnalysisManager
                                   N_Vector rhsQB,
                                   void*    user_data);
 
+      int   getMonitorStepCount(RealT tf, RealT dt_monitor) const;
+      RealT getMonitorTime(RealT tf, RealT dt_monitor, int step, int nsteps) const;
+      void  updateModelState(RealT t);
+
     private:
       static constexpr ScalarT DEFAULT_REL_TOL = 1e-5;
 
@@ -200,8 +193,6 @@ namespace AnalysisManager
       SUNLinearSolver linearSolverB_{};
 
       RealT t_init_{};
-      RealT t_final_{};
-      int   nout_{}; ///< Number of integration outputs
 
       N_Vector yy_{};  ///< Solution vector
       N_Vector yp_{};  ///< Solution derivatives vector

--- a/GridKit/Solver/Optimization/DynamicConstraint.cpp
+++ b/GridKit/Solver/Optimization/DynamicConstraint.cpp
@@ -10,11 +10,14 @@ namespace AnalysisManager
   {
 
     template <class ScalarT, typename IdxT>
-    DynamicConstraint<ScalarT, IdxT>::DynamicConstraint(Sundials::Ida<ScalarT, IdxT>* integrator)
+    DynamicConstraint<ScalarT, IdxT>::DynamicConstraint(Sundials::Ida<ScalarT, IdxT>* integrator,
+                                                        RealT                         t_init,
+                                                        RealT                         t_final,
+                                                        RealT                         dt_monitor)
       : OptimizationSolver<ScalarT, IdxT>(integrator),
-        t_init_(integrator_->getInitialTime()),
-        t_final_(integrator_->getFinalTime()),
-        nout_(integrator_->getNumberOutputTimes())
+        t_init_(t_init),
+        t_final_(t_final),
+        dt_monitor_(dt_monitor)
     {
       model_ = integrator_->getModel();
     }
@@ -157,7 +160,7 @@ namespace AnalysisManager
       integrator_->initializeQuadrature();
 
       int status = 0;
-      status     = integrator_->runSimulationQuadrature(t_final_, nout_);
+      status     = integrator_->runSimulationQuadrature(t_final_, dt_monitor_);
       if (status)
       {
         std::cerr << "Integration failed when using Pm = " << x[0] << "\n";
@@ -210,7 +213,7 @@ namespace AnalysisManager
         integrator_->initializeQuadrature();
 
         int status = 0;
-        status     = integrator_->runForwardSimulation(t_final_, nout_);
+        status     = integrator_->runForwardSimulation(t_final_, dt_monitor_);
         if (status)
         {
           std::cerr << "Forward integration for adjoint solution failed when using Pm = " << x[0] << "\n";

--- a/GridKit/Solver/Optimization/DynamicConstraint.hpp
+++ b/GridKit/Solver/Optimization/DynamicConstraint.hpp
@@ -39,7 +39,10 @@ namespace AnalysisManager
       using IpoptData                 = Ipopt::IpoptData;
 
     public:
-      DynamicConstraint(Sundials::Ida<ScalarT, IdxT>* integrator);
+      DynamicConstraint(Sundials::Ida<ScalarT, IdxT>* integrator,
+                        RealT                         t_init,
+                        RealT                         t_final,
+                        RealT                         dt_monitor = 0);
       virtual ~DynamicConstraint();
 
       /// Returns sizes of the model components
@@ -82,7 +85,7 @@ namespace AnalysisManager
     private:
       RealT t_init_;
       RealT t_final_;
-      int   nout_;
+      RealT dt_monitor_;
     };
 
   } // namespace IpoptInterface

--- a/GridKit/Solver/Optimization/DynamicObjective.cpp
+++ b/GridKit/Solver/Optimization/DynamicObjective.cpp
@@ -10,11 +10,14 @@ namespace AnalysisManager
   {
 
     template <class ScalarT, typename IdxT>
-    DynamicObjective<ScalarT, IdxT>::DynamicObjective(Sundials::Ida<ScalarT, IdxT>* integrator)
+    DynamicObjective<ScalarT, IdxT>::DynamicObjective(Sundials::Ida<ScalarT, IdxT>* integrator,
+                                                      RealT                         t_init,
+                                                      RealT                         t_final,
+                                                      RealT                         dt_monitor)
       : OptimizationSolver<ScalarT, IdxT>(integrator),
-        t_init_(integrator_->getInitialTime()),
-        t_final_(integrator_->getFinalTime()),
-        nout_(integrator_->getNumberOutputTimes())
+        t_init_(t_init),
+        t_final_(t_final),
+        dt_monitor_(dt_monitor)
     {
       model_ = integrator_->getModel();
     }
@@ -112,7 +115,7 @@ namespace AnalysisManager
       integrator_->getSavedInitialCondition();
       integrator_->initializeSimulation(t_init_);
       integrator_->initializeQuadrature();
-      integrator_->runSimulationQuadrature(t_final_, nout_);
+      integrator_->runSimulationQuadrature(t_final_, dt_monitor_);
 
       // Assuming objective function is given as the integral (quadrature) 0
       obj_value = (integrator_->getIntegral())[0];
@@ -141,7 +144,7 @@ namespace AnalysisManager
       integrator_->getSavedInitialCondition();
       integrator_->initializeSimulation(t_init_);
       integrator_->initializeQuadrature();
-      integrator_->runForwardSimulation(t_final_, nout_);
+      integrator_->runForwardSimulation(t_final_, dt_monitor_);
 
       integrator_->initializeBackwardSimulation(t_final_);
       integrator_->runBackwardSimulation(t_init_);

--- a/GridKit/Solver/Optimization/DynamicObjective.hpp
+++ b/GridKit/Solver/Optimization/DynamicObjective.hpp
@@ -35,7 +35,10 @@ namespace AnalysisManager
       using IpoptData                 = Ipopt::IpoptData;
 
     public:
-      DynamicObjective(Sundials::Ida<ScalarT, IdxT>* integrator);
+      DynamicObjective(Sundials::Ida<ScalarT, IdxT>* integrator,
+                       RealT                         t_init,
+                       RealT                         t_final,
+                       RealT                         dt_monitor = 0);
       virtual ~DynamicObjective();
 
       /// Returns sizes of the model components
@@ -78,7 +81,7 @@ namespace AnalysisManager
     private:
       RealT t_init_;
       RealT t_final_;
-      int   nout_;
+      RealT dt_monitor_;
     };
 
   } // namespace IpoptInterface

--- a/application/PhasorDynamics/AnalysisUtilities.hpp
+++ b/application/PhasorDynamics/AnalysisUtilities.hpp
@@ -50,8 +50,8 @@ namespace GridKit
     {
       /// path to system model JSON file
       fs::path                 system_model_file;
-      /// time step size
-      double                   dt;
+      /// monitor output time step size
+      double                   dt_monitor;
       /// max time
       double                   tmax;
       /// relative tolerance for the solver
@@ -90,7 +90,7 @@ namespace GridKit
       using namespace magic_enum;
 
       j.at("system_model_file").get_to(c.system_model_file);
-      j.at("dt").get_to(c.dt);
+      j.at("dt_monitor").get_to(c.dt_monitor);
       j.at("tmax").get_to(c.tmax);
       c.rel_tol  = j.value("rel_tol", DEFAULT_SOLVER_REL_TOL);
       c.abs_tol  = j.value("abs_tol", DEFAULT_SOLVER_ABS_TOL);

--- a/application/PhasorDynamics/AnalysisUtilities.hpp
+++ b/application/PhasorDynamics/AnalysisUtilities.hpp
@@ -54,6 +54,10 @@ namespace GridKit
       double                   dt;
       /// max time
       double                   tmax;
+      /// relative tolerance for the solver
+      double                   rel_tol;
+      /// absolute tolerance for the solver
+      double                   abs_tol;
       /// set of system events
       std::vector<SystemEvent> events;
       /// path to output file
@@ -73,6 +77,9 @@ namespace GridKit
     using json = ::nlohmann::json;
     using Log  = ::GridKit::Utilities::Logger;
 
+    inline constexpr double DEFAULT_SOLVER_REL_TOL = 1.0e-7;
+    inline constexpr double DEFAULT_SOLVER_ABS_TOL = 1.0e-9;
+
     /**
      * @brief JSON parser implemntation for `StudyData`
      */
@@ -83,6 +90,8 @@ namespace GridKit
       j.at("system_model_file").get_to(c.system_model_file);
       j.at("dt").get_to(c.dt);
       j.at("tmax").get_to(c.tmax);
+      c.rel_tol = j.value("rel_tol", DEFAULT_SOLVER_REL_TOL);
+      c.abs_tol = j.value("abs_tol", DEFAULT_SOLVER_ABS_TOL);
 
       for (auto& raw_event : j.at("events"))
       {

--- a/application/PhasorDynamics/AnalysisUtilities.hpp
+++ b/application/PhasorDynamics/AnalysisUtilities.hpp
@@ -58,6 +58,8 @@ namespace GridKit
       double                   rel_tol;
       /// absolute tolerance for the solver
       double                   abs_tol;
+      /// fixed solver time step size, or 0 for adaptive stepping
+      double                   fixed_dt;
       /// set of system events
       std::vector<SystemEvent> events;
       /// path to output file
@@ -90,8 +92,9 @@ namespace GridKit
       j.at("system_model_file").get_to(c.system_model_file);
       j.at("dt").get_to(c.dt);
       j.at("tmax").get_to(c.tmax);
-      c.rel_tol = j.value("rel_tol", DEFAULT_SOLVER_REL_TOL);
-      c.abs_tol = j.value("abs_tol", DEFAULT_SOLVER_ABS_TOL);
+      c.rel_tol  = j.value("rel_tol", DEFAULT_SOLVER_REL_TOL);
+      c.abs_tol  = j.value("abs_tol", DEFAULT_SOLVER_ABS_TOL);
+      c.fixed_dt = j.value("fixed_dt", 0.0);
 
       for (auto& raw_event : j.at("events"))
       {

--- a/application/PhasorDynamics/AnalysisUtilities.hpp
+++ b/application/PhasorDynamics/AnalysisUtilities.hpp
@@ -50,7 +50,7 @@ namespace GridKit
     {
       /// path to system model JSON file
       fs::path                 system_model_file;
-      /// monitor output time step size
+      /// monitor output time step size, or 0 for no intermediate monitoring
       double                   dt_monitor;
       /// max time
       double                   tmax;
@@ -90,7 +90,7 @@ namespace GridKit
       using namespace magic_enum;
 
       j.at("system_model_file").get_to(c.system_model_file);
-      j.at("dt_monitor").get_to(c.dt_monitor);
+      c.dt_monitor = j.value("dt_monitor", 0.0);
       j.at("tmax").get_to(c.tmax);
       c.rel_tol  = j.value("rel_tol", DEFAULT_SOLVER_REL_TOL);
       c.abs_tol  = j.value("abs_tol", DEFAULT_SOLVER_ABS_TOL);

--- a/application/PhasorDynamics/AnalysisUtilities.hpp
+++ b/application/PhasorDynamics/AnalysisUtilities.hpp
@@ -59,7 +59,7 @@ namespace GridKit
       /// absolute tolerance for the solver
       double                   abs_tol;
       /// fixed solver time step size, or 0 for adaptive stepping
-      double                   fixed_dt;
+      double                   dt_fixed;
       /// set of system events
       std::vector<SystemEvent> events;
       /// path to output file
@@ -94,7 +94,7 @@ namespace GridKit
       j.at("tmax").get_to(c.tmax);
       c.rel_tol  = j.value("rel_tol", DEFAULT_SOLVER_REL_TOL);
       c.abs_tol  = j.value("abs_tol", DEFAULT_SOLVER_ABS_TOL);
-      c.fixed_dt = j.value("fixed_dt", 0.0);
+      c.dt_fixed = j.value("dt_fixed", 0.0);
 
       for (auto& raw_event : j.at("events"))
       {

--- a/application/PhasorDynamics/ContingencyAnalysis.cpp
+++ b/application/PhasorDynamics/ContingencyAnalysis.cpp
@@ -37,6 +37,7 @@ TestStatus runStudy(StudyData study_data)
   // Set up simulation
   Ida<scalar_type, index_type> ida(&sys);
   ida.setTolerance(study_data.rel_tol, study_data.abs_tol);
+  ida.setFixedStep(study_data.fixed_dt);
   ida.configureSimulation();
 
   using EventType = SystemEvent::Type;

--- a/application/PhasorDynamics/ContingencyAnalysis.cpp
+++ b/application/PhasorDynamics/ContingencyAnalysis.cpp
@@ -36,7 +36,7 @@ TestStatus runStudy(StudyData study_data)
 
   // Set up simulation
   Ida<scalar_type, index_type> ida(&sys);
-  ida.setTolerance(1e-7, 1e-9);
+  ida.setTolerance(study_data.rel_tol, study_data.abs_tol);
   ida.configureSimulation();
 
   using EventType = SystemEvent::Type;

--- a/application/PhasorDynamics/ContingencyAnalysis.cpp
+++ b/application/PhasorDynamics/ContingencyAnalysis.cpp
@@ -43,7 +43,7 @@ TestStatus runStudy(StudyData study_data)
   using EventType = SystemEvent::Type;
 
   // Initilize simultation for first run
-  real_type dt         = study_data.dt;
+  real_type dt_monitor = study_data.dt_monitor;
   real_type final_time = study_data.tmax;
   real_type curr_time  = 0.0;
   ida.initializeSimulation(0.0, false);
@@ -51,7 +51,7 @@ TestStatus runStudy(StudyData study_data)
   for (const auto& event : study_data.events)
   {
     // Run to event time
-    int nout = static_cast<int>(std::round((event.time - curr_time) / dt));
+    int nout = static_cast<int>(std::round((event.time - curr_time) / dt_monitor));
     ida.runSimulation(event.time, nout);
 
     // Set up run for event (to start at event time)
@@ -71,7 +71,7 @@ TestStatus runStudy(StudyData study_data)
   }
 
   // Run to final time
-  int nout = static_cast<int>(std::round((final_time - curr_time) / dt));
+  int nout = static_cast<int>(std::round((final_time - curr_time) / dt_monitor));
   ida.runSimulation(final_time, nout);
 
   // Stop the variable monitor

--- a/application/PhasorDynamics/ContingencyAnalysis.cpp
+++ b/application/PhasorDynamics/ContingencyAnalysis.cpp
@@ -45,14 +45,12 @@ TestStatus runStudy(StudyData study_data)
   // Initilize simultation for first run
   real_type dt_monitor = study_data.dt_monitor;
   real_type final_time = study_data.tmax;
-  real_type curr_time  = 0.0;
   ida.initializeSimulation(0.0, false);
 
   for (const auto& event : study_data.events)
   {
     // Run to event time
-    int nout = static_cast<int>(std::round((event.time - curr_time) / dt_monitor));
-    ida.runSimulation(event.time, nout);
+    ida.runSimulation(event.time, dt_monitor);
 
     // Set up run for event (to start at event time)
     switch (event.type)
@@ -67,12 +65,10 @@ TestStatus runStudy(StudyData study_data)
 
     // Re-initialize simulation at event time
     ida.initializeSimulation(event.time, true);
-    curr_time = event.time;
   }
 
   // Run to final time
-  int nout = static_cast<int>(std::round((final_time - curr_time) / dt_monitor));
-  ida.runSimulation(final_time, nout);
+  ida.runSimulation(final_time, dt_monitor);
 
   // Stop the variable monitor
   sys.stopMonitor();

--- a/application/PhasorDynamics/ContingencyAnalysis.cpp
+++ b/application/PhasorDynamics/ContingencyAnalysis.cpp
@@ -37,7 +37,7 @@ TestStatus runStudy(StudyData study_data)
   // Set up simulation
   Ida<scalar_type, index_type> ida(&sys);
   ida.setTolerance(study_data.rel_tol, study_data.abs_tol);
-  ida.setFixedStep(study_data.fixed_dt);
+  ida.setFixedStep(study_data.dt_fixed);
   ida.configureSimulation();
 
   using EventType = SystemEvent::Type;

--- a/application/PhasorDynamics/DynamicSimulation.cpp
+++ b/application/PhasorDynamics/DynamicSimulation.cpp
@@ -30,6 +30,7 @@ int main(int argc, const char* argv[])
   // Set up simulation
   Ida<scalar_type, index_type> ida(&sys);
   ida.setTolerance(study.rel_tol, study.abs_tol);
+  ida.setFixedStep(study.fixed_dt);
   ida.configureSimulation();
 
   // Start timer

--- a/application/PhasorDynamics/DynamicSimulation.cpp
+++ b/application/PhasorDynamics/DynamicSimulation.cpp
@@ -29,7 +29,7 @@ int main(int argc, const char* argv[])
 
   // Set up simulation
   Ida<scalar_type, index_type> ida(&sys);
-  ida.setTolerance(1e-7, 1e-9);
+  ida.setTolerance(study.rel_tol, study.abs_tol);
   ida.configureSimulation();
 
   // Start timer

--- a/application/PhasorDynamics/DynamicSimulation.cpp
+++ b/application/PhasorDynamics/DynamicSimulation.cpp
@@ -39,15 +39,13 @@ int main(int argc, const char* argv[])
   using EventType = SystemEvent::Type;
 
   // Initilize simultation for first run
-  real_type dt_monitor = study.dt_monitor;
+  auto      dt_monitor = study.dt_monitor;
   real_type final_time = study.tmax;
-  real_type curr_time  = 0.0;
   ida.initializeSimulation(0.0);
   for (const auto& event : study.events)
   {
     // Run to event time
-    int nout = static_cast<int>(std::round((event.time - curr_time) / dt_monitor));
-    ida.runSimulation(event.time, nout);
+    ida.runSimulation(event.time, dt_monitor);
 
     // Set up run for event (to start at event time)
     switch (event.type)
@@ -62,12 +60,10 @@ int main(int argc, const char* argv[])
 
     // Re-initialize simulation at event time
     ida.initializeSimulation(event.time);
-    curr_time = event.time;
   }
 
   // Run to final time
-  int nout = static_cast<int>(std::round((final_time - curr_time) / dt_monitor));
-  ida.runSimulation(final_time, nout);
+  ida.runSimulation(final_time, dt_monitor);
 
   real_type stop = static_cast<real_type>(clock());
 

--- a/application/PhasorDynamics/DynamicSimulation.cpp
+++ b/application/PhasorDynamics/DynamicSimulation.cpp
@@ -39,14 +39,14 @@ int main(int argc, const char* argv[])
   using EventType = SystemEvent::Type;
 
   // Initilize simultation for first run
-  real_type dt         = study.dt;
+  real_type dt_monitor = study.dt_monitor;
   real_type final_time = study.tmax;
   real_type curr_time  = 0.0;
   ida.initializeSimulation(0.0);
   for (const auto& event : study.events)
   {
     // Run to event time
-    int nout = static_cast<int>(std::round((event.time - curr_time) / dt));
+    int nout = static_cast<int>(std::round((event.time - curr_time) / dt_monitor));
     ida.runSimulation(event.time, nout);
 
     // Set up run for event (to start at event time)
@@ -66,7 +66,7 @@ int main(int argc, const char* argv[])
   }
 
   // Run to final time
-  int nout = static_cast<int>(std::round((final_time - curr_time) / dt));
+  int nout = static_cast<int>(std::round((final_time - curr_time) / dt_monitor));
   ida.runSimulation(final_time, nout);
 
   real_type stop = static_cast<real_type>(clock());

--- a/application/PhasorDynamics/DynamicSimulation.cpp
+++ b/application/PhasorDynamics/DynamicSimulation.cpp
@@ -30,7 +30,7 @@ int main(int argc, const char* argv[])
   // Set up simulation
   Ida<scalar_type, index_type> ida(&sys);
   ida.setTolerance(study.rel_tol, study.abs_tol);
-  ida.setFixedStep(study.fixed_dt);
+  ida.setFixedStep(study.dt_fixed);
   ida.configureSimulation();
 
   // Start timer

--- a/application/PhasorDynamics/README.md
+++ b/application/PhasorDynamics/README.md
@@ -5,7 +5,7 @@
    Name               | Value
  ---------------------|-------------------------------------------------------
   `system_model_file` | Path to the system model file[^1]
-  `dt_monitor`        | Monitor output time interval for recorded simulation results
+  `dt_monitor`        | Monitor output time interval for recorded simulation results (default: 0, no intermediate monitoring)
   `tmax`              | A floating-point value for max time
   `rel_tol`           | Relative solver tolerance (default: 1.0e-7)
   `abs_tol`           | Absolute solver tolerance override (default: 1.0e-9)

--- a/application/PhasorDynamics/README.md
+++ b/application/PhasorDynamics/README.md
@@ -9,7 +9,7 @@
   `tmax`              | A floating-point value for max time
   `rel_tol`           | Relative solver tolerance (default: 1.0e-7)
   `abs_tol`           | Absolute solver tolerance override (default: 1.0e-9)
-  `fixed_dt`          | Fixed solver time step size, or 0 for adaptive stepping (default: 0)
+  `dt_fixed`          | Fixed solver time step size, or 0 for adaptive stepping (default: 0)
   `events`            | An array of event groups (see [Events](#events) below)
   `output_file`       | Path to output (CSV) file (optional)
   `reference_file`    | A string containing the name of the case (optional)

--- a/application/PhasorDynamics/README.md
+++ b/application/PhasorDynamics/README.md
@@ -9,6 +9,7 @@
   `tmax`              | A floating-point value for max time
   `rel_tol`           | Relative solver tolerance (default: 1.0e-7)
   `abs_tol`           | Absolute solver tolerance override (default: 1.0e-9)
+  `fixed_dt`          | Fixed solver time step size, or 0 for adaptive stepping (default: 0)
   `events`            | An array of event groups (see [Events](#events) below)
   `output_file`       | Path to output (CSV) file (optional)
   `reference_file`    | A string containing the name of the case (optional)

--- a/application/PhasorDynamics/README.md
+++ b/application/PhasorDynamics/README.md
@@ -7,6 +7,8 @@
   `system_model_file` | Path to the system model file[^1]
   `dt`                | A floating-point value for time step size
   `tmax`              | A floating-point value for max time
+  `rel_tol`           | Relative solver tolerance (default: 1.0e-7)
+  `abs_tol`           | Absolute solver tolerance override (default: 1.0e-9)
   `events`            | An array of event groups (see [Events](#events) below)
   `output_file`       | Path to output (CSV) file (optional)
   `reference_file`    | A string containing the name of the case (optional)

--- a/application/PhasorDynamics/README.md
+++ b/application/PhasorDynamics/README.md
@@ -5,7 +5,7 @@
    Name               | Value
  ---------------------|-------------------------------------------------------
   `system_model_file` | Path to the system model file[^1]
-  `dt`                | A floating-point value for time step size
+  `dt_monitor`        | Monitor output time interval for recorded simulation results
   `tmax`              | A floating-point value for max time
   `rel_tol`           | Relative solver tolerance (default: 1.0e-7)
   `abs_tol`           | Absolute solver tolerance override (default: 1.0e-9)

--- a/examples/Experimental/AdjointSensitivity/AdjointSensitivity.cpp
+++ b/examples/Experimental/AdjointSensitivity/AdjointSensitivity.cpp
@@ -53,7 +53,7 @@ int main()
   idas->configureQuadrature();
   idas->initializeQuadrature();
 
-  idas->runSimulation(0.1, 2);
+  idas->runSimulation(0.1, 0.05);
   idas->saveInitialCondition();
 
   // create initial condition after a fault
@@ -61,7 +61,7 @@ int main()
     idas->getSavedInitialCondition();
     gen->V() = 0.0;
     idas->initializeSimulation(t_init);
-    idas->runSimulation(0.1, 20);
+    idas->runSimulation(0.1, 0.005);
     gen->V() = 1.0;
     idas->saveInitialCondition();
   }
@@ -73,7 +73,7 @@ int main()
   idas->getSavedInitialCondition();
   idas->initializeSimulation(t_init);
   idas->initializeQuadrature();
-  idas->runSimulationQuadrature(t_final, 100);
+  idas->runSimulationQuadrature(t_final, (t_final - t_init) / 100.0);
 
   std::cout << "\n\nCost of computing objective function:\n\n";
   idas->printFinalStats();
@@ -92,7 +92,7 @@ int main()
     idas->getSavedInitialCondition();
     idas->initializeSimulation(t_init);
     idas->initializeQuadrature();
-    idas->runSimulationQuadrature(t_final, 100);
+    idas->runSimulationQuadrature(t_final, (t_final - t_init) / 100.0);
 
     std::cout << "\n\nCost of computing derivative with respect to parameter "
               << i << ":\n\n";
@@ -112,7 +112,7 @@ int main()
   idas->getSavedInitialCondition();
   idas->initializeSimulation(t_init);
   idas->initializeQuadrature();
-  idas->runForwardSimulation(t_final, 100);
+  idas->runForwardSimulation(t_final, (t_final - t_init) / 100.0);
 
   std::cout << "\n\nCost of forward simulation for adjoint\n"
             << "sensitivity analysis:\n\n";

--- a/examples/Experimental/DynamicConstrainedOpt/DynamicConstrainedOpt.cpp
+++ b/examples/Experimental/DynamicConstrainedOpt/DynamicConstrainedOpt.cpp
@@ -54,18 +54,18 @@ int main()
 
   double t_fault = 0.02;
   double t_clear = 0.06;
-  idas.runSimulation(t_fault);
+  idas.runSimulation(t_fault, t_fault - t_init);
   // create initial condition after a fault
   {
     gen.V() = 0.0;
-    idas.runSimulation(t_clear, 2);
+    idas.runSimulation(t_clear, (t_clear - t_init) / 2.0);
     gen.V()     = 1.0;
     gen.theta() = -0.01;
     idas.saveInitialCondition();
   }
 
-  // Set integration time for dynamic constrained optimization
-  idas.setIntegrationTime(t_init, t_final, 100);
+  // Set monitoring interval for dynamic constrained optimization
+  double dt_monitor = (t_final - t_init) / 100.0;
 
   // Guess optimization parameter value
   double Pm = 0.7;
@@ -92,7 +92,7 @@ int main()
 
   // Create dynamic objective interface to Ipopt solver
   Ipopt::SmartPtr<Ipopt::TNLP> ipoptDynamicObjectiveInterface =
-      new IpoptInterface::DynamicObjective<double, size_t>(&idas);
+      new IpoptInterface::DynamicObjective<double, size_t>(&idas, t_init, t_final, dt_monitor);
 
   auto* param = model.param().getData();
 
@@ -123,7 +123,7 @@ int main()
 
   // Create dynamic constraint interface to Ipopt solver
   Ipopt::SmartPtr<Ipopt::TNLP> ipoptDynamicConstraintInterface =
-      new IpoptInterface::DynamicConstraint<double, size_t>(&idas);
+      new IpoptInterface::DynamicConstraint<double, size_t>(&idas, t_init, t_final, dt_monitor);
 
   // Initialize problem
   param[0] = Pm;

--- a/examples/Experimental/GenConstLoad/GenConstLoad.cpp
+++ b/examples/Experimental/GenConstLoad/GenConstLoad.cpp
@@ -54,11 +54,11 @@ int main()
   idas->configureQuadrature();
   idas->initializeQuadrature();
 
-  idas->runSimulationQuadrature(0.1, 2);
+  idas->runSimulationQuadrature(0.1, 0.05);
   idas->saveInitialCondition();
 
-  // Set integration time for dynamic constrained optimization
-  idas->setIntegrationTime(t_init, t_final, 250);
+  // Set monitoring interval for dynamic constrained optimization
+  double dt_monitor = (t_final - t_init) / 250.0;
 
   // Guess optimization parameter values
   double T2 = 0.15;
@@ -86,7 +86,7 @@ int main()
 
   // Create interface to Ipopt solver
   Ipopt::SmartPtr<Ipopt::TNLP> ipoptDynamicObjectiveInterface =
-      new IpoptInterface::DynamicObjective<double, size_t>(idas);
+      new IpoptInterface::DynamicObjective<double, size_t>(idas, t_init, t_final, dt_monitor);
 
   auto* param = model->param().getData();
 

--- a/examples/Experimental/GenInfiniteBus/GenInfiniteBus.cpp
+++ b/examples/Experimental/GenInfiniteBus/GenInfiniteBus.cpp
@@ -63,13 +63,13 @@ int main()
     idas.getSavedInitialCondition();
     gen.V() = 0.0;
     idas.initializeSimulation(t_init);
-    idas.runSimulation(t_clear, 20);
+    idas.runSimulation(t_clear, (t_clear - t_init) / 20.0);
     gen.V() = 1.0;
     idas.saveInitialCondition();
   }
 
-  // Set integration time for dynamic constrained optimization
-  idas.setIntegrationTime(t_init, t_final, 100);
+  // Set monitoring interval for dynamic constrained optimization
+  double dt_monitor = (t_final - t_init) / 100.0;
 
   // Guess initial values of optimization parameters
   double Pm = 1.0;
@@ -98,7 +98,7 @@ int main()
 
   // Create dynamic objective interface to Ipopt solver
   Ipopt::SmartPtr<Ipopt::TNLP> ipoptDynamicObjectiveInterface =
-      new IpoptInterface::DynamicObjective<double, size_t>(&idas);
+      new IpoptInterface::DynamicObjective<double, size_t>(&idas, t_init, t_final, dt_monitor);
 
   auto* param = model.param().getData();
 
@@ -124,7 +124,7 @@ int main()
 
   // Create dynamic constraint interface to Ipopt solver
   Ipopt::SmartPtr<Ipopt::TNLP> ipoptDynamicConstraintInterface =
-      new IpoptInterface::DynamicConstraint<double, size_t>(&idas);
+      new IpoptInterface::DynamicConstraint<double, size_t>(&idas, t_init, t_final, dt_monitor);
 
   // Store dynamic objective optimization results
   double* results = new double[model.sizeParams()];

--- a/examples/Experimental/ParameterEstimation/ParameterEstimation.cpp
+++ b/examples/Experimental/ParameterEstimation/ParameterEstimation.cpp
@@ -74,13 +74,13 @@ int main()
     idas.getSavedInitialCondition();
     gen.V() = 0.0;
     idas.initializeSimulation(t_init);
-    idas.runSimulation(t_clear, 20);
+    idas.runSimulation(t_clear, (t_clear - t_init) / 20.0);
     gen.V() = 1.0;
     idas.saveInitialCondition();
   }
 
-  // Set integration time for dynamic constrained optimization
-  idas.setIntegrationTime(t_init, t_final, 100);
+  // Set monitoring interval for dynamic constrained optimization
+  double dt_monitor = (t_final - t_init) / 100.0;
 
   auto* param = model.param().getData();
 
@@ -107,7 +107,7 @@ int main()
 
   // Create dynamic objective interface to Ipopt solver
   Ipopt::SmartPtr<Ipopt::TNLP> ipoptDynamicObjectiveInterface =
-      new IpoptInterface::DynamicObjective<double, size_t>(&idas);
+      new IpoptInterface::DynamicObjective<double, size_t>(&idas, t_init, t_final, dt_monitor);
 
   // Solve the problem
   status = ipoptApp->OptimizeTNLP(ipoptDynamicObjectiveInterface);
@@ -135,7 +135,7 @@ int main()
 
   // Create dynamic constraint interface to Ipopt solver
   Ipopt::SmartPtr<Ipopt::TNLP> ipoptDynamicConstraintInterface =
-      new IpoptInterface::DynamicConstraint<double, size_t>(&idas);
+      new IpoptInterface::DynamicConstraint<double, size_t>(&idas, t_init, t_final, dt_monitor);
 
   // Solve the problem
   status = ipoptApp->OptimizeTNLP(ipoptDynamicConstraintInterface);

--- a/examples/PhasorDynamics/Large/Illinois/illinois.solver.json
+++ b/examples/PhasorDynamics/Large/Illinois/illinois.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "illinois.json",
-    "dt": 0.00416666666666,
+    "dt_monitor": 0.00416666666666,
     "tmax": 20.0,
     "events": [
         { "time": 10.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Large/Illinois/illinois.solver.json
+++ b/examples/PhasorDynamics/Large/Illinois/illinois.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "illinois.json",
-    "dt_monitor": 0.00416666666666,
+    "dt_monitor": 0.004166666666666667,
     "tmax": 20.0,
     "events": [
         { "time": 10.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Large/Texas/texas.solver.json
+++ b/examples/PhasorDynamics/Large/Texas/texas.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "texas.json",
-    "dt_monitor": 0.00416666666666,
+    "dt_monitor": 0.004166666666666667,
     "tmax": 20.0,
     "events": [
         { "time": 10.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Large/Texas/texas.solver.json
+++ b/examples/PhasorDynamics/Large/Texas/texas.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "texas.json",
-    "dt": 0.00416666666666,
+    "dt_monitor": 0.00416666666666,
     "tmax": 20.0,
     "events": [
         { "time": 10.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Large/WECC/wecc.solver.json
+++ b/examples/PhasorDynamics/Large/WECC/wecc.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "wecc.json",
-    "dt_monitor": 0.00416666666666,
+    "dt_monitor": 0.004166666666666667,
     "tmax": 20.0,
     "events": [
         { "time": 10.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Large/WECC/wecc.solver.json
+++ b/examples/PhasorDynamics/Large/WECC/wecc.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "wecc.json",
-    "dt": 0.00416666666666,
+    "dt_monitor": 0.00416666666666,
     "tmax": 20.0,
     "events": [
         { "time": 10.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Medium/Hawaii/hawaii.solver.json
+++ b/examples/PhasorDynamics/Medium/Hawaii/hawaii.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "hawaii.json",
-    "dt": 0.00416666666666,
+    "dt_monitor": 0.00416666666666,
     "tmax": 10.0,
     "events": [
         { "time": 1.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Medium/Hawaii/hawaii.solver.json
+++ b/examples/PhasorDynamics/Medium/Hawaii/hawaii.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "hawaii.json",
-    "dt_monitor": 0.00416666666666,
+    "dt_monitor": 0.004166666666666667,
     "tmax": 10.0,
     "events": [
         { "time": 1.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Medium/NewEngland/newengland.solver.json
+++ b/examples/PhasorDynamics/Medium/NewEngland/newengland.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "newengland.json",
-    "dt_monitor": 0.00416666666666,
+    "dt_monitor": 0.004166666666666667,
     "tmax": 20.0,
     "events": [
         { "time": 10.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Medium/NewEngland/newengland.solver.json
+++ b/examples/PhasorDynamics/Medium/NewEngland/newengland.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "newengland.json",
-    "dt": 0.00416666666666,
+    "dt_monitor": 0.00416666666666,
     "tmax": 20.0,
     "events": [
         { "time": 10.0, "type": "fault_on", "element_id": 0 },

--- a/examples/PhasorDynamics/Small/TenGen/Classical/TenGenClassical.cpp
+++ b/examples/PhasorDynamics/Small/TenGen/Classical/TenGenClassical.cpp
@@ -165,20 +165,17 @@ int main()
   ida.initializeSimulation(0.0, false);
 
   // Run for 1s
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault to ground and run for 0.1s
   fault.setStatus(1);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear fault and run until t = 10s.
   fault.setStatus(0);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   fileout.close();

--- a/examples/PhasorDynamics/Small/TenGen/Genrou/TenGenGenrou.cpp
+++ b/examples/PhasorDynamics/Small/TenGen/Genrou/TenGenGenrou.cpp
@@ -151,20 +151,17 @@ int main()
   ida.initializeSimulation(0.0, false);
 
   // Run for 1s
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault to ground and run for 0.1s
   fault.setStatus(1);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear fault and run until t = 10s.
   fault.setStatus(0);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   fileout.close();

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.cpp
@@ -235,20 +235,17 @@ int main()
   ida.initializeSimulation(0.0);
 
   // Run for 1s
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault to ground and run for 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   /* Check worst-case error */

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.solver.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "ThreeBusBasic.case.json",
-    "dt_monitor":   0.00416666666666,
+    "dt_monitor":   0.004166666666666667,
     "tmax":  10,
     "events": [
         {"time": 1, "type": "fault_on", "element_id": 0},

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.solver.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "ThreeBusBasic.case.json",
-    "dt":   0.00416666666666,
+    "dt_monitor":   0.00416666666666,
     "tmax":  10,
     "events": [
         {"time": 1, "type": "fault_on", "element_id": 0},

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasicJson.cpp
@@ -84,20 +84,17 @@ int main(int argc, const char* argv[])
   ida.initializeSimulation(0.0);
 
   // Run for 1s
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout);
+  ida.runSimulation(1.0, dt);
 
   // Introduce fault to ground and run for 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout);
+  ida.runSimulation(1.1, dt);
 
   // Clear fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout);
+  ida.runSimulation(10.0, dt);
   real_type stop = static_cast<real_type>(clock());
 
   // Stop the variable monitor

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.cpp
@@ -205,20 +205,17 @@ int main()
   ida.initializeSimulation(0.0);
 
   // Run for 1s
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault to ground and run for 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   /* Check worst-case error */

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassicalJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassicalJson.cpp
@@ -152,20 +152,17 @@ int main(int argc, const char* argv[])
   ida.initializeSimulation(0.0);
 
   // Run for 1s
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault to ground and run for 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   /* Check worst-case error */

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.solver.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "ThreeBusConstantSource.case.json",
-    "dt":   0.00416666666666,
+    "dt_monitor":   0.00416666666666,
     "tmax":  10,
     "events": [
         {"time": 1, "type": "fault_on", "element_id": 0},

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.solver.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "ThreeBusConstantSource.case.json",
-    "dt_monitor":   0.00416666666666,
+    "dt_monitor":   0.004166666666666667,
     "tmax":  10,
     "events": [
         {"time": 1, "type": "fault_on", "element_id": 0},

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ZipLoad/ThreeBusZipLoadJson.cpp
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ZipLoad/ThreeBusZipLoadJson.cpp
@@ -150,20 +150,17 @@ int main(int argc, const char* argv[])
   ida.initializeSimulation(0.0, false);
 
   // Run for 1s
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault to ground and run for 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0, false);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1, false);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   /* Check worst-case error */

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.cpp
@@ -150,20 +150,17 @@ int main()
 
   // Run for 1s
   ida.initializeSimulation(0.0, false);
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault and run for the next 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear the fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   real_type error_V = 0.0; // error in |V|

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.solver.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "TwoBusBasic.case.json",
-    "dt_monitor":   0.00416666666666,
+    "dt_monitor":   0.004166666666666667,
     "tmax":  10,
     "events": [
         {"time": 1, "type": "fault_on", "element_id": 0},

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.solver.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "TwoBusBasic.case.json",
-    "dt":   0.00416666666666,
+    "dt_monitor":   0.00416666666666,
     "tmax":  10,
     "events": [
         {"time": 1, "type": "fault_on", "element_id": 0},

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasicJson.cpp
@@ -130,20 +130,17 @@ int main(int argc, const char* argv[])
 
   // Run for 1s
   ida.initializeSimulation(0.0, false);
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault and run for the next 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear the fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   real_type error_V = 0.0; // error in |V|

--- a/examples/PhasorDynamics/Tiny/TwoBus/Gensal/Gensal.solver.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Gensal/Gensal.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "Gensal.case.json",
-    "dt_monitor": 0.00416666666666,
+    "dt_monitor": 0.004166666666666667,
     "tmax": 30.0,
     "events": [
         {"time": 1.0, "type": "fault_on",  "element_id": 0},

--- a/examples/PhasorDynamics/Tiny/TwoBus/Gensal/Gensal.solver.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Gensal/Gensal.solver.json
@@ -1,6 +1,6 @@
 {
     "system_model_file": "Gensal.case.json",
-    "dt": 0.00416666666666,
+    "dt_monitor": 0.00416666666666,
     "tmax": 30.0,
     "events": [
         {"time": 1.0, "type": "fault_on",  "element_id": 0},

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.cpp
@@ -208,20 +208,17 @@ int main()
 
   // Run for 1s
   ida.initializeSimulation(0.0, false);
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault and run for the next 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear the fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   real_type error_V   = 0.0; // error in |V|

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1Json.cpp
@@ -139,22 +139,19 @@ int main(int argc, const char* argv[])
 
   // Run for 1s
   ida.initializeSimulation(0.0, false);
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault and run for the next 0.1s
   // fault.setStatus(true);
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear the fault and run until t = 10s.
   // fault.setStatus(false);
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   real_type error_V   = 0.0; // error in |V|

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.cpp
@@ -173,20 +173,17 @@ int main()
 
   // Run for 1s
   ida.initializeSimulation(0.0, false);
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault and run for the next 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear the fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   real_type error_V = 0.0; // error in |V|

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1Json.cpp
@@ -134,20 +134,17 @@ int main(int argc, const char* argv[])
 
   // Run for 1s
   ida.initializeSimulation(0.0, false);
-  int nout = static_cast<int>(std::round((1.0 - 0.0) / dt));
-  ida.runSimulation(1.0, nout, output_cb);
+  ida.runSimulation(1.0, dt, output_cb);
 
   // Introduce fault and run for the next 0.1s
   fault->setStatus(true);
   ida.initializeSimulation(1.0);
-  nout = static_cast<int>(std::round((1.1 - 1.0) / dt));
-  ida.runSimulation(1.1, nout, output_cb);
+  ida.runSimulation(1.1, dt, output_cb);
 
   // Clear the fault and run until t = 10s.
   fault->setStatus(false);
   ida.initializeSimulation(1.1);
-  nout = static_cast<int>(std::round((10.0 - 1.1) / dt));
-  ida.runSimulation(10.0, nout, output_cb);
+  ida.runSimulation(10.0, dt, output_cb);
   real_type stop = static_cast<real_type>(clock());
 
   real_type error_V = 0.0; // error in |V|

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -468,7 +468,7 @@ namespace GridKit
         ida.configureSimulation();
 
         ida.initializeSimulation(0.0, false);
-        ida.runSimulation(1.0, 1.0);
+        ida.runSimulation(1.0);
         auto stats = ida.getStats();
 
         success *= (stats.num_steps_ == n_steps);
@@ -491,7 +491,7 @@ namespace GridKit
           ida.configureSimulation();
 
           ida.initializeSimulation(0.0, false);
-          ida.runSimulation(1.0, 1.0);
+          ida.runSimulation(1.0);
 
           return ida.getStats().num_steps_;
         };

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -394,9 +394,63 @@ namespace GridKit
         };
 
         ida.initializeSimulation(0.0, false);
-        ida.runSimulation(1.0, n_steps, output_cb);
+        ida.runSimulation(1.0, 1.0 / n_steps, output_cb);
 
         success *= (observed_steps == n_steps);
+
+        return success.report(__func__);
+      }
+
+      TestOutcome dtMonitorZero()
+      {
+        TestStatus success = true;
+
+        Model::NullEvaluator<ScalarT, IdxT> model;
+
+        Ida<double, size_t> ida(&model);
+        ida.configureSimulation();
+
+        unsigned observed_steps = 0;
+        double   observed_t     = 0.0;
+        auto     output_cb      = [&](double t)
+        {
+          observed_steps++;
+          observed_t = t;
+        };
+
+        ida.initializeSimulation(0.0, false);
+        ida.runSimulation(1.0, 0.0, output_cb);
+
+        success *= (observed_steps == 1);
+        success *= (observed_t == 1.0);
+
+        return success.report(__func__);
+      }
+
+      TestOutcome dtMonitorSuppressesEpsilonFinalStep()
+      {
+        TestStatus success = true;
+
+        Model::NullEvaluator<ScalarT, IdxT> model;
+
+        Ida<double, size_t> ida(&model);
+        ida.configureSimulation();
+
+        unsigned observed_steps = 0;
+        double   observed_t     = 0.0;
+        auto     output_cb      = [&](double t)
+        {
+          observed_steps++;
+          observed_t = t;
+        };
+
+        const double tf = std::nextafter(1.0, 2.0);
+
+        ida.initializeSimulation(0.0, false);
+        ida.runSimulation(tf, 0.25, output_cb);
+
+        success *= (observed_steps == 4);
+        success *= (observed_t == tf);
 
         return success.report(__func__);
       }
@@ -414,7 +468,7 @@ namespace GridKit
         ida.configureSimulation();
 
         ida.initializeSimulation(0.0, false);
-        ida.runSimulation(1.0);
+        ida.runSimulation(1.0, 1.0);
         auto stats = ida.getStats();
 
         success *= (stats.num_steps_ == n_steps);
@@ -437,7 +491,7 @@ namespace GridKit
           ida.configureSimulation();
 
           ida.initializeSimulation(0.0, false);
-          ida.runSimulation(1.0);
+          ida.runSimulation(1.0, 1.0);
 
           return ida.getStats().num_steps_;
         };

--- a/tests/UnitTests/Solver/Dynamic/runIdaTests.cpp
+++ b/tests/UnitTests/Solver/Dynamic/runIdaTests.cpp
@@ -9,6 +9,8 @@ int main()
   GridKit::Testing::IdaTests<double, size_t> test;
 
   result += test.callback();
+  result += test.dtMonitorZero();
+  result += test.dtMonitorSuppressesEpsilonFinalStep();
   result += test.fixedStep();
   result += test.suppressAlgebraicErrors();
 


### PR DESCRIPTION
## Description
 
I think these options will be needed for the fixed versus adaptive time step comparisons.
 
 ## Proposed changes
 
This adds JSON options for tolerances and a fixed time step
 
 ## Checklist

 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
I noticed the existing `dt` JSON option has a few issues. It is documented as solver time step but it seems to be the output/monitoring time step. Perhaps it should be rename `monitor_dt` and the new `fixed_dt` should be called `dt`. Also with this rounding, the monitoring is not guaranteed to occur every `dt` simulation time.
https://github.com/ORNL/GridKit/blob/c099ac0037b27c03d4ec9964cd3a006429a636eb/application/PhasorDynamics/DynamicSimulation.cpp#L48
Any suggestions on how to handle this @pelesh?
