### PR TITLE
Misc sphinx, doxygen, RTD hygiene

### DIFF
--- a/GridKit/AutomaticDifferentiation/Enzyme/SparseJacobians.hpp
+++ b/GridKit/AutomaticDifferentiation/Enzyme/SparseJacobians.hpp
@@ -1,5 +1,5 @@
 /**
- * @file SparseWrapper.hpp
+ * @file SparseJacobians.hpp
  * @author Nicholson Koukpaizan (koukpaizannk@ornl.gov)
  *
  */

--- a/GridKit/LinearAlgebra/Solver/CMakeLists.txt
+++ b/GridKit/LinearAlgebra/Solver/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 if(GRIDKIT_ENABLE_RESOLVE)
   gridkit_add_library(
     resolve_system_solver

--- a/GridKit/LinearAlgebra/Solver/CMakeLists.txt
+++ b/GridKit/LinearAlgebra/Solver/CMakeLists.txt
@@ -1,3 +1,5 @@
+install(FILES LinearSolver.hpp DESTINATION include/GridKit/LinearAlgebra/Solver)
+
 if(GRIDKIT_ENABLE_RESOLVE)
   gridkit_add_library(
     resolve_system_solver

--- a/GridKit/LinearAlgebra/Solver/CMakeLists.txt
+++ b/GridKit/LinearAlgebra/Solver/CMakeLists.txt
@@ -1,4 +1,3 @@
-install(FILES LinearSolver.hpp DESTINATION include/GridKit/LinearAlgebra/Solver)
 
 if(GRIDKIT_ENABLE_RESOLVE)
   gridkit_add_library(

--- a/GridKit/LinearAlgebra/Solver/CMakeLists.txt
+++ b/GridKit/LinearAlgebra/Solver/CMakeLists.txt
@@ -2,6 +2,6 @@ if(GRIDKIT_ENABLE_RESOLVE)
   gridkit_add_library(
     resolve_system_solver
     SOURCES ResolveSystemSolver.cpp
-    HEADERS ResolveSystemSolver.hpp
+    HEADERS LinearSolver.hpp ResolveSystemSolver.hpp
     LINK_LIBRARIES PRIVATE ReSolve::ReSolve)
 endif()

--- a/GridKit/LinearAlgebra/Solver/LinearSolver.hpp
+++ b/GridKit/LinearAlgebra/Solver/LinearSolver.hpp
@@ -11,7 +11,8 @@ namespace GridKit
   {
 
     /**
-     * @brief An interface for linear solvers to be used in GridKit, such as in \ref Integrator::Rosenbrock.
+     * @brief Interface for linear solvers used by GridKit integrators, including
+     *        \ref AnalysisManager::NativeDynamicSolver::Rosenbrock "Rosenbrock".
      *
      */
     template <class ScalarT, typename IdxT>

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/README.md
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/README.md
@@ -155,7 +155,7 @@ The IEEET1 differential equations, as derived from the model diagram, are:
 \end{aligned}
 ```
 
-CommonMath defines the smooth [Anti-Windup](../../../../CommonMath.md#anti-windup-indicator) target and approximation.
+CommonMath defines the smooth [Anti-Windup](../../../../CommonMath.md#antiwindup) target and approximation.
 
 ### Algebraic Equations
 

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/README.md
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/README.md
@@ -72,7 +72,7 @@ The TGOV1 differential equations, as derived from the model diagram.
 \end{aligned}
 ```
 
-CommonMath defines the [Anti-Windup](../../../../CommonMath.md#anti-windup-indicator)
+CommonMath defines the [Anti-Windup](../../../../CommonMath.md#antiwindup)
 target and smooth approximation.
 
 ### Algebraic Equations

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -41,17 +41,17 @@ namespace GridKit
       /// Internal variables of a `Tgov1`
       enum class Tgov1InternalVariables : size_t
       {
-        PTX, ///< $P_{tx}$
-        PV,  ///< $P_v$
-        PM,  ///< $P_m$
+        PTX, ///< \f$P_{tx}\f$
+        PV,  ///< \f$P_v\f$
+        PM,  ///< \f$P_m\f$
         MAXIMUM,
       };
 
       /// External variables of a `Tgov1`
       enum class Tgov1ExternalVariables : size_t
       {
-        DELTAOMEGA, ///< $\Delta_\omega$
-        PREF,       ///< $P_{ref}$
+        DELTAOMEGA, ///< \f$\Delta_\omega\f$
+        PREF,       ///< \f$P_{ref}\f$
         MAXIMUM,
       };
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/Genrou.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/Genrou.hpp
@@ -1,5 +1,5 @@
 /**
- * @file Genrou.cpp
+ * @file Genrou.hpp
  * @author Adam Birchfield (abirchfield@tamu.edu)
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Declaration of a GENROU generator model.
@@ -36,33 +36,33 @@ namespace GridKit
     /// Internal variables of a `Genrou`
     enum class GenrouInternalVariables : size_t
     {
-      DELTA,  ///< $\delta$
-      OMEGA,  ///< $\omega$
-      PSIPD,  ///< $\psi'_d$
-      PSIPQ,  ///< $\psi'_q$
-      EPD,    ///< $E'_d$
-      EPQ,    ///< $E'_q$
-      VD,     ///< $V_d$
-      VQ,     ///< $V_q$
-      ID,     ///< $I_d$
-      IQ,     ///< $I_q$
-      IR,     ///< $I_r$
-      II,     ///< $I_i$
-      PSIPPQ, ///< $\psi''_q$
-      PSIPPD, ///< $\psi''_d$
-      PSIPP,  ///< $\psi''$
-      TE,     ///< $T_e$
-      KSAT,   ///< $k_{sat}$
+      DELTA,  ///< \f$\delta\f$
+      OMEGA,  ///< \f$\omega\f$
+      PSIPD,  ///< \f$\psi'_d\f$
+      PSIPQ,  ///< \f$\psi'_q\f$
+      EPD,    ///< \f$E'_d\f$
+      EPQ,    ///< \f$E'_q\f$
+      VD,     ///< \f$V_d\f$
+      VQ,     ///< \f$V_q\f$
+      ID,     ///< \f$I_d\f$
+      IQ,     ///< \f$I_q\f$
+      IR,     ///< \f$I_r\f$
+      II,     ///< \f$I_i\f$
+      PSIPPQ, ///< \f$\psi''_q\f$
+      PSIPPD, ///< \f$\psi''_d\f$
+      PSIPP,  ///< \f$\psi''\f$
+      TE,     ///< \f$T_e\f$
+      KSAT,   ///< \f$k_{sat}\f$
       MAXIMUM,
     };
 
     /// External variables of a `Genrou`
     enum class GenrouExternalVariables : size_t
     {
-      VR,  ///< $V_r$
-      VI,  ///< $V_i$
-      PM,  ///< $P_m$
-      EFD, ///< $E_{fd}$
+      VR,  ///< \f$V_r\f$
+      VI,  ///< \f$V_i\f$
+      PM,  ///< \f$P_m\f$
+      EFD, ///< \f$E_{fd}\f$
       MAXIMUM,
     };
 

--- a/GridKit/Model/PhasorDynamics/SystemModelData.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.hpp
@@ -111,14 +111,12 @@ namespace GridKit
       std::vector<MonitorSinkSpec> monitor_sink;
     };
 
-    ///@{
     /**
      * @brief Generate system model data from a JSON input file
      */
-    SystemModelData<double, size_t> parseSystemModelData(std::istream&);
-    SystemModelData<double, size_t> parseSystemModelData(std::istream&&);
-    SystemModelData<double, size_t> parseSystemModelData(const std::filesystem::path&);
-    SystemModelData<double, size_t> parseSystemModelData(const std::string&);
-    ///@}
+    SystemModelData<double, size_t> parseSystemModelData(std::istream& stream);
+    SystemModelData<double, size_t> parseSystemModelData(std::istream&& stream);
+    SystemModelData<double, size_t> parseSystemModelData(const std::filesystem::path& filePath);
+    SystemModelData<double, size_t> parseSystemModelData(const std::string& fileName);
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -108,9 +108,7 @@ namespace GridKit
     /**
      * @brief Allocate system vectors and construct the system CSR Jacobian
      *
-     * @param[in] s size of the vector (total number of unknowns)
-     *
-     * @post System model vectors allocated with size s
+     * @post System model vectors allocated with the computed total number of unknowns
      * @post CSR Jacobian sparsity pattern is computed
      * @post COO->CSR mapping is computed
      * @post Every component's \ref CircuitComponent::y_int_, \ref CircuitComponent::yp_int_, and \ref CircuitComponent::f_int_ pointers
@@ -416,7 +414,7 @@ namespace GridKit
     }
 
     /**
-     * @brief Creates the system Jacobian representing \alpha dF/dy' + dF/dy
+     * @brief Creates the system Jacobian representing \f$\alpha dF/dy' + dF/dy\f$
      *
      * Updates the CSR Jacobian values using the per-component mappings
      * computed during allocate().

--- a/GridKit/Model/PowerFlow/CMakeLists.txt
+++ b/GridKit/Model/PowerFlow/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(MiniGrid)
 
 install(
   FILES MatpowerParser.hpp
+        ModelEvaluatorImpl.hpp
         PowerFlowData.hpp
         SystemModel.hpp
         SystemModelPowerFlow.hpp

--- a/GridKit/Model/PowerFlow/MatpowerParser.hpp
+++ b/GridKit/Model/PowerFlow/MatpowerParser.hpp
@@ -1,9 +1,8 @@
 
 /**
- * @file FileIO.hpp
+ * @file MatpowerParser.hpp
  * @author Slaven Peles <slaven.peles@pnnl.gov>
- *
- * Contains definition of a utility for reading lookup tables.
+ * @brief Utilities for parsing MATPOWER case data.
  *
  */
 #pragma once
@@ -23,6 +22,7 @@ namespace GridKit
 {
   using namespace GridKit::PowerFlowData;
 
+  /// @cond DOXYGEN_INTERNAL
   static const std::string matlab_syntax_error{
       "Only a subset of Matlab syntax is supported."
       "\n\t'=' for assignment must be on the same line as the field, eg "
@@ -31,10 +31,12 @@ namespace GridKit
       "initialization."
       "\n\tEach row of a matrix must be terminated by a semicolon."};
 
-  std::ostream& logs()
+  /// @endcond
+
+  inline std::ostream& logs()
   {
 #ifndef NDEBUG
-    std::cerr << "[FileIO.hpp]: ";
+    std::cerr << "[MatpowerParser.hpp]: ";
     return std::cerr;
 #else
     static std::ofstream ofs;
@@ -43,19 +45,19 @@ namespace GridKit
 #endif
   }
 
-  void ltrim(std::string& s)
+  inline void ltrim(std::string& s)
   {
     const std::string nothing = "";
     s                         = std::regex_replace(s, std::regex("^\\s+"), nothing);
   }
 
-  void rtrim(std::string& s)
+  inline void rtrim(std::string& s)
   {
     const std::string nothing = "";
     s                         = std::regex_replace(s, std::regex("\\s+$"), nothing);
   }
 
-  void trim_matlab_comments(std::string& s)
+  inline void trim_matlab_comments(std::string& s)
   {
     const std::string nothing = "";
     s                         = std::regex_replace(s, std::regex("%.+"), nothing);
@@ -65,7 +67,7 @@ namespace GridKit
   //
   // For example, the string "   mpc.bus =  [ ... ] % Some comment" will
   // return the value "bus".
-  std::string getMatPowerComponent(const std::string& line)
+  inline std::string getMatPowerComponent(const std::string& line)
   {
     logs() << "Getting matpower component from line\n";
     std::regex  pat("mpc.([a-zA-Z]+)\\s*=.+");
@@ -86,7 +88,7 @@ namespace GridKit
 
   // Ensure that all of the given line has been consumed, and that the only
   // remaining non-whitespace character left in the line is a semicolon.
-  void checkEndOfMatrixRow(std::istream& is)
+  inline void checkEndOfMatrixRow(std::istream& is)
   {
     std::string rest;
     is >> rest;

--- a/GridKit/Model/PowerFlow/SystemModelPowerFlow.hpp
+++ b/GridKit/Model/PowerFlow/SystemModelPowerFlow.hpp
@@ -1,6 +1,6 @@
 
 /**
- * @file SystemSteadyStaeModel.hpp
+ * @file SystemModelPowerFlow.hpp
  * @author Slaven Peles <slaven.peles@pnnl.gov>
  *
  * Contains definition of power flow analysis class.
@@ -12,7 +12,12 @@
 #include <iostream>
 #include <vector>
 
+#include <GridKit/Model/PowerFlow/Branch/Branch.hpp>
+#include <GridKit/Model/PowerFlow/Bus/BusFactory.hpp>
+#include <GridKit/Model/PowerFlow/Generator/GeneratorFactory.hpp>
+#include <GridKit/Model/PowerFlow/Load/Load.hpp>
 #include <GridKit/Model/PowerFlow/ModelEvaluatorImpl.hpp>
+#include <GridKit/Model/PowerFlow/PowerFlowData.hpp>
 #include <GridKit/ScalarTraits.hpp>
 
 namespace GridKit

--- a/GridKit/Model/VariableMonitorController.hpp
+++ b/GridKit/Model/VariableMonitorController.hpp
@@ -73,6 +73,7 @@ namespace GridKit
        * If `spec.file_name` is empty, `std::cout` is used.
        *
        * @param spec Specifies details for the sink.
+       * @param os Output stream used when `spec.file_name` is empty.
        */
       void addSink(const SinkSpec& spec, std::ostream& os = std::cout)
       {

--- a/GridKit/Testing/CommandLine.hpp
+++ b/GridKit/Testing/CommandLine.hpp
@@ -10,8 +10,6 @@ namespace GridKit
 
     /**
      * @brief Conveniently create a command-line string
-     *
-     * \example[33] CliOptionsTests.cpp
      */
     template <int NArgs>
     struct CommandLine

--- a/GridKit/Testing/TestHelpers.hpp
+++ b/GridKit/Testing/TestHelpers.hpp
@@ -1,6 +1,6 @@
 
 /**
- * @file UnitTest.hpp
+ * @file TestHelpers.hpp
  *
  * @author Slaven Peles <peless@ornl.gov>, ORNL
  *

--- a/GridKit/Testing/Testing.hpp
+++ b/GridKit/Testing/Testing.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /**
- * @file TestingCore.hpp
+ * @file Testing.hpp
  *
  * @author Slaven Peles <peless@ornl.gov>, ORNL
  *

--- a/GridKit/Utilities/FileIO.hpp
+++ b/GridKit/Utilities/FileIO.hpp
@@ -23,7 +23,7 @@ namespace GridKit
    *
    * @tparam ScalarT
    * @param[out] table object in memory where the data from the input stream is
-   * @param[in] filename input stream to space and newline separated data
+   * @param[in] idata input stream containing space- and newline-separated data
    * @param[out] ti initial time returned
    * @param[out] tf final time returned
    *

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -3,9 +3,19 @@ OUTPUT_DIRECTORY = .
 
 INPUT = ../GridKit
 RECURSIVE = YES
-EXCLUDE_PATTERNS = *.md
+FILE_PATTERNS = *.hpp *.tpp
+EXCLUDE_PATTERNS = *.md \
+                   *.cpp \
+                   */Model/PhasorDynamics/*Impl.hpp \
+                   */Model/VariableMonitorImpl.hpp \
+                   */Utilities/CliArgs/CliArgsImpl.hpp \
+                   */AutomaticDifferentiation/Enzyme/LowerSparseStorage.hpp
 FULL_PATH_NAMES = YES
 STRIP_FROM_PATH = ..
+
+MACRO_EXPANSION = YES
+EXPAND_ONLY_PREDEF = YES
+PREDEFINED = "__attribute__(x)="
 
 GENERATE_HTML = NO
 GENERATE_LATEX = NO
@@ -14,4 +24,5 @@ XML_OUTPUT = xml
 XML_PROGRAMLISTING = NO
 
 EXTRACT_ALL = YES
+WARN_AS_ERROR = FAIL_ON_WARNINGS
 QUIET = YES

--- a/docs/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
+++ b/docs/GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
@@ -1,6 +1,6 @@
 # GENROU
 
-```{include} ../../../../../../GridKit/Model/PhasorDynamics/SynchronousMachine/GENROUwS/README.md
+```{include} ../../../../../../GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/README.md
 :start-line: 1
 :relative-images:
 ```

--- a/docs/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/README.md
+++ b/docs/GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/README.md
@@ -1,6 +1,6 @@
 # GENSAL
 
-```{include} ../../../../../../GridKit/Model/PhasorDynamics/SynchronousMachine/GENSALwS/README.md
+```{include} ../../../../../../GridKit/Model/PhasorDynamics/SynchronousMachine/GENSAL/README.md
 :start-line: 1
 :relative-images:
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,7 @@
 GridKit Core <api/reference/namespace_GridKit>
 Solvers <api/reference/namespace_AnalysisManager>
 Phasor Dynamics <api/reference/namespace_GridKit__PhasorDynamics>
+Concepts <api/concepts>
 Power Electronics <api/reference/namespace_GridKit__PowerElectronics>
 Power Flow Data <api/reference/namespace_GridKit__PowerFlowData>
 Linear Algebra <api/reference/namespace_GridKit__LinearAlgebra>

--- a/docs/api/concepts.md
+++ b/docs/api/concepts.md
@@ -1,0 +1,8 @@
+# C++ Concepts
+
+Exhale does not yet generate pages for C++ concepts, so the public concepts
+below are rendered directly through Breathe.
+
+```{doxygenconcept} GridKit::PhasorDynamics::EnumHasMaximumValueAndIsSizeT
+:project: GridKit
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ html_theme_options = {
 }
 
 myst_enable_extensions = [
+    "alert",
     "amsmath",
     "dollarmath",
     "html_image",
@@ -53,3 +54,8 @@ exclude_patterns = [
     "_build",
     "README.md",
 ]
+
+# Breathe renders public nested types with their parent and Exhale also gives
+# those types standalone pages. Sphinx otherwise reports the intentional
+# duplicate declarations when both pages are read.
+suppress_warnings = ["duplicate_declaration.cpp"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx
-breathe
-exhale
-myst-parser
-sphinx-rtd-theme
+sphinx==9.1.0
+breathe==4.36.0
+exhale==0.3.7
+myst-parser==5.1.0
+sphinx-rtd-theme==3.1.0


### PR DESCRIPTION
## Description
 
Fixing various incorrect file annotations, metadata, and settings that were triggering warnings for Doxygen, Sphinx, and RTD.
 
 ## Proposed changes
 
- Correct Doxygen annotations, metadata, math, and warning settings.
- Pin the documentation dependencies and enable MyST alerts (callouts, which work on GitHub too)
- Fix stale documentation wrappers and missing public API coverage.
- Repair incomplete installed headers and header linkage issues.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- Not worth a test 
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- N/A I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
In preparation for the improved case documentation. RTD has been fantastic thusfar