### PR TITLE
Distinction of Magnetization vs. Line Shunt  (Validation)

### DIFF
--- a/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/Branch.hpp
@@ -204,6 +204,8 @@ namespace GridKit
       RealT X_{0.0};
       RealT G_{0.0};
       RealT B_{0.0};
+      RealT Gmag_{0.0};
+      RealT Bmag_{0.0};
       RealT tap_{1.0};
       RealT phase_{0.0};
       IdxT  bus1_id_{0};

--- a/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
@@ -17,8 +17,10 @@ namespace GridKit
     {
       R,     ///< Line series resistance
       X,     ///< Line series reactance
-      G,     ///< Total shunt conductance
-      B,     ///< Total shunt susceptance
+      G,     ///< Total line shunt conductance
+      B,     ///< Total line shunt susceptance
+      Gmag,  ///< Magnetizing shunt conductance at bus 1 (from bus, tapped side)
+      Bmag,  ///< Magnetizing shunt susceptance at bus 1 (from bus, tapped side)
       tap,   ///< Off-nominal tap magnitude on bus1 side
       phase, ///< Phase shift angle in radians
     };

--- a/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchData.hpp
@@ -15,49 +15,49 @@ namespace GridKit
     /// Initial parameters for a branch
     enum class BranchParameters
     {
-      R,     ///< Line series resistance
-      X,     ///< Line series reactance
-      G,     ///< Total line shunt conductance
-      B,     ///< Total line shunt susceptance
-      Gmag,  ///< Magnetizing shunt conductance at bus 1 (from bus, tapped side)
-      Bmag,  ///< Magnetizing shunt susceptance at bus 1 (from bus, tapped side)
-      tap,   ///< Off-nominal tap magnitude on bus1 side
-      phase, ///< Phase shift angle in radians
+      R,     ///< \f$R\f$ Branch series resistance [p.u.]
+      X,     ///< \f$X\f$ Branch series reactance [p.u.]
+      G,     ///< \f$G\f$ Total line shunt conductance, split equally between the two terminals [p.u.]
+      B,     ///< \f$B\f$ Total line shunt susceptance, split equally between the two terminals [p.u.]
+      Gmag,  ///< \f$G_{\mathrm{mag}}\f$ Magnetizing shunt conductance at bus 1, the tapped side [p.u.]
+      Bmag,  ///< \f$B_{\mathrm{mag}}\f$ Magnetizing shunt susceptance at bus 1, the tapped side [p.u.]
+      tap,   ///< \f$\tau\f$ Off-nominal tap magnitude on the bus-1 side [p.u.]
+      phase, ///< \f$\theta\f$ Off-nominal phase-shift angle [rad]
     };
 
     /// Buses for a branch
     enum class BranchBuses : size_t
     {
-      bus1, ///< Unique ID of bus 1
-      bus2, ///< Unique ID of bus 2
-      SIZE
+      bus1, ///< \f$V_{\mathrm{r}1},V_{\mathrm{i}1}\f$ Required Known bus-1 terminal voltage, the tapped side [p.u.]
+      bus2, ///< \f$V_{\mathrm{r}2},V_{\mathrm{i}2}\f$ Required Known bus-2 terminal voltage [p.u.]
+      SIZE  ///< Number of branch bus ports
     };
 
     /// Signal inputs supported for a branch
     enum class BranchSignalInputs : size_t
     {
-      SIZE
+      SIZE ///< Number of branch input-signal ports
     };
 
     /// Signal outputs supported for a branch
     enum class BranchSignalOutputs : size_t
     {
-      SIZE
+      SIZE ///< Number of branch output-signal ports
     };
 
     /// Variables able to be monitored for a branch
     enum class BranchMonitorableVariables
     {
-      ir1,
-      ii1,
-      im1,
-      p1,
-      q1,
-      ir2,
-      ii2,
-      im2,
-      p2,
-      q2
+      ir1, ///< \f$I_{\mathrm{r}1}\f$ Bus-1 terminal-current real component [p.u.]
+      ii1, ///< \f$I_{\mathrm{i}1}\f$ Bus-1 terminal-current imaginary component [p.u.]
+      im1, ///< \f$I_{\mathrm{m}1}\f$ Bus-1 terminal-current magnitude [p.u.]
+      p1,  ///< \f$P_1\f$ Bus-1 terminal active power [p.u.]
+      q1,  ///< \f$Q_1\f$ Bus-1 terminal reactive power [p.u.]
+      ir2, ///< \f$I_{\mathrm{r}2}\f$ Bus-2 terminal-current real component [p.u.]
+      ii2, ///< \f$I_{\mathrm{i}2}\f$ Bus-2 terminal-current imaginary component [p.u.]
+      im2, ///< \f$I_{\mathrm{m}2}\f$ Bus-2 terminal-current magnitude [p.u.]
+      p2,  ///< \f$P_2\f$ Bus-2 terminal active power [p.u.]
+      q2   ///< \f$Q_2\f$ Bus-2 terminal reactive power [p.u.]
     };
 
     /**

--- a/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Branch/BranchImpl.hpp
@@ -51,8 +51,8 @@ namespace GridKit
      * @param bus2 - pointer to bus-2
      * @param R - line series resistance
      * @param X - line series reactance
-     * @param G - total shunt conductance
-     * @param B - total shunt susceptance
+     * @param G - total line shunt conductance
+     * @param B - total line shunt susceptance
      * @param tap - off-nominal tap magnitude on bus1 side
      * @param phase - phase shift angle in radians
      */
