### PR TITLE
Message about expected errors in tests

### DIFF
--- a/GridKit/AutomaticDifferentiation/DependencyTracking/VariableImplementation.hpp
+++ b/GridKit/AutomaticDifferentiation/DependencyTracking/VariableImplementation.hpp
@@ -52,23 +52,23 @@ namespace GridKit
     */
     void Variable::print(std::ostream& os) const
     {
-      os << value_;
+      os << "value " << value_;
 
       if (is_fixed_)
       {
-        os << " (fixed)";
+        os << ", (fixed)";
         return;
       }
 
       if (variable_number_ != INVALID_VAR_NUMBER)
       {
-        os << " (variable " << variable_number_ << ")";
+        os << ", (variable " << variable_number_ << ")";
         return;
       }
 
       if (!dependencies_.empty())
       {
-        os << " dependencies: [ ";
+        os << ", dependencies: [ ";
         for (auto& p : dependencies_)
           os << "(" << p.first << ", " << p.second << ") ";
         os << "]";

--- a/GridKit/Model/PhasorDynamics/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/CMakeLists.txt
@@ -47,9 +47,16 @@ add_library(GridKit::phasor_dynamics_components ALIAS phasor_dynamics_components
 add_library(GridKit::phasor_dynamics_components_dependency_tracking ALIAS
             phasor_dynamics_components_dependency_tracking)
 
+
+if(GRIDKIT_ENABLE_ENZYME)
+  set(_system_model_source SystemModelEnzyme.cpp)
+else()
+  set(_system_model_source SystemModel.cpp)
+endif()
+
 gridkit_add_library(
   phasor_dynamics_systemmodel
-  SOURCES SystemModel.cpp SystemModelData.cpp
+  SOURCES ${_system_model_source} SystemModelData.cpp
   HEADERS SystemModel.hpp SystemModelData.hpp
   LINK_LIBRARIES
     PUBLIC

--- a/GridKit/Model/PhasorDynamics/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/CMakeLists.txt
@@ -47,7 +47,6 @@ add_library(GridKit::phasor_dynamics_components ALIAS phasor_dynamics_components
 add_library(GridKit::phasor_dynamics_components_dependency_tracking ALIAS
             phasor_dynamics_components_dependency_tracking)
 
-
 if(GRIDKIT_ENABLE_ENZYME)
   set(_system_model_source SystemModelEnzyme.cpp)
 else()

--- a/GridKit/Model/PhasorDynamics/SystemModel.cpp
+++ b/GridKit/Model/PhasorDynamics/SystemModel.cpp
@@ -4,6 +4,19 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    /**
+     * @brief By default, Jacobians are not available
+     *
+     */
+    template <typename scalar_type, typename index_type>
+    bool SystemModel<scalar_type, index_type>::hasJacobian()
+    {
+      Log::warning() << "GridKit was not built with Enzyme. "
+                     << "Falling back to dense Jacobians in PhasorDynamics.\n";
+
+      return false;
+    }
+
     // Available template instantiations
     // template class SystemModel<double, long int>;
     template class SystemModel<double, size_t>;

--- a/GridKit/Model/PhasorDynamics/SystemModelDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelDependencyTracking.cpp
@@ -4,6 +4,18 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    /**
+     * @brief By default, Jacobians are not available
+     *
+     * DependencyTracking::Variable stores the Jacobian as dependency maps. 
+     * @todo Construct a Jacobian based on the dependency maps.
+     */
+    template <typename scalar_type, typename index_type>
+    bool SystemModel<scalar_type, index_type>::hasJacobian()
+    {
+      return false;
+    }
+
     // Available template instantiations
     // template class SystemModel<DependencyTracking::Variable, long int>;
     template class SystemModel<DependencyTracking::Variable, size_t>;

--- a/GridKit/Model/PhasorDynamics/SystemModelDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelDependencyTracking.cpp
@@ -7,7 +7,7 @@ namespace GridKit
     /**
      * @brief By default, Jacobians are not available
      *
-     * DependencyTracking::Variable stores the Jacobian as dependency maps. 
+     * DependencyTracking::Variable stores the Jacobian as dependency maps.
      * @todo Construct a Jacobian based on the dependency maps.
      */
     template <typename scalar_type, typename index_type>

--- a/GridKit/Model/PhasorDynamics/SystemModelEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelEnzyme.cpp
@@ -1,0 +1,42 @@
+#include "SystemModelImpl.hpp"
+
+namespace GridKit
+{
+  namespace PhasorDynamics
+  {
+    /**
+     * @brief Check components for Jacobian availability
+     *
+     * @return true
+     * @return false
+     */
+    template <typename scalar_type, typename index_type>
+    bool SystemModel<scalar_type, index_type>::hasJacobian()
+    {
+      bool has_jacobian = true;
+      for (const auto& component : components_)
+      {
+        has_jacobian = has_jacobian && component->hasJacobian();
+      }
+
+      for (const auto& bus : buses_)
+      {
+        has_jacobian = has_jacobian && bus->hasJacobian();
+      }
+
+      if (!has_jacobian)
+      {
+        Log::warning() << "GridKit was built with Enzyme, but some models "
+                          "don't have Jacobians available. "
+                          "Falling back to dense Jacobians in PhasorDynamics.\n";
+      }
+
+      return has_jacobian;
+    }
+
+    // Available template instantiations
+    // template class SystemModel<double, long int>;
+    template class SystemModel<double, size_t>;
+
+  } // namespace PhasorDynamics
+} // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
@@ -589,41 +589,6 @@ namespace GridKit
     }
 
     /**
-     * @brief Check components for Jacobian availability
-     *
-     * @return true
-     * @return false
-     */
-    template <typename scalar_type, typename index_type>
-    bool SystemModel<scalar_type, index_type>::hasJacobian()
-    {
-      bool has_jacobian = false;
-#ifdef GRIDKIT_ENABLE_ENZYME
-      has_jacobian = true;
-      for (const auto& component : components_)
-      {
-        has_jacobian = has_jacobian && component->hasJacobian();
-      }
-
-      for (const auto& bus : buses_)
-      {
-        has_jacobian = has_jacobian && bus->hasJacobian();
-      }
-
-      if (!has_jacobian)
-      {
-        Log::warning() << "GridKit was built with Enzyme, but some models "
-                          "don't have Jacobians available. "
-                          "Falling back to dense Jacobians in PhasorDynamics.\n";
-      }
-#else
-      Log::warning() << "GridKit was not built with Enzyme. "
-                     << "Falling back to dense Jacobians in PhasorDynamics.\n";
-#endif
-      return has_jacobian;
-    }
-
-    /**
      * @brief Initialize buses first, then all the other components.
      *
      * @pre All buses and components must be allocated at this point.

--- a/tests/UnitTests/LinearAlgebra/Vector/VectorTests.hpp
+++ b/tests/UnitTests/LinearAlgebra/Vector/VectorTests.hpp
@@ -8,12 +8,15 @@
 #include <GridKit/LinearAlgebra/Vector/Vector.hpp>
 #include <GridKit/MemoryUtilities/MemoryUtils.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
 
 namespace GridKit
 {
   namespace Testing
   {
     using namespace LinearAlgebra;
+
+    using Log = ::GridKit::Utilities::Logger;
 
     /**
      * @class Tests for vector operations.
@@ -201,6 +204,10 @@ namespace GridKit
         status *= replacement_storage[0] == ScalarT{3.0};
 
         // Owned vector storage must not be replaced by external storage.
+        Log::setVerbosity(Log::Verbosity::EVERYTHING);
+        Log::misc() << "Testing that owned vector storage cannot be replaced by external storage. "
+                    << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::WARNINGS);
         Vector<ScalarT, IdxT> owned(N);
         status                 *= owned.allocate(memory::HOST) == 0;
         auto* const owned_data  = owned.getData(memory::HOST);

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -10,11 +10,13 @@
 #include <GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
 
 namespace GridKit
 {
   namespace Testing
   {
+    using Log = ::GridKit::Utilities::Logger;
 
     template <class ScalarT, typename IdxT>
     class BranchTests
@@ -288,8 +290,9 @@ namespace GridKit
         // Verifies invalid branch parameters are rejected.
         TestStatus success = true;
 
-        std::cout << "Testing that invalid branch parameters are rejected. "
-                  << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::EVERYTHING);
+        Log::misc() << "Testing that invalid branch parameters are rejected. "
+                    << "Logged errors are are expected.\n";
 
         PhasorDynamics::Bus<ScalarT, IdxT> bus1(1.0, 0.0);
         PhasorDynamics::Bus<ScalarT, IdxT> bus2(1.0, 0.0);

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -293,6 +293,7 @@ namespace GridKit
         Log::setVerbosity(Log::Verbosity::EVERYTHING);
         Log::misc() << "Testing that invalid branch parameters are rejected. "
                     << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::WARNINGS);
 
         PhasorDynamics::Bus<ScalarT, IdxT> bus1(1.0, 0.0);
         PhasorDynamics::Bus<ScalarT, IdxT> bus2(1.0, 0.0);

--- a/tests/UnitTests/PhasorDynamics/BranchTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BranchTests.hpp
@@ -288,6 +288,9 @@ namespace GridKit
         // Verifies invalid branch parameters are rejected.
         TestStatus success = true;
 
+        std::cout << "Testing that invalid branch parameters are rejected. "
+                  << "Logged errors are are expected.\n";
+
         PhasorDynamics::Bus<ScalarT, IdxT> bus1(1.0, 0.0);
         PhasorDynamics::Bus<ScalarT, IdxT> bus2(1.0, 0.0);
 

--- a/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
@@ -12,12 +12,15 @@
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
 #include <GridKit/Utilities/MapFromCsr.hpp>
 
 namespace GridKit
 {
   namespace Testing
   {
+    using Log = ::GridKit::Utilities::Logger;
+
     template <class ScalarT, typename IdxT>
     class ExciterIeeet1Tests
     {
@@ -181,8 +184,10 @@ namespace GridKit
       {
         TestStatus success = true;
 
-        std::cout << "Testing that invalid saturation parameters are rejected. "
-                  << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::EVERYTHING);
+        Log::misc() << "Testing that invalid saturation parameters are rejected. "
+                    << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::WARNINGS);
 
         using Params = PhasorDynamics::Exciter::Ieeet1Parameters;
 

--- a/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterIeeet1Tests.hpp
@@ -181,6 +181,9 @@ namespace GridKit
       {
         TestStatus success = true;
 
+        std::cout << "Testing that invalid saturation parameters are rejected. "
+                  << "Logged errors are are expected.\n";
+
         using Params = PhasorDynamics::Exciter::Ieeet1Parameters;
 
         auto data                    = makeTestData();

--- a/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
@@ -207,6 +207,9 @@ namespace GridKit
 
         TestStatus success = true;
 
+        std::cout << "Testing that invalid parameters are rejected. "
+                  << "Logged errors are are expected.\n";
+
         PhasorDynamics::Bus<ScalarT, IdxT> bus(1.0, 0.0);
 
         auto missing = makeTestData();
@@ -254,6 +257,8 @@ namespace GridKit
         success *= (system.evaluateResidual() == 0);
         success *= (system.size() == 5);
 
+        std::cout << "Testing that model with missing EFD data is rejected. "
+                  << "Logged errors are are expected.\n";
         auto missing_efd = data;
         missing_efd.sexspti[0].signal_outputs.erase(SignalOutput::efd);
         SystemModel<ScalarT, IdxT> missing_efd_system(missing_efd);

--- a/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
@@ -323,8 +323,8 @@ namespace GridKit
         success       *= (system.evaluateResidual() == 0);
         const auto* f  = system.getResidual().getData();
         success       *= isEqual(f[consumer_vtr_residual],
-                                 static_cast<ScalarT>(0.75),
-                                 kTol);
+                           static_cast<ScalarT>(0.75),
+                           kTol);
 
         return success.report(__func__);
       }

--- a/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ExciterSexsPtiTests.hpp
@@ -14,12 +14,15 @@
 #include <GridKit/Model/PhasorDynamics/SystemModelData.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
 #include <GridKit/Utilities/MapFromCsr.hpp>
 
 namespace GridKit
 {
   namespace Testing
   {
+    using Log = GridKit::Utilities::Logger;
+
     template <class ScalarT, typename IdxT>
     class ExciterSexsPtiTests
     {
@@ -207,8 +210,10 @@ namespace GridKit
 
         TestStatus success = true;
 
-        std::cout << "Testing that invalid parameters are rejected. "
-                  << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::EVERYTHING);
+        Log::misc() << "Testing that invalid parameters are rejected. "
+                    << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::WARNINGS);
 
         PhasorDynamics::Bus<ScalarT, IdxT> bus(1.0, 0.0);
 
@@ -257,8 +262,10 @@ namespace GridKit
         success *= (system.evaluateResidual() == 0);
         success *= (system.size() == 5);
 
-        std::cout << "Testing that model with missing EFD data is rejected. "
-                  << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::EVERYTHING);
+        Log::misc() << "Testing that model with missing EFD data is rejected. "
+                    << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::WARNINGS);
         auto missing_efd = data;
         missing_efd.sexspti[0].signal_outputs.erase(SignalOutput::efd);
         SystemModel<ScalarT, IdxT> missing_efd_system(missing_efd);
@@ -316,8 +323,8 @@ namespace GridKit
         success       *= (system.evaluateResidual() == 0);
         const auto* f  = system.getResidual().getData();
         success       *= isEqual(f[consumer_vtr_residual],
-                           static_cast<ScalarT>(0.75),
-                           kTol);
+                                 static_cast<ScalarT>(0.75),
+                                 kTol);
 
         return success.report(__func__);
       }

--- a/tests/UnitTests/PhasorDynamics/SystemTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/SystemTests.hpp
@@ -303,6 +303,8 @@ namespace GridKit
         auto sys        = SystemModel<double, size_t>(data);
 
         TestStatus status{true};
+        std::cout << "Testing for exceptions when signals are incorrectly configured. "
+                  << "Logged errors are are expected.\n";
         status *= throws<std::runtime_error>(
             [&]()
             { sys.allocate(); });
@@ -323,6 +325,8 @@ namespace GridKit
 
         status *= bus.allocate() == 0;
         system.addBus(&bus);
+        std::cout << "Testing for exceptions when when a child cannot bind to system storage. "
+                  << "Logged errors are are expected.\n";
         status *= throws<std::runtime_error>(
             [&]()
             { system.allocate(); });

--- a/tests/UnitTests/PhasorDynamics/SystemTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/SystemTests.hpp
@@ -18,6 +18,7 @@
 #include <GridKit/Model/PhasorDynamics/SystemModelData.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
 #include <GridKit/Utilities/MapFromCsr.hpp>
 
 namespace GridKit
@@ -26,6 +27,8 @@ namespace GridKit
   {
     using GridKit::PhasorDynamics::BranchBuses;
     using GridKit::PhasorDynamics::BranchParameters;
+
+    using Log = ::GridKit::Utilities::Logger;
 
     template <class ScalarT, typename IdxT>
     class SystemTests
@@ -303,8 +306,10 @@ namespace GridKit
         auto sys        = SystemModel<double, size_t>(data);
 
         TestStatus status{true};
-        std::cout << "Testing for exceptions when signals are incorrectly configured. "
-                  << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::EVERYTHING);
+        Log::misc() << "Testing for exceptions when signals are incorrectly configured. "
+                    << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::WARNINGS);
         status *= throws<std::runtime_error>(
             [&]()
             { sys.allocate(); });
@@ -325,8 +330,10 @@ namespace GridKit
 
         status *= bus.allocate() == 0;
         system.addBus(&bus);
-        std::cout << "Testing for exceptions when when a child cannot bind to system storage. "
-                  << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::EVERYTHING);
+        Log::misc() << "Testing for exceptions when when a child cannot bind to system storage. "
+                    << "Logged errors are are expected.\n";
+        Log::setVerbosity(Log::Verbosity::WARNINGS);
         status *= throws<std::runtime_error>(
             [&]()
             { system.allocate(); });

--- a/tests/UnitTests/Utilities/CliArgsTests.hpp
+++ b/tests/UnitTests/Utilities/CliArgsTests.hpp
@@ -62,6 +62,7 @@ namespace GridKit
         status *= args["flag1"].as<bool>() == false;
 
         // bad: duplicate name
+        Log::misc() << "Expect error because options cannot be duplicated\n";
         status *= throws<std::runtime_error>(
             [&]()
             {
@@ -148,6 +149,7 @@ namespace GridKit
         status *=
             args.get<double, 3>("params") == args["params"].as<double, 3>();
 
+        Log::misc() << "Expect error while testing that unrecognized options are rejected\n";
         status *= throws<std::runtime_error>(
             [&]()
             { args.get("bad"); });

--- a/tests/UnitTests/Utilities/CliArgsTests.hpp
+++ b/tests/UnitTests/Utilities/CliArgsTests.hpp
@@ -62,7 +62,9 @@ namespace GridKit
         status *= args["flag1"].as<bool>() == false;
 
         // bad: duplicate name
+        Log::setVerbosity(Log::Verbosity::EVERYTHING);
         Log::misc() << "Expect error because options cannot be duplicated\n";
+        Log::setVerbosity(Log::Verbosity::WARNINGS);
         status *= throws<std::runtime_error>(
             [&]()
             {
@@ -149,7 +151,9 @@ namespace GridKit
         status *=
             args.get<double, 3>("params") == args["params"].as<double, 3>();
 
+        Log::setVerbosity(Log::Verbosity::EVERYTHING);
         Log::misc() << "Expect error while testing that unrecognized options are rejected\n";
+        Log::setVerbosity(Log::Verbosity::WARNINGS);
         status *= throws<std::runtime_error>(
             [&]()
             { args.get("bad"); });


### PR DESCRIPTION
 ## Description
 
Closes #495 
 
 ## Proposed changes
- Improve printing of `DependencyTracking::Variable` to reduce confusion.
- Use Logger to message the user about expected error in tests
- Separate compilation units for `PhasorDynamics::SystemModel` with and without Enzyme to suppress `nullptr` Jacobian warnings when testing with `DependencyTracking::Variable`.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
cc @lukelowry