### PR TITLE
Made screaming snake case convention explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Removed `COO_Matrix` class.
 - Added portable `Vector` class and policy-based memory utilities.
 - Added new `Rosenbrock` integrator.
+- Clarified naming conventions for macros.
 
 ## v0.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,6 +285,10 @@ name. Use all caps (screaming snake case).
    constexpr double EXP = 2.7183      // Yes
 ```
 
+### Macros
+
+Macros should use all caps, same as constants.
+
 ### Enums (enumerated types)
 
 Always define `enum`s inside `GridKit` namespace. The `enum` name should


### PR DESCRIPTION
## Description
 
 _We were using screaming snake case for macros without explicitly saying it._
 
 ## Proposed changes
 
 _Updated docs._
 
 ## Checklist
Other items N/A. Docs only PR. 

- [x] The new code is documented.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.

 