@@ -174,6 +174,8 @@ namespace GridKit
       check(std::isfinite(X_), "X must be finite");
       check(std::isfinite(G_), "G must be finite");
       check(std::isfinite(B_), "B must be finite");
+      check(std::isfinite(Gmag_), "Gmag must be finite");
+      check(std::isfinite(Bmag_), "Bmag must be finite");
       check(std::isfinite(tap_), "tap must be finite");
       check(std::isfinite(phase_), "phase must be finite");
       check(R_ * R_ + X_ * X_ > RealT{0.0}, "R and X cannot both be zero");
@@ -353,6 +355,8 @@ namespace GridKit
       readRealParameter(data, Parameter::X, X_);
       readRealParameter(data, Parameter::G, G_);
       readRealParameter(data, Parameter::B, B_);
+      readRealParameter(data, Parameter::Gmag, Gmag_);
+      readRealParameter(data, Parameter::Bmag, Bmag_);
       readRealParameter(data, Parameter::tap, tap_);
       readRealParameter(data, Parameter::phase, phase_);
 
@@ -496,11 +500,11 @@ namespace GridKit
       const RealT cos_ph  = std::cos(phase_);
       const RealT sin_ph  = std::sin(phase_);
 
-      const RealT g_diag = -(g_br + RealT{0.5} * G_);
-      const RealT b_diag = -(b_br + RealT{0.5} * B_);
+      const RealT g_diag = -g_br;
+      const RealT b_diag = -b_br;
 
-      g11_ = g_diag * inv_tap * inv_tap;
-      b11_ = b_diag * inv_tap * inv_tap;
+      g11_ = g_diag * inv_tap * inv_tap - RealT{0.5} * G_ - Gmag_;
+      b11_ = b_diag * inv_tap * inv_tap - RealT{0.5} * B_ - Bmag_;
 
       g12_ = (g_br * cos_ph - b_br * sin_ph) * inv_tap;
       b12_ = (b_br * cos_ph + g_br * sin_ph) * inv_tap;
@@ -508,8 +512,8 @@ namespace GridKit
       g21_ = (g_br * cos_ph + b_br * sin_ph) * inv_tap;
       b21_ = (b_br * cos_ph - g_br * sin_ph) * inv_tap;
 
-      g22_ = g_diag;
-      b22_ = b_diag;
+      g22_ = g_diag - RealT{0.5} * G_;
+      b22_ = b_diag - RealT{0.5} * B_;
     }
 
   } // namespace PhasorDynamics

--- a/GridKit/Model/PhasorDynamics/Branch/README.md
+++ b/GridKit/Model/PhasorDynamics/Branch/README.md
@@ -7,30 +7,24 @@ contributions are oriented entering the adjacent buses.
 Notes:
 - Setting $\tau = 1$ and $\theta = 0$ gives the ordinary symmetric
   transmission-line $\pi$ model.
-- $G$ and $B$ are total branch shunt values split equally between terminals.
+- The total line shunt $G + jB$ is split equally between the two terminals,
+  while the magnetizing shunt $G_\text{mag} + jB_\text{mag}$ is connected at
+  bus 1; both shunts are added outside the $\mathbf{M}$ transformation.
 - The branch has no solver-owned variables; it contributes current residuals
   directly to the connected buses.
 
-## Circuit Diagram
-
-An ideal complex tap is placed on the bus-1 side of the branch equivalent. The
-ordinary transmission-line $\pi$ model is recovered with $\tau = 1$ and
-$\theta = 0$.
-
-![](../../../../docs/Figures/transformer-branch.png)
-
-Figure 1: Branch equivalent circuit
-
 ## Model Parameters
 
