### PR TITLE
Add appropriate throws in parsers and update example

### DIFF
--- a/GridKit/Model/PhasorDynamics/Bus/BusDataJSONParser.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusDataJSONParser.hpp
@@ -65,6 +65,7 @@ namespace GridKit
       {
         Log::error() << "\n\tInvalid bus class: \"" << string_class << "\"."
                      << error_context.str() << std::endl;
+        throw std::runtime_error("JSON parser failed");
       }
 
       using Parameters = typename BusData<RealT, IdxT>::Parameters;
@@ -94,6 +95,7 @@ namespace GridKit
                          << raw_parameter.value()
                          << " (typed as \"" << raw_parameter.value().type_name()
                          << "\")." << error_context.str() << std::endl;
+            throw std::runtime_error("JSON parser failed");
           }
         }
         else

--- a/GridKit/Model/PhasorDynamics/ComponentDataJSONParser.hpp
+++ b/GridKit/Model/PhasorDynamics/ComponentDataJSONParser.hpp
@@ -115,6 +115,7 @@ namespace GridKit
         Log::error() << "\n\tInvalid port mapping: \"" << raw_port.key()
                      << "\" has no value." << error_context.str()
                      << std::endl;
+        throw std::runtime_error("JSON parser failed");
       }
 
       if (j.contains("mon"))

--- a/GridKit/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
@@ -97,7 +97,7 @@ namespace GridKit
           raw_component.get_to(adapter);
           sm.adapter.push_back(adapter);
         }
-        if (kind == "Branch")
+        else if (kind == "Branch")
         {
           typename SystemModelData<RealT, IdxT>::BranchDataT branch;
           raw_component.get_to(branch);
@@ -174,6 +174,7 @@ namespace GridKit
           Log::error() << "\n\tInvalid device class: \"" << kind << "\". "
                        << "\n\tSee the \"devices\" list in your JSON file."
                        << std::endl;
+          throw std::runtime_error("JSON parser failed");
         }
       }
     }

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.case.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.case.json
@@ -97,7 +97,7 @@
             }
         },
         {
-            "class": "Load",
+            "class": "LoadZ",
             "ports": {
                 "bus": 3
             },


### PR DESCRIPTION
## Description
 
Make JSON parser code throw when appropriate in addition to reporting an error.
 
 _Closes #476_
 
 ## Proposed changes
 
- Add error throwing where appropriate in parser code
- Fix example JSON file (`Load` -> `LoadZ`)
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.