-Symbol      | Units   | Description                                      | Typical Value | Note
-------------|---------|--------------------------------------------------|---------------|------
-$R$         | [p.u.]  | Branch series resistance                         |               |
-$X$         | [p.u.]  | Branch series reactance                          |               |
-$G$         | [p.u.]  | Total branch shunt conductance                   | 0             |
-$B$         | [p.u.]  | Total branch shunt susceptance                   | 0             |
-$\tau$      | [p.u.]  | Off-nominal tap magnitude on bus-1 side          | 1             | Parameter name: `tap`
-$\theta$    | [rad]   | Phase-shift angle                                | 0             | Parameter name: `phase`
+Symbol               | Units  | JSON    | Description                             | Typical Value | Note
+---------------------|--------|---------|-----------------------------------------|---------------|------
+$R$                  | [p.u.] | `R`     | Branch series resistance                |               |
+$X$                  | [p.u.] | `X`     | Branch series reactance                 |               |
+$G$                  | [p.u.] | `G`     | Total line shunt conductance            | 0.0           |
+$B$                  | [p.u.] | `B`     | Total line shunt susceptance            | 0.0           |
+$G_\text{mag}$       | [p.u.] | `Gmag`  | Magnetizing shunt conductance at bus 1  | 0.0           |
+$B_\text{mag}$       | [p.u.] | `Bmag`  | Magnetizing shunt susceptance at bus 1  | 0.0           |
+$\tau$               | [p.u.] | `tap`   | Off-nominal tap magnitude on bus-1 side | 1.0           |
+$\theta$             | [rad]  | `phase` | Phase-shift angle                       | 0.0           |
 
 ### Parameter Validation
 
@@ -38,7 +32,8 @@ Invalid Branch parameter sets are rejected by the following checks:
 
 ```math
 \begin{aligned}
-  &R, X, G, B, \tau, \theta \in \mathbb{R}\ \text{and finite} \\
+  &R, X, G, B, G_\text{mag}, B_\text{mag}, \tau, \theta
+    \in \mathbb{R}\ \text{and finite} \\
   &R^2 + X^2 > 0 \\
   &\tau > 0
 \end{aligned}
@@ -46,17 +41,17 @@ Invalid Branch parameter sets are rejected by the following checks:
 
 ### Model Derived Parameters
 
-The series and shunt admittances are:
+The series, magnetizing shunt, and line shunt admittances are:
 
 ```math
 \begin{aligned}
-  Y_{\mathrm{br}} &= \dfrac{1}{R + jX} \\
-  Y_{\mathrm{sh}} &= G + jB
+  Y_{\mathrm{br}}  &= \dfrac{1}{R + jX} \\
+  Y_{\mathrm{mag}} &= G_\text{mag} + jB_\text{mag} \\
+  Y_{\mathrm{sh}}  &= G + jB
 \end{aligned}
 ```
 
-The nominal $\pi$-branch admittance matrix is the sum of the series and shunt
-admittance contributions:
+The series, magnetizing shunt, and line shunt admittance matrices are:
 
 ```math
 \begin{aligned}
@@ -67,7 +62,16 @@ admittance contributions:
       Y_{\mathrm{br}}
       & -Y_{\mathrm{br}}
     \end{bmatrix}
-    +
+    \\
+  \mathbf{Y}_\text{mag}
+    &=
+    \begin{bmatrix}
+      -Y_{\mathrm{mag}} & 0 \\
+      0 & 0
+    \end{bmatrix}
+    \\
+  \mathbf{Y}_\text{sh}
+    &=
     \dfrac{1}{2}
     \begin{bmatrix}
       -Y_{\mathrm{sh}} & 0 \\
@@ -85,8 +89,23 @@ The off-nominal transformer transformation uses bus 1 as the tap side:
     \begin{bmatrix}
       \tau^{-1} & 0 \\
       0 & e^{j\theta}
-    \end{bmatrix} \\
-  \mathbf{Y} &= \mathbf{M}^{\dagger}\mathbf{Y}_0\mathbf{M}
+    \end{bmatrix}
+\end{aligned}
+```
+
+The magnetizing and line shunts are added outside the transformation:
+
+```math
+\begin{aligned}
+  \mathbf{Y}
+    &=
+    \mathbf{M}^{\dagger}
+    \mathbf{Y}_0
+    \mathbf{M}
+    +
+    \mathbf{Y}_\text{mag}
+    +
+    \mathbf{Y}_\text{sh}
 \end{aligned}
 ```
 

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -92,13 +92,15 @@ namespace GridKit
 
       TestOutcome offNominalResidual()
       {
-        // Verifies tap and phase-shift current residual contributions.
+        // Verifies tap, phase-shift, line-shunt, and bus-1 magnetizing-shunt contributions.
         TestStatus success = true;
 
         RealT R{2.0};
         RealT X{4.0};
-        RealT G{0.2};
-        RealT B{1.2};
+        RealT G{0.4};
+        RealT B{0.8};
+        RealT Gmag{0.2};
+        RealT Bmag{1.2};
         RealT tap{1.25};
         RealT phase{0.3};
 
@@ -107,10 +109,10 @@ namespace GridKit
         ScalarT Vr2{30.0};
         ScalarT Vi2{40.0};
 
-        const ScalarT Ir1{12.719793434963478};
-        const ScalarT Ii1{-4.047960563981182};
-        const ScalarT Ir2{13.821345956502421};
-        const ScalarT Ii2{-21.182080826645354};
+        const ScalarT Ir1{33.679793434963472};
+        const ScalarT Ii1{-22.927960563981181};
+        const ScalarT Ir2{2.821345956502423};
+        const ScalarT Ii2{-19.182080826645358};
 
         PhasorDynamics::Bus<ScalarT, IdxT> bus1(Vr1, Vi1);
         PhasorDynamics::Bus<ScalarT, IdxT> bus2(Vr2, Vi2);
@@ -121,7 +123,20 @@ namespace GridKit
         bus2.initialize();
         bus2.evaluateResidual();
 
-        PhasorDynamics::Branch<ScalarT, IdxT> branch(&bus1, &bus2, R, X, G, B, tap, phase);
+        using Data      = typename PhasorDynamics::Branch<ScalarT, IdxT>::ModelDataT;
+        using Parameter = typename Data::Parameters;
+
+        Data data;
+        data.parameters[Parameter::R]     = R;
+        data.parameters[Parameter::X]     = X;
+        data.parameters[Parameter::G]     = G;
+        data.parameters[Parameter::B]     = B;
+        data.parameters[Parameter::Gmag]  = Gmag;
+        data.parameters[Parameter::Bmag]  = Bmag;
+        data.parameters[Parameter::tap]   = tap;
+        data.parameters[Parameter::phase] = phase;
+
+        PhasorDynamics::Branch<ScalarT, IdxT> branch(&bus1, &bus2, data);
         branch.allocate();
         branch.evaluateResidual();
 
@@ -390,12 +405,12 @@ namespace GridKit
         const std::complex<RealT> ybr{g, b};
         const std::complex<RealT> ysh{G, B};
         const std::complex<RealT> rotation{std::cos(phase), std::sin(phase)};
-        const std::complex<RealT> ydiag = -(ybr + RealT{0.5} * ysh);
+        const std::complex<RealT> ydiag = -ybr;
 
-        const std::complex<RealT> y11 = ydiag * inv_tap * inv_tap;
+        const std::complex<RealT> y11 = ydiag * inv_tap * inv_tap - RealT{0.5} * ysh;
         const std::complex<RealT> y12 = ybr * rotation * inv_tap;
         const std::complex<RealT> y21 = ybr * std::conj(rotation) * inv_tap;
-        const std::complex<RealT> y22 = ydiag;
+        const std::complex<RealT> y22 = ydiag - RealT{0.5} * ysh;
 
         std::vector<DependencyTracking::Variable::DependencyMap> dependencies(4);
         dependencies[0] = {{0, y11.real()}, {1, -y11.imag()}, {2, y12.real()}, {3, -y12.imag()}};

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -66,7 +66,7 @@ namespace GridKit
                    { "number": 2, "class": "BusInfinite", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "params": {"kv": 115.0} }
                ],
                "devices": [
-                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0, "tap":1.05, "phase":0.1} },
+                   { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0, "Gmag":0.01, "Bmag":0.02, "tap":1.05, "phase":0.1} },
                    { "class": "Genrou", "ports": {"bus":1}, "id": "1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
                           "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
                    { "class": "Gensal", "ports": {"bus":1}, "id": "2", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05,
@@ -121,6 +121,8 @@ namespace GridKit
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::X]) == 0.1;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::G]) == 0.0;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::B]) == 0.0;
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::Gmag]) == 0.01;
+        success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::Bmag]) == 0.02;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::tap]) == 1.05;
         success *= std::get<RealT>(result.branch[0].parameters[BranchParameters::phase]) == 0.1;
         success *= result.branch[0].buses[BranchBuses::bus1] == 1;


### PR DESCRIPTION
## Description

Implementation on `develop` treats the shunt as a magnetizing admittance, which should have a distinct parameter from the line shunt admittance, which does not observe the effects of phase/tap changes. 

Before these changes, the Branch model is presumed to be either a XFMR or a line but not a line & XFMR in series. We need to support this edge case


MATPOWER does not seem to make this distinction, but PowerWorld models this correctly. This contributed marginally to errors in magnetization admittances in some cases.
 
Required before `0.2` release.
 
 ## Proposed changes
 
- Add magnetic charging admittance term
- Move G and B contribution outside of tap/phase transformation
 
 ## Checklist

 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- NA I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
Need to update the circuit mdoel diagram in future
 
