### PR TITLE
Input Format corrections for v0.2 release

### DIFF
--- a/GridKit/Model/PhasorDynamics/Bus/BusData.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusData.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <map>
-#include <optional>
 #include <set>
 #include <string>
 #include <type_traits>
@@ -69,11 +68,6 @@ namespace GridKit
       BusType bus_type{BusType::INVALID}; ///< The kind of bus this data is for
 
       std::map<Parameters, ParameterValue> parameters; ///< Mapping of parameters to parameter values
-
-      // TODO: Bus-level freq_base and va_base are parsed but not applied.
-      // Prefer removing them as bus parameters in a future cleanup.
-      std::optional<RealT> freq_base; ///< Override for the system-wide base frequency
-      std::optional<RealT> va_base;   ///< Override for the system-wide power base
 
       /// Alias
       using MonitorableVariables = BusMonitorableVariables;

--- a/GridKit/Model/PhasorDynamics/Bus/BusDataJSONParser.hpp
+++ b/GridKit/Model/PhasorDynamics/Bus/BusDataJSONParser.hpp
@@ -53,11 +53,11 @@ namespace GridKit
       j.at("number").get_to(bd.bus_id);
 
       auto string_class = j.at("class").get<std::string>();
-      if (string_class == "bus")
+      if (string_class == "Bus")
       {
         bd.bus_type = BusData<RealT, IdxT>::BusType::DEFAULT;
       }
-      else if (string_class == "infinite_bus")
+      else if (string_class == "BusInfinite")
       {
         bd.bus_type = BusData<RealT, IdxT>::BusType::SLACK;
       }
@@ -104,16 +104,6 @@ namespace GridKit
                        << "\" has no value." << error_context.str()
                        << std::endl;
         }
-      }
-
-      if (j.contains("freq_base"))
-      {
-        j.at("freq_base").get_to(bd.freq_base);
-      }
-
-      if (j.contains("va_base"))
-      {
-        j.at("va_base").get_to(bd.va_base);
       }
 
       if (j.contains("mon"))

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp
@@ -33,16 +33,10 @@ namespace GridKit
       };
 
       /**
-       * @brief Temporary TGOV1 bus keys.
-       *
-       * NOTE: The TGOV1 bus key is accepted only so existing flat JSON
-       * cases continue to parse without case-file churn. TGOV1 does not use
-       * this bus key, and it should be removed when the JSON port format
-       * is updated.
+       * @brief Placeholder enum for TGOV1 bus keys.
        */
       enum class Tgov1Buses : size_t
       {
-        bus,
         SIZE,
       };
 

--- a/GridKit/Model/PhasorDynamics/INPUT_FORMAT.md
+++ b/GridKit/Model/PhasorDynamics/INPUT_FORMAT.md
@@ -1,7 +1,7 @@
 # Grid Dynamics case format specification
 
 Adam Birchfield, Texas A&M University, 2/28/2025
-Version 0.1
+Version 0.2
 
 ## Overview
 
@@ -34,11 +34,10 @@ also be encoded as [MessagePack](https://msgpack.org).
 
 ## Format
 
-The root element in the format is an object with three keys: `header`,
-`buses`, and `devices`. `header` contains information about the case,
-`buses` is an array of buses (which can include electrical buses of
-different types as well as signal buses), and `devices` is an array
-of system devices.
+The root object contains `header`, `params`, `buses`, and `devices`, and may
+also contain `signals` and `monitors`. `header` contains information about
+the case, `params` contains system-wide parameters, `buses` is an array of
+electrical buses, and `devices` is an array of system devices.
 
 ### Header
 
@@ -46,14 +45,21 @@ Contained in the `header` key is an object with the following items:
 
    Name              | Value
  --------------------|-------------------------------------------------------
-  `format_version`   | Non-negative integer indicating the format version
-  `format_revision`  | Non-negative integer indicating the format revision
+  `format_version`   | Number `0.2`
+  `format_revision`  | Integer `0`
   `case_name`        | A string containing the name of the case
   `case_date_time`   | Optional string in the ISO 8601 format indicating a datetime associated with the case. Including a time is optional, but if one is specified, it is recommended that a UTC offset be included.
   `case_description` | A string with more specific description of what is modeled in the case
   `case_comments`    | A string with additional notes as needed
-  `freq_base`        | A floating point value indicating the system frequency base in hertz (Hz). This is commonly 60 Hz
-  `va_base`          | A floating point value indicating the system power base in volt-amperes (VA). This is commonly 100e6 VA
+
+### System Parameters
+
+Contained in the `params` key is an object with the following items:
+
+  Name        | Value
+  ------------|-------------------------------------------------------
+  `freq_base` | A floating point value indicating the system frequency base in hertz (Hz). This is commonly 60 Hz
+  `va_base`   | A floating point value indicating the system power base in volt-amperes (VA). This is commonly 100e6 VA
 
 ### Monitors
 
@@ -81,9 +87,9 @@ a bus and has the following fields:
 
   Name               | Description
   -------------------|------------------------------------------------------
-  `number`           | Unique positive (> 0) integer identifying the node
+  `number`           | Unique non-negative integer identifying the bus
   `class`            | A string indicating the class of node. See the table below for more information
-  `name`             | Optional string containing the name of the node. This may be empty or non-unique
+  `name`             | String containing the name of the node. This may be empty or non-unique
   `init`             | Optional object mapping string variable names to floating point values, specifying default voltages or signal values. The available initialization variables are dependent upon the node class. Any variables missing will be given default values, which are specified beneath the table below. If this object is missing, all variables will be given default values. See the table below for more information
   `params`           | Object mapping bus parameter names to values. Supported parameter: `kv`, the bus voltage base in kV.
   `mon`              | Optional field, which is an array specifying variables to monitor the value of in an output channel. Available variables include all the initialization variables, along with others as determined by the node class. See the table below for more information
@@ -96,12 +102,10 @@ specified:
 
   Bus class          | Description                                                | Initialization variables | Other variables available to monitor
   -------------------|------------------------------------------------------------|------------------------- | -------------------------
-  `bus`              | Positive-sequence, AC phasor domain bus                    | `Vr`, `Vi`               | `Vm`, `Va`
-  `infinite_bus`     | Positive-sequence, AC phasor domain bus with fixed voltage | `Vr`, `Vi`               | `Vm`, `Va`
-  `emt_bus`          | 3-phase bus with instantaneous voltages                    | `Va`, `Vb`, `Vc`         |
+  `Bus`              | Positive-sequence, AC phasor domain bus                    | `Vr`, `Vi`               | `Vm`, `Va`
+  `BusInfinite`      | Positive-sequence, AC phasor domain bus with fixed voltage | `Vr`, `Vi`               | `Vm`, `Va`
 
-For fields named `Vr` or `Va`, the default value is `1.0`, otherwise it is
-`0.0`. This list is subject to change.
+`Vr` defaults to `1.0`, and `Vi` defaults to `0.0`.
 
 ### Signals
 
@@ -110,8 +114,8 @@ a signal and has the following fields:
 
   Name               | Description
   -------------------|------------------------------------------------------
-  `signal_id`        | Unique positive (> 0) integer identifying the signal
-  `name`             | Optional string containing the name or description of the signal. This may be empty or non-unique
+  `signal_id`        | Unique non-negative integer identifying the signal
+  `name`             | String containing the name or description of the signal. This may be empty or non-unique
 
 All interactions with signals are handled by `devices`, which reference signals via `signal_id`
 
@@ -124,10 +128,10 @@ represent a device and has the following fields:
   Name              | Description
   ------------------|------------------------------------------------------
   `class`           | A string indicating the class of device. See the table below for more information
-  `ports`           | An object mapping the object's port names (depending on the device class as specified in the table below) to the associated bus number to which it is connected. Any field listed under variables available to monitor can also be added here as a read-only port
-  `id`              | A string disambiguating the device from others. Each device in a class must have a unique combination of required port bus numbers and this string. This string should be 1 or 2 characters long.
-  `params`          | An object mapping initialization parameters to numerical values, depending on the class. See the table below for more information
-  `mon`             | Optional field, which is an array specifying variables to record the value of in an output channel. Available variables are determined by the device class, as specified in the table below
+  `ports`           | An object mapping the device's port names to associated bus numbers or signal IDs
+  `id`              | A string disambiguating the device from others
+  `params`          | An object mapping initialization parameters to Boolean or numerical values
+  `mon`             | Optional field, which is an array specifying variables to record in an output channel
   `extension`       | Optional field containing an object with implementation-defined keys
 
 For more information, see the detailed documentation for each device class containing equations, electrical bus configuration, and signal inlets/outlets specifications.
@@ -137,41 +141,42 @@ For more information, see the detailed documentation for each device class conta
 As of the current version and revision, the following device classes
 are specified:
 
-  Device class         | Description                                          | Ports                            | Initialization parameters   | Variables available to monitor
-  ---------------------|------------------------------------------------------|----------------------------------|---------------------------- | -------------------------
-  `Branch`             | algebraic pi model for a line or off-nominal transformer branch | `bus1`, `bus2`                   | `R`, `X`, `G`, `B`, `tap`, `phase` | `ir1`, `ii1`, `im1`, `p1`, `q1`, `ir2`, `ii2`, `im2`, `p2`, `q2`
-  `Load`               | a basic static impedence load model                  | `bus`                            | `R`, `X` | `p`, `q`
-  `Genrou`             | 6th order machine model                              | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqop`, `Tqopp`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xqp`, `Xqpp`, `Xl`, `S10`, `S12`, `mva`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`, `speed`
-  `Gensal`             | 5th order salient-pole machine model                 | `bus`, `pmech`\*, `speed`\*, `efd`\*    | `p0`, `q0`, `H`, `D`, `Ra`, `Tdop`, `Tdopp`, `Tqopp`, `Xd`, `Xdp`, `Xdpp`, `Xq`, `Xl`, `S10`, `S12`, `mva`  | `ir`, `ii`, `p`, `q`, `delta`, `omega`, `speed`, `Eqp`, `psidp`, `psiqpp`, `psidpp`, `vd`, `vq`, `te`, `id`, `iq`
-  `GenClassical`       | the classical machine model                          | `bus`, `pmech`\*, `speed`\*, `efd`\*  | `p0`, `q0`, `H`, `D`, `Ra`, `Xdp`, `mva` | `ir`, `ii`, `p`, `q`, `delta`, `omega`
-  `Tgov1 `             | the TGOV1 governor model                             | `pmech`, `speed`                 | `Trate`, `R`, `T1`, `T2`, `T3`, `Pvmax`, `Pvmin`, `Dt` | `none`
-  `Regca`              | WECC REGCA renewable generator/converter model       | `bus`, `ipcmd`\*, `iqcmd`\*, `ibranchr`\*, `ibranchi`\*, `pbranch`\*, `qbranch`\* | `p0`, `q0`, `mva`, `Tg`, `TM`, `Rqmax`, `Rqmin`, `Rpmax`, `sL`, `IL1`, `VL0`, `VL1`, `VA0`, `VA1`, `Vhvmax`, `Qmin`, `Khv`, `Xe` | `ir`, `ii`, `p`, `q`
-  `Ieeet1`             | the IEEET1 exciter model                             | `bus`, `speed`, `efd`, `vs`\*    | `Tr`, `Ka`, `Ta`, `Ke`, `Te`, `Kf`, `Tf`, `Vrmin`, `Vrmax`, `E1`, `E2`, `Se1`, `Se2`, `Ispdlim` | `efd`, `ksat`
-  `Esdc1a`             | the ESDC1A exciter model                             | `bus`, `efd`, `speed`\*, `vref`\*, `vs`\*, `vuel`\* | `Tr`, `Ka`, `Ta`, `Tb`, `Tc`, `Vrmax`, `Vrmin`, `Ke`, `Te`, `Kf`, `Tf1`, `Spdmlt`, `E1`, `Se1`, `E2`, `Se2`, `UEL`, `exclim` | `efd`, `vc`, `vr`, `vf`, `se`, `vfe`
-  `SexsPti`            | the SEXS-PTI simplified exciter model                | `bus`, `efd`, `vs`\*             | `Ta`, `Tb`, `Te`, `K`, `Efdmax`, `Efdmin` | `efd`
-  `Ieeest`             | the IEEEST stabilizer model                          | `input`, `output`                | `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `T1`, `T2`, `T3`, `T4`, `T5`, `T6`, `Ks`, `Lsmin`, `Lsmax`, `Vcl`, `Vcu`, `Tdelay` | `vss`
-  `BusFault`           | simple impedance-based fault at a bus                | `bus`, `status`\*                | `state0`, `R`, `X` | `state`, `ir`, `ii`
-  `BusToSignalAdapter` | signal adapter component for a bus                   | `bus`, `vr`, `vi`, `ir`, `ii`    |                             |
-
-Ports marked with \* are optional and, if missing, will be assumed to be
-connected to a constant value. This list is subject to change.
+  Device class | Description
+  -------------|------------
+  [Branch](Branch/README.md) | algebraic pi model for a line or off-nominal transformer branch
+  [BusFault](BusFault/README.md) | simple impedance-based fault at a bus
+  [BusToSignalAdapter](BusToSignalAdapter/README.md) | signal adapter component for a bus
+  [LoadZ](Load/LoadZ/README.md) | Constant-impedance load model
+  [LoadZIP](Load/LoadZIP/README.md) | ZIP load model
+  [Genrou](SynchronousMachine/GENROU/README.md) | 6th order machine model
+  [Gensal](SynchronousMachine/GENSAL/README.md) | 5th order salient-pole machine model
+  [GenClassical](SynchronousMachine/GenClassical/README.md) | the classical machine model
+  [Regca](Converter/REGCA/README.md) | WECC REGCA renewable generator/converter model
+  [Tgov1](Governor/Tgov1/README.md) | the TGOV1 governor model
+  [Ieeet1](Exciter/IEEET1/README.md) | the IEEET1 exciter model
+  [Esdc1a](Exciter/ESDC1A/README.md) | the ESDC1A exciter model
+  [SexsPti](Exciter/SEXS-PTI/README.md) | the SEXS-PTI simplified exciter model
+  [Ieeest](Stabilizer/IEEEST/README.md) | the IEEEST stabilizer model
+  [ConstantSignalSource](SignalSource/README.md) | Constant complex signal source
 
 ## Example File for a 2-Bus System
 
 ```json
 {
    "header": {
-       "format_version": 0,
-       "format_revision": 1,
+       "format_version": 0.2,
+       "format_revision": 0,
        "case_name": "Two-bus test case 1",
        "case_description": "A two-bus test case for demonstrating the dynamics format",
-       "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
+       "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed"
+   },
+   "params": {
        "freq_base": 60.0,
        "va_base": 100e6
    },
    "buses": [
-       { "number": 1, "class": "bus", "name": "Bus 1", "init": {"Vr":0.994988, "Vi":0.099997}, "params": {"kv": 115.0}, "mon": ["Vr", "Vi"] },
-       { "number": 2, "class": "infinite_bus", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "params": {"kv": 115.0} }
+       { "number": 1, "class": "Bus", "name": "Bus 1", "init": {"Vr":0.994988, "Vi":0.099997}, "params": {"kv": 115.0}, "mon": ["Vr", "Vi"] },
+       { "number": 2, "class": "BusInfinite", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "params": {"kv": 115.0} }
    ],
    "signals": [
        { "signal_id": 1, "name": "Machine Speed Deviation"},
@@ -181,7 +186,7 @@ connected to a constant value. This list is subject to change.
    "devices": [
        { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0} },
        { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
-       { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"Trate":100.0, "R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0, "Pvmin":1, "Dt":0}},
+       { "class": "Tgov1", "ports": {"speed": 1, "pmech":2}, "id": "DV2", "params": {"Trate":100.0, "R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":1, "Pvmin":0, "Dt":0}},
        { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "DV3", "params": {"Tr":0.0, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1, "Vrmax":1, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlim":0}},
        { "class": "BusFault", "ports": {"bus":1}, "id": "EVT1", "params": {"state0": false, "R":0.0, "X":1e-3} }
    ]
@@ -197,8 +202,8 @@ represents a time point and gives the value for each channel. The first
 channel is always "Time [s]". The second channel is always "Solver
 Status", an integer where 0 is success, positive integers are warnings
 and negative integers are terminal errors. Then the other channels come
-from any nodes or devices which have the "monitor" property specified in
-their extra data, with one channel for each item in the monitor array.
+from any buses or devices which have the `mon` property specified, with
+one channel for each item in the `mon` array.
 The channels must be in the order they appear in the input file. In the
 example above, 4 channels are identified: "Vr" and "Vi" for Bus 1 and
 "delta" and "omega" for the GENROU device at Bus 1. A sample output file

--- a/GridKit/Model/PhasorDynamics/SystemModelData.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.hpp
@@ -63,7 +63,7 @@ namespace GridKit
       ///
       /// If not relevant (i.e. if not working in the context of the case
       /// format), this will not contain a value
-      std::optional<unsigned short> format_version;
+      std::optional<double> format_version;
 
       /// The revision of the grid dynamics case format this system model was
       /// parsed from

--- a/GridKit/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelDataJSONParser.hpp
@@ -51,8 +51,10 @@ namespace GridKit
 
       header.at("case_description").get_to(sm.case_description);
       header.at("case_comments").get_to(sm.case_comments);
-      header.at("freq_base").get_to(sm.freq_base);
-      header.at("va_base").get_to(sm.va_base);
+
+      const auto& params = j.at("params");
+      params.at("freq_base").get_to(sm.freq_base);
+      params.at("va_base").get_to(sm.va_base);
 
       if (j.contains("monitors"))
       {

--- a/examples/PhasorDynamics/Large/Illinois/illinois.case.json
+++ b/examples/PhasorDynamics/Large/Illinois/illinois.case.json
@@ -1,17 +1,19 @@
 {
     "header": {
-        "format_version": 0.1,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "ACTIVSg200",
         "case_description": "Based on Illinois grid, the ACTIVSg200 case is a 200 bus power system test case that is entirely synthetic, built from public information and a statistical  analysis of real power systems. It bears no relation to the actual grid in this location, except that generation and load profiles are similar.",
-        "case_comments": "",
+        "case_comments": ""
+    },
+    "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
     "buses": [
         {
             "number": 1,
-            "class": "bus",
+            "class": "Bus",
             "name": "CREVE COEUR 0",
             "init": {
                 "Vr": 0.23063551423613704,
@@ -25,7 +27,7 @@
         },
         {
             "number": 2,
-            "class": "bus",
+            "class": "Bus",
             "name": "CREVE COEUR 1",
             "init": {
                 "Vr": 0.2302636252686343,
@@ -39,7 +41,7 @@
         },
         {
             "number": 3,
-            "class": "bus",
+            "class": "Bus",
             "name": "ILLIOPOLIS 0",
             "init": {
                 "Vr": 0.21216440498326256,
@@ -53,7 +55,7 @@
         },
         {
             "number": 4,
-            "class": "bus",
+            "class": "Bus",
             "name": "ILLIOPOLIS 1",
             "init": {
                 "Vr": 0.21207510607859667,
@@ -67,7 +69,7 @@
         },
         {
             "number": 5,
-            "class": "bus",
+            "class": "Bus",
             "name": "PAXTON 2 0",
             "init": {
                 "Vr": 0.14476958935953108,
@@ -81,7 +83,7 @@
         },
         {
             "number": 6,
-            "class": "bus",
+            "class": "Bus",
             "name": "PAXTON 2 1",
             "init": {
                 "Vr": 0.14441742001456687,
@@ -95,7 +97,7 @@
         },
         {
             "number": 7,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 9 0",
             "init": {
                 "Vr": 0.20881458732050032,
@@ -109,7 +111,7 @@
         },
         {
             "number": 8,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 9 1",
             "init": {
                 "Vr": 0.20766766396098874,
@@ -123,7 +125,7 @@
         },
         {
             "number": 9,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 8 0",
             "init": {
                 "Vr": 0.22076783108857512,
@@ -137,7 +139,7 @@
         },
         {
             "number": 10,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 8 1",
             "init": {
                 "Vr": 0.21819856801827828,
@@ -151,7 +153,7 @@
         },
         {
             "number": 11,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOVINGTON 0",
             "init": {
                 "Vr": 0.24569956921410488,
@@ -165,7 +167,7 @@
         },
         {
             "number": 12,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOVINGTON 1",
             "init": {
                 "Vr": 0.24568265897146266,
@@ -179,7 +181,7 @@
         },
         {
             "number": 13,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOVINGTON 2",
             "init": {
                 "Vr": 0.24555603745422316,
@@ -193,7 +195,7 @@
         },
         {
             "number": 14,
-            "class": "bus",
+            "class": "Bus",
             "name": "DECATUR 3 0",
             "init": {
                 "Vr": 0.268686535497011,
@@ -207,7 +209,7 @@
         },
         {
             "number": 15,
-            "class": "bus",
+            "class": "Bus",
             "name": "DECATUR 3 1",
             "init": {
                 "Vr": 0.24950583252699574,
@@ -221,7 +223,7 @@
         },
         {
             "number": 16,
-            "class": "bus",
+            "class": "Bus",
             "name": "DECATUR 3 2",
             "init": {
                 "Vr": 0.24724823932654302,
@@ -235,7 +237,7 @@
         },
         {
             "number": 17,
-            "class": "bus",
+            "class": "Bus",
             "name": "MASON CITY 0",
             "init": {
                 "Vr": 0.18281919671698352,
@@ -249,7 +251,7 @@
         },
         {
             "number": 18,
-            "class": "bus",
+            "class": "Bus",
             "name": "MASON CITY 1",
             "init": {
                 "Vr": 0.1827740805473377,
@@ -263,7 +265,7 @@
         },
         {
             "number": 19,
-            "class": "bus",
+            "class": "Bus",
             "name": "MASON CITY 2",
             "init": {
                 "Vr": 0.1827812407889226,
@@ -277,7 +279,7 @@
         },
         {
             "number": 20,
-            "class": "bus",
+            "class": "Bus",
             "name": "MASON CITY 3",
             "init": {
                 "Vr": 0.18275870029970614,
@@ -291,7 +293,7 @@
         },
         {
             "number": 21,
-            "class": "bus",
+            "class": "Bus",
             "name": "MASON CITY 4",
             "init": {
                 "Vr": 0.1825279991493386,
@@ -305,7 +307,7 @@
         },
         {
             "number": 22,
-            "class": "bus",
+            "class": "Bus",
             "name": "BETHANY 0",
             "init": {
                 "Vr": 0.24518586090921626,
@@ -319,7 +321,7 @@
         },
         {
             "number": 23,
-            "class": "bus",
+            "class": "Bus",
             "name": "BETHANY 1",
             "init": {
                 "Vr": 0.24511420048660224,
@@ -333,7 +335,7 @@
         },
         {
             "number": 24,
-            "class": "bus",
+            "class": "Bus",
             "name": "BETHANY 2",
             "init": {
                 "Vr": 0.2450701028295127,
@@ -347,7 +349,7 @@
         },
         {
             "number": 25,
-            "class": "bus",
+            "class": "Bus",
             "name": "RANKIN 0",
             "init": {
                 "Vr": 0.1401953999450343,
@@ -361,7 +363,7 @@
         },
         {
             "number": 26,
-            "class": "bus",
+            "class": "Bus",
             "name": "RANKIN 1",
             "init": {
                 "Vr": 0.14014028887826324,
@@ -375,7 +377,7 @@
         },
         {
             "number": 27,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINDSOR 0",
             "init": {
                 "Vr": 0.2423152557383985,
@@ -389,7 +391,7 @@
         },
         {
             "number": 28,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINDSOR 1",
             "init": {
                 "Vr": 0.24216934731559245,
@@ -403,7 +405,7 @@
         },
         {
             "number": 29,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEKIN 2 0",
             "init": {
                 "Vr": 0.2361176480435794,
@@ -417,7 +419,7 @@
         },
         {
             "number": 30,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEKIN 2 1",
             "init": {
                 "Vr": 0.23332354375115258,
@@ -431,7 +433,7 @@
         },
         {
             "number": 31,
-            "class": "bus",
+            "class": "Bus",
             "name": "HEYWORTH 0",
             "init": {
                 "Vr": 0.14829296517875634,
@@ -445,7 +447,7 @@
         },
         {
             "number": 32,
-            "class": "bus",
+            "class": "Bus",
             "name": "HEYWORTH 1",
             "init": {
                 "Vr": 0.14826554637774972,
@@ -459,7 +461,7 @@
         },
         {
             "number": 33,
-            "class": "bus",
+            "class": "Bus",
             "name": "HEYWORTH 2",
             "init": {
                 "Vr": 0.14796920043196776,
@@ -473,7 +475,7 @@
         },
         {
             "number": 34,
-            "class": "bus",
+            "class": "Bus",
             "name": "DECATUR 2 0",
             "init": {
                 "Vr": 0.22796568856060362,
@@ -487,7 +489,7 @@
         },
         {
             "number": 35,
-            "class": "bus",
+            "class": "Bus",
             "name": "DECATUR 2 1",
             "init": {
                 "Vr": 0.22674893565964294,
@@ -501,7 +503,7 @@
         },
         {
             "number": 36,
-            "class": "bus",
+            "class": "Bus",
             "name": "LINCOLN 0",
             "init": {
                 "Vr": 0.14914967509646085,
@@ -515,7 +517,7 @@
         },
         {
             "number": 37,
-            "class": "bus",
+            "class": "Bus",
             "name": "LINCOLN 1",
             "init": {
                 "Vr": 0.148986962473615,
@@ -529,7 +531,7 @@
         },
         {
             "number": 38,
-            "class": "bus",
+            "class": "Bus",
             "name": "LINCOLN 2",
             "init": {
                 "Vr": 0.14772138204106008,
@@ -543,7 +545,7 @@
         },
         {
             "number": 39,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHERMAN 0",
             "init": {
                 "Vr": 0.18576769410316782,
@@ -557,7 +559,7 @@
         },
         {
             "number": 40,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHERMAN 1",
             "init": {
                 "Vr": 0.1856661423374356,
@@ -571,7 +573,7 @@
         },
         {
             "number": 41,
-            "class": "bus",
+            "class": "Bus",
             "name": "URBANA 2 0",
             "init": {
                 "Vr": 0.11592432562014109,
@@ -585,7 +587,7 @@
         },
         {
             "number": 42,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 8 0",
             "init": {
                 "Vr": 0.22180912327546878,
@@ -599,7 +601,7 @@
         },
         {
             "number": 43,
-            "class": "bus",
+            "class": "Bus",
             "name": "CARLOCK 0",
             "init": {
                 "Vr": 0.17474399566378596,
@@ -613,7 +615,7 @@
         },
         {
             "number": 44,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLEASANT PLAINS 0",
             "init": {
                 "Vr": 0.21869054538242141,
@@ -627,7 +629,7 @@
         },
         {
             "number": 45,
-            "class": "bus",
+            "class": "Bus",
             "name": "LE ROY 0",
             "init": {
                 "Vr": 0.25495154169044293,
@@ -641,7 +643,7 @@
         },
         {
             "number": 46,
-            "class": "bus",
+            "class": "Bus",
             "name": "LE ROY 1",
             "init": {
                 "Vr": 0.24061113098964718,
@@ -655,7 +657,7 @@
         },
         {
             "number": 47,
-            "class": "bus",
+            "class": "Bus",
             "name": "DECATUR 1 0",
             "init": {
                 "Vr": 0.2588544360107327,
@@ -669,7 +671,7 @@
         },
         {
             "number": 48,
-            "class": "bus",
+            "class": "Bus",
             "name": "RANTOUL 2 0",
             "init": {
                 "Vr": 0.14541475027271317,
@@ -683,7 +685,7 @@
         },
         {
             "number": 49,
-            "class": "bus",
+            "class": "Bus",
             "name": "RANTOUL 2 1",
             "init": {
                 "Vr": 0.16975389826059847,
@@ -697,7 +699,7 @@
         },
         {
             "number": 50,
-            "class": "bus",
+            "class": "Bus",
             "name": "RANTOUL 2 2",
             "init": {
                 "Vr": 0.16390564307948935,
@@ -711,7 +713,7 @@
         },
         {
             "number": 51,
-            "class": "bus",
+            "class": "Bus",
             "name": "RANTOUL 2 3",
             "init": {
                 "Vr": 0.17348796529068666,
@@ -725,7 +727,7 @@
         },
         {
             "number": 52,
-            "class": "bus",
+            "class": "Bus",
             "name": "RANTOUL 2 4",
             "init": {
                 "Vr": 0.1627760996650275,
@@ -739,7 +741,7 @@
         },
         {
             "number": 53,
-            "class": "bus",
+            "class": "Bus",
             "name": "RANTOUL 2 5",
             "init": {
                 "Vr": 0.19724461954155262,
@@ -753,7 +755,7 @@
         },
         {
             "number": 54,
-            "class": "bus",
+            "class": "Bus",
             "name": "MACON 0",
             "init": {
                 "Vr": 0.2506584219180536,
@@ -767,7 +769,7 @@
         },
         {
             "number": 55,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELLSWORTH 2 0",
             "init": {
                 "Vr": 0.2395380689436477,
@@ -781,7 +783,7 @@
         },
         {
             "number": 56,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELLSWORTH 2 1",
             "init": {
                 "Vr": 0.23399706489951247,
@@ -795,7 +797,7 @@
         },
         {
             "number": 57,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT PULASKI 0",
             "init": {
                 "Vr": 0.20317195804784327,
@@ -809,7 +811,7 @@
         },
         {
             "number": 58,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAPELLA 0",
             "init": {
                 "Vr": 0.15350247990757754,
@@ -823,7 +825,7 @@
         },
         {
             "number": 59,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROANOKE 0",
             "init": {
                 "Vr": 0.1734932276275927,
@@ -837,7 +839,7 @@
         },
         {
             "number": 60,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREEN VALLEY 0",
             "init": {
                 "Vr": 0.25958077138683394,
@@ -851,7 +853,7 @@
         },
         {
             "number": 61,
-            "class": "bus",
+            "class": "Bus",
             "name": "BLOOMINGTON 3 0",
             "init": {
                 "Vr": 0.23015627881092182,
@@ -865,7 +867,7 @@
         },
         {
             "number": 62,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 7 0",
             "init": {
                 "Vr": 0.20583011672668522,
@@ -879,7 +881,7 @@
         },
         {
             "number": 63,
-            "class": "bus",
+            "class": "Bus",
             "name": "BEMENT 0",
             "init": {
                 "Vr": 0.21652205399668142,
@@ -893,7 +895,7 @@
         },
         {
             "number": 64,
-            "class": "bus",
+            "class": "Bus",
             "name": "PAXTON 1 0",
             "init": {
                 "Vr": 0.14979947138888017,
@@ -907,7 +909,7 @@
         },
         {
             "number": 65,
-            "class": "bus",
+            "class": "Bus",
             "name": "PAXTON 1 1",
             "init": {
                 "Vr": 0.15513932722990803,
@@ -921,7 +923,7 @@
         },
         {
             "number": 66,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT ZION 0",
             "init": {
                 "Vr": 0.26849141044589425,
@@ -935,7 +937,7 @@
         },
         {
             "number": 67,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT ZION 1",
             "init": {
                 "Vr": 0.2753451882938677,
@@ -949,7 +951,7 @@
         },
         {
             "number": 68,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT ZION 2",
             "init": {
                 "Vr": 0.33753938525396715,
@@ -963,7 +965,7 @@
         },
         {
             "number": 69,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT ZION 3",
             "init": {
                 "Vr": 0.2938586744014201,
@@ -977,7 +979,7 @@
         },
         {
             "number": 70,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT ZION 4",
             "init": {
                 "Vr": 0.32076736518770155,
@@ -991,7 +993,7 @@
         },
         {
             "number": 71,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT ZION 5",
             "init": {
                 "Vr": 0.29038341544952173,
@@ -1005,7 +1007,7 @@
         },
         {
             "number": 72,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT ZION 6",
             "init": {
                 "Vr": 0.288578466615434,
@@ -1019,7 +1021,7 @@
         },
         {
             "number": 73,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT ZION 7",
             "init": {
                 "Vr": 0.30713482373553097,
@@ -1033,7 +1035,7 @@
         },
         {
             "number": 74,
-            "class": "bus",
+            "class": "Bus",
             "name": "RANTOUL 1 0",
             "init": {
                 "Vr": 0.13302382862619713,
@@ -1047,7 +1049,7 @@
         },
         {
             "number": 75,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIMFIELD 0",
             "init": {
                 "Vr": 0.2659005963287278,
@@ -1061,7 +1063,7 @@
         },
         {
             "number": 76,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIMFIELD 1",
             "init": {
                 "Vr": 0.27826688159769547,
@@ -1075,7 +1077,7 @@
         },
         {
             "number": 77,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIMFIELD 2",
             "init": {
                 "Vr": 0.2865179157146396,
@@ -1089,7 +1091,7 @@
         },
         {
             "number": 78,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIMFIELD 3",
             "init": {
                 "Vr": 0.2659005963287278,
@@ -1103,7 +1105,7 @@
         },
         {
             "number": 79,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIMFIELD 4",
             "init": {
                 "Vr": 0.2659005963287278,
@@ -1117,7 +1119,7 @@
         },
         {
             "number": 80,
-            "class": "bus",
+            "class": "Bus",
             "name": "WELDON 0",
             "init": {
                 "Vr": 0.14104895113031155,
@@ -1131,7 +1133,7 @@
         },
         {
             "number": 81,
-            "class": "bus",
+            "class": "Bus",
             "name": "GIBSON CITY 2 0",
             "init": {
                 "Vr": 0.20954233835008054,
@@ -1145,7 +1147,7 @@
         },
         {
             "number": 82,
-            "class": "bus",
+            "class": "Bus",
             "name": "GIBSON CITY 2 1",
             "init": {
                 "Vr": 0.186540925722252,
@@ -1159,7 +1161,7 @@
         },
         {
             "number": 83,
-            "class": "bus",
+            "class": "Bus",
             "name": "MINIER 0",
             "init": {
                 "Vr": 0.17591993217170224,
@@ -1173,7 +1175,7 @@
         },
         {
             "number": 84,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUDSON 0",
             "init": {
                 "Vr": 0.17127350511742376,
@@ -1187,7 +1189,7 @@
         },
         {
             "number": 85,
-            "class": "bus",
+            "class": "Bus",
             "name": "ATHENS 0",
             "init": {
                 "Vr": 0.18099447293783139,
@@ -1201,7 +1203,7 @@
         },
         {
             "number": 86,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA HEIGHTS 0",
             "init": {
                 "Vr": 0.21459487314027384,
@@ -1215,7 +1217,7 @@
         },
         {
             "number": 87,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 6 0",
             "init": {
                 "Vr": 0.2886967796020357,
@@ -1229,7 +1231,7 @@
         },
         {
             "number": 88,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 6 1",
             "init": {
                 "Vr": 0.255411766461533,
@@ -1243,7 +1245,7 @@
         },
         {
             "number": 89,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLINTON 3 0",
             "init": {
                 "Vr": 0.1695664724937894,
@@ -1257,7 +1259,7 @@
         },
         {
             "number": 90,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLINTON 3 1",
             "init": {
                 "Vr": 0.19415603749973764,
@@ -1271,7 +1273,7 @@
         },
         {
             "number": 91,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLINTON 3 2",
             "init": {
                 "Vr": 0.17842096084050393,
@@ -1285,7 +1287,7 @@
         },
         {
             "number": 92,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLINTON 3 3",
             "init": {
                 "Vr": 0.1695664724937894,
@@ -1299,7 +1301,7 @@
         },
         {
             "number": 93,
-            "class": "bus",
+            "class": "Bus",
             "name": "TUSCOLA 2 0",
             "init": {
                 "Vr": 0.2263867604485204,
@@ -1313,7 +1315,7 @@
         },
         {
             "number": 94,
-            "class": "bus",
+            "class": "Bus",
             "name": "TUSCOLA 2 1",
             "init": {
                 "Vr": 0.2747178750048836,
@@ -1327,7 +1329,7 @@
         },
         {
             "number": 95,
-            "class": "bus",
+            "class": "Bus",
             "name": "KENNEY 0",
             "init": {
                 "Vr": 0.16084127257909717,
@@ -1341,7 +1343,7 @@
         },
         {
             "number": 96,
-            "class": "bus",
+            "class": "Bus",
             "name": "MANSFIELD 0",
             "init": {
                 "Vr": 0.2102283042243888,
@@ -1355,7 +1357,7 @@
         },
         {
             "number": 97,
-            "class": "bus",
+            "class": "Bus",
             "name": "MANITO 0",
             "init": {
                 "Vr": 0.23683870500773374,
@@ -1369,7 +1371,7 @@
         },
         {
             "number": 98,
-            "class": "bus",
+            "class": "Bus",
             "name": "DUNLAP 0",
             "init": {
                 "Vr": 0.2812088829767149,
@@ -1383,7 +1385,7 @@
         },
         {
             "number": 99,
-            "class": "bus",
+            "class": "Bus",
             "name": "DUNLAP 1",
             "init": {
                 "Vr": 0.2544731172485158,
@@ -1397,7 +1399,7 @@
         },
         {
             "number": 100,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 3 0",
             "init": {
                 "Vr": 0.12893378640783457,
@@ -1411,7 +1413,7 @@
         },
         {
             "number": 101,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 7 0",
             "init": {
                 "Vr": 0.21611396938472394,
@@ -1425,7 +1427,7 @@
         },
         {
             "number": 102,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELLSWORTH 1 0",
             "init": {
                 "Vr": 0.24346259083341318,
@@ -1439,7 +1441,7 @@
         },
         {
             "number": 103,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELLSWORTH 1 1",
             "init": {
                 "Vr": 0.23321003497097156,
@@ -1453,7 +1455,7 @@
         },
         {
             "number": 104,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELLSWORTH 1 2",
             "init": {
                 "Vr": 0.2611516841480211,
@@ -1467,7 +1469,7 @@
         },
         {
             "number": 105,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELLSWORTH 1 3",
             "init": {
                 "Vr": 0.26526001492303525,
@@ -1481,7 +1483,7 @@
         },
         {
             "number": 106,
-            "class": "bus",
+            "class": "Bus",
             "name": "TOWANDA 0",
             "init": {
                 "Vr": 0.22531257686439501,
@@ -1495,7 +1497,7 @@
         },
         {
             "number": 107,
-            "class": "bus",
+            "class": "Bus",
             "name": "BLOOMINGTON 2 0",
             "init": {
                 "Vr": 0.15162117656120708,
@@ -1509,7 +1511,7 @@
         },
         {
             "number": 108,
-            "class": "bus",
+            "class": "Bus",
             "name": "PRINCEVILLE 0",
             "init": {
                 "Vr": 0.2510447512092732,
@@ -1523,7 +1525,7 @@
         },
         {
             "number": 109,
-            "class": "bus",
+            "class": "Bus",
             "name": "DELAVAN 0",
             "init": {
                 "Vr": 0.19253404028644736,
@@ -1537,7 +1539,7 @@
         },
         {
             "number": 110,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 6 0",
             "init": {
                 "Vr": 0.21711934576059158,
@@ -1551,7 +1553,7 @@
         },
         {
             "number": 111,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAVOY 0",
             "init": {
                 "Vr": 0.11207635800599634,
@@ -1565,7 +1567,7 @@
         },
         {
             "number": 112,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORMAL 2 0",
             "init": {
                 "Vr": 0.2318411409998272,
@@ -1579,7 +1581,7 @@
         },
         {
             "number": 113,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORMAL 2 1",
             "init": {
                 "Vr": 0.17073809310952937,
@@ -1593,7 +1595,7 @@
         },
         {
             "number": 114,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORMAL 2 2",
             "init": {
                 "Vr": 0.2336905032467782,
@@ -1607,7 +1609,7 @@
         },
         {
             "number": 115,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORMAL 2 3",
             "init": {
                 "Vr": 0.26421870332258324,
@@ -1621,7 +1623,7 @@
         },
         {
             "number": 116,
-            "class": "bus",
+            "class": "Bus",
             "name": "EAST PEORIA 0",
             "init": {
                 "Vr": 0.2706990674809,
@@ -1635,7 +1637,7 @@
         },
         {
             "number": 117,
-            "class": "bus",
+            "class": "Bus",
             "name": "EAST PEORIA 1",
             "init": {
                 "Vr": 0.22411504303968308,
@@ -1649,7 +1651,7 @@
         },
         {
             "number": 118,
-            "class": "bus",
+            "class": "Bus",
             "name": "HANNA CITY 0",
             "init": {
                 "Vr": 0.2403867945433958,
@@ -1663,7 +1665,7 @@
         },
         {
             "number": 119,
-            "class": "bus",
+            "class": "Bus",
             "name": "METAMORA 0",
             "init": {
                 "Vr": 0.1831284278058181,
@@ -1677,7 +1679,7 @@
         },
         {
             "number": 120,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREENVIEW 0",
             "init": {
                 "Vr": 0.18092103614580804,
@@ -1691,7 +1693,7 @@
         },
         {
             "number": 121,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLINTON 2 0",
             "init": {
                 "Vr": 0.28038275083851405,
@@ -1705,7 +1707,7 @@
         },
         {
             "number": 122,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLINTON 2 1",
             "init": {
                 "Vr": 0.24102962049019988,
@@ -1719,7 +1721,7 @@
         },
         {
             "number": 123,
-            "class": "bus",
+            "class": "Bus",
             "name": "BARTONVILLE 0",
             "init": {
                 "Vr": 0.31057387107646955,
@@ -1733,7 +1735,7 @@
         },
         {
             "number": 124,
-            "class": "bus",
+            "class": "Bus",
             "name": "BARTONVILLE 1",
             "init": {
                 "Vr": 0.25969233104611555,
@@ -1747,7 +1749,7 @@
         },
         {
             "number": 125,
-            "class": "bus",
+            "class": "Bus",
             "name": "BARTONVILLE 2",
             "init": {
                 "Vr": 0.45770089489049043,
@@ -1761,7 +1763,7 @@
         },
         {
             "number": 126,
-            "class": "bus",
+            "class": "Bus",
             "name": "BARTONVILLE 3",
             "init": {
                 "Vr": 0.40640171813902803,
@@ -1775,7 +1777,7 @@
         },
         {
             "number": 127,
-            "class": "bus",
+            "class": "Bus",
             "name": "BARTONVILLE 4",
             "init": {
                 "Vr": 0.3593500858129866,
@@ -1789,7 +1791,7 @@
         },
         {
             "number": 128,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORMAL 1 0",
             "init": {
                 "Vr": 0.23434254312060618,
@@ -1803,7 +1805,7 @@
         },
         {
             "number": 129,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORMAL 1 1",
             "init": {
                 "Vr": 0.16676340571036466,
@@ -1817,7 +1819,7 @@
         },
         {
             "number": 130,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEXINGTON 0",
             "init": {
                 "Vr": 0.21965340514991777,
@@ -1831,7 +1833,7 @@
         },
         {
             "number": 131,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 5 0",
             "init": {
                 "Vr": 0.22017408405937197,
@@ -1845,7 +1847,7 @@
         },
         {
             "number": 132,
-            "class": "bus",
+            "class": "Bus",
             "name": "MORTON 0",
             "init": {
                 "Vr": 0.18219166114541638,
@@ -1859,7 +1861,7 @@
         },
         {
             "number": 133,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEKIN 1 0",
             "init": {
                 "Vr": 0.3077864810757717,
@@ -1873,7 +1875,7 @@
         },
         {
             "number": 134,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEKIN 1 1",
             "init": {
                 "Vr": 0.28099941216683355,
@@ -1887,7 +1889,7 @@
         },
         {
             "number": 135,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEKIN 1 2",
             "init": {
                 "Vr": 0.37292491293718105,
@@ -1901,7 +1903,7 @@
         },
         {
             "number": 136,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEKIN 1 3",
             "init": {
                 "Vr": 0.36861972257298803,
@@ -1915,7 +1917,7 @@
         },
         {
             "number": 137,
-            "class": "bus",
+            "class": "Bus",
             "name": "NIANTIC 0",
             "init": {
                 "Vr": 0.219064321227321,
@@ -1929,7 +1931,7 @@
         },
         {
             "number": 138,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLFAX 0",
             "init": {
                 "Vr": 0.17689654640918814,
@@ -1943,7 +1945,7 @@
         },
         {
             "number": 139,
-            "class": "bus",
+            "class": "Bus",
             "name": "EL PASO 0",
             "init": {
                 "Vr": 0.16958416000426438,
@@ -1957,7 +1959,7 @@
         },
         {
             "number": 140,
-            "class": "bus",
+            "class": "Bus",
             "name": "TREMONT 0",
             "init": {
                 "Vr": 0.2518504762467575,
@@ -1971,7 +1973,7 @@
         },
         {
             "number": 141,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 4 0",
             "init": {
                 "Vr": 0.21743832115952033,
@@ -1985,7 +1987,7 @@
         },
         {
             "number": 142,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 3 0",
             "init": {
                 "Vr": 0.21760492986180222,
@@ -1999,7 +2001,7 @@
         },
         {
             "number": 143,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 2 0",
             "init": {
                 "Vr": 0.15600146327674594,
@@ -2013,7 +2015,7 @@
         },
         {
             "number": 144,
-            "class": "bus",
+            "class": "Bus",
             "name": "EUREKA 0",
             "init": {
                 "Vr": 0.2103264464887105,
@@ -2027,7 +2029,7 @@
         },
         {
             "number": 145,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHATHAM 0",
             "init": {
                 "Vr": 0.23524464064960768,
@@ -2041,7 +2043,7 @@
         },
         {
             "number": 146,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOPEDALE 2 0",
             "init": {
                 "Vr": 0.17211439855301833,
@@ -2055,7 +2057,7 @@
         },
         {
             "number": 147,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOPEDALE 2 1",
             "init": {
                 "Vr": 0.1884177561230628,
@@ -2069,7 +2071,7 @@
         },
         {
             "number": 148,
-            "class": "bus",
+            "class": "Bus",
             "name": "WASHINGTON 0",
             "init": {
                 "Vr": 0.19804700298243869,
@@ -2083,7 +2085,7 @@
         },
         {
             "number": 149,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 5 0",
             "init": {
                 "Vr": 0.30018093984311683,
@@ -2097,7 +2099,7 @@
         },
         {
             "number": 150,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 5 1",
             "init": {
                 "Vr": 0.2693222167379729,
@@ -2111,7 +2113,7 @@
         },
         {
             "number": 151,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 5 2",
             "init": {
                 "Vr": 0.333132848069612,
@@ -2125,7 +2127,7 @@
         },
         {
             "number": 152,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 5 3",
             "init": {
                 "Vr": 0.40181365526426566,
@@ -2139,7 +2141,7 @@
         },
         {
             "number": 153,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 5 4",
             "init": {
                 "Vr": 0.43125165272511196,
@@ -2153,7 +2155,7 @@
         },
         {
             "number": 154,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 5 5",
             "init": {
                 "Vr": 0.3748329798878099,
@@ -2167,7 +2169,7 @@
         },
         {
             "number": 155,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 5 6",
             "init": {
                 "Vr": 0.3726595937551803,
@@ -2181,7 +2183,7 @@
         },
         {
             "number": 156,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 2 0",
             "init": {
                 "Vr": 0.3072525265667353,
@@ -2195,7 +2197,7 @@
         },
         {
             "number": 157,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 2 1",
             "init": {
                 "Vr": 0.28672436838103543,
@@ -2209,7 +2211,7 @@
         },
         {
             "number": 158,
-            "class": "bus",
+            "class": "Bus",
             "name": "MT ZION 0",
             "init": {
                 "Vr": 0.25365447929470386,
@@ -2223,7 +2225,7 @@
         },
         {
             "number": 159,
-            "class": "bus",
+            "class": "Bus",
             "name": "BUFFALO 0",
             "init": {
                 "Vr": 0.197508837989496,
@@ -2237,7 +2239,7 @@
         },
         {
             "number": 160,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 4 0",
             "init": {
                 "Vr": 0.23148213710726082,
@@ -2251,7 +2253,7 @@
         },
         {
             "number": 161,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 4 1",
             "init": {
                 "Vr": 0.26597839912406396,
@@ -2265,7 +2267,7 @@
         },
         {
             "number": 162,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONGERVILLE 0",
             "init": {
                 "Vr": 0.21398811238093915,
@@ -2279,7 +2281,7 @@
         },
         {
             "number": 163,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 1 0",
             "init": {
                 "Vr": 0.11588661241689759,
@@ -2293,7 +2295,7 @@
         },
         {
             "number": 164,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 1 1",
             "init": {
                 "Vr": 0.11588661241689759,
@@ -2307,7 +2309,7 @@
         },
         {
             "number": 165,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 1 2",
             "init": {
                 "Vr": 0.11588661241689759,
@@ -2321,7 +2323,7 @@
         },
         {
             "number": 166,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 1 3",
             "init": {
                 "Vr": 0.11588661241689759,
@@ -2335,7 +2337,7 @@
         },
         {
             "number": 167,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 1 4",
             "init": {
                 "Vr": 0.12189593200577416,
@@ -2349,7 +2351,7 @@
         },
         {
             "number": 168,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 1 5",
             "init": {
                 "Vr": 0.11588661241689759,
@@ -2363,7 +2365,7 @@
         },
         {
             "number": 169,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 1 6",
             "init": {
                 "Vr": 0.11588661241689759,
@@ -2377,7 +2379,7 @@
         },
         {
             "number": 170,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAMPAIGN 1 7",
             "init": {
                 "Vr": 0.1274883215301569,
@@ -2391,7 +2393,7 @@
         },
         {
             "number": 171,
-            "class": "bus",
+            "class": "Bus",
             "name": "FISHER 0",
             "init": {
                 "Vr": 0.15151344980961381,
@@ -2405,7 +2407,7 @@
         },
         {
             "number": 172,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOMER 0",
             "init": {
                 "Vr": 0.12198101464720269,
@@ -2419,7 +2421,7 @@
         },
         {
             "number": 173,
-            "class": "bus",
+            "class": "Bus",
             "name": "TUSCOLA 1 0",
             "init": {
                 "Vr": 0.12129757262339194,
@@ -2433,7 +2435,7 @@
         },
         {
             "number": 174,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHITE HEATH 0",
             "init": {
                 "Vr": 0.14881924421287274,
@@ -2447,7 +2449,7 @@
         },
         {
             "number": 175,
-            "class": "bus",
+            "class": "Bus",
             "name": "TOLONO 0",
             "init": {
                 "Vr": 0.11351336226989216,
@@ -2461,7 +2463,7 @@
         },
         {
             "number": 176,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 3 0",
             "init": {
                 "Vr": 0.24441435860785576,
@@ -2475,7 +2477,7 @@
         },
         {
             "number": 177,
-            "class": "bus",
+            "class": "Bus",
             "name": "MACKINAW 0",
             "init": {
                 "Vr": 0.1534507012704009,
@@ -2489,7 +2491,7 @@
         },
         {
             "number": 178,
-            "class": "bus",
+            "class": "Bus",
             "name": "URBANA 1 0",
             "init": {
                 "Vr": 0.19939306869046278,
@@ -2503,7 +2505,7 @@
         },
         {
             "number": 179,
-            "class": "bus",
+            "class": "Bus",
             "name": "URBANA 1 1",
             "init": {
                 "Vr": 0.14642562680313195,
@@ -2517,7 +2519,7 @@
         },
         {
             "number": 180,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAINT JOSEPH 0",
             "init": {
                 "Vr": 0.12556059952569523,
@@ -2531,7 +2533,7 @@
         },
         {
             "number": 181,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 2 0",
             "init": {
                 "Vr": 0.2332665979694632,
@@ -2545,7 +2547,7 @@
         },
         {
             "number": 182,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 2 1",
             "init": {
                 "Vr": 0.2853613361111407,
@@ -2559,7 +2561,7 @@
         },
         {
             "number": 183,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 2 2",
             "init": {
                 "Vr": 0.26477862772347854,
@@ -2573,7 +2575,7 @@
         },
         {
             "number": 184,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONTICELLO 0",
             "init": {
                 "Vr": 0.1584208171077444,
@@ -2587,7 +2589,7 @@
         },
         {
             "number": 185,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUBURN 0",
             "init": {
                 "Vr": 0.24385726937768853,
@@ -2601,7 +2603,7 @@
         },
         {
             "number": 186,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOPEDALE 1 0",
             "init": {
                 "Vr": 0.20601188297869166,
@@ -2615,7 +2617,7 @@
         },
         {
             "number": 187,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLINTON 1 0",
             "init": {
                 "Vr": 0.29651419015149005,
@@ -2629,7 +2631,7 @@
         },
         {
             "number": 188,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLINTON 1 1",
             "init": {
                 "Vr": 0.22088782481698535,
@@ -2643,7 +2645,7 @@
         },
         {
             "number": 189,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLINTON 1 2",
             "init": {
                 "Vr": 0.338564005669986,
@@ -2657,7 +2659,7 @@
         },
         {
             "number": 190,
-            "class": "bus",
+            "class": "Bus",
             "name": "MAHOMET 0",
             "init": {
                 "Vr": 0.13453543350800665,
@@ -2671,7 +2673,7 @@
         },
         {
             "number": 191,
-            "class": "bus",
+            "class": "Bus",
             "name": "VILLA GROVE 0",
             "init": {
                 "Vr": 0.17322743574658098,
@@ -2685,7 +2687,7 @@
         },
         {
             "number": 192,
-            "class": "bus",
+            "class": "Bus",
             "name": "BLOOMINGTON 1 0",
             "init": {
                 "Vr": 0.1487480063190215,
@@ -2699,7 +2701,7 @@
         },
         {
             "number": 193,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEORIA 1 0",
             "init": {
                 "Vr": 0.22254319700767655,
@@ -2713,7 +2715,7 @@
         },
         {
             "number": 194,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGFIELD 1 0",
             "init": {
                 "Vr": 0.2498529689903615,
@@ -2727,7 +2729,7 @@
         },
         {
             "number": 195,
-            "class": "bus",
+            "class": "Bus",
             "name": "GIBSON CITY 1 0",
             "init": {
                 "Vr": 0.18065978519009476,
@@ -2741,7 +2743,7 @@
         },
         {
             "number": 196,
-            "class": "bus",
+            "class": "Bus",
             "name": "GIBSON CITY 1 1",
             "init": {
                 "Vr": 0.18065978519009476,
@@ -2755,7 +2757,7 @@
         },
         {
             "number": 197,
-            "class": "bus",
+            "class": "Bus",
             "name": "GIBSON CITY 1 2",
             "init": {
                 "Vr": 0.22049327183260617,
@@ -2769,7 +2771,7 @@
         },
         {
             "number": 198,
-            "class": "bus",
+            "class": "Bus",
             "name": "MAPLETON 0",
             "init": {
                 "Vr": 0.2398180827217694,
@@ -2783,7 +2785,7 @@
         },
         {
             "number": 199,
-            "class": "bus",
+            "class": "Bus",
             "name": "GIFFORD 0",
             "init": {
                 "Vr": 0.12981497936692685,
@@ -2797,7 +2799,7 @@
         },
         {
             "number": 200,
-            "class": "bus",
+            "class": "Bus",
             "name": "PETERSBURG 0",
             "init": {
                 "Vr": 0.2216244225682356,

--- a/examples/PhasorDynamics/Large/Texas/texas.case.json
+++ b/examples/PhasorDynamics/Large/Texas/texas.case.json
@@ -1,10 +1,12 @@
 {
     "header": {
-        "format_version": 0.1,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "ACTIVSg2000",
         "case_description": "",
-        "case_comments": "",
+        "case_comments": ""
+    },
+    "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
@@ -17,7 +19,7 @@
     "buses": [
         {
             "number": 1001,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 2 0",
             "init": {
                 "Vr": 0.906988705094851,
@@ -31,7 +33,7 @@
         },
         {
             "number": 1002,
-            "class": "bus",
+            "class": "Bus",
             "name": "PRESIDIO 2 0",
             "init": {
                 "Vr": 0.9717123902573229,
@@ -45,7 +47,7 @@
         },
         {
             "number": 1003,
-            "class": "bus",
+            "class": "Bus",
             "name": "O DONNELL 1 0",
             "init": {
                 "Vr": 0.9681608277297838,
@@ -59,7 +61,7 @@
         },
         {
             "number": 1004,
-            "class": "bus",
+            "class": "Bus",
             "name": "O DONNELL 1 1",
             "init": {
                 "Vr": 0.9623321924186682,
@@ -73,7 +75,7 @@
         },
         {
             "number": 1005,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 5 0",
             "init": {
                 "Vr": 0.9701058782434328,
@@ -87,7 +89,7 @@
         },
         {
             "number": 1006,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 5 1",
             "init": {
                 "Vr": 0.9737820006832745,
@@ -101,7 +103,7 @@
         },
         {
             "number": 1007,
-            "class": "bus",
+            "class": "Bus",
             "name": "VAN HORN 0",
             "init": {
                 "Vr": 0.9763588600976093,
@@ -115,7 +117,7 @@
         },
         {
             "number": 1008,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRAAN 2 0",
             "init": {
                 "Vr": 1.0120914021083107,
@@ -129,7 +131,7 @@
         },
         {
             "number": 1009,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRAAN 2 1",
             "init": {
                 "Vr": 1.0094592872146175,
@@ -143,7 +145,7 @@
         },
         {
             "number": 1010,
-            "class": "bus",
+            "class": "Bus",
             "name": "PRESIDIO 1 0",
             "init": {
                 "Vr": 0.985363703151467,
@@ -157,7 +159,7 @@
         },
         {
             "number": 1011,
-            "class": "bus",
+            "class": "Bus",
             "name": "PRESIDIO 1 1",
             "init": {
                 "Vr": 0.9942653745413838,
@@ -171,7 +173,7 @@
         },
         {
             "number": 1012,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANDERSON 0",
             "init": {
                 "Vr": 0.9186933874128294,
@@ -185,7 +187,7 @@
         },
         {
             "number": 1013,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONAHANS 2 0",
             "init": {
                 "Vr": 0.9721570695278151,
@@ -199,7 +201,7 @@
         },
         {
             "number": 1014,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANDFALLS 0",
             "init": {
                 "Vr": 0.9931675829684254,
@@ -213,7 +215,7 @@
         },
         {
             "number": 1015,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARFA 0",
             "init": {
                 "Vr": 0.979611973877834,
@@ -227,7 +229,7 @@
         },
         {
             "number": 1016,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARDEN CITY 0",
             "init": {
                 "Vr": 0.981526855922096,
@@ -241,7 +243,7 @@
         },
         {
             "number": 1017,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 4 0",
             "init": {
                 "Vr": 0.9173144674426199,
@@ -255,7 +257,7 @@
         },
         {
             "number": 1018,
-            "class": "bus",
+            "class": "Bus",
             "name": "NOTREES 0",
             "init": {
                 "Vr": 0.9323108499696858,
@@ -269,7 +271,7 @@
         },
         {
             "number": 1019,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDLAND 4 0",
             "init": {
                 "Vr": 0.9283360267661245,
@@ -283,7 +285,7 @@
         },
         {
             "number": 1020,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 1 0",
             "init": {
                 "Vr": 0.9892974485838533,
@@ -297,7 +299,7 @@
         },
         {
             "number": 1021,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 1 1",
             "init": {
                 "Vr": 0.9898488626069741,
@@ -311,7 +313,7 @@
         },
         {
             "number": 1022,
-            "class": "bus",
+            "class": "Bus",
             "name": "O DONNELL 2 0",
             "init": {
                 "Vr": 0.9752703691875501,
@@ -325,7 +327,7 @@
         },
         {
             "number": 1023,
-            "class": "bus",
+            "class": "Bus",
             "name": "O DONNELL 2 1",
             "init": {
                 "Vr": 1.0017681259441857,
@@ -339,7 +341,7 @@
         },
         {
             "number": 1024,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 6 0",
             "init": {
                 "Vr": 0.940290347536956,
@@ -353,7 +355,7 @@
         },
         {
             "number": 1025,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRINGS 0",
             "init": {
                 "Vr": 0.9895387990646831,
@@ -367,7 +369,7 @@
         },
         {
             "number": 1026,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRINGS 1",
             "init": {
                 "Vr": 0.9965255662084647,
@@ -381,7 +383,7 @@
         },
         {
             "number": 1027,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDLAND 2 0",
             "init": {
                 "Vr": 0.9124937526723228,
@@ -395,7 +397,7 @@
         },
         {
             "number": 1028,
-            "class": "bus",
+            "class": "Bus",
             "name": "COAHOMA 0",
             "init": {
                 "Vr": 0.970655847616052,
@@ -409,7 +411,7 @@
         },
         {
             "number": 1029,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDLAND 3 0",
             "init": {
                 "Vr": 0.9163419812529112,
@@ -423,7 +425,7 @@
         },
         {
             "number": 1030,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALPINE 0",
             "init": {
                 "Vr": 0.9898189908653177,
@@ -437,7 +439,7 @@
         },
         {
             "number": 1031,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT DAVIS 0",
             "init": {
                 "Vr": 0.9703000016411445,
@@ -451,7 +453,7 @@
         },
         {
             "number": 1032,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCCAMEY 1 0",
             "init": {
                 "Vr": 0.9827360116408174,
@@ -465,7 +467,7 @@
         },
         {
             "number": 1033,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCCAMEY 1 1",
             "init": {
                 "Vr": 0.9809646615943778,
@@ -479,7 +481,7 @@
         },
         {
             "number": 1034,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 4 0",
             "init": {
                 "Vr": 0.9748474686811264,
@@ -493,7 +495,7 @@
         },
         {
             "number": 1035,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 4 1",
             "init": {
                 "Vr": 0.981260564963184,
@@ -507,7 +509,7 @@
         },
         {
             "number": 1036,
-            "class": "bus",
+            "class": "Bus",
             "name": "CRANE 0",
             "init": {
                 "Vr": 0.9761800681039543,
@@ -521,7 +523,7 @@
         },
         {
             "number": 1037,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 5 0",
             "init": {
                 "Vr": 0.9035457676770856,
@@ -535,7 +537,7 @@
         },
         {
             "number": 1038,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT STOCKTON 1 0",
             "init": {
                 "Vr": 1.0105119342137745,
@@ -549,7 +551,7 @@
         },
         {
             "number": 1039,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT STOCKTON 1 1",
             "init": {
                 "Vr": 0.9990799985265085,
@@ -563,7 +565,7 @@
         },
         {
             "number": 1040,
-            "class": "bus",
+            "class": "Bus",
             "name": "ANDREWS 0",
             "init": {
                 "Vr": 0.9327212746139295,
@@ -577,7 +579,7 @@
         },
         {
             "number": 1041,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORSAN 0",
             "init": {
                 "Vr": 0.9697833864160675,
@@ -591,7 +593,7 @@
         },
         {
             "number": 1042,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORSAN 1",
             "init": {
                 "Vr": 0.9697833864160675,
@@ -605,7 +607,7 @@
         },
         {
             "number": 1043,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORSAN 2",
             "init": {
                 "Vr": 0.9783129071431819,
@@ -619,7 +621,7 @@
         },
         {
             "number": 1044,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG LAKE 0",
             "init": {
                 "Vr": 0.9127475834810703,
@@ -633,7 +635,7 @@
         },
         {
             "number": 1045,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDLAND 5 0",
             "init": {
                 "Vr": 0.8942788963835491,
@@ -647,7 +649,7 @@
         },
         {
             "number": 1046,
-            "class": "bus",
+            "class": "Bus",
             "name": "OZONA 0",
             "init": {
                 "Vr": 0.9493827752156213,
@@ -661,7 +663,7 @@
         },
         {
             "number": 1047,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONAHANS 1 0",
             "init": {
                 "Vr": 0.9802840235040473,
@@ -675,7 +677,7 @@
         },
         {
             "number": 1048,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONAHANS 1 1",
             "init": {
                 "Vr": 0.9802840235040473,
@@ -689,7 +691,7 @@
         },
         {
             "number": 1049,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONAHANS 1 2",
             "init": {
                 "Vr": 0.9802840235040473,
@@ -703,7 +705,7 @@
         },
         {
             "number": 1050,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONAHANS 1 3",
             "init": {
                 "Vr": 0.9893424935269048,
@@ -717,7 +719,7 @@
         },
         {
             "number": 1051,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONAHANS 1 4",
             "init": {
                 "Vr": 0.9927635185235976,
@@ -731,7 +733,7 @@
         },
         {
             "number": 1052,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONAHANS 1 5",
             "init": {
                 "Vr": 0.9872891920964051,
@@ -745,7 +747,7 @@
         },
         {
             "number": 1053,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONAHANS 1 6",
             "init": {
                 "Vr": 0.9785529286400816,
@@ -759,7 +761,7 @@
         },
         {
             "number": 1054,
-            "class": "bus",
+            "class": "Bus",
             "name": "STANTON 0",
             "init": {
                 "Vr": 0.9364025396106576,
@@ -773,7 +775,7 @@
         },
         {
             "number": 1055,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODONNELL 0",
             "init": {
                 "Vr": 0.9556301651997864,
@@ -787,7 +789,7 @@
         },
         {
             "number": 1056,
-            "class": "bus",
+            "class": "Bus",
             "name": "LENORAH 0",
             "init": {
                 "Vr": 0.9556323151997315,
@@ -801,7 +803,7 @@
         },
         {
             "number": 1057,
-            "class": "bus",
+            "class": "Bus",
             "name": "LENORAH 1",
             "init": {
                 "Vr": 0.9556323151997315,
@@ -815,7 +817,7 @@
         },
         {
             "number": 1058,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRAAN 3 0",
             "init": {
                 "Vr": 1.0053938849478126,
@@ -829,7 +831,7 @@
         },
         {
             "number": 1059,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRAAN 3 1",
             "init": {
                 "Vr": 1.0053938849478126,
@@ -843,7 +845,7 @@
         },
         {
             "number": 1060,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRAAN 3 2",
             "init": {
                 "Vr": 1.0053938849478126,
@@ -857,7 +859,7 @@
         },
         {
             "number": 1061,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 6 0",
             "init": {
                 "Vr": 0.9660248323862802,
@@ -871,7 +873,7 @@
         },
         {
             "number": 1062,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 6 1",
             "init": {
                 "Vr": 0.9660248323862802,
@@ -885,7 +887,7 @@
         },
         {
             "number": 1063,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 6 2",
             "init": {
                 "Vr": 0.9660248323862802,
@@ -899,7 +901,7 @@
         },
         {
             "number": 1064,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 3 0",
             "init": {
                 "Vr": 0.8909140573875893,
@@ -913,7 +915,7 @@
         },
         {
             "number": 1065,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 3 0",
             "init": {
                 "Vr": 0.9733690018665346,
@@ -927,7 +929,7 @@
         },
         {
             "number": 1066,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 3 1",
             "init": {
                 "Vr": 0.9914197386953144,
@@ -941,7 +943,7 @@
         },
         {
             "number": 1067,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 7 0",
             "init": {
                 "Vr": 0.964134914694925,
@@ -955,7 +957,7 @@
         },
         {
             "number": 1068,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDLAND 1 0",
             "init": {
                 "Vr": 0.9468090160461404,
@@ -969,7 +971,7 @@
         },
         {
             "number": 1069,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRAAN 1 0",
             "init": {
                 "Vr": 1.014694741924372,
@@ -983,7 +985,7 @@
         },
         {
             "number": 1070,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRAAN 1 1",
             "init": {
                 "Vr": 1.036860558652829,
@@ -997,7 +999,7 @@
         },
         {
             "number": 1071,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 0",
             "init": {
                 "Vr": 0.9218979210015521,
@@ -1011,7 +1013,7 @@
         },
         {
             "number": 1072,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 1",
             "init": {
                 "Vr": 0.9874847525984342,
@@ -1025,7 +1027,7 @@
         },
         {
             "number": 1073,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 2",
             "init": {
                 "Vr": 1.0049672284339874,
@@ -1039,7 +1041,7 @@
         },
         {
             "number": 1074,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 3",
             "init": {
                 "Vr": 1.000731646657823,
@@ -1053,7 +1055,7 @@
         },
         {
             "number": 1075,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 4",
             "init": {
                 "Vr": 0.9930001460702078,
@@ -1067,7 +1069,7 @@
         },
         {
             "number": 1076,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 5",
             "init": {
                 "Vr": 0.9218979210015521,
@@ -1081,7 +1083,7 @@
         },
         {
             "number": 1077,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 6",
             "init": {
                 "Vr": 0.9218979210015521,
@@ -1095,7 +1097,7 @@
         },
         {
             "number": 1078,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 7",
             "init": {
                 "Vr": 0.9912872256506823,
@@ -1109,7 +1111,7 @@
         },
         {
             "number": 1079,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 8",
             "init": {
                 "Vr": 0.7989631200266906,
@@ -1123,7 +1125,7 @@
         },
         {
             "number": 1080,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 9",
             "init": {
                 "Vr": 0.9931971168182813,
@@ -1137,7 +1139,7 @@
         },
         {
             "number": 1081,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODESSA 1 10",
             "init": {
                 "Vr": 0.9752791286139819,
@@ -1151,7 +1153,7 @@
         },
         {
             "number": 1082,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT STOCKTON 2 0",
             "init": {
                 "Vr": 1.0174395526371172,
@@ -1165,7 +1167,7 @@
         },
         {
             "number": 1083,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT STOCKTON 3 0",
             "init": {
                 "Vr": 1.006876881023387,
@@ -1179,7 +1181,7 @@
         },
         {
             "number": 1084,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG SPRING 2 0",
             "init": {
                 "Vr": 0.9855215041256111,
@@ -1193,7 +1195,7 @@
         },
         {
             "number": 1085,
-            "class": "bus",
+            "class": "Bus",
             "name": "KERMIT 0",
             "init": {
                 "Vr": 0.9747332767715894,
@@ -1207,7 +1209,7 @@
         },
         {
             "number": 1086,
-            "class": "bus",
+            "class": "Bus",
             "name": "PECOS 0",
             "init": {
                 "Vr": 0.9702065714380703,
@@ -1221,7 +1223,7 @@
         },
         {
             "number": 1087,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHEFFIELD 0",
             "init": {
                 "Vr": 0.9885886893008948,
@@ -1235,7 +1237,7 @@
         },
         {
             "number": 1088,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCCAMEY 2 0",
             "init": {
                 "Vr": 0.9782168831727207,
@@ -1249,7 +1251,7 @@
         },
         {
             "number": 1089,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAMESA 0",
             "init": {
                 "Vr": 0.9191139859876781,
@@ -1263,7 +1265,7 @@
         },
         {
             "number": 1090,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLDSMITH 0",
             "init": {
                 "Vr": 0.9797968150207038,
@@ -1277,7 +1279,7 @@
         },
         {
             "number": 1091,
-            "class": "bus",
+            "class": "Bus",
             "name": "RALLS 2 0",
             "init": {
                 "Vr": 0.8860840473965916,
@@ -1291,7 +1293,7 @@
         },
         {
             "number": 2001,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 3 0",
             "init": {
                 "Vr": 0.5061868115005276,
@@ -1305,7 +1307,7 @@
         },
         {
             "number": 2002,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAVOY 0",
             "init": {
                 "Vr": 0.4867907083520078,
@@ -1319,7 +1321,7 @@
         },
         {
             "number": 2003,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAVOY 1",
             "init": {
                 "Vr": 0.4508987864052233,
@@ -1333,7 +1335,7 @@
         },
         {
             "number": 2004,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAVOY 2",
             "init": {
                 "Vr": 0.4867907083520078,
@@ -1347,7 +1349,7 @@
         },
         {
             "number": 2005,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAVOY 3",
             "init": {
                 "Vr": 0.4867907083520078,
@@ -1361,7 +1363,7 @@
         },
         {
             "number": 2006,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAVOY 4",
             "init": {
                 "Vr": 0.4867907083520078,
@@ -1375,7 +1377,7 @@
         },
         {
             "number": 2007,
-            "class": "bus",
+            "class": "Bus",
             "name": "HONEY GROVE 0",
             "init": {
                 "Vr": 0.5100889082280878,
@@ -1389,7 +1391,7 @@
         },
         {
             "number": 2008,
-            "class": "bus",
+            "class": "Bus",
             "name": "MEMPHIS 0",
             "init": {
                 "Vr": 0.8586749088998609,
@@ -1403,7 +1405,7 @@
         },
         {
             "number": 2009,
-            "class": "bus",
+            "class": "Bus",
             "name": "IOWA PARK 0",
             "init": {
                 "Vr": 0.7239675024188705,
@@ -1417,7 +1419,7 @@
         },
         {
             "number": 2010,
-            "class": "bus",
+            "class": "Bus",
             "name": "VERNON 2 0",
             "init": {
                 "Vr": 0.8302730600063408,
@@ -1431,7 +1433,7 @@
         },
         {
             "number": 2011,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 2 0",
             "init": {
                 "Vr": 0.882571280140297,
@@ -1445,7 +1447,7 @@
         },
         {
             "number": 2012,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 2 1",
             "init": {
                 "Vr": 0.8936177333115812,
@@ -1459,7 +1461,7 @@
         },
         {
             "number": 2013,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 2 2",
             "init": {
                 "Vr": 0.8969478212244676,
@@ -1473,7 +1475,7 @@
         },
         {
             "number": 2014,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHILDRESS 0",
             "init": {
                 "Vr": 0.8527111859790951,
@@ -1487,7 +1489,7 @@
         },
         {
             "number": 2015,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORESTBURG 0",
             "init": {
                 "Vr": 0.4589119431882633,
@@ -1501,7 +1503,7 @@
         },
         {
             "number": 2016,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHERMAN 3 0",
             "init": {
                 "Vr": 0.35166983895676246,
@@ -1515,7 +1517,7 @@
         },
         {
             "number": 2017,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 4 0",
             "init": {
                 "Vr": 0.8739709283045762,
@@ -1529,7 +1531,7 @@
         },
         {
             "number": 2018,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 4 1",
             "init": {
                 "Vr": 0.879367941177268,
@@ -1543,7 +1545,7 @@
         },
         {
             "number": 2019,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 4 2",
             "init": {
                 "Vr": 0.8739709283045762,
@@ -1557,7 +1559,7 @@
         },
         {
             "number": 2020,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 6 0",
             "init": {
                 "Vr": 0.709251484041151,
@@ -1571,7 +1573,7 @@
         },
         {
             "number": 2021,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 2 0",
             "init": {
                 "Vr": 0.5614008148350945,
@@ -1585,7 +1587,7 @@
         },
         {
             "number": 2022,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 2 1",
             "init": {
                 "Vr": 0.5306306358444848,
@@ -1599,7 +1601,7 @@
         },
         {
             "number": 2023,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 2 2",
             "init": {
                 "Vr": 0.5872432550543003,
@@ -1613,7 +1615,7 @@
         },
         {
             "number": 2024,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 2 3",
             "init": {
                 "Vr": 0.5968802832918452,
@@ -1627,7 +1629,7 @@
         },
         {
             "number": 2025,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 4 0",
             "init": {
                 "Vr": 0.7175020317254467,
@@ -1641,7 +1643,7 @@
         },
         {
             "number": 2026,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHEELER 0",
             "init": {
                 "Vr": 0.8817130713931436,
@@ -1655,7 +1657,7 @@
         },
         {
             "number": 2027,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEPORT 0",
             "init": {
                 "Vr": 0.49991635488958414,
@@ -1669,7 +1671,7 @@
         },
         {
             "number": 2028,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 3 0",
             "init": {
                 "Vr": 0.679870791713168,
@@ -1683,7 +1685,7 @@
         },
         {
             "number": 2029,
-            "class": "bus",
+            "class": "Bus",
             "name": "SILVERTON 0",
             "init": {
                 "Vr": 0.8640975078986024,
@@ -1697,7 +1699,7 @@
         },
         {
             "number": 2030,
-            "class": "bus",
+            "class": "Bus",
             "name": "BONHAM 0",
             "init": {
                 "Vr": 0.4381101096082832,
@@ -1711,7 +1713,7 @@
         },
         {
             "number": 2031,
-            "class": "bus",
+            "class": "Bus",
             "name": "MATADOR 0",
             "init": {
                 "Vr": 0.8936838073204861,
@@ -1725,7 +1727,7 @@
         },
         {
             "number": 2032,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARTHUR CITY 0",
             "init": {
                 "Vr": 0.5201894474684673,
@@ -1739,7 +1741,7 @@
         },
         {
             "number": 2033,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEONARD 0",
             "init": {
                 "Vr": 0.41569746725085294,
@@ -1753,7 +1755,7 @@
         },
         {
             "number": 2034,
-            "class": "bus",
+            "class": "Bus",
             "name": "GORDONVILLE 0",
             "init": {
                 "Vr": 0.36202512555471816,
@@ -1767,7 +1769,7 @@
         },
         {
             "number": 2035,
-            "class": "bus",
+            "class": "Bus",
             "name": "KNOX CITY 0",
             "init": {
                 "Vr": 0.881086623649472,
@@ -1781,7 +1783,7 @@
         },
         {
             "number": 2036,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 7 0",
             "init": {
                 "Vr": 0.7169479245261249,
@@ -1795,7 +1797,7 @@
         },
         {
             "number": 2037,
-            "class": "bus",
+            "class": "Bus",
             "name": "LINDSAY 0",
             "init": {
                 "Vr": 0.45857438736776424,
@@ -1809,7 +1811,7 @@
         },
         {
             "number": 2038,
-            "class": "bus",
+            "class": "Bus",
             "name": "ECTOR 0",
             "init": {
                 "Vr": 0.4421044988177462,
@@ -1823,7 +1825,7 @@
         },
         {
             "number": 2039,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUNSET 0",
             "init": {
                 "Vr": 0.4915584154760221,
@@ -1837,7 +1839,7 @@
         },
         {
             "number": 2040,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLARKSVILLE 0",
             "init": {
                 "Vr": 0.5192383965551884,
@@ -1851,7 +1853,7 @@
         },
         {
             "number": 2041,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 3 0",
             "init": {
                 "Vr": 0.9130677892809097,
@@ -1865,7 +1867,7 @@
         },
         {
             "number": 2042,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 3 1",
             "init": {
                 "Vr": 0.9256397530796974,
@@ -1879,7 +1881,7 @@
         },
         {
             "number": 2043,
-            "class": "bus",
+            "class": "Bus",
             "name": "SADLER 0",
             "init": {
                 "Vr": 0.35722753357548864,
@@ -1893,7 +1895,7 @@
         },
         {
             "number": 2044,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHITESBORO 0",
             "init": {
                 "Vr": 0.428648148322751,
@@ -1907,7 +1909,7 @@
         },
         {
             "number": 2045,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHEPPARD AFB 0",
             "init": {
                 "Vr": 0.7022329931723604,
@@ -1921,7 +1923,7 @@
         },
         {
             "number": 2046,
-            "class": "bus",
+            "class": "Bus",
             "name": "POTTSBORO 0",
             "init": {
                 "Vr": 0.36823356626684683,
@@ -1935,7 +1937,7 @@
         },
         {
             "number": 2047,
-            "class": "bus",
+            "class": "Bus",
             "name": "BELLS 0",
             "init": {
                 "Vr": 0.4361159595699853,
@@ -1949,7 +1951,7 @@
         },
         {
             "number": 2048,
-            "class": "bus",
+            "class": "Bus",
             "name": "CROSBYTON 0",
             "init": {
                 "Vr": 0.8786047253208136,
@@ -1963,7 +1965,7 @@
         },
         {
             "number": 2049,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELECTRA 0",
             "init": {
                 "Vr": 0.7736462733281889,
@@ -1977,7 +1979,7 @@
         },
         {
             "number": 2050,
-            "class": "bus",
+            "class": "Bus",
             "name": "PATTONVILLE 0",
             "init": {
                 "Vr": 0.4530567190100787,
@@ -1991,7 +1993,7 @@
         },
         {
             "number": 2051,
-            "class": "bus",
+            "class": "Bus",
             "name": "HENRIETTA 0",
             "init": {
                 "Vr": 0.5851607106434116,
@@ -2005,7 +2007,7 @@
         },
         {
             "number": 2052,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 6 0",
             "init": {
                 "Vr": 0.8671799714814007,
@@ -2019,7 +2021,7 @@
         },
         {
             "number": 2053,
-            "class": "bus",
+            "class": "Bus",
             "name": "BOWIE 0",
             "init": {
                 "Vr": 0.5104568791148018,
@@ -2033,7 +2035,7 @@
         },
         {
             "number": 2054,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 1 0",
             "init": {
                 "Vr": 0.7318995894810533,
@@ -2047,7 +2049,7 @@
         },
         {
             "number": 2055,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 1 1",
             "init": {
                 "Vr": 0.7218590254597587,
@@ -2061,7 +2063,7 @@
         },
         {
             "number": 2056,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 1 2",
             "init": {
                 "Vr": 0.7318995894810533,
@@ -2075,7 +2077,7 @@
         },
         {
             "number": 2057,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 1 3",
             "init": {
                 "Vr": 0.7747229423693008,
@@ -2089,7 +2091,7 @@
         },
         {
             "number": 2058,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHITE DEER 0",
             "init": {
                 "Vr": 0.916817332375796,
@@ -2103,7 +2105,7 @@
         },
         {
             "number": 2059,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHITE DEER 1",
             "init": {
                 "Vr": 0.9333685215183947,
@@ -2117,7 +2119,7 @@
         },
         {
             "number": 2060,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROXTON 0",
             "init": {
                 "Vr": 0.47425672510582983,
@@ -2131,7 +2133,7 @@
         },
         {
             "number": 2061,
-            "class": "bus",
+            "class": "Bus",
             "name": "VERNON 1 0",
             "init": {
                 "Vr": 0.8154184582051532,
@@ -2145,7 +2147,7 @@
         },
         {
             "number": 2062,
-            "class": "bus",
+            "class": "Bus",
             "name": "VERNON 1 1",
             "init": {
                 "Vr": 0.8361730307781851,
@@ -2159,7 +2161,7 @@
         },
         {
             "number": 2063,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENISON 2 0",
             "init": {
                 "Vr": 0.3790716608992711,
@@ -2173,7 +2175,7 @@
         },
         {
             "number": 2064,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUMNER 0",
             "init": {
                 "Vr": 0.5024466297266856,
@@ -2187,7 +2189,7 @@
         },
         {
             "number": 2065,
-            "class": "bus",
+            "class": "Bus",
             "name": "GAINESVILLE 0",
             "init": {
                 "Vr": 0.4284771480497073,
@@ -2201,7 +2203,7 @@
         },
         {
             "number": 2066,
-            "class": "bus",
+            "class": "Bus",
             "name": "ASPERMONT 0",
             "init": {
                 "Vr": 0.9045580173293993,
@@ -2215,7 +2217,7 @@
         },
         {
             "number": 2067,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 5 0",
             "init": {
                 "Vr": 0.7171148344674462,
@@ -2229,7 +2231,7 @@
         },
         {
             "number": 2068,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINDTHORST 0",
             "init": {
                 "Vr": 0.7456410415642482,
@@ -2243,7 +2245,7 @@
         },
         {
             "number": 2069,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOWE 0",
             "init": {
                 "Vr": 0.370491893893209,
@@ -2257,7 +2259,7 @@
         },
         {
             "number": 2070,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARCHER 2 0",
             "init": {
                 "Vr": 0.7519888536023523,
@@ -2271,7 +2273,7 @@
         },
         {
             "number": 2071,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARCHER 2 1",
             "init": {
                 "Vr": 0.7913124156936044,
@@ -2285,7 +2287,7 @@
         },
         {
             "number": 2072,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLLINSVILLE 0",
             "init": {
                 "Vr": 0.3991324399253156,
@@ -2299,7 +2301,7 @@
         },
         {
             "number": 2073,
-            "class": "bus",
+            "class": "Bus",
             "name": "JAYTON 0",
             "init": {
                 "Vr": 0.9244610528633298,
@@ -2313,7 +2315,7 @@
         },
         {
             "number": 2074,
-            "class": "bus",
+            "class": "Bus",
             "name": "JAYTON 1",
             "init": {
                 "Vr": 0.9284903192569056,
@@ -2327,7 +2329,7 @@
         },
         {
             "number": 2075,
-            "class": "bus",
+            "class": "Bus",
             "name": "JAYTON 2",
             "init": {
                 "Vr": 0.9284903192569056,
@@ -2341,7 +2343,7 @@
         },
         {
             "number": 2076,
-            "class": "bus",
+            "class": "Bus",
             "name": "JAYTON 3",
             "init": {
                 "Vr": 0.9359025118757334,
@@ -2355,7 +2357,7 @@
         },
         {
             "number": 2077,
-            "class": "bus",
+            "class": "Bus",
             "name": "MUENSTER 1 0",
             "init": {
                 "Vr": 0.49683279275512215,
@@ -2369,7 +2371,7 @@
         },
         {
             "number": 2078,
-            "class": "bus",
+            "class": "Bus",
             "name": "MUENSTER 1 1",
             "init": {
                 "Vr": 0.5458810623346293,
@@ -2383,7 +2385,7 @@
         },
         {
             "number": 2079,
-            "class": "bus",
+            "class": "Bus",
             "name": "PADUCAH 0",
             "init": {
                 "Vr": 0.849938335619018,
@@ -2397,7 +2399,7 @@
         },
         {
             "number": 2080,
-            "class": "bus",
+            "class": "Bus",
             "name": "NOCONA 0",
             "init": {
                 "Vr": 0.5402670605354176,
@@ -2411,7 +2413,7 @@
         },
         {
             "number": 2081,
-            "class": "bus",
+            "class": "Bus",
             "name": "DODD CITY 0",
             "init": {
                 "Vr": 0.42702341919379866,
@@ -2425,7 +2427,7 @@
         },
         {
             "number": 2082,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 2 0",
             "init": {
                 "Vr": 0.7158239474885301,
@@ -2439,7 +2441,7 @@
         },
         {
             "number": 2083,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 2 1",
             "init": {
                 "Vr": 0.7455537132924556,
@@ -2453,7 +2455,7 @@
         },
         {
             "number": 2084,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 2 2",
             "init": {
                 "Vr": 0.7158239474885301,
@@ -2467,7 +2469,7 @@
         },
         {
             "number": 2085,
-            "class": "bus",
+            "class": "Bus",
             "name": "WICHITA FALLS 2 3",
             "init": {
                 "Vr": 0.7158239474885301,
@@ -2481,7 +2483,7 @@
         },
         {
             "number": 2086,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONTAGUE 0",
             "init": {
                 "Vr": 0.5100428787394182,
@@ -2495,7 +2497,7 @@
         },
         {
             "number": 2087,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPUR 0",
             "init": {
                 "Vr": 0.9084619900075903,
@@ -2509,7 +2511,7 @@
         },
         {
             "number": 2088,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARCHER 1 0",
             "init": {
                 "Vr": 0.7498752837225754,
@@ -2523,7 +2525,7 @@
         },
         {
             "number": 2089,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARCHER 1 1",
             "init": {
                 "Vr": 0.7892385515532477,
@@ -2537,7 +2539,7 @@
         },
         {
             "number": 2090,
-            "class": "bus",
+            "class": "Bus",
             "name": "ANNONA 0",
             "init": {
                 "Vr": 0.4906827686149153,
@@ -2551,7 +2553,7 @@
         },
         {
             "number": 2091,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEYMOUR 0",
             "init": {
                 "Vr": 0.8509840029768739,
@@ -2565,7 +2567,7 @@
         },
         {
             "number": 2092,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENISON 1 0",
             "init": {
                 "Vr": 0.4059363014623672,
@@ -2579,7 +2581,7 @@
         },
         {
             "number": 2093,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 5 0",
             "init": {
                 "Vr": 0.8873439244733586,
@@ -2593,7 +2595,7 @@
         },
         {
             "number": 2094,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 5 1",
             "init": {
                 "Vr": 0.8873439244733586,
@@ -2607,7 +2609,7 @@
         },
         {
             "number": 2095,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 5 2",
             "init": {
                 "Vr": 0.8873439244733586,
@@ -2621,7 +2623,7 @@
         },
         {
             "number": 2096,
-            "class": "bus",
+            "class": "Bus",
             "name": "RALLS 1 0",
             "init": {
                 "Vr": 0.9114518927588653,
@@ -2635,7 +2637,7 @@
         },
         {
             "number": 2097,
-            "class": "bus",
+            "class": "Bus",
             "name": "RALLS 1 1",
             "init": {
                 "Vr": 0.9148252137002726,
@@ -2649,7 +2651,7 @@
         },
         {
             "number": 2098,
-            "class": "bus",
+            "class": "Bus",
             "name": "RALLS 1 2",
             "init": {
                 "Vr": 0.8923573135526706,
@@ -2663,7 +2665,7 @@
         },
         {
             "number": 2099,
-            "class": "bus",
+            "class": "Bus",
             "name": "RALLS 1 3",
             "init": {
                 "Vr": 0.9122152043779238,
@@ -2677,7 +2679,7 @@
         },
         {
             "number": 2100,
-            "class": "bus",
+            "class": "Bus",
             "name": "RALLS 1 4",
             "init": {
                 "Vr": 0.9239679442309932,
@@ -2691,7 +2693,7 @@
         },
         {
             "number": 2101,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHERMAN 1 0",
             "init": {
                 "Vr": 0.46940978091445795,
@@ -2705,7 +2707,7 @@
         },
         {
             "number": 2102,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHERMAN 1 1",
             "init": {
                 "Vr": 0.44700900240095126,
@@ -2719,7 +2721,7 @@
         },
         {
             "number": 2103,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHERMAN 1 2",
             "init": {
                 "Vr": 0.46940978091445795,
@@ -2733,7 +2735,7 @@
         },
         {
             "number": 2104,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHERMAN 1 3",
             "init": {
                 "Vr": 0.46940978091445795,
@@ -2747,7 +2749,7 @@
         },
         {
             "number": 2105,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHERMAN 1 4",
             "init": {
                 "Vr": 0.46940978091445795,
@@ -2761,7 +2763,7 @@
         },
         {
             "number": 2106,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHITEWRIGHT 0",
             "init": {
                 "Vr": 0.4048912515510283,
@@ -2775,7 +2777,7 @@
         },
         {
             "number": 2107,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHERMAN 2 0",
             "init": {
                 "Vr": 0.4308818958020793,
@@ -2789,7 +2791,7 @@
         },
         {
             "number": 2108,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCHESTER 0",
             "init": {
                 "Vr": 0.7280288001472393,
@@ -2803,7 +2805,7 @@
         },
         {
             "number": 2109,
-            "class": "bus",
+            "class": "Bus",
             "name": "BURKBURNETT 0",
             "init": {
                 "Vr": 0.699907650797119,
@@ -2817,7 +2819,7 @@
         },
         {
             "number": 2110,
-            "class": "bus",
+            "class": "Bus",
             "name": "MUENSTER 2 0",
             "init": {
                 "Vr": 0.48151942436618145,
@@ -2831,7 +2833,7 @@
         },
         {
             "number": 2111,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARCHER CITY 0",
             "init": {
                 "Vr": 0.6576655496333957,
@@ -2845,7 +2847,7 @@
         },
         {
             "number": 2112,
-            "class": "bus",
+            "class": "Bus",
             "name": "PETROLIA 0",
             "init": {
                 "Vr": 0.6505853174540027,
@@ -2859,7 +2861,7 @@
         },
         {
             "number": 2113,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 1 0",
             "init": {
                 "Vr": 0.5682411207827553,
@@ -2873,7 +2875,7 @@
         },
         {
             "number": 2114,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 1 1",
             "init": {
                 "Vr": 0.5479965885809808,
@@ -2887,7 +2889,7 @@
         },
         {
             "number": 2115,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 1 2",
             "init": {
                 "Vr": 0.6198351519400699,
@@ -2901,7 +2903,7 @@
         },
         {
             "number": 2116,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 1 3",
             "init": {
                 "Vr": 0.5956748672101092,
@@ -2915,7 +2917,7 @@
         },
         {
             "number": 2117,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 1 4",
             "init": {
                 "Vr": 0.6269122950982009,
@@ -2929,7 +2931,7 @@
         },
         {
             "number": 2118,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 1 5",
             "init": {
                 "Vr": 0.6329517008693931,
@@ -2943,7 +2945,7 @@
         },
         {
             "number": 2119,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 1 6",
             "init": {
                 "Vr": 0.6014468804627877,
@@ -2957,7 +2959,7 @@
         },
         {
             "number": 2120,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARIS 1 7",
             "init": {
                 "Vr": 0.6348254133569818,
@@ -2971,7 +2973,7 @@
         },
         {
             "number": 2121,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAGWELL 0",
             "init": {
                 "Vr": 0.5090225293163825,
@@ -2985,7 +2987,7 @@
         },
         {
             "number": 2122,
-            "class": "bus",
+            "class": "Bus",
             "name": "TELEPHONE 0",
             "init": {
                 "Vr": 0.4860327011031951,
@@ -2999,7 +3001,7 @@
         },
         {
             "number": 2123,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANHANDLE 1 0",
             "init": {
                 "Vr": 0.9188795920036009,
@@ -3013,7 +3015,7 @@
         },
         {
             "number": 2124,
-            "class": "bus",
+            "class": "Bus",
             "name": "VAN ALSTYNE 0",
             "init": {
                 "Vr": 0.3874605269264037,
@@ -3027,7 +3029,7 @@
         },
         {
             "number": 2125,
-            "class": "bus",
+            "class": "Bus",
             "name": "TIOGA 0",
             "init": {
                 "Vr": 0.38887366390782135,
@@ -3041,7 +3043,7 @@
         },
         {
             "number": 2126,
-            "class": "bus",
+            "class": "Bus",
             "name": "VALLEY VIEW 0",
             "init": {
                 "Vr": 0.4002482956979889,
@@ -3055,7 +3057,7 @@
         },
         {
             "number": 2127,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIAMI 0",
             "init": {
                 "Vr": 0.8649727294148429,
@@ -3069,7 +3071,7 @@
         },
         {
             "number": 2128,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIAMI 1",
             "init": {
                 "Vr": 0.8714975143989732,
@@ -3083,7 +3085,7 @@
         },
         {
             "number": 2129,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRENTON 0",
             "init": {
                 "Vr": 0.4074418048787618,
@@ -3097,7 +3099,7 @@
         },
         {
             "number": 2130,
-            "class": "bus",
+            "class": "Bus",
             "name": "HASKELL 0",
             "init": {
                 "Vr": 0.745876500233554,
@@ -3111,7 +3113,7 @@
         },
         {
             "number": 2131,
-            "class": "bus",
+            "class": "Bus",
             "name": "HASKELL 1",
             "init": {
                 "Vr": 0.7715878935552478,
@@ -3125,7 +3127,7 @@
         },
         {
             "number": 2132,
-            "class": "bus",
+            "class": "Bus",
             "name": "HASKELL 2",
             "init": {
                 "Vr": 0.7642370463023433,
@@ -3139,7 +3141,7 @@
         },
         {
             "number": 2133,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAINT JO 0",
             "init": {
                 "Vr": 0.5047410649989142,
@@ -3153,7 +3155,7 @@
         },
         {
             "number": 3001,
-            "class": "bus",
+            "class": "Bus",
             "name": "KERRVILLE 0",
             "init": {
                 "Vr": 0.5701033134970086,
@@ -3167,7 +3169,7 @@
         },
         {
             "number": 3002,
-            "class": "bus",
+            "class": "Bus",
             "name": "KERRVILLE 1",
             "init": {
                 "Vr": 0.5277033465303035,
@@ -3181,7 +3183,7 @@
         },
         {
             "number": 3003,
-            "class": "bus",
+            "class": "Bus",
             "name": "SWEETWATER 4 0",
             "init": {
                 "Vr": 0.9666197573456613,
@@ -3195,7 +3197,7 @@
         },
         {
             "number": 3004,
-            "class": "bus",
+            "class": "Bus",
             "name": "SWEETWATER 4 1",
             "init": {
                 "Vr": 0.9704134741713321,
@@ -3209,7 +3211,7 @@
         },
         {
             "number": 3005,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEAKEY 0",
             "init": {
                 "Vr": 0.5375598779864367,
@@ -3223,7 +3225,7 @@
         },
         {
             "number": 3006,
-            "class": "bus",
+            "class": "Bus",
             "name": "HAMLIN 0",
             "init": {
                 "Vr": 0.8969235505176038,
@@ -3237,7 +3239,7 @@
         },
         {
             "number": 3007,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERKEL 3 0",
             "init": {
                 "Vr": 0.9229503506887331,
@@ -3251,7 +3253,7 @@
         },
         {
             "number": 3008,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLEMAN 0",
             "init": {
                 "Vr": 0.7954063564470197,
@@ -3265,7 +3267,7 @@
         },
         {
             "number": 3009,
-            "class": "bus",
+            "class": "Bus",
             "name": "SONORA 0",
             "init": {
                 "Vr": 0.8737936467761047,
@@ -3279,7 +3281,7 @@
         },
         {
             "number": 3010,
-            "class": "bus",
+            "class": "Bus",
             "name": "CAMP WOOD 0",
             "init": {
                 "Vr": 0.5438728394997382,
@@ -3293,7 +3295,7 @@
         },
         {
             "number": 3011,
-            "class": "bus",
+            "class": "Bus",
             "name": "LLANO 0",
             "init": {
                 "Vr": 0.4909081864204501,
@@ -3307,7 +3309,7 @@
         },
         {
             "number": 3012,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILLOW CITY 0",
             "init": {
                 "Vr": 0.4977848821690402,
@@ -3321,7 +3323,7 @@
         },
         {
             "number": 3013,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 4 0",
             "init": {
                 "Vr": 0.8953060769851092,
@@ -3335,7 +3337,7 @@
         },
         {
             "number": 3014,
-            "class": "bus",
+            "class": "Bus",
             "name": "KINGSLAND 0",
             "init": {
                 "Vr": 0.6087735552488727,
@@ -3349,7 +3351,7 @@
         },
         {
             "number": 3015,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 6 0",
             "init": {
                 "Vr": 0.9707945353223782,
@@ -3363,7 +3365,7 @@
         },
         {
             "number": 3016,
-            "class": "bus",
+            "class": "Bus",
             "name": "BLACKWELL 0",
             "init": {
                 "Vr": 0.9386109261106379,
@@ -3377,7 +3379,7 @@
         },
         {
             "number": 3017,
-            "class": "bus",
+            "class": "Bus",
             "name": "BLACKWELL 1",
             "init": {
                 "Vr": 0.9671667938740507,
@@ -3391,7 +3393,7 @@
         },
         {
             "number": 3018,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHRISTOVAL 0",
             "init": {
                 "Vr": 0.9001475257061994,
@@ -3405,7 +3407,7 @@
         },
         {
             "number": 3019,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHRISTOVAL 1",
             "init": {
                 "Vr": 0.8855272132760998,
@@ -3419,7 +3421,7 @@
         },
         {
             "number": 3020,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHRISTOVAL 2",
             "init": {
                 "Vr": 0.9335435917824334,
@@ -3433,7 +3435,7 @@
         },
         {
             "number": 3021,
-            "class": "bus",
+            "class": "Bus",
             "name": "LUEDERS 0",
             "init": {
                 "Vr": 0.8172199985081726,
@@ -3447,7 +3449,7 @@
         },
         {
             "number": 3022,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLORADO CITY 0",
             "init": {
                 "Vr": 0.9493340284833793,
@@ -3461,7 +3463,7 @@
         },
         {
             "number": 3023,
-            "class": "bus",
+            "class": "Bus",
             "name": "STAMFORD 0",
             "init": {
                 "Vr": 0.9151842883430563,
@@ -3475,7 +3477,7 @@
         },
         {
             "number": 3024,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELDORADO 0",
             "init": {
                 "Vr": 0.8778700271724756,
@@ -3489,7 +3491,7 @@
         },
         {
             "number": 3025,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN SABA 0",
             "init": {
                 "Vr": 0.7013924511635911,
@@ -3503,7 +3505,7 @@
         },
         {
             "number": 3026,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 2 0",
             "init": {
                 "Vr": 0.8249454453987112,
@@ -3517,7 +3519,7 @@
         },
         {
             "number": 3027,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 2 1",
             "init": {
                 "Vr": 0.8107223809984195,
@@ -3531,7 +3533,7 @@
         },
         {
             "number": 3028,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 2 2",
             "init": {
                 "Vr": 0.8610419351668669,
@@ -3545,7 +3547,7 @@
         },
         {
             "number": 3029,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOMETA 0",
             "init": {
                 "Vr": 0.6113025193966722,
@@ -3559,7 +3561,7 @@
         },
         {
             "number": 3030,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANGELO 1 0",
             "init": {
                 "Vr": 0.7800171109682392,
@@ -3573,7 +3575,7 @@
         },
         {
             "number": 3031,
-            "class": "bus",
+            "class": "Bus",
             "name": "TUSCOLA 0",
             "init": {
                 "Vr": 0.8978396589442057,
@@ -3587,7 +3589,7 @@
         },
         {
             "number": 3032,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 7 0",
             "init": {
                 "Vr": 0.8925361270971847,
@@ -3601,7 +3603,7 @@
         },
         {
             "number": 3033,
-            "class": "bus",
+            "class": "Bus",
             "name": "SNYDER 1 0",
             "init": {
                 "Vr": 0.9743004590951353,
@@ -3615,7 +3617,7 @@
         },
         {
             "number": 3034,
-            "class": "bus",
+            "class": "Bus",
             "name": "SNYDER 1 1",
             "init": {
                 "Vr": 1.0247622444280382,
@@ -3629,7 +3631,7 @@
         },
         {
             "number": 3035,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHEROKEE 0",
             "init": {
                 "Vr": 0.7145705028815835,
@@ -3643,7 +3645,7 @@
         },
         {
             "number": 3036,
-            "class": "bus",
+            "class": "Bus",
             "name": "RICHLAND SPRINGS 0",
             "init": {
                 "Vr": 0.7456501589486393,
@@ -3657,7 +3659,7 @@
         },
         {
             "number": 3037,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 2 0",
             "init": {
                 "Vr": 0.9274390831441112,
@@ -3671,7 +3673,7 @@
         },
         {
             "number": 3038,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 2 1",
             "init": {
                 "Vr": 0.9461093177934565,
@@ -3685,7 +3687,7 @@
         },
         {
             "number": 3039,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 2 2",
             "init": {
                 "Vr": 0.9579773552516309,
@@ -3699,7 +3701,7 @@
         },
         {
             "number": 3040,
-            "class": "bus",
+            "class": "Bus",
             "name": "BALLINGER 0",
             "init": {
                 "Vr": 0.8234624661287792,
@@ -3713,7 +3715,7 @@
         },
         {
             "number": 3041,
-            "class": "bus",
+            "class": "Bus",
             "name": "SILVER 0",
             "init": {
                 "Vr": 0.8901303431159063,
@@ -3727,7 +3729,7 @@
         },
         {
             "number": 3042,
-            "class": "bus",
+            "class": "Bus",
             "name": "SILVER 1",
             "init": {
                 "Vr": 0.9527829844250632,
@@ -3741,7 +3743,7 @@
         },
         {
             "number": 3043,
-            "class": "bus",
+            "class": "Bus",
             "name": "SILVER 2",
             "init": {
                 "Vr": 0.8901303431159063,
@@ -3755,7 +3757,7 @@
         },
         {
             "number": 3044,
-            "class": "bus",
+            "class": "Bus",
             "name": "SILVER 3",
             "init": {
                 "Vr": 0.8901303431159063,
@@ -3769,7 +3771,7 @@
         },
         {
             "number": 3045,
-            "class": "bus",
+            "class": "Bus",
             "name": "SILVER 4",
             "init": {
                 "Vr": 0.8901303431159063,
@@ -3783,7 +3785,7 @@
         },
         {
             "number": 3046,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 5 0",
             "init": {
                 "Vr": 0.8363168768168476,
@@ -3797,7 +3799,7 @@
         },
         {
             "number": 3047,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 5 1",
             "init": {
                 "Vr": 0.9641410009400163,
@@ -3811,7 +3813,7 @@
         },
         {
             "number": 3048,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 5 2",
             "init": {
                 "Vr": 0.7652579028902087,
@@ -3825,7 +3827,7 @@
         },
         {
             "number": 3049,
-            "class": "bus",
+            "class": "Bus",
             "name": "ANSON 0",
             "init": {
                 "Vr": 0.8719368526329532,
@@ -3839,7 +3841,7 @@
         },
         {
             "number": 3050,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEL RIO 0",
             "init": {
                 "Vr": 0.8488889985798521,
@@ -3853,7 +3855,7 @@
         },
         {
             "number": 3051,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEL RIO 1",
             "init": {
                 "Vr": 0.815201537034619,
@@ -3867,7 +3869,7 @@
         },
         {
             "number": 3052,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUNT 0",
             "init": {
                 "Vr": 0.524184696848489,
@@ -3881,7 +3883,7 @@
         },
         {
             "number": 3053,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINGATE 0",
             "init": {
                 "Vr": 0.9164252098649337,
@@ -3895,7 +3897,7 @@
         },
         {
             "number": 3054,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINGATE 1",
             "init": {
                 "Vr": 0.9019993053342348,
@@ -3909,7 +3911,7 @@
         },
         {
             "number": 3055,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINGATE 2",
             "init": {
                 "Vr": 0.9480302168825022,
@@ -3923,7 +3925,7 @@
         },
         {
             "number": 3056,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINGATE 3",
             "init": {
                 "Vr": 0.966314540228312,
@@ -3937,7 +3939,7 @@
         },
         {
             "number": 3057,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINGATE 4",
             "init": {
                 "Vr": 0.9652059316414613,
@@ -3951,7 +3953,7 @@
         },
         {
             "number": 3058,
-            "class": "bus",
+            "class": "Bus",
             "name": "STERLING CITY 1 0",
             "init": {
                 "Vr": 0.9429981347449773,
@@ -3965,7 +3967,7 @@
         },
         {
             "number": 3059,
-            "class": "bus",
+            "class": "Bus",
             "name": "STERLING CITY 1 1",
             "init": {
                 "Vr": 0.9662122767983776,
@@ -3979,7 +3981,7 @@
         },
         {
             "number": 3060,
-            "class": "bus",
+            "class": "Bus",
             "name": "STERLING CITY 1 2",
             "init": {
                 "Vr": 0.997623237991429,
@@ -3993,7 +3995,7 @@
         },
         {
             "number": 3061,
-            "class": "bus",
+            "class": "Bus",
             "name": "STERLING CITY 1 3",
             "init": {
                 "Vr": 0.9857751691851291,
@@ -4007,7 +4009,7 @@
         },
         {
             "number": 3062,
-            "class": "bus",
+            "class": "Bus",
             "name": "STERLING CITY 1 4",
             "init": {
                 "Vr": 0.9692042620956938,
@@ -4021,7 +4023,7 @@
         },
         {
             "number": 3063,
-            "class": "bus",
+            "class": "Bus",
             "name": "STERLING CITY 1 5",
             "init": {
                 "Vr": 0.9765973756510097,
@@ -4035,7 +4037,7 @@
         },
         {
             "number": 3064,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 4 0",
             "init": {
                 "Vr": 0.9686791002927706,
@@ -4049,7 +4051,7 @@
         },
         {
             "number": 3065,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 4 1",
             "init": {
                 "Vr": 0.9769051103419225,
@@ -4063,7 +4065,7 @@
         },
         {
             "number": 3066,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRADY 0",
             "init": {
                 "Vr": 0.7401034333429531,
@@ -4077,7 +4079,7 @@
         },
         {
             "number": 3067,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRENT 1 0",
             "init": {
                 "Vr": 0.9673218129823591,
@@ -4091,7 +4093,7 @@
         },
         {
             "number": 3068,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRENT 1 1",
             "init": {
                 "Vr": 0.9949954327590675,
@@ -4105,7 +4107,7 @@
         },
         {
             "number": 3069,
-            "class": "bus",
+            "class": "Bus",
             "name": "OVALO 0",
             "init": {
                 "Vr": 0.8699007613807118,
@@ -4119,7 +4121,7 @@
         },
         {
             "number": 3070,
-            "class": "bus",
+            "class": "Bus",
             "name": "NOLAN 0",
             "init": {
                 "Vr": 0.951475137371001,
@@ -4133,7 +4135,7 @@
         },
         {
             "number": 3071,
-            "class": "bus",
+            "class": "Bus",
             "name": "NOLAN 1",
             "init": {
                 "Vr": 0.9638968940842589,
@@ -4147,7 +4149,7 @@
         },
         {
             "number": 3072,
-            "class": "bus",
+            "class": "Bus",
             "name": "MILES 0",
             "init": {
                 "Vr": 0.7906836444004562,
@@ -4161,7 +4163,7 @@
         },
         {
             "number": 3073,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRACKETTVILLE 2 0",
             "init": {
                 "Vr": 0.5859827419544021,
@@ -4175,7 +4177,7 @@
         },
         {
             "number": 3074,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRACKETTVILLE 2 1",
             "init": {
                 "Vr": 0.6187392759221617,
@@ -4189,7 +4191,7 @@
         },
         {
             "number": 3075,
-            "class": "bus",
+            "class": "Bus",
             "name": "MASON 0",
             "init": {
                 "Vr": 0.7664099803594898,
@@ -4203,7 +4205,7 @@
         },
         {
             "number": 3076,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRACKETTVILLE 3 0",
             "init": {
                 "Vr": 0.5635246620854883,
@@ -4217,7 +4219,7 @@
         },
         {
             "number": 3077,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 6 0",
             "init": {
                 "Vr": 0.885685738260724,
@@ -4231,7 +4233,7 @@
         },
         {
             "number": 3078,
-            "class": "bus",
+            "class": "Bus",
             "name": "HERMLEIGH 0",
             "init": {
                 "Vr": 0.9201880552722109,
@@ -4245,7 +4247,7 @@
         },
         {
             "number": 3079,
-            "class": "bus",
+            "class": "Bus",
             "name": "HERMLEIGH 1",
             "init": {
                 "Vr": 0.9300701783531298,
@@ -4259,7 +4261,7 @@
         },
         {
             "number": 3080,
-            "class": "bus",
+            "class": "Bus",
             "name": "HERMLEIGH 2",
             "init": {
                 "Vr": 0.940233598441853,
@@ -4273,7 +4275,7 @@
         },
         {
             "number": 3081,
-            "class": "bus",
+            "class": "Bus",
             "name": "HERMLEIGH 3",
             "init": {
                 "Vr": 0.9788648752483878,
@@ -4287,7 +4289,7 @@
         },
         {
             "number": 3082,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERKEL 1 0",
             "init": {
                 "Vr": 0.9013825652228505,
@@ -4301,7 +4303,7 @@
         },
         {
             "number": 3083,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERKEL 1 1",
             "init": {
                 "Vr": 0.9251374380354186,
@@ -4315,7 +4317,7 @@
         },
         {
             "number": 3084,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERKEL 1 2",
             "init": {
                 "Vr": 0.9501517265697911,
@@ -4329,7 +4331,7 @@
         },
         {
             "number": 3085,
-            "class": "bus",
+            "class": "Bus",
             "name": "LORAINE 1 0",
             "init": {
                 "Vr": 0.955283999935503,
@@ -4343,7 +4345,7 @@
         },
         {
             "number": 3086,
-            "class": "bus",
+            "class": "Bus",
             "name": "LORAINE 1 1",
             "init": {
                 "Vr": 0.9798584005150708,
@@ -4357,7 +4359,7 @@
         },
         {
             "number": 3087,
-            "class": "bus",
+            "class": "Bus",
             "name": "LORAINE 1 2",
             "init": {
                 "Vr": 0.955283999935503,
@@ -4371,7 +4373,7 @@
         },
         {
             "number": 3088,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 1 0",
             "init": {
                 "Vr": 0.8618970033787146,
@@ -4385,7 +4387,7 @@
         },
         {
             "number": 3089,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 1 1",
             "init": {
                 "Vr": 0.8325722943794344,
@@ -4399,7 +4401,7 @@
         },
         {
             "number": 3090,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 1 2",
             "init": {
                 "Vr": 0.8232817815343423,
@@ -4413,7 +4415,7 @@
         },
         {
             "number": 3091,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 1 3",
             "init": {
                 "Vr": 0.8107591012378451,
@@ -4427,7 +4429,7 @@
         },
         {
             "number": 3092,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 1 4",
             "init": {
                 "Vr": 0.931471080298744,
@@ -4441,7 +4443,7 @@
         },
         {
             "number": 3093,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKSPRINGS 0",
             "init": {
                 "Vr": 0.5326174017694728,
@@ -4455,7 +4457,7 @@
         },
         {
             "number": 3094,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERKEL 2 0",
             "init": {
                 "Vr": 0.9336517576160807,
@@ -4469,7 +4471,7 @@
         },
         {
             "number": 3095,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERKEL 2 1",
             "init": {
                 "Vr": 1.003064628497694,
@@ -4483,7 +4485,7 @@
         },
         {
             "number": 3096,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLUVANNA 2 0",
             "init": {
                 "Vr": 0.953568651390384,
@@ -4497,7 +4499,7 @@
         },
         {
             "number": 3097,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLUVANNA 2 1",
             "init": {
                 "Vr": 0.9610950215176387,
@@ -4511,7 +4513,7 @@
         },
         {
             "number": 3098,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLUVANNA 2 2",
             "init": {
                 "Vr": 1.014146719618655,
@@ -4525,7 +4527,7 @@
         },
         {
             "number": 3099,
-            "class": "bus",
+            "class": "Bus",
             "name": "DYESS AFB 0",
             "init": {
                 "Vr": 0.8771470047613907,
@@ -4539,7 +4541,7 @@
         },
         {
             "number": 3100,
-            "class": "bus",
+            "class": "Bus",
             "name": "HAWLEY 0",
             "init": {
                 "Vr": 0.8215514834734491,
@@ -4553,7 +4555,7 @@
         },
         {
             "number": 3101,
-            "class": "bus",
+            "class": "Bus",
             "name": "BUCHANAN DAM 2 0",
             "init": {
                 "Vr": 0.6743986242365361,
@@ -4567,7 +4569,7 @@
         },
         {
             "number": 3102,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 3 0",
             "init": {
                 "Vr": 0.8025007197382534,
@@ -4581,7 +4583,7 @@
         },
         {
             "number": 3103,
-            "class": "bus",
+            "class": "Bus",
             "name": "SWEETWATER 5 0",
             "init": {
                 "Vr": 0.9449830385981269,
@@ -4595,7 +4597,7 @@
         },
         {
             "number": 3104,
-            "class": "bus",
+            "class": "Bus",
             "name": "BUCHANAN DAM 1 0",
             "init": {
                 "Vr": 0.6845034228017983,
@@ -4609,7 +4611,7 @@
         },
         {
             "number": 3105,
-            "class": "bus",
+            "class": "Bus",
             "name": "BUCHANAN DAM 1 1",
             "init": {
                 "Vr": 0.7521721766371673,
@@ -4623,7 +4625,7 @@
         },
         {
             "number": 3106,
-            "class": "bus",
+            "class": "Bus",
             "name": "BUCHANAN DAM 1 2",
             "init": {
                 "Vr": 0.7590990517652897,
@@ -4637,7 +4639,7 @@
         },
         {
             "number": 3107,
-            "class": "bus",
+            "class": "Bus",
             "name": "INGRAM 0",
             "init": {
                 "Vr": 0.5198438420492019,
@@ -4651,7 +4653,7 @@
         },
         {
             "number": 3108,
-            "class": "bus",
+            "class": "Bus",
             "name": "KEMPNER 0",
             "init": {
                 "Vr": 0.5528023949363916,
@@ -4665,7 +4667,7 @@
         },
         {
             "number": 3109,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLUVANNA 1 0",
             "init": {
                 "Vr": 0.9690949876924562,
@@ -4679,7 +4681,7 @@
         },
         {
             "number": 3110,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLUVANNA 1 1",
             "init": {
                 "Vr": 1.0218019279675834,
@@ -4693,7 +4695,7 @@
         },
         {
             "number": 3111,
-            "class": "bus",
+            "class": "Bus",
             "name": "STERLING CITY 2 0",
             "init": {
                 "Vr": 0.9695874387246756,
@@ -4707,7 +4709,7 @@
         },
         {
             "number": 3112,
-            "class": "bus",
+            "class": "Bus",
             "name": "STERLING CITY 2 1",
             "init": {
                 "Vr": 0.9893358909186311,
@@ -4721,7 +4723,7 @@
         },
         {
             "number": 3113,
-            "class": "bus",
+            "class": "Bus",
             "name": "STERLING CITY 2 2",
             "init": {
                 "Vr": 0.9893381189818082,
@@ -4735,7 +4737,7 @@
         },
         {
             "number": 3114,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANGELO 2 0",
             "init": {
                 "Vr": 0.8378660270451406,
@@ -4749,7 +4751,7 @@
         },
         {
             "number": 3115,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROTAN 0",
             "init": {
                 "Vr": 0.9339560307222905,
@@ -4763,7 +4765,7 @@
         },
         {
             "number": 3116,
-            "class": "bus",
+            "class": "Bus",
             "name": "SYNDER 0",
             "init": {
                 "Vr": 0.9703629569576547,
@@ -4777,7 +4779,7 @@
         },
         {
             "number": 3117,
-            "class": "bus",
+            "class": "Bus",
             "name": "SYNDER 1",
             "init": {
                 "Vr": 0.9772933394315059,
@@ -4791,7 +4793,7 @@
         },
         {
             "number": 3118,
-            "class": "bus",
+            "class": "Bus",
             "name": "SYNDER 2",
             "init": {
                 "Vr": 0.9807402464034277,
@@ -4805,7 +4807,7 @@
         },
         {
             "number": 3119,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRACKETTVILLE 1 0",
             "init": {
                 "Vr": 0.6360272650938141,
@@ -4819,7 +4821,7 @@
         },
         {
             "number": 3120,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRACKETTVILLE 1 1",
             "init": {
                 "Vr": 0.6566619286931263,
@@ -4833,7 +4835,7 @@
         },
         {
             "number": 3121,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 1 0",
             "init": {
                 "Vr": 0.976079941877759,
@@ -4847,7 +4849,7 @@
         },
         {
             "number": 3122,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 1 1",
             "init": {
                 "Vr": 0.991190996222338,
@@ -4861,7 +4863,7 @@
         },
         {
             "number": 3123,
-            "class": "bus",
+            "class": "Bus",
             "name": "UVALDE 0",
             "init": {
                 "Vr": 0.5461278523306753,
@@ -4875,7 +4877,7 @@
         },
         {
             "number": 3124,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREDERICKSBURG 0",
             "init": {
                 "Vr": 0.5196324222663754,
@@ -4889,7 +4891,7 @@
         },
         {
             "number": 3125,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABILENE 5 0",
             "init": {
                 "Vr": 0.7962540484090406,
@@ -4903,7 +4905,7 @@
         },
         {
             "number": 3126,
-            "class": "bus",
+            "class": "Bus",
             "name": "SABINAL 0",
             "init": {
                 "Vr": 0.556837925504426,
@@ -4917,7 +4919,7 @@
         },
         {
             "number": 3127,
-            "class": "bus",
+            "class": "Bus",
             "name": "SWEETWATER 2 0",
             "init": {
                 "Vr": 0.9768840635261858,
@@ -4931,7 +4933,7 @@
         },
         {
             "number": 3128,
-            "class": "bus",
+            "class": "Bus",
             "name": "LORAINE 2 0",
             "init": {
                 "Vr": 0.9603822355912799,
@@ -4945,7 +4947,7 @@
         },
         {
             "number": 3129,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSCOE 3 0",
             "init": {
                 "Vr": 0.9827176367989502,
@@ -4959,7 +4961,7 @@
         },
         {
             "number": 3130,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANGELO 3 0",
             "init": {
                 "Vr": 0.9529513057376802,
@@ -4973,7 +4975,7 @@
         },
         {
             "number": 3131,
-            "class": "bus",
+            "class": "Bus",
             "name": "TUSOCOLA 0",
             "init": {
                 "Vr": 0.9449355778961129,
@@ -4987,7 +4989,7 @@
         },
         {
             "number": 3132,
-            "class": "bus",
+            "class": "Bus",
             "name": "EDEN 0",
             "init": {
                 "Vr": 0.7628947309118165,
@@ -5001,7 +5003,7 @@
         },
         {
             "number": 3133,
-            "class": "bus",
+            "class": "Bus",
             "name": "SNYDER 2 0",
             "init": {
                 "Vr": 0.9459668717580365,
@@ -5015,7 +5017,7 @@
         },
         {
             "number": 3134,
-            "class": "bus",
+            "class": "Bus",
             "name": "SNYDER 2 1",
             "init": {
                 "Vr": 0.9398998493596704,
@@ -5029,7 +5031,7 @@
         },
         {
             "number": 3135,
-            "class": "bus",
+            "class": "Bus",
             "name": "SNYDER 2 2",
             "init": {
                 "Vr": 0.9533851035441355,
@@ -5043,7 +5045,7 @@
         },
         {
             "number": 3136,
-            "class": "bus",
+            "class": "Bus",
             "name": "SNYDER 2 3",
             "init": {
                 "Vr": 0.9659188792081269,
@@ -5057,7 +5059,7 @@
         },
         {
             "number": 3137,
-            "class": "bus",
+            "class": "Bus",
             "name": "SWEETWATER 1 0",
             "init": {
                 "Vr": 0.9349281546698109,
@@ -5071,7 +5073,7 @@
         },
         {
             "number": 3138,
-            "class": "bus",
+            "class": "Bus",
             "name": "MENARD 0",
             "init": {
                 "Vr": 0.7920493301353757,
@@ -5085,7 +5087,7 @@
         },
         {
             "number": 3139,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINTERS 0",
             "init": {
                 "Vr": 0.8640492102760782,
@@ -5099,7 +5101,7 @@
         },
         {
             "number": 3140,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLDSBORO 0",
             "init": {
                 "Vr": 0.8632836163546072,
@@ -5113,7 +5115,7 @@
         },
         {
             "number": 3141,
-            "class": "bus",
+            "class": "Bus",
             "name": "SWEETWATER 3 0",
             "init": {
                 "Vr": 0.9707284765411324,
@@ -5127,7 +5129,7 @@
         },
         {
             "number": 3142,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOODFELLOW AFB 0",
             "init": {
                 "Vr": 0.7848478428773153,
@@ -5141,7 +5143,7 @@
         },
         {
             "number": 3143,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ANNA 0",
             "init": {
                 "Vr": 0.785099106157585,
@@ -5155,7 +5157,7 @@
         },
         {
             "number": 3144,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROWENA 0",
             "init": {
                 "Vr": 0.7708372347160642,
@@ -5169,7 +5171,7 @@
         },
         {
             "number": 3145,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRENT 2 0",
             "init": {
                 "Vr": 0.9241083508583886,
@@ -5183,7 +5185,7 @@
         },
         {
             "number": 3146,
-            "class": "bus",
+            "class": "Bus",
             "name": "JUNCTION 0",
             "init": {
                 "Vr": 0.8350139757929754,
@@ -5197,7 +5199,7 @@
         },
         {
             "number": 3147,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAMPASAS 0",
             "init": {
                 "Vr": 0.5776894533209861,
@@ -5211,7 +5213,7 @@
         },
         {
             "number": 4002,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAUGHLIN A F B 0",
             "init": {
                 "Vr": 0.6153646589276422,
@@ -5225,7 +5227,7 @@
         },
         {
             "number": 4003,
-            "class": "bus",
+            "class": "Bus",
             "name": "EDINBURG 3 0",
             "init": {
                 "Vr": 0.309568884626667,
@@ -5239,7 +5241,7 @@
         },
         {
             "number": 4004,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 7 0",
             "init": {
                 "Vr": 0.5734833242200257,
@@ -5253,7 +5255,7 @@
         },
         {
             "number": 4005,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 7 1",
             "init": {
                 "Vr": 0.5095108811409308,
@@ -5267,7 +5269,7 @@
         },
         {
             "number": 4006,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRUNI 2 0",
             "init": {
                 "Vr": 0.5827243677944772,
@@ -5281,7 +5283,7 @@
         },
         {
             "number": 4007,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCALLEN 2 0",
             "init": {
                 "Vr": 0.3005940441398527,
@@ -5295,7 +5297,7 @@
         },
         {
             "number": 4008,
-            "class": "bus",
+            "class": "Bus",
             "name": "POTEET 0",
             "init": {
                 "Vr": 0.5745867874046081,
@@ -5309,7 +5311,7 @@
         },
         {
             "number": 4009,
-            "class": "bus",
+            "class": "Bus",
             "name": "SARITA 3 0",
             "init": {
                 "Vr": 0.7055685046492534,
@@ -5323,7 +5325,7 @@
         },
         {
             "number": 4010,
-            "class": "bus",
+            "class": "Bus",
             "name": "SARITA 3 1",
             "init": {
                 "Vr": 0.7449252036528138,
@@ -5337,7 +5339,7 @@
         },
         {
             "number": 4011,
-            "class": "bus",
+            "class": "Bus",
             "name": "HEBBRONVILLE 0",
             "init": {
                 "Vr": 0.5494224072541258,
@@ -5351,7 +5353,7 @@
         },
         {
             "number": 4012,
-            "class": "bus",
+            "class": "Bus",
             "name": "PROGRESO 0",
             "init": {
                 "Vr": 0.3661588745545348,
@@ -5365,7 +5367,7 @@
         },
         {
             "number": 4013,
-            "class": "bus",
+            "class": "Bus",
             "name": "EDINBURG 2 0",
             "init": {
                 "Vr": 0.325651380602147,
@@ -5379,7 +5381,7 @@
         },
         {
             "number": 4014,
-            "class": "bus",
+            "class": "Bus",
             "name": "EAGLE PASS 0",
             "init": {
                 "Vr": 0.6189180874099924,
@@ -5393,7 +5395,7 @@
         },
         {
             "number": 4015,
-            "class": "bus",
+            "class": "Bus",
             "name": "EAGLE PASS 1",
             "init": {
                 "Vr": 0.6000033863968315,
@@ -5407,7 +5409,7 @@
         },
         {
             "number": 4016,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHARLOTTE 0",
             "init": {
                 "Vr": 0.6474855148954662,
@@ -5421,7 +5423,7 @@
         },
         {
             "number": 4017,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 4 0",
             "init": {
                 "Vr": 0.6704815954637373,
@@ -5435,7 +5437,7 @@
         },
         {
             "number": 4018,
-            "class": "bus",
+            "class": "Bus",
             "name": "WOODSBORO 0",
             "init": {
                 "Vr": 0.6808106653734245,
@@ -5449,7 +5451,7 @@
         },
         {
             "number": 4019,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERCEDES 0",
             "init": {
                 "Vr": 0.38329991592020346,
@@ -5463,7 +5465,7 @@
         },
         {
             "number": 4020,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 16 0",
             "init": {
                 "Vr": 0.6295009549105502,
@@ -5477,7 +5479,7 @@
         },
         {
             "number": 4021,
-            "class": "bus",
+            "class": "Bus",
             "name": "EDCOUCH 0",
             "init": {
                 "Vr": 0.397531464447226,
@@ -5491,7 +5493,7 @@
         },
         {
             "number": 4022,
-            "class": "bus",
+            "class": "Bus",
             "name": "ENCINAL 0",
             "init": {
                 "Vr": 0.5117172188868464,
@@ -5505,7 +5507,7 @@
         },
         {
             "number": 4023,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOORE 0",
             "init": {
                 "Vr": 0.618564308516105,
@@ -5519,7 +5521,7 @@
         },
         {
             "number": 4024,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHRISTINE 0",
             "init": {
                 "Vr": 0.7559425639862108,
@@ -5533,7 +5535,7 @@
         },
         {
             "number": 4025,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHRISTINE 1",
             "init": {
                 "Vr": 0.706265813298298,
@@ -5547,7 +5549,7 @@
         },
         {
             "number": 4026,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHRISTINE 2",
             "init": {
                 "Vr": 0.8454534813304967,
@@ -5561,7 +5563,7 @@
         },
         {
             "number": 4027,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCALLEN 3 0",
             "init": {
                 "Vr": 0.3040092195069853,
@@ -5575,7 +5577,7 @@
         },
         {
             "number": 4028,
-            "class": "bus",
+            "class": "Bus",
             "name": "FANNIN 0",
             "init": {
                 "Vr": 0.843815597195705,
@@ -5589,7 +5591,7 @@
         },
         {
             "number": 4029,
-            "class": "bus",
+            "class": "Bus",
             "name": "FANNIN 1",
             "init": {
                 "Vr": 0.8240840876187889,
@@ -5603,7 +5605,7 @@
         },
         {
             "number": 4030,
-            "class": "bus",
+            "class": "Bus",
             "name": "FANNIN 2",
             "init": {
                 "Vr": 0.8710494168747783,
@@ -5617,7 +5619,7 @@
         },
         {
             "number": 4031,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN YGNACIO 0",
             "init": {
                 "Vr": 0.5471884443472657,
@@ -5631,7 +5633,7 @@
         },
         {
             "number": 4032,
-            "class": "bus",
+            "class": "Bus",
             "name": "KINGSVILLE 0",
             "init": {
                 "Vr": 0.5661060775159074,
@@ -5645,7 +5647,7 @@
         },
         {
             "number": 4033,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 6 0",
             "init": {
                 "Vr": 0.523844056724729,
@@ -5659,7 +5661,7 @@
         },
         {
             "number": 4034,
-            "class": "bus",
+            "class": "Bus",
             "name": "HIDALGO 0",
             "init": {
                 "Vr": 0.32543906500767256,
@@ -5673,7 +5675,7 @@
         },
         {
             "number": 4035,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 18 0",
             "init": {
                 "Vr": 0.6509997926844103,
@@ -5687,7 +5689,7 @@
         },
         {
             "number": 4036,
-            "class": "bus",
+            "class": "Bus",
             "name": "CRYSTAL CITY 0",
             "init": {
                 "Vr": 0.567793578384418,
@@ -5701,7 +5703,7 @@
         },
         {
             "number": 4037,
-            "class": "bus",
+            "class": "Bus",
             "name": "SINTON 0",
             "init": {
                 "Vr": 0.6618063996650071,
@@ -5715,7 +5717,7 @@
         },
         {
             "number": 4038,
-            "class": "bus",
+            "class": "Bus",
             "name": "BEEVILLE 0",
             "init": {
                 "Vr": 0.6598611512892653,
@@ -5729,7 +5731,7 @@
         },
         {
             "number": 4039,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION 4 0",
             "init": {
                 "Vr": 0.49384923174292905,
@@ -5743,7 +5745,7 @@
         },
         {
             "number": 4040,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION 4 1",
             "init": {
                 "Vr": 0.4420226524340553,
@@ -5757,7 +5759,7 @@
         },
         {
             "number": 4041,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN JUAN 0",
             "init": {
                 "Vr": 0.41964349123189315,
@@ -5771,7 +5773,7 @@
         },
         {
             "number": 4042,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN JUAN 1",
             "init": {
                 "Vr": 0.3374395063013278,
@@ -5785,7 +5787,7 @@
         },
         {
             "number": 4043,
-            "class": "bus",
+            "class": "Bus",
             "name": "FALCON HEIGHTS 2 0",
             "init": {
                 "Vr": 0.540176440318263,
@@ -5799,7 +5801,7 @@
         },
         {
             "number": 4044,
-            "class": "bus",
+            "class": "Bus",
             "name": "FALCON HEIGHTS 1 0",
             "init": {
                 "Vr": 0.5599298877753356,
@@ -5813,7 +5815,7 @@
         },
         {
             "number": 4045,
-            "class": "bus",
+            "class": "Bus",
             "name": "FALCON HEIGHTS 1 1",
             "init": {
                 "Vr": 0.6800608010960819,
@@ -5827,7 +5829,7 @@
         },
         {
             "number": 4046,
-            "class": "bus",
+            "class": "Bus",
             "name": "FALCON HEIGHTS 1 2",
             "init": {
                 "Vr": 0.6184355398937909,
@@ -5841,7 +5843,7 @@
         },
         {
             "number": 4047,
-            "class": "bus",
+            "class": "Bus",
             "name": "FALCON HEIGHTS 1 3",
             "init": {
                 "Vr": 0.5826358924213912,
@@ -5855,7 +5857,7 @@
         },
         {
             "number": 4048,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA JOYA 0",
             "init": {
                 "Vr": 0.40904379750001846,
@@ -5869,7 +5871,7 @@
         },
         {
             "number": 4049,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEBASTIAN 2 0",
             "init": {
                 "Vr": 0.49954494670767885,
@@ -5883,7 +5885,7 @@
         },
         {
             "number": 4050,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEBASTIAN 2 1",
             "init": {
                 "Vr": 0.5467238143246018,
@@ -5897,7 +5899,7 @@
         },
         {
             "number": 4051,
-            "class": "bus",
+            "class": "Bus",
             "name": "BISHOP 0",
             "init": {
                 "Vr": 0.5745576996348933,
@@ -5911,7 +5913,7 @@
         },
         {
             "number": 4052,
-            "class": "bus",
+            "class": "Bus",
             "name": "BISHOP 1",
             "init": {
                 "Vr": 0.654581673870538,
@@ -5925,7 +5927,7 @@
         },
         {
             "number": 4053,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARMSTRONG 2 0",
             "init": {
                 "Vr": 0.6471544514681722,
@@ -5939,7 +5941,7 @@
         },
         {
             "number": 4054,
-            "class": "bus",
+            "class": "Bus",
             "name": "SKIDMORE 0",
             "init": {
                 "Vr": 0.659277987655802,
@@ -5953,7 +5955,7 @@
         },
         {
             "number": 4055,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 9 0",
             "init": {
                 "Vr": 0.6678853432244426,
@@ -5967,7 +5969,7 @@
         },
         {
             "number": 4056,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREGORY 0",
             "init": {
                 "Vr": 0.7933513023863814,
@@ -5981,7 +5983,7 @@
         },
         {
             "number": 4057,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREGORY 1",
             "init": {
                 "Vr": 0.7154394761281578,
@@ -5995,7 +5997,7 @@
         },
         {
             "number": 4058,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREGORY 2",
             "init": {
                 "Vr": 0.8353023687263136,
@@ -6009,7 +6011,7 @@
         },
         {
             "number": 4059,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREGORY 3",
             "init": {
                 "Vr": 0.8255929566622977,
@@ -6023,7 +6025,7 @@
         },
         {
             "number": 4060,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREGORY 4",
             "init": {
                 "Vr": 0.8612336571769704,
@@ -6037,7 +6039,7 @@
         },
         {
             "number": 4061,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREGORY 5",
             "init": {
                 "Vr": 0.8507442761800266,
@@ -6051,7 +6053,7 @@
         },
         {
             "number": 4062,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREGORY 6",
             "init": {
                 "Vr": 0.871106337230381,
@@ -6065,7 +6067,7 @@
         },
         {
             "number": 4063,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREGORY 7",
             "init": {
                 "Vr": 0.8437521387895577,
@@ -6079,7 +6081,7 @@
         },
         {
             "number": 4064,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 2 0",
             "init": {
                 "Vr": 0.6663732670906286,
@@ -6093,7 +6095,7 @@
         },
         {
             "number": 4065,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 2 1",
             "init": {
                 "Vr": 0.7469736940585818,
@@ -6107,7 +6109,7 @@
         },
         {
             "number": 4066,
-            "class": "bus",
+            "class": "Bus",
             "name": "WESLACO 0",
             "init": {
                 "Vr": 0.29468471695141113,
@@ -6121,7 +6123,7 @@
         },
         {
             "number": 4067,
-            "class": "bus",
+            "class": "Bus",
             "name": "HARLINGEN 1 0",
             "init": {
                 "Vr": 0.4291249701962547,
@@ -6135,7 +6137,7 @@
         },
         {
             "number": 4068,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELSA 0",
             "init": {
                 "Vr": 0.30149380998588493,
@@ -6149,7 +6151,7 @@
         },
         {
             "number": 4069,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 17 0",
             "init": {
                 "Vr": 0.6686090004316739,
@@ -6163,7 +6165,7 @@
         },
         {
             "number": 4070,
-            "class": "bus",
+            "class": "Bus",
             "name": "BROWNSVILLE 2 0",
             "init": {
                 "Vr": 0.6341849815971308,
@@ -6177,7 +6179,7 @@
         },
         {
             "number": 4071,
-            "class": "bus",
+            "class": "Bus",
             "name": "BROWNSVILLE 2 1",
             "init": {
                 "Vr": 0.5608263605699925,
@@ -6191,7 +6193,7 @@
         },
         {
             "number": 4072,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 10 0",
             "init": {
                 "Vr": 0.6731960962885981,
@@ -6205,7 +6207,7 @@
         },
         {
             "number": 4073,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION 1 0",
             "init": {
                 "Vr": 0.4907450069419697,
@@ -6219,7 +6221,7 @@
         },
         {
             "number": 4074,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION 1 1",
             "init": {
                 "Vr": 0.4548684429607155,
@@ -6233,7 +6235,7 @@
         },
         {
             "number": 4075,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION 1 2",
             "init": {
                 "Vr": 0.4907450069419697,
@@ -6247,7 +6249,7 @@
         },
         {
             "number": 4076,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION 1 3",
             "init": {
                 "Vr": 0.5839778802847232,
@@ -6261,7 +6263,7 @@
         },
         {
             "number": 4077,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION 1 4",
             "init": {
                 "Vr": 0.5518408033971345,
@@ -6275,7 +6277,7 @@
         },
         {
             "number": 4078,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 8 0",
             "init": {
                 "Vr": 0.6603248265144896,
@@ -6289,7 +6291,7 @@
         },
         {
             "number": 4079,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION 3 0",
             "init": {
                 "Vr": 0.38772277159895024,
@@ -6303,7 +6305,7 @@
         },
         {
             "number": 4080,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 3 0",
             "init": {
                 "Vr": 0.7395918177352708,
@@ -6317,7 +6319,7 @@
         },
         {
             "number": 4081,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 3 1",
             "init": {
                 "Vr": 0.6852154695301031,
@@ -6331,7 +6333,7 @@
         },
         {
             "number": 4082,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 3 2",
             "init": {
                 "Vr": 0.8248702440898179,
@@ -6345,7 +6347,7 @@
         },
         {
             "number": 4083,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 3 3",
             "init": {
                 "Vr": 0.8190995092817546,
@@ -6359,7 +6361,7 @@
         },
         {
             "number": 4084,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 3 4",
             "init": {
                 "Vr": 0.7874021308134844,
@@ -6373,7 +6375,7 @@
         },
         {
             "number": 4085,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 3 5",
             "init": {
                 "Vr": 0.7712302820233544,
@@ -6387,7 +6389,7 @@
         },
         {
             "number": 4086,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIO HONDO 0",
             "init": {
                 "Vr": 0.49733078738185604,
@@ -6401,7 +6403,7 @@
         },
         {
             "number": 4087,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 5 0",
             "init": {
                 "Vr": 0.6659266112940451,
@@ -6415,7 +6417,7 @@
         },
         {
             "number": 4088,
-            "class": "bus",
+            "class": "Bus",
             "name": "PHARR 0",
             "init": {
                 "Vr": 0.31190242994314576,
@@ -6429,7 +6431,7 @@
         },
         {
             "number": 4089,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 0",
             "init": {
                 "Vr": 0.43570180110014634,
@@ -6443,7 +6445,7 @@
         },
         {
             "number": 4090,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 1",
             "init": {
                 "Vr": 0.43570180110014634,
@@ -6457,7 +6459,7 @@
         },
         {
             "number": 4091,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 2",
             "init": {
                 "Vr": 0.4793046740266428,
@@ -6471,7 +6473,7 @@
         },
         {
             "number": 4092,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 3",
             "init": {
                 "Vr": 0.43570180110014634,
@@ -6485,7 +6487,7 @@
         },
         {
             "number": 4093,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 4",
             "init": {
                 "Vr": 0.4974519980201412,
@@ -6499,7 +6501,7 @@
         },
         {
             "number": 4094,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 5",
             "init": {
                 "Vr": 0.46059500757685695,
@@ -6513,7 +6515,7 @@
         },
         {
             "number": 4095,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 6",
             "init": {
                 "Vr": 0.48377173076452035,
@@ -6527,7 +6529,7 @@
         },
         {
             "number": 4096,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 7",
             "init": {
                 "Vr": 0.43570180110014634,
@@ -6541,7 +6543,7 @@
         },
         {
             "number": 4097,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 8",
             "init": {
                 "Vr": 0.4898244349725248,
@@ -6555,7 +6557,7 @@
         },
         {
             "number": 4098,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 1 9",
             "init": {
                 "Vr": 0.43570180110014634,
@@ -6569,7 +6571,7 @@
         },
         {
             "number": 4099,
-            "class": "bus",
+            "class": "Bus",
             "name": "ODEM 0",
             "init": {
                 "Vr": 0.6401926471640568,
@@ -6583,7 +6585,7 @@
         },
         {
             "number": 4100,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 13 0",
             "init": {
                 "Vr": 0.6729478034696112,
@@ -6597,7 +6599,7 @@
         },
         {
             "number": 4101,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 3 0",
             "init": {
                 "Vr": 0.5249173329555035,
@@ -6611,7 +6613,7 @@
         },
         {
             "number": 4102,
-            "class": "bus",
+            "class": "Bus",
             "name": "OLMITO 0",
             "init": {
                 "Vr": 0.5246004239743645,
@@ -6625,7 +6627,7 @@
         },
         {
             "number": 4103,
-            "class": "bus",
+            "class": "Bus",
             "name": "EDINBURG 1 0",
             "init": {
                 "Vr": 0.284738665837642,
@@ -6639,7 +6641,7 @@
         },
         {
             "number": 4104,
-            "class": "bus",
+            "class": "Bus",
             "name": "TAFT 2 0",
             "init": {
                 "Vr": 0.6880070865430011,
@@ -6653,7 +6655,7 @@
         },
         {
             "number": 4105,
-            "class": "bus",
+            "class": "Bus",
             "name": "TAFT 2 1",
             "init": {
                 "Vr": 0.7376952417014637,
@@ -6667,7 +6669,7 @@
         },
         {
             "number": 4106,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT ISABEL 0",
             "init": {
                 "Vr": 0.5309723551197588,
@@ -6681,7 +6683,7 @@
         },
         {
             "number": 4107,
-            "class": "bus",
+            "class": "Bus",
             "name": "DONNA 0",
             "init": {
                 "Vr": 0.3114805584558103,
@@ -6695,7 +6697,7 @@
         },
         {
             "number": 4108,
-            "class": "bus",
+            "class": "Bus",
             "name": "INGLESIDE 0",
             "init": {
                 "Vr": 0.7065216510289346,
@@ -6709,7 +6711,7 @@
         },
         {
             "number": 4109,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 11 0",
             "init": {
                 "Vr": 0.6359938590061325,
@@ -6723,7 +6725,7 @@
         },
         {
             "number": 4110,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOS FRESNOS 0",
             "init": {
                 "Vr": 0.4611260838155883,
@@ -6737,7 +6739,7 @@
         },
         {
             "number": 4111,
-            "class": "bus",
+            "class": "Bus",
             "name": "HARLINGEN 2 0",
             "init": {
                 "Vr": 0.3878768921430157,
@@ -6751,7 +6753,7 @@
         },
         {
             "number": 4112,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIVIERA 0",
             "init": {
                 "Vr": 0.5937000591312821,
@@ -6765,7 +6767,7 @@
         },
         {
             "number": 4113,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 1 0",
             "init": {
                 "Vr": 0.5822534898165516,
@@ -6779,7 +6781,7 @@
         },
         {
             "number": 4114,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 1 1",
             "init": {
                 "Vr": 0.5450997392083171,
@@ -6793,7 +6795,7 @@
         },
         {
             "number": 4115,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 1 2",
             "init": {
                 "Vr": 0.6455462333865615,
@@ -6807,7 +6809,7 @@
         },
         {
             "number": 4116,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 1 3",
             "init": {
                 "Vr": 0.6449351673154525,
@@ -6821,7 +6823,7 @@
         },
         {
             "number": 4117,
-            "class": "bus",
+            "class": "Bus",
             "name": "JOURDANTON 0",
             "init": {
                 "Vr": 0.6815188933012765,
@@ -6835,7 +6837,7 @@
         },
         {
             "number": 4118,
-            "class": "bus",
+            "class": "Bus",
             "name": "GEORGE WEST 0",
             "init": {
                 "Vr": 0.5498894734065641,
@@ -6849,7 +6851,7 @@
         },
         {
             "number": 4119,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROMA 0",
             "init": {
                 "Vr": 0.5391337891064691,
@@ -6863,7 +6865,7 @@
         },
         {
             "number": 4120,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 12 0",
             "init": {
                 "Vr": 0.6666184961773965,
@@ -6877,7 +6879,7 @@
         },
         {
             "number": 4121,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA MARIA 0",
             "init": {
                 "Vr": 0.3742005185365288,
@@ -6891,7 +6893,7 @@
         },
         {
             "number": 4122,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCALLEN 1 0",
             "init": {
                 "Vr": 0.32425352411899405,
@@ -6905,7 +6907,7 @@
         },
         {
             "number": 4123,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 7 0",
             "init": {
                 "Vr": 0.6388191806620158,
@@ -6919,7 +6921,7 @@
         },
         {
             "number": 4124,
-            "class": "bus",
+            "class": "Bus",
             "name": "FALFURRIAS 0",
             "init": {
                 "Vr": 0.4683011883362188,
@@ -6933,7 +6935,7 @@
         },
         {
             "number": 4125,
-            "class": "bus",
+            "class": "Bus",
             "name": "PETTUS 0",
             "init": {
                 "Vr": 0.6912073222809043,
@@ -6947,7 +6949,7 @@
         },
         {
             "number": 4126,
-            "class": "bus",
+            "class": "Bus",
             "name": "BROWNSVILLE 3 0",
             "init": {
                 "Vr": 0.5597039014366902,
@@ -6961,7 +6963,7 @@
         },
         {
             "number": 4127,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALICE 0",
             "init": {
                 "Vr": 0.5334545469851933,
@@ -6975,7 +6977,7 @@
         },
         {
             "number": 4128,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIO GRANDE CITY 0",
             "init": {
                 "Vr": 0.35801741323256964,
@@ -6989,7 +6991,7 @@
         },
         {
             "number": 4129,
-            "class": "bus",
+            "class": "Bus",
             "name": "PREMONT 0",
             "init": {
                 "Vr": 0.5763842793570878,
@@ -7003,7 +7005,7 @@
         },
         {
             "number": 4130,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREER 0",
             "init": {
                 "Vr": 0.5527283043094807,
@@ -7017,7 +7019,7 @@
         },
         {
             "number": 4131,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARSALL 0",
             "init": {
                 "Vr": 0.6561905786354278,
@@ -7031,7 +7033,7 @@
         },
         {
             "number": 4132,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARSALL 1",
             "init": {
                 "Vr": 0.6420913800331812,
@@ -7045,7 +7047,7 @@
         },
         {
             "number": 4133,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARSALL 2",
             "init": {
                 "Vr": 0.6561905786354278,
@@ -7059,7 +7061,7 @@
         },
         {
             "number": 4134,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARSALL 3",
             "init": {
                 "Vr": 0.6640822430110105,
@@ -7073,7 +7075,7 @@
         },
         {
             "number": 4135,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARSALL 4",
             "init": {
                 "Vr": 0.6638147232363392,
@@ -7087,7 +7089,7 @@
         },
         {
             "number": 4136,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARSALL 5",
             "init": {
                 "Vr": 0.6660599776532381,
@@ -7101,7 +7103,7 @@
         },
         {
             "number": 4137,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARSALL 6",
             "init": {
                 "Vr": 0.6561905786354278,
@@ -7115,7 +7117,7 @@
         },
         {
             "number": 4138,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARSALL 7",
             "init": {
                 "Vr": 0.6561905786354278,
@@ -7129,7 +7131,7 @@
         },
         {
             "number": 4139,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANDIA 0",
             "init": {
                 "Vr": 0.5723219828857181,
@@ -7143,7 +7145,7 @@
         },
         {
             "number": 4140,
-            "class": "bus",
+            "class": "Bus",
             "name": "SARITA 1 0",
             "init": {
                 "Vr": 0.6838310980743126,
@@ -7157,7 +7159,7 @@
         },
         {
             "number": 4141,
-            "class": "bus",
+            "class": "Bus",
             "name": "SARITA 1 1",
             "init": {
                 "Vr": 0.6382954828045427,
@@ -7171,7 +7173,7 @@
         },
         {
             "number": 4142,
-            "class": "bus",
+            "class": "Bus",
             "name": "SARITA 1 2",
             "init": {
                 "Vr": 0.7166862804975184,
@@ -7185,7 +7187,7 @@
         },
         {
             "number": 4143,
-            "class": "bus",
+            "class": "Bus",
             "name": "DILLEY 0",
             "init": {
                 "Vr": 0.5954660133147983,
@@ -7199,7 +7201,7 @@
         },
         {
             "number": 4144,
-            "class": "bus",
+            "class": "Bus",
             "name": "ORANGE GROVE 0",
             "init": {
                 "Vr": 0.5551131161068147,
@@ -7213,7 +7215,7 @@
         },
         {
             "number": 4145,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORTLAND 0",
             "init": {
                 "Vr": 0.6840215552264131,
@@ -7227,7 +7229,7 @@
         },
         {
             "number": 4146,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 4 0",
             "init": {
                 "Vr": 0.5800836334348209,
@@ -7241,7 +7243,7 @@
         },
         {
             "number": 4147,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 4 1",
             "init": {
                 "Vr": 0.5526018421951363,
@@ -7255,7 +7257,7 @@
         },
         {
             "number": 4148,
-            "class": "bus",
+            "class": "Bus",
             "name": "THREE RIVERS 0",
             "init": {
                 "Vr": 0.5320212611714878,
@@ -7269,7 +7271,7 @@
         },
         {
             "number": 4149,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKPORT 0",
             "init": {
                 "Vr": 0.7057300898195722,
@@ -7283,7 +7285,7 @@
         },
         {
             "number": 4150,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 15 0",
             "init": {
                 "Vr": 0.6577731165183236,
@@ -7297,7 +7299,7 @@
         },
         {
             "number": 4151,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARMSTRONG 1 0",
             "init": {
                 "Vr": 0.6636572606722859,
@@ -7311,7 +7313,7 @@
         },
         {
             "number": 4152,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARMSTRONG 1 1",
             "init": {
                 "Vr": 0.6795394585474834,
@@ -7325,7 +7327,7 @@
         },
         {
             "number": 4153,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARMSTRONG 1 2",
             "init": {
                 "Vr": 0.6950090345704489,
@@ -7339,7 +7341,7 @@
         },
         {
             "number": 4154,
-            "class": "bus",
+            "class": "Bus",
             "name": "PENITAS 0",
             "init": {
                 "Vr": 0.3852726669500904,
@@ -7353,7 +7355,7 @@
         },
         {
             "number": 4155,
-            "class": "bus",
+            "class": "Bus",
             "name": "SULLIVAN CITY 0",
             "init": {
                 "Vr": 0.4205588915917875,
@@ -7367,7 +7369,7 @@
         },
         {
             "number": 4156,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 6 0",
             "init": {
                 "Vr": 0.6474269519855291,
@@ -7381,7 +7383,7 @@
         },
         {
             "number": 4157,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION 2 0",
             "init": {
                 "Vr": 0.34902133545890757,
@@ -7395,7 +7397,7 @@
         },
         {
             "number": 4158,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 1 0",
             "init": {
                 "Vr": 0.7546970978933906,
@@ -7409,7 +7411,7 @@
         },
         {
             "number": 4159,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 1 1",
             "init": {
                 "Vr": 0.692690581911542,
@@ -7423,7 +7425,7 @@
         },
         {
             "number": 4160,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 1 2",
             "init": {
                 "Vr": 0.7963587032857992,
@@ -7437,7 +7439,7 @@
         },
         {
             "number": 4161,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 1 3",
             "init": {
                 "Vr": 0.7991147772247741,
@@ -7451,7 +7453,7 @@
         },
         {
             "number": 4162,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 1 4",
             "init": {
                 "Vr": 0.8075378882798041,
@@ -7465,7 +7467,7 @@
         },
         {
             "number": 4163,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 1 5",
             "init": {
                 "Vr": 0.7546970978933906,
@@ -7479,7 +7481,7 @@
         },
         {
             "number": 4164,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRULLA 0",
             "init": {
                 "Vr": 0.43651385986268376,
@@ -7493,7 +7495,7 @@
         },
         {
             "number": 4165,
-            "class": "bus",
+            "class": "Bus",
             "name": "SARITA 2 0",
             "init": {
                 "Vr": 0.7079599616646579,
@@ -7507,7 +7509,7 @@
         },
         {
             "number": 4166,
-            "class": "bus",
+            "class": "Bus",
             "name": "SARITA 2 1",
             "init": {
                 "Vr": 0.745968129692896,
@@ -7521,7 +7523,7 @@
         },
         {
             "number": 4167,
-            "class": "bus",
+            "class": "Bus",
             "name": "HARGILL 0",
             "init": {
                 "Vr": 0.3813573969492255,
@@ -7535,7 +7537,7 @@
         },
         {
             "number": 4168,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORPUS CHRISTI 14 0",
             "init": {
                 "Vr": 0.6877567738289313,
@@ -7549,7 +7551,7 @@
         },
         {
             "number": 4169,
-            "class": "bus",
+            "class": "Bus",
             "name": "MATHIS 0",
             "init": {
                 "Vr": 0.6097226589514989,
@@ -7563,7 +7565,7 @@
         },
         {
             "number": 4170,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARANSAS PASS 0",
             "init": {
                 "Vr": 0.6784184318139066,
@@ -7577,7 +7579,7 @@
         },
         {
             "number": 4171,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN BENITO 0",
             "init": {
                 "Vr": 0.472944640137779,
@@ -7591,7 +7593,7 @@
         },
         {
             "number": 4172,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLEASANTON 0",
             "init": {
                 "Vr": 0.6397455774273554,
@@ -7605,7 +7607,7 @@
         },
         {
             "number": 4173,
-            "class": "bus",
+            "class": "Bus",
             "name": "REFUGIO 0",
             "init": {
                 "Vr": 0.7610955881007369,
@@ -7619,7 +7621,7 @@
         },
         {
             "number": 4174,
-            "class": "bus",
+            "class": "Bus",
             "name": "LYTLE 0",
             "init": {
                 "Vr": 0.5492173801087831,
@@ -7633,7 +7635,7 @@
         },
         {
             "number": 4175,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 2 0",
             "init": {
                 "Vr": 0.576030347791889,
@@ -7647,7 +7649,7 @@
         },
         {
             "number": 4176,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRUNI 1 0",
             "init": {
                 "Vr": 0.6316560286330599,
@@ -7661,7 +7663,7 @@
         },
         {
             "number": 4177,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRUNI 1 1",
             "init": {
                 "Vr": 0.6796362534060123,
@@ -7675,7 +7677,7 @@
         },
         {
             "number": 4178,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLIAD 0",
             "init": {
                 "Vr": 0.7036411195068882,
@@ -7689,7 +7691,7 @@
         },
         {
             "number": 4179,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN DIEGO 0",
             "init": {
                 "Vr": 0.5355915134565419,
@@ -7703,7 +7705,7 @@
         },
         {
             "number": 4180,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT ARANSAS 0",
             "init": {
                 "Vr": 0.6636511647650717,
@@ -7717,7 +7719,7 @@
         },
         {
             "number": 4181,
-            "class": "bus",
+            "class": "Bus",
             "name": "TAFT 1 0",
             "init": {
                 "Vr": 0.7933443097076055,
@@ -7731,7 +7733,7 @@
         },
         {
             "number": 4182,
-            "class": "bus",
+            "class": "Bus",
             "name": "TAFT 1 1",
             "init": {
                 "Vr": 0.7319565518390404,
@@ -7745,7 +7747,7 @@
         },
         {
             "number": 4183,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN PERLITA 0",
             "init": {
                 "Vr": 0.65985712918958,
@@ -7759,7 +7761,7 @@
         },
         {
             "number": 4184,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN PERLITA 1",
             "init": {
                 "Vr": 0.5429971411808483,
@@ -7773,7 +7775,7 @@
         },
         {
             "number": 4185,
-            "class": "bus",
+            "class": "Bus",
             "name": "ZAPATA 0",
             "init": {
                 "Vr": 0.5327414135284771,
@@ -7787,7 +7789,7 @@
         },
         {
             "number": 4186,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA ROSA 2 0",
             "init": {
                 "Vr": 0.36085756265783514,
@@ -7801,7 +7803,7 @@
         },
         {
             "number": 4187,
-            "class": "bus",
+            "class": "Bus",
             "name": "COTULLA 0",
             "init": {
                 "Vr": 0.5192664991990583,
@@ -7815,7 +7817,7 @@
         },
         {
             "number": 4188,
-            "class": "bus",
+            "class": "Bus",
             "name": "QUEMADO 0",
             "init": {
                 "Vr": 0.6192577178513838,
@@ -7829,7 +7831,7 @@
         },
         {
             "number": 4189,
-            "class": "bus",
+            "class": "Bus",
             "name": "CARRIZO SPRINGS 0",
             "init": {
                 "Vr": 0.5478067906175155,
@@ -7843,7 +7845,7 @@
         },
         {
             "number": 4190,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAREDO 5 0",
             "init": {
                 "Vr": 0.530795098361766,
@@ -7857,7 +7859,7 @@
         },
         {
             "number": 4191,
-            "class": "bus",
+            "class": "Bus",
             "name": "RAYMONDVILLE 0",
             "init": {
                 "Vr": 0.5681912262875887,
@@ -7871,7 +7873,7 @@
         },
         {
             "number": 4192,
-            "class": "bus",
+            "class": "Bus",
             "name": "BROWNSVILLE 1 0",
             "init": {
                 "Vr": 0.6498298018862776,
@@ -7885,7 +7887,7 @@
         },
         {
             "number": 4193,
-            "class": "bus",
+            "class": "Bus",
             "name": "BROWNSVILLE 1 1",
             "init": {
                 "Vr": 0.6073615419099466,
@@ -7899,7 +7901,7 @@
         },
         {
             "number": 4194,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEBASTIAN 1 0",
             "init": {
                 "Vr": 0.4827393396337376,
@@ -7913,7 +7915,7 @@
         },
         {
             "number": 4195,
-            "class": "bus",
+            "class": "Bus",
             "name": "OILTON 0",
             "init": {
                 "Vr": 0.6482595395840459,
@@ -7927,7 +7929,7 @@
         },
         {
             "number": 4196,
-            "class": "bus",
+            "class": "Bus",
             "name": "OILTON 1",
             "init": {
                 "Vr": 0.6260217102021088,
@@ -7941,7 +7943,7 @@
         },
         {
             "number": 4197,
-            "class": "bus",
+            "class": "Bus",
             "name": "OILTON 2",
             "init": {
                 "Vr": 0.5953596179510116,
@@ -7955,7 +7957,7 @@
         },
         {
             "number": 5003,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARLAND 5 0",
             "init": {
                 "Vr": 0.3299083021939882,
@@ -7969,7 +7971,7 @@
         },
         {
             "number": 5004,
-            "class": "bus",
+            "class": "Bus",
             "name": "KERENS 0",
             "init": {
                 "Vr": 0.44458960100032513,
@@ -7983,7 +7985,7 @@
         },
         {
             "number": 5005,
-            "class": "bus",
+            "class": "Bus",
             "name": "LIPAN 0",
             "init": {
                 "Vr": 0.5830700475433515,
@@ -7997,7 +7999,7 @@
         },
         {
             "number": 5006,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 24 0",
             "init": {
                 "Vr": 0.33933279781313047,
@@ -8011,7 +8013,7 @@
         },
         {
             "number": 5007,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENTON 4 0",
             "init": {
                 "Vr": 0.40838377749980076,
@@ -8025,7 +8027,7 @@
         },
         {
             "number": 5008,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALBANY 2 0",
             "init": {
                 "Vr": 0.7363068432052318,
@@ -8039,7 +8041,7 @@
         },
         {
             "number": 5009,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 21 0",
             "init": {
                 "Vr": 0.31952861264761384,
@@ -8053,7 +8055,7 @@
         },
         {
             "number": 5010,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLANO 2 0",
             "init": {
                 "Vr": 0.35252273094624187,
@@ -8067,7 +8069,7 @@
         },
         {
             "number": 5011,
-            "class": "bus",
+            "class": "Bus",
             "name": "THORNTON 0",
             "init": {
                 "Vr": 0.5744240976070858,
@@ -8081,7 +8083,7 @@
         },
         {
             "number": 5012,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENTON 5 0",
             "init": {
                 "Vr": 0.39991722531001933,
@@ -8095,7 +8097,7 @@
         },
         {
             "number": 5013,
-            "class": "bus",
+            "class": "Bus",
             "name": "EARLY 0",
             "init": {
                 "Vr": 0.6439186532327483,
@@ -8109,7 +8111,7 @@
         },
         {
             "number": 5014,
-            "class": "bus",
+            "class": "Bus",
             "name": "DECATUR 0",
             "init": {
                 "Vr": 0.4611758556803354,
@@ -8123,7 +8125,7 @@
         },
         {
             "number": 5015,
-            "class": "bus",
+            "class": "Bus",
             "name": "KELLER 2 0",
             "init": {
                 "Vr": 0.48286886510761323,
@@ -8137,7 +8139,7 @@
         },
         {
             "number": 5016,
-            "class": "bus",
+            "class": "Bus",
             "name": "KELLER 2 1",
             "init": {
                 "Vr": 0.409981992632717,
@@ -8151,7 +8153,7 @@
         },
         {
             "number": 5017,
-            "class": "bus",
+            "class": "Bus",
             "name": "PONDER 0",
             "init": {
                 "Vr": 0.3861961124889466,
@@ -8165,7 +8167,7 @@
         },
         {
             "number": 5018,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSBORO 1 0",
             "init": {
                 "Vr": 0.6671979454499806,
@@ -8179,7 +8181,7 @@
         },
         {
             "number": 5019,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSBORO 1 1",
             "init": {
                 "Vr": 0.6426274692247631,
@@ -8193,7 +8195,7 @@
         },
         {
             "number": 5020,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSBORO 1 2",
             "init": {
                 "Vr": 0.6854149754390578,
@@ -8207,7 +8209,7 @@
         },
         {
             "number": 5021,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALEDO 1 0",
             "init": {
                 "Vr": 0.5134059756314091,
@@ -8221,7 +8223,7 @@
         },
         {
             "number": 5022,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALEDO 1 1",
             "init": {
                 "Vr": 0.4555305670623362,
@@ -8235,7 +8237,7 @@
         },
         {
             "number": 5023,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALEDO 1 2",
             "init": {
                 "Vr": 0.5134059756314091,
@@ -8249,7 +8251,7 @@
         },
         {
             "number": 5024,
-            "class": "bus",
+            "class": "Bus",
             "name": "GATESVILLE 4 0",
             "init": {
                 "Vr": 0.5677471655690081,
@@ -8263,7 +8265,7 @@
         },
         {
             "number": 5025,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLEBURNE 2 0",
             "init": {
                 "Vr": 0.464326833855271,
@@ -8277,7 +8279,7 @@
         },
         {
             "number": 5026,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 14 0",
             "init": {
                 "Vr": 0.38135101111424397,
@@ -8291,7 +8293,7 @@
         },
         {
             "number": 5027,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 23 0",
             "init": {
                 "Vr": 0.3688868303941987,
@@ -8305,7 +8307,7 @@
         },
         {
             "number": 5028,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 1 0",
             "init": {
                 "Vr": 0.3691969462555116,
@@ -8319,7 +8321,7 @@
         },
         {
             "number": 5029,
-            "class": "bus",
+            "class": "Bus",
             "name": "TROY 0",
             "init": {
                 "Vr": 0.5822456004936277,
@@ -8333,7 +8335,7 @@
         },
         {
             "number": 5030,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRINGTOWN 0",
             "init": {
                 "Vr": 0.4040460551787779,
@@ -8347,7 +8349,7 @@
         },
         {
             "number": 5031,
-            "class": "bus",
+            "class": "Bus",
             "name": "PRINCETON 0",
             "init": {
                 "Vr": 0.4015004346271286,
@@ -8361,7 +8363,7 @@
         },
         {
             "number": 5032,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 27 0",
             "init": {
                 "Vr": 0.34843326582991674,
@@ -8375,7 +8377,7 @@
         },
         {
             "number": 5033,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 0",
             "init": {
                 "Vr": 0.4485612980789067,
@@ -8389,7 +8391,7 @@
         },
         {
             "number": 5034,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 1",
             "init": {
                 "Vr": 0.4108544478806648,
@@ -8403,7 +8405,7 @@
         },
         {
             "number": 5035,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 2",
             "init": {
                 "Vr": 0.4485612980789067,
@@ -8417,7 +8419,7 @@
         },
         {
             "number": 5036,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 3",
             "init": {
                 "Vr": 0.4485612980789067,
@@ -8431,7 +8433,7 @@
         },
         {
             "number": 5037,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 4",
             "init": {
                 "Vr": 0.46213930355078825,
@@ -8445,7 +8447,7 @@
         },
         {
             "number": 5038,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 5",
             "init": {
                 "Vr": 0.4624754339392702,
@@ -8459,7 +8461,7 @@
         },
         {
             "number": 5039,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 6",
             "init": {
                 "Vr": 0.4566314411625987,
@@ -8473,7 +8475,7 @@
         },
         {
             "number": 5040,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 7",
             "init": {
                 "Vr": 0.4656169332032475,
@@ -8487,7 +8489,7 @@
         },
         {
             "number": 5041,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 8",
             "init": {
                 "Vr": 0.4614853527238355,
@@ -8501,7 +8503,7 @@
         },
         {
             "number": 5042,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 1 9",
             "init": {
                 "Vr": 0.4632233662254056,
@@ -8515,7 +8517,7 @@
         },
         {
             "number": 5043,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROYSE CITY 0",
             "init": {
                 "Vr": 0.3465980750004995,
@@ -8529,7 +8531,7 @@
         },
         {
             "number": 5044,
-            "class": "bus",
+            "class": "Bus",
             "name": "BOYD 0",
             "init": {
                 "Vr": 0.45519074528170606,
@@ -8543,7 +8545,7 @@
         },
         {
             "number": 5045,
-            "class": "bus",
+            "class": "Bus",
             "name": "STEPHENVILLE 0",
             "init": {
                 "Vr": 0.6675730410657321,
@@ -8557,7 +8559,7 @@
         },
         {
             "number": 5046,
-            "class": "bus",
+            "class": "Bus",
             "name": "STEPHENVILLE 1",
             "init": {
                 "Vr": 0.6388419289825342,
@@ -8571,7 +8573,7 @@
         },
         {
             "number": 5047,
-            "class": "bus",
+            "class": "Bus",
             "name": "MANSFIELD 0",
             "init": {
                 "Vr": 0.5102147782128226,
@@ -8585,7 +8587,7 @@
         },
         {
             "number": 5048,
-            "class": "bus",
+            "class": "Bus",
             "name": "MANSFIELD 1",
             "init": {
                 "Vr": 0.4379371268332192,
@@ -8599,7 +8601,7 @@
         },
         {
             "number": 5049,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREENVILLE 1 0",
             "init": {
                 "Vr": 0.5085483338588275,
@@ -8613,7 +8615,7 @@
         },
         {
             "number": 5050,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREENVILLE 1 1",
             "init": {
                 "Vr": 0.4377002775810368,
@@ -8627,7 +8629,7 @@
         },
         {
             "number": 5051,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREENVILLE 1 2",
             "init": {
                 "Vr": 0.5237915593756797,
@@ -8641,7 +8643,7 @@
         },
         {
             "number": 5052,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREENVILLE 1 3",
             "init": {
                 "Vr": 0.4591915697654935,
@@ -8655,7 +8657,7 @@
         },
         {
             "number": 5053,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLANO 4 0",
             "init": {
                 "Vr": 0.35072147215906085,
@@ -8669,7 +8671,7 @@
         },
         {
             "number": 5054,
-            "class": "bus",
+            "class": "Bus",
             "name": "GROESBECK 0",
             "init": {
                 "Vr": 0.5404713559511476,
@@ -8683,7 +8685,7 @@
         },
         {
             "number": 5055,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAHAM 0",
             "init": {
                 "Vr": 0.6460865955436182,
@@ -8697,7 +8699,7 @@
         },
         {
             "number": 5056,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAHAM 1",
             "init": {
                 "Vr": 0.633738734698402,
@@ -8711,7 +8713,7 @@
         },
         {
             "number": 5057,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAHAM 2",
             "init": {
                 "Vr": 0.6460865955436182,
@@ -8725,7 +8727,7 @@
         },
         {
             "number": 5058,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAHAM 3",
             "init": {
                 "Vr": 0.6796324869178536,
@@ -8739,7 +8741,7 @@
         },
         {
             "number": 5059,
-            "class": "bus",
+            "class": "Bus",
             "name": "MABANK 2 0",
             "init": {
                 "Vr": 0.43932194182793954,
@@ -8753,7 +8755,7 @@
         },
         {
             "number": 5060,
-            "class": "bus",
+            "class": "Bus",
             "name": "MABANK 2 1",
             "init": {
                 "Vr": 0.40442378342677443,
@@ -8767,7 +8769,7 @@
         },
         {
             "number": 5061,
-            "class": "bus",
+            "class": "Bus",
             "name": "MABANK 2 2",
             "init": {
                 "Vr": 0.3594329875021404,
@@ -8781,7 +8783,7 @@
         },
         {
             "number": 5062,
-            "class": "bus",
+            "class": "Bus",
             "name": "MABANK 2 3",
             "init": {
                 "Vr": 0.27857332348860286,
@@ -8795,7 +8797,7 @@
         },
         {
             "number": 5063,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 1 0",
             "init": {
                 "Vr": 0.47656801524118836,
@@ -8809,7 +8811,7 @@
         },
         {
             "number": 5064,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 1 1",
             "init": {
                 "Vr": 0.4066914416818661,
@@ -8823,7 +8825,7 @@
         },
         {
             "number": 5065,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 1 2",
             "init": {
                 "Vr": 0.4786246052594545,
@@ -8837,7 +8839,7 @@
         },
         {
             "number": 5066,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 1 3",
             "init": {
                 "Vr": 0.47656801524118836,
@@ -8851,7 +8853,7 @@
         },
         {
             "number": 5067,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 1 4",
             "init": {
                 "Vr": 0.5256431687821088,
@@ -8865,7 +8867,7 @@
         },
         {
             "number": 5068,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 1 5",
             "init": {
                 "Vr": 0.5275719713418678,
@@ -8879,7 +8881,7 @@
         },
         {
             "number": 5069,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 1 6",
             "init": {
                 "Vr": 0.5302048830059369,
@@ -8893,7 +8895,7 @@
         },
         {
             "number": 5070,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 41 0",
             "init": {
                 "Vr": 0.34000479179203,
@@ -8907,7 +8909,7 @@
         },
         {
             "number": 5071,
-            "class": "bus",
+            "class": "Bus",
             "name": "WACO 3 0",
             "init": {
                 "Vr": 0.5863803849026636,
@@ -8921,7 +8923,7 @@
         },
         {
             "number": 5072,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 19 0",
             "init": {
                 "Vr": 0.34806021368892226,
@@ -8935,7 +8937,7 @@
         },
         {
             "number": 5073,
-            "class": "bus",
+            "class": "Bus",
             "name": "BANGS 0",
             "init": {
                 "Vr": 0.7037840221253662,
@@ -8949,7 +8951,7 @@
         },
         {
             "number": 5074,
-            "class": "bus",
+            "class": "Bus",
             "name": "PROSPER 0",
             "init": {
                 "Vr": 0.3538548438143677,
@@ -8963,7 +8965,7 @@
         },
         {
             "number": 5075,
-            "class": "bus",
+            "class": "Bus",
             "name": "EVANT 0",
             "init": {
                 "Vr": 0.5527233548902204,
@@ -8977,7 +8979,7 @@
         },
         {
             "number": 5076,
-            "class": "bus",
+            "class": "Bus",
             "name": "TERRELL 1 0",
             "init": {
                 "Vr": 0.3221644251840573,
@@ -8991,7 +8993,7 @@
         },
         {
             "number": 5077,
-            "class": "bus",
+            "class": "Bus",
             "name": "TERRELL 1 1",
             "init": {
                 "Vr": 0.31322594547994137,
@@ -9005,7 +9007,7 @@
         },
         {
             "number": 5078,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUBREY 0",
             "init": {
                 "Vr": 0.39426015698797917,
@@ -9019,7 +9021,7 @@
         },
         {
             "number": 5079,
-            "class": "bus",
+            "class": "Bus",
             "name": "WACO 4 0",
             "init": {
                 "Vr": 0.5675113748784727,
@@ -9033,7 +9035,7 @@
         },
         {
             "number": 5080,
-            "class": "bus",
+            "class": "Bus",
             "name": "LORENA 0",
             "init": {
                 "Vr": 0.5444236877069212,
@@ -9047,7 +9049,7 @@
         },
         {
             "number": 5081,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT HOOD 0",
             "init": {
                 "Vr": 0.5675365914277362,
@@ -9061,7 +9063,7 @@
         },
         {
             "number": 5082,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 5 0",
             "init": {
                 "Vr": 0.3516522105956544,
@@ -9075,7 +9077,7 @@
         },
         {
             "number": 5083,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 3 0",
             "init": {
                 "Vr": 0.4528465677633925,
@@ -9089,7 +9091,7 @@
         },
         {
             "number": 5084,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 3 1",
             "init": {
                 "Vr": 0.3787104633502456,
@@ -9103,7 +9105,7 @@
         },
         {
             "number": 5085,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 38 0",
             "init": {
                 "Vr": 0.346561684750428,
@@ -9117,7 +9119,7 @@
         },
         {
             "number": 5086,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 9 0",
             "init": {
                 "Vr": 0.3564039031240364,
@@ -9131,7 +9133,7 @@
         },
         {
             "number": 5087,
-            "class": "bus",
+            "class": "Bus",
             "name": "MILFORD 0",
             "init": {
                 "Vr": 0.4424601778985137,
@@ -9145,7 +9147,7 @@
         },
         {
             "number": 5088,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLIFTON 1 0",
             "init": {
                 "Vr": 0.5168622444442617,
@@ -9159,7 +9161,7 @@
         },
         {
             "number": 5089,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLIFTON 1 1",
             "init": {
                 "Vr": 0.5168622444442617,
@@ -9173,7 +9175,7 @@
         },
         {
             "number": 5090,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 15 0",
             "init": {
                 "Vr": 0.32983333481685306,
@@ -9187,7 +9189,7 @@
         },
         {
             "number": 5091,
-            "class": "bus",
+            "class": "Bus",
             "name": "FROST 0",
             "init": {
                 "Vr": 0.45171900907308404,
@@ -9201,7 +9203,7 @@
         },
         {
             "number": 5092,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANDVIEW 0",
             "init": {
                 "Vr": 0.3910534935444655,
@@ -9215,7 +9217,7 @@
         },
         {
             "number": 5093,
-            "class": "bus",
+            "class": "Bus",
             "name": "HASLET 0",
             "init": {
                 "Vr": 0.38808329767778765,
@@ -9229,7 +9231,7 @@
         },
         {
             "number": 5094,
-            "class": "bus",
+            "class": "Bus",
             "name": "BARDWELL 0",
             "init": {
                 "Vr": 0.49315476460168484,
@@ -9243,7 +9245,7 @@
         },
         {
             "number": 5095,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAKE DALLAS 0",
             "init": {
                 "Vr": 0.3562551903213965,
@@ -9257,7 +9259,7 @@
         },
         {
             "number": 5096,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLANO 1 0",
             "init": {
                 "Vr": 0.36824045762971225,
@@ -9271,7 +9273,7 @@
         },
         {
             "number": 5097,
-            "class": "bus",
+            "class": "Bus",
             "name": "EULESS 2 0",
             "init": {
                 "Vr": 0.3796013268092778,
@@ -9285,7 +9287,7 @@
         },
         {
             "number": 5098,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 24 0",
             "init": {
                 "Vr": 0.370827282819113,
@@ -9299,7 +9301,7 @@
         },
         {
             "number": 5099,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLOWER MOUND 2 0",
             "init": {
                 "Vr": 0.3588758390157458,
@@ -9313,7 +9315,7 @@
         },
         {
             "number": 5100,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 11 0",
             "init": {
                 "Vr": 0.35595762495357597,
@@ -9327,7 +9329,7 @@
         },
         {
             "number": 5101,
-            "class": "bus",
+            "class": "Bus",
             "name": "COMANCHE 0",
             "init": {
                 "Vr": 0.6233599378359018,
@@ -9341,7 +9343,7 @@
         },
         {
             "number": 5102,
-            "class": "bus",
+            "class": "Bus",
             "name": "RICHARDSON 2 0",
             "init": {
                 "Vr": 0.4344249996502257,
@@ -9355,7 +9357,7 @@
         },
         {
             "number": 5103,
-            "class": "bus",
+            "class": "Bus",
             "name": "RICHARDSON 2 1",
             "init": {
                 "Vr": 0.36234848928368013,
@@ -9369,7 +9371,7 @@
         },
         {
             "number": 5104,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 8 0",
             "init": {
                 "Vr": 0.38874669239966386,
@@ -9383,7 +9385,7 @@
         },
         {
             "number": 5105,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRVING 1 0",
             "init": {
                 "Vr": 0.3348647617891185,
@@ -9397,7 +9399,7 @@
         },
         {
             "number": 5106,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRVING 1 1",
             "init": {
                 "Vr": 0.3348647617891185,
@@ -9411,7 +9413,7 @@
         },
         {
             "number": 5107,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRVING 1 2",
             "init": {
                 "Vr": 0.3348647617891185,
@@ -9425,7 +9427,7 @@
         },
         {
             "number": 5108,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 44 0",
             "init": {
                 "Vr": 0.37958635677844443,
@@ -9439,7 +9441,7 @@
         },
         {
             "number": 5109,
-            "class": "bus",
+            "class": "Bus",
             "name": "LANCASTER 1 0",
             "init": {
                 "Vr": 0.3558677593677906,
@@ -9453,7 +9455,7 @@
         },
         {
             "number": 5110,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALO PINTO 2 0",
             "init": {
                 "Vr": 0.579557526688305,
@@ -9467,7 +9469,7 @@
         },
         {
             "number": 5111,
-            "class": "bus",
+            "class": "Bus",
             "name": "ADDISON 0",
             "init": {
                 "Vr": 0.32789435815627943,
@@ -9481,7 +9483,7 @@
         },
         {
             "number": 5112,
-            "class": "bus",
+            "class": "Bus",
             "name": "HICO 0",
             "init": {
                 "Vr": 0.5692038946399361,
@@ -9495,7 +9497,7 @@
         },
         {
             "number": 5113,
-            "class": "bus",
+            "class": "Bus",
             "name": "KRUM 0",
             "init": {
                 "Vr": 0.3846411263996949,
@@ -9509,7 +9511,7 @@
         },
         {
             "number": 5114,
-            "class": "bus",
+            "class": "Bus",
             "name": "KAUFMAN 0",
             "init": {
                 "Vr": 0.35855389101842744,
@@ -9523,7 +9525,7 @@
         },
         {
             "number": 5115,
-            "class": "bus",
+            "class": "Bus",
             "name": "CADDO MILLS 0",
             "init": {
                 "Vr": 0.3974112518953334,
@@ -9537,7 +9539,7 @@
         },
         {
             "number": 5116,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLANO 7 0",
             "init": {
                 "Vr": 0.3375095944250824,
@@ -9551,7 +9553,7 @@
         },
         {
             "number": 5117,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 5 0",
             "init": {
                 "Vr": 0.35532646190919004,
@@ -9565,7 +9567,7 @@
         },
         {
             "number": 5118,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAIRD 0",
             "init": {
                 "Vr": 0.7199344094152605,
@@ -9579,7 +9581,7 @@
         },
         {
             "number": 5119,
-            "class": "bus",
+            "class": "Bus",
             "name": "PERRIN 0",
             "init": {
                 "Vr": 0.5605378124135122,
@@ -9593,7 +9595,7 @@
         },
         {
             "number": 5120,
-            "class": "bus",
+            "class": "Bus",
             "name": "BROWNWOOD 0",
             "init": {
                 "Vr": 0.7058860956716073,
@@ -9607,7 +9609,7 @@
         },
         {
             "number": 5121,
-            "class": "bus",
+            "class": "Bus",
             "name": "BROWNWOOD 1",
             "init": {
                 "Vr": 0.695499695714653,
@@ -9621,7 +9623,7 @@
         },
         {
             "number": 5122,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 6 0",
             "init": {
                 "Vr": 0.332512251795547,
@@ -9635,7 +9637,7 @@
         },
         {
             "number": 5123,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARLIN 0",
             "init": {
                 "Vr": 0.6140829183557911,
@@ -9649,7 +9651,7 @@
         },
         {
             "number": 5124,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARLIN 1",
             "init": {
                 "Vr": 0.6257300643415592,
@@ -9663,7 +9665,7 @@
         },
         {
             "number": 5125,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 6 0",
             "init": {
                 "Vr": 0.3904836664659164,
@@ -9677,7 +9679,7 @@
         },
         {
             "number": 5126,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 8 0",
             "init": {
                 "Vr": 0.32196635016597625,
@@ -9691,7 +9693,7 @@
         },
         {
             "number": 5127,
-            "class": "bus",
+            "class": "Bus",
             "name": "JONESBORO 0",
             "init": {
                 "Vr": 0.5661792691268097,
@@ -9705,7 +9707,7 @@
         },
         {
             "number": 5128,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 33 0",
             "init": {
                 "Vr": 0.3354775469144293,
@@ -9719,7 +9721,7 @@
         },
         {
             "number": 5129,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLDTHWAITE 2 0",
             "init": {
                 "Vr": 0.6485503846813502,
@@ -9733,7 +9735,7 @@
         },
         {
             "number": 5130,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLANO 5 0",
             "init": {
                 "Vr": 0.3521052367464629,
@@ -9747,7 +9749,7 @@
         },
         {
             "number": 5131,
-            "class": "bus",
+            "class": "Bus",
             "name": "BELTON 0",
             "init": {
                 "Vr": 0.6519053096939935,
@@ -9761,7 +9763,7 @@
         },
         {
             "number": 5132,
-            "class": "bus",
+            "class": "Bus",
             "name": "BELTON 1",
             "init": {
                 "Vr": 0.6166106849118999,
@@ -9775,7 +9777,7 @@
         },
         {
             "number": 5133,
-            "class": "bus",
+            "class": "Bus",
             "name": "TOLAR 0",
             "init": {
                 "Vr": 0.5756648601230309,
@@ -9789,7 +9791,7 @@
         },
         {
             "number": 5134,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRECKENRIDGE 0",
             "init": {
                 "Vr": 0.6815091773146786,
@@ -9803,7 +9805,7 @@
         },
         {
             "number": 5135,
-            "class": "bus",
+            "class": "Bus",
             "name": "EASTLAND 0",
             "init": {
                 "Vr": 0.6183384986832491,
@@ -9817,7 +9819,7 @@
         },
         {
             "number": 5136,
-            "class": "bus",
+            "class": "Bus",
             "name": "COOPER 0",
             "init": {
                 "Vr": 0.4555929018148159,
@@ -9831,7 +9833,7 @@
         },
         {
             "number": 5137,
-            "class": "bus",
+            "class": "Bus",
             "name": "WACO 1 0",
             "init": {
                 "Vr": 0.5988993402258884,
@@ -9845,7 +9847,7 @@
         },
         {
             "number": 5138,
-            "class": "bus",
+            "class": "Bus",
             "name": "WACO 1 1",
             "init": {
                 "Vr": 0.578688490837265,
@@ -9859,7 +9861,7 @@
         },
         {
             "number": 5139,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 42 0",
             "init": {
                 "Vr": 0.3195661126086893,
@@ -9873,7 +9875,7 @@
         },
         {
             "number": 5140,
-            "class": "bus",
+            "class": "Bus",
             "name": "GATESVILLE 1 0",
             "init": {
                 "Vr": 0.5602462862368639,
@@ -9887,7 +9889,7 @@
         },
         {
             "number": 5141,
-            "class": "bus",
+            "class": "Bus",
             "name": "ANNA 0",
             "init": {
                 "Vr": 0.39450472339314235,
@@ -9901,7 +9903,7 @@
         },
         {
             "number": 5142,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOODY 0",
             "init": {
                 "Vr": 0.5618578776043814,
@@ -9915,7 +9917,7 @@
         },
         {
             "number": 5143,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 2 0",
             "init": {
                 "Vr": 0.3930119883981368,
@@ -9929,7 +9931,7 @@
         },
         {
             "number": 5144,
-            "class": "bus",
+            "class": "Bus",
             "name": "WACO 6 0",
             "init": {
                 "Vr": 0.5592909204035983,
@@ -9943,7 +9945,7 @@
         },
         {
             "number": 5145,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAND PRAIRIE 1 0",
             "init": {
                 "Vr": 0.3655832600549904,
@@ -9957,7 +9959,7 @@
         },
         {
             "number": 5146,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROWLETT 2 0",
             "init": {
                 "Vr": 0.3563765812843916,
@@ -9971,7 +9973,7 @@
         },
         {
             "number": 5147,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLANO 6 0",
             "init": {
                 "Vr": 0.33021361174947383,
@@ -9985,7 +9987,7 @@
         },
         {
             "number": 5148,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRVING 5 0",
             "init": {
                 "Vr": 0.33049864449078215,
@@ -9999,7 +10001,7 @@
         },
         {
             "number": 5149,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 7 0",
             "init": {
                 "Vr": 0.32364866797295894,
@@ -10013,7 +10015,7 @@
         },
         {
             "number": 5150,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYSON 2 0",
             "init": {
                 "Vr": 0.580615073252491,
@@ -10027,7 +10029,7 @@
         },
         {
             "number": 5151,
-            "class": "bus",
+            "class": "Bus",
             "name": "MORGAN 0",
             "init": {
                 "Vr": 0.5429179638288808,
@@ -10041,7 +10043,7 @@
         },
         {
             "number": 5152,
-            "class": "bus",
+            "class": "Bus",
             "name": "SACHSE 0",
             "init": {
                 "Vr": 0.3457264331033684,
@@ -10055,7 +10057,7 @@
         },
         {
             "number": 5153,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARADISE 0",
             "init": {
                 "Vr": 0.49515043615325616,
@@ -10069,7 +10071,7 @@
         },
         {
             "number": 5154,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIO VISTA 0",
             "init": {
                 "Vr": 0.5274156988210269,
@@ -10083,7 +10085,7 @@
         },
         {
             "number": 5155,
-            "class": "bus",
+            "class": "Bus",
             "name": "STRAWN 0",
             "init": {
                 "Vr": 0.6540561575103769,
@@ -10097,7 +10099,7 @@
         },
         {
             "number": 5156,
-            "class": "bus",
+            "class": "Bus",
             "name": "May-00",
             "init": {
                 "Vr": 0.659479215994452,
@@ -10111,7 +10113,7 @@
         },
         {
             "number": 5157,
-            "class": "bus",
+            "class": "Bus",
             "name": "DESOTO 0",
             "init": {
                 "Vr": 0.35077888189606116,
@@ -10125,7 +10127,7 @@
         },
         {
             "number": 5158,
-            "class": "bus",
+            "class": "Bus",
             "name": "MESQUITE 2 0",
             "init": {
                 "Vr": 0.3568545093076196,
@@ -10139,7 +10141,7 @@
         },
         {
             "number": 5159,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSEBUD 0",
             "init": {
                 "Vr": 0.6071576466461251,
@@ -10153,7 +10155,7 @@
         },
         {
             "number": 5160,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENTON 2 0",
             "init": {
                 "Vr": 0.4088904819400057,
@@ -10167,7 +10169,7 @@
         },
         {
             "number": 5161,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 4 0",
             "init": {
                 "Vr": 0.3326181305215117,
@@ -10181,7 +10183,7 @@
         },
         {
             "number": 5162,
-            "class": "bus",
+            "class": "Bus",
             "name": "AXTELL 0",
             "init": {
                 "Vr": 0.5254552436087124,
@@ -10195,7 +10197,7 @@
         },
         {
             "number": 5163,
-            "class": "bus",
+            "class": "Bus",
             "name": "NOLANVILLE 0",
             "init": {
                 "Vr": 0.5967942054440076,
@@ -10209,7 +10211,7 @@
         },
         {
             "number": 5164,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENTON 1 0",
             "init": {
                 "Vr": 0.47118245971860456,
@@ -10223,7 +10225,7 @@
         },
         {
             "number": 5165,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENTON 1 1",
             "init": {
                 "Vr": 0.42170181278643587,
@@ -10237,7 +10239,7 @@
         },
         {
             "number": 5166,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENTON 1 2",
             "init": {
                 "Vr": 0.5088364450063512,
@@ -10251,7 +10253,7 @@
         },
         {
             "number": 5167,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENTON 1 3",
             "init": {
                 "Vr": 0.47278912789071814,
@@ -10265,7 +10267,7 @@
         },
         {
             "number": 5168,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 39 0",
             "init": {
                 "Vr": 0.3161583425077989,
@@ -10279,7 +10281,7 @@
         },
         {
             "number": 5169,
-            "class": "bus",
+            "class": "Bus",
             "name": "DUBLIN 1 0",
             "init": {
                 "Vr": 0.6189593060373808,
@@ -10293,7 +10295,7 @@
         },
         {
             "number": 5170,
-            "class": "bus",
+            "class": "Bus",
             "name": "DUBLIN 1 1",
             "init": {
                 "Vr": 0.6387277001932458,
@@ -10307,7 +10309,7 @@
         },
         {
             "number": 5171,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERTENS 0",
             "init": {
                 "Vr": 0.46416696065656254,
@@ -10321,7 +10323,7 @@
         },
         {
             "number": 5172,
-            "class": "bus",
+            "class": "Bus",
             "name": "WEATHERFORD 1 0",
             "init": {
                 "Vr": 0.43174831802888297,
@@ -10335,7 +10337,7 @@
         },
         {
             "number": 5173,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLANO 3 0",
             "init": {
                 "Vr": 0.3474546654902336,
@@ -10349,7 +10351,7 @@
         },
         {
             "number": 5174,
-            "class": "bus",
+            "class": "Bus",
             "name": "MALONE 0",
             "init": {
                 "Vr": 0.4808084982949578,
@@ -10363,7 +10365,7 @@
         },
         {
             "number": 5175,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENTON 3 0",
             "init": {
                 "Vr": 0.40054004644074764,
@@ -10377,7 +10379,7 @@
         },
         {
             "number": 5176,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAFORD 0",
             "init": {
                 "Vr": 0.6078225820570344,
@@ -10391,7 +10393,7 @@
         },
         {
             "number": 5177,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 8 0",
             "init": {
                 "Vr": 0.3598332231943911,
@@ -10405,7 +10407,7 @@
         },
         {
             "number": 5178,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKWALL 1 0",
             "init": {
                 "Vr": 0.3421340883711681,
@@ -10419,7 +10421,7 @@
         },
         {
             "number": 5179,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORSICANA 2 0",
             "init": {
                 "Vr": 0.5472703959179275,
@@ -10433,7 +10435,7 @@
         },
         {
             "number": 5180,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORSICANA 2 1",
             "init": {
                 "Vr": 0.5223742936677434,
@@ -10447,7 +10449,7 @@
         },
         {
             "number": 5181,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARLAND 2 0",
             "init": {
                 "Vr": 0.3344535482715078,
@@ -10461,7 +10463,7 @@
         },
         {
             "number": 5182,
-            "class": "bus",
+            "class": "Bus",
             "name": "GATESVILLE 2 0",
             "init": {
                 "Vr": 0.5662122684810516,
@@ -10475,7 +10477,7 @@
         },
         {
             "number": 5183,
-            "class": "bus",
+            "class": "Bus",
             "name": "CARROLLTON 3 0",
             "init": {
                 "Vr": 0.31824789967638695,
@@ -10489,7 +10491,7 @@
         },
         {
             "number": 5184,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 26 0",
             "init": {
                 "Vr": 0.33663981687405087,
@@ -10503,7 +10505,7 @@
         },
         {
             "number": 5185,
-            "class": "bus",
+            "class": "Bus",
             "name": "RHOME 0",
             "init": {
                 "Vr": 0.4161462328771168,
@@ -10517,7 +10519,7 @@
         },
         {
             "number": 5186,
-            "class": "bus",
+            "class": "Bus",
             "name": "VENUS 0",
             "init": {
                 "Vr": 0.39559029670650814,
@@ -10531,7 +10533,7 @@
         },
         {
             "number": 5187,
-            "class": "bus",
+            "class": "Bus",
             "name": "OLNEY 2 0",
             "init": {
                 "Vr": 0.6414192614991606,
@@ -10545,7 +10547,7 @@
         },
         {
             "number": 5188,
-            "class": "bus",
+            "class": "Bus",
             "name": "CARROLLTON 1 0",
             "init": {
                 "Vr": 0.33695424940525426,
@@ -10559,7 +10561,7 @@
         },
         {
             "number": 5189,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 20 0",
             "init": {
                 "Vr": 0.3387853312388549,
@@ -10573,7 +10575,7 @@
         },
         {
             "number": 5190,
-            "class": "bus",
+            "class": "Bus",
             "name": "GORDON 0",
             "init": {
                 "Vr": 0.5352808560915985,
@@ -10587,7 +10589,7 @@
         },
         {
             "number": 5191,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERIDIAN 0",
             "init": {
                 "Vr": 0.5575029200287783,
@@ -10601,7 +10603,7 @@
         },
         {
             "number": 5192,
-            "class": "bus",
+            "class": "Bus",
             "name": "KILLEEN 4 0",
             "init": {
                 "Vr": 0.6384389131117492,
@@ -10615,7 +10617,7 @@
         },
         {
             "number": 5193,
-            "class": "bus",
+            "class": "Bus",
             "name": "KILLEEN 4 1",
             "init": {
                 "Vr": 0.6179192544872273,
@@ -10629,7 +10631,7 @@
         },
         {
             "number": 5194,
-            "class": "bus",
+            "class": "Bus",
             "name": "DUNCANVILLE 1 0",
             "init": {
                 "Vr": 0.3612090140297283,
@@ -10643,7 +10645,7 @@
         },
         {
             "number": 5195,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARGYLE 0",
             "init": {
                 "Vr": 0.3784590370486791,
@@ -10657,7 +10659,7 @@
         },
         {
             "number": 5196,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYSON 1 0",
             "init": {
                 "Vr": 0.6212442310653459,
@@ -10671,7 +10673,7 @@
         },
         {
             "number": 5197,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYSON 1 1",
             "init": {
                 "Vr": 0.5963894748194829,
@@ -10685,7 +10687,7 @@
         },
         {
             "number": 5198,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYSON 1 2",
             "init": {
                 "Vr": 0.6296372721173762,
@@ -10699,7 +10701,7 @@
         },
         {
             "number": 5199,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 12 0",
             "init": {
                 "Vr": 0.3709782748219074,
@@ -10713,7 +10715,7 @@
         },
         {
             "number": 5200,
-            "class": "bus",
+            "class": "Bus",
             "name": "MINERAL WELLS 0",
             "init": {
                 "Vr": 0.5542127002403543,
@@ -10727,7 +10729,7 @@
         },
         {
             "number": 5201,
-            "class": "bus",
+            "class": "Bus",
             "name": "COOLIDGE 0",
             "init": {
                 "Vr": 0.5739045327124901,
@@ -10741,7 +10743,7 @@
         },
         {
             "number": 5202,
-            "class": "bus",
+            "class": "Bus",
             "name": "RICE 0",
             "init": {
                 "Vr": 0.44871709642127305,
@@ -10755,7 +10757,7 @@
         },
         {
             "number": 5203,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 35 0",
             "init": {
                 "Vr": 0.3270037684413465,
@@ -10769,7 +10771,7 @@
         },
         {
             "number": 5204,
-            "class": "bus",
+            "class": "Bus",
             "name": "POOLVILLE 0",
             "init": {
                 "Vr": 0.577022501150357,
@@ -10783,7 +10785,7 @@
         },
         {
             "number": 5205,
-            "class": "bus",
+            "class": "Bus",
             "name": "POOLVILLE 1",
             "init": {
                 "Vr": 0.5514230895464494,
@@ -10797,7 +10799,7 @@
         },
         {
             "number": 5206,
-            "class": "bus",
+            "class": "Bus",
             "name": "POOLVILLE 2",
             "init": {
                 "Vr": 0.6133195902497963,
@@ -10811,7 +10813,7 @@
         },
         {
             "number": 5207,
-            "class": "bus",
+            "class": "Bus",
             "name": "POOLVILLE 3",
             "init": {
                 "Vr": 0.5958685790342177,
@@ -10825,7 +10827,7 @@
         },
         {
             "number": 5208,
-            "class": "bus",
+            "class": "Bus",
             "name": "POOLVILLE 4",
             "init": {
                 "Vr": 0.5998462421372993,
@@ -10839,7 +10841,7 @@
         },
         {
             "number": 5209,
-            "class": "bus",
+            "class": "Bus",
             "name": "WALNUT SPRINGS 0",
             "init": {
                 "Vr": 0.5552678465328648,
@@ -10853,7 +10855,7 @@
         },
         {
             "number": 5210,
-            "class": "bus",
+            "class": "Bus",
             "name": "BEDFORD 2 0",
             "init": {
                 "Vr": 0.36616604276328507,
@@ -10867,7 +10869,7 @@
         },
         {
             "number": 5211,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUBBARD 0",
             "init": {
                 "Vr": 0.5305548700605708,
@@ -10881,7 +10883,7 @@
         },
         {
             "number": 5212,
-            "class": "bus",
+            "class": "Bus",
             "name": "FERRIS 0",
             "init": {
                 "Vr": 0.3771081485650514,
@@ -10895,7 +10897,7 @@
         },
         {
             "number": 5213,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARLAND 4 0",
             "init": {
                 "Vr": 0.33542173253706525,
@@ -10909,7 +10911,7 @@
         },
         {
             "number": 5214,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 32 0",
             "init": {
                 "Vr": 0.34292719806869365,
@@ -10923,7 +10925,7 @@
         },
         {
             "number": 5215,
-            "class": "bus",
+            "class": "Bus",
             "name": "PILOT POINT 0",
             "init": {
                 "Vr": 0.37416429461870315,
@@ -10937,7 +10939,7 @@
         },
         {
             "number": 5216,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 6 0",
             "init": {
                 "Vr": 0.36337031002100584,
@@ -10951,7 +10953,7 @@
         },
         {
             "number": 5217,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORTH RICHLAND HILLS 2 0",
             "init": {
                 "Vr": 0.36407214720836667,
@@ -10965,7 +10967,7 @@
         },
         {
             "number": 5218,
-            "class": "bus",
+            "class": "Bus",
             "name": "JUSTIN 0",
             "init": {
                 "Vr": 0.39444833359478004,
@@ -10979,7 +10981,7 @@
         },
         {
             "number": 5219,
-            "class": "bus",
+            "class": "Bus",
             "name": "SCURRY 0",
             "init": {
                 "Vr": 0.3729818675093364,
@@ -10993,7 +10995,7 @@
         },
         {
             "number": 5220,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANGER 0",
             "init": {
                 "Vr": 0.3878528928882904,
@@ -11007,7 +11009,7 @@
         },
         {
             "number": 5221,
-            "class": "bus",
+            "class": "Bus",
             "name": "KILLEEN 1 0",
             "init": {
                 "Vr": 0.5683517028663164,
@@ -11021,7 +11023,7 @@
         },
         {
             "number": 5222,
-            "class": "bus",
+            "class": "Bus",
             "name": "MABANK 1 0",
             "init": {
                 "Vr": 0.39792641369107223,
@@ -11035,7 +11037,7 @@
         },
         {
             "number": 5223,
-            "class": "bus",
+            "class": "Bus",
             "name": "MEXIA 0",
             "init": {
                 "Vr": 0.5231584387394798,
@@ -11049,7 +11051,7 @@
         },
         {
             "number": 5224,
-            "class": "bus",
+            "class": "Bus",
             "name": "CARROLLTON 2 0",
             "init": {
                 "Vr": 0.3285795343863097,
@@ -11063,7 +11065,7 @@
         },
         {
             "number": 5225,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEVADA 0",
             "init": {
                 "Vr": 0.3778361040408432,
@@ -11077,7 +11079,7 @@
         },
         {
             "number": 5226,
-            "class": "bus",
+            "class": "Bus",
             "name": "ZEPHYR 0",
             "init": {
                 "Vr": 0.6450519375615716,
@@ -11091,7 +11093,7 @@
         },
         {
             "number": 5227,
-            "class": "bus",
+            "class": "Bus",
             "name": "TERRELL 2 0",
             "init": {
                 "Vr": 0.32727751165852104,
@@ -11105,7 +11107,7 @@
         },
         {
             "number": 5228,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 14 0",
             "init": {
                 "Vr": 0.374903844703728,
@@ -11119,7 +11121,7 @@
         },
         {
             "number": 5229,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 13 0",
             "init": {
                 "Vr": 0.3508703650418292,
@@ -11133,7 +11135,7 @@
         },
         {
             "number": 5230,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 28 0",
             "init": {
                 "Vr": 0.33458695004267924,
@@ -11147,7 +11149,7 @@
         },
         {
             "number": 5231,
-            "class": "bus",
+            "class": "Bus",
             "name": "HAMILTON 0",
             "init": {
                 "Vr": 0.5901735574791144,
@@ -11161,7 +11163,7 @@
         },
         {
             "number": 5232,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 7 0",
             "init": {
                 "Vr": 0.34584270755310675,
@@ -11175,7 +11177,7 @@
         },
         {
             "number": 5233,
-            "class": "bus",
+            "class": "Bus",
             "name": "EULESS 1 0",
             "init": {
                 "Vr": 0.35555633767131556,
@@ -11189,7 +11191,7 @@
         },
         {
             "number": 5234,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRISCO 1 0",
             "init": {
                 "Vr": 0.37280606868161786,
@@ -11203,7 +11205,7 @@
         },
         {
             "number": 5235,
-            "class": "bus",
+            "class": "Bus",
             "name": "SALADO 0",
             "init": {
                 "Vr": 0.5981150904439554,
@@ -11217,7 +11219,7 @@
         },
         {
             "number": 5236,
-            "class": "bus",
+            "class": "Bus",
             "name": "OLNEY 1 0",
             "init": {
                 "Vr": 0.7056090670146686,
@@ -11231,7 +11233,7 @@
         },
         {
             "number": 5237,
-            "class": "bus",
+            "class": "Bus",
             "name": "OLNEY 1 1",
             "init": {
                 "Vr": 0.7294426639288307,
@@ -11245,7 +11247,7 @@
         },
         {
             "number": 5238,
-            "class": "bus",
+            "class": "Bus",
             "name": "OLNEY 1 2",
             "init": {
                 "Vr": 0.7151055025300335,
@@ -11259,7 +11261,7 @@
         },
         {
             "number": 5239,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLDTHWAITE 1 0",
             "init": {
                 "Vr": 0.6838736888336172,
@@ -11273,7 +11275,7 @@
         },
         {
             "number": 5240,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLDTHWAITE 1 1",
             "init": {
                 "Vr": 0.6603390746455785,
@@ -11287,7 +11289,7 @@
         },
         {
             "number": 5241,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLDTHWAITE 1 2",
             "init": {
                 "Vr": 0.6404386449084157,
@@ -11301,7 +11303,7 @@
         },
         {
             "number": 5242,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLDTHWAITE 1 3",
             "init": {
                 "Vr": 0.6404386449084157,
@@ -11315,7 +11317,7 @@
         },
         {
             "number": 5243,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLDTHWAITE 1 4",
             "init": {
                 "Vr": 0.7012928852142486,
@@ -11329,7 +11331,7 @@
         },
         {
             "number": 5244,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 22 0",
             "init": {
                 "Vr": 0.3765758238083412,
@@ -11343,7 +11345,7 @@
         },
         {
             "number": 5245,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAPEVINE 0",
             "init": {
                 "Vr": 0.33449966884371035,
@@ -11357,7 +11359,7 @@
         },
         {
             "number": 5246,
-            "class": "bus",
+            "class": "Bus",
             "name": "GLEN ROSE 2 0",
             "init": {
                 "Vr": 0.5693917145300756,
@@ -11371,7 +11373,7 @@
         },
         {
             "number": 5247,
-            "class": "bus",
+            "class": "Bus",
             "name": "KOPPERL 0",
             "init": {
                 "Vr": 0.5414556270288243,
@@ -11385,7 +11387,7 @@
         },
         {
             "number": 5248,
-            "class": "bus",
+            "class": "Bus",
             "name": "BEDFORD 1 0",
             "init": {
                 "Vr": 0.36297863148368525,
@@ -11399,7 +11401,7 @@
         },
         {
             "number": 5249,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 29 0",
             "init": {
                 "Vr": 0.4272707457769754,
@@ -11413,7 +11415,7 @@
         },
         {
             "number": 5250,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 5 0",
             "init": {
                 "Vr": 0.373730236851451,
@@ -11427,7 +11429,7 @@
         },
         {
             "number": 5251,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAND PRAIRIE 2 0",
             "init": {
                 "Vr": 0.3507505967152193,
@@ -11441,7 +11443,7 @@
         },
         {
             "number": 5252,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 22 0",
             "init": {
                 "Vr": 0.3257598894093661,
@@ -11455,7 +11457,7 @@
         },
         {
             "number": 5253,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLOWER MOUND 1 0",
             "init": {
                 "Vr": 0.35856315775837927,
@@ -11469,7 +11471,7 @@
         },
         {
             "number": 5254,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROANOKE 0",
             "init": {
                 "Vr": 0.37195446637973084,
@@ -11483,7 +11485,7 @@
         },
         {
             "number": 5255,
-            "class": "bus",
+            "class": "Bus",
             "name": "MILLSAP 0",
             "init": {
                 "Vr": 0.5463057418240471,
@@ -11497,7 +11499,7 @@
         },
         {
             "number": 5256,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORRESTON 0",
             "init": {
                 "Vr": 0.4234031864076935,
@@ -11511,7 +11513,7 @@
         },
         {
             "number": 5257,
-            "class": "bus",
+            "class": "Bus",
             "name": "ITALY 0",
             "init": {
                 "Vr": 0.433493725761623,
@@ -11525,7 +11527,7 @@
         },
         {
             "number": 5258,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORNEY 0",
             "init": {
                 "Vr": 0.34395524367905045,
@@ -11539,7 +11541,7 @@
         },
         {
             "number": 5259,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAVON 0",
             "init": {
                 "Vr": 0.3663931268730639,
@@ -11553,7 +11555,7 @@
         },
         {
             "number": 5260,
-            "class": "bus",
+            "class": "Bus",
             "name": "GLEN ROSE 1 0",
             "init": {
                 "Vr": 0.5991951349370523,
@@ -11567,7 +11569,7 @@
         },
         {
             "number": 5261,
-            "class": "bus",
+            "class": "Bus",
             "name": "GLEN ROSE 1 1",
             "init": {
                 "Vr": 0.5820070155799698,
@@ -11581,7 +11583,7 @@
         },
         {
             "number": 5262,
-            "class": "bus",
+            "class": "Bus",
             "name": "GLEN ROSE 1 2",
             "init": {
                 "Vr": 0.6591502630755537,
@@ -11595,7 +11597,7 @@
         },
         {
             "number": 5263,
-            "class": "bus",
+            "class": "Bus",
             "name": "GLEN ROSE 1 3",
             "init": {
                 "Vr": 0.6360118572044624,
@@ -11609,7 +11611,7 @@
         },
         {
             "number": 5264,
-            "class": "bus",
+            "class": "Bus",
             "name": "DE LEON 0",
             "init": {
                 "Vr": 0.6000532382123898,
@@ -11623,7 +11625,7 @@
         },
         {
             "number": 5265,
-            "class": "bus",
+            "class": "Bus",
             "name": "KELLER 1 0",
             "init": {
                 "Vr": 0.39071225076253185,
@@ -11637,7 +11639,7 @@
         },
         {
             "number": 5266,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR HILL 0",
             "init": {
                 "Vr": 0.36423856860980286,
@@ -11651,7 +11653,7 @@
         },
         {
             "number": 5267,
-            "class": "bus",
+            "class": "Bus",
             "name": "MC GREGOR 0",
             "init": {
                 "Vr": 0.5448986236220011,
@@ -11665,7 +11667,7 @@
         },
         {
             "number": 5268,
-            "class": "bus",
+            "class": "Bus",
             "name": "COMMERCE 0",
             "init": {
                 "Vr": 0.4351570405629441,
@@ -11679,7 +11681,7 @@
         },
         {
             "number": 5269,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDLOTHIAN 2 0",
             "init": {
                 "Vr": 0.43224702126548475,
@@ -11693,7 +11695,7 @@
         },
         {
             "number": 5270,
-            "class": "bus",
+            "class": "Bus",
             "name": "WEST 0",
             "init": {
                 "Vr": 0.5263339948661595,
@@ -11707,7 +11709,7 @@
         },
         {
             "number": 5271,
-            "class": "bus",
+            "class": "Bus",
             "name": "BARTLETT 0",
             "init": {
                 "Vr": 0.6022917783687938,
@@ -11721,7 +11723,7 @@
         },
         {
             "number": 5272,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 16 0",
             "init": {
                 "Vr": 0.33502730806330844,
@@ -11735,7 +11737,7 @@
         },
         {
             "number": 5273,
-            "class": "bus",
+            "class": "Bus",
             "name": "COPPELL 0",
             "init": {
                 "Vr": 0.33930440211328516,
@@ -11749,7 +11751,7 @@
         },
         {
             "number": 5274,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILMER 0",
             "init": {
                 "Vr": 0.35840453861174904,
@@ -11763,7 +11765,7 @@
         },
         {
             "number": 5275,
-            "class": "bus",
+            "class": "Bus",
             "name": "DAWSON 0",
             "init": {
                 "Vr": 0.5123092818329199,
@@ -11777,7 +11779,7 @@
         },
         {
             "number": 5276,
-            "class": "bus",
+            "class": "Bus",
             "name": "MART 0",
             "init": {
                 "Vr": 0.5931999933485954,
@@ -11791,7 +11793,7 @@
         },
         {
             "number": 5277,
-            "class": "bus",
+            "class": "Bus",
             "name": "LITTLE ELM 0",
             "init": {
                 "Vr": 0.3534171809920468,
@@ -11805,7 +11807,7 @@
         },
         {
             "number": 5278,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEMPLE 2 0",
             "init": {
                 "Vr": 0.6196768542651161,
@@ -11819,7 +11821,7 @@
         },
         {
             "number": 5279,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEMPLE 1 0",
             "init": {
                 "Vr": 0.652137715188588,
@@ -11833,7 +11835,7 @@
         },
         {
             "number": 5280,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEMPLE 1 1",
             "init": {
                 "Vr": 0.6313273230010814,
@@ -11847,7 +11849,7 @@
         },
         {
             "number": 5281,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEMPLE 1 2",
             "init": {
                 "Vr": 0.6869216207080711,
@@ -11861,7 +11863,7 @@
         },
         {
             "number": 5282,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEMPLE 1 3",
             "init": {
                 "Vr": 0.6818440726050967,
@@ -11875,7 +11877,7 @@
         },
         {
             "number": 5283,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEMPLE 1 4",
             "init": {
                 "Vr": 0.652137715188588,
@@ -11889,7 +11891,7 @@
         },
         {
             "number": 5284,
-            "class": "bus",
+            "class": "Bus",
             "name": "QUINLAN 0",
             "init": {
                 "Vr": 0.3797481014995582,
@@ -11903,7 +11905,7 @@
         },
         {
             "number": 5285,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHICO 0",
             "init": {
                 "Vr": 0.49792578478828936,
@@ -11917,7 +11919,7 @@
         },
         {
             "number": 5286,
-            "class": "bus",
+            "class": "Bus",
             "name": "DUBLIN 2 0",
             "init": {
                 "Vr": 0.5990529258327476,
@@ -11931,7 +11933,7 @@
         },
         {
             "number": 5287,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 2 0",
             "init": {
                 "Vr": 0.34665966735917475,
@@ -11945,7 +11947,7 @@
         },
         {
             "number": 5288,
-            "class": "bus",
+            "class": "Bus",
             "name": "WOLFE CITY 0",
             "init": {
                 "Vr": 0.4355338012882829,
@@ -11959,7 +11961,7 @@
         },
         {
             "number": 5289,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 26 0",
             "init": {
                 "Vr": 0.33208517896690465,
@@ -11973,7 +11975,7 @@
         },
         {
             "number": 5290,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHITNEY 0",
             "init": {
                 "Vr": 0.5044768465645214,
@@ -11987,7 +11989,7 @@
         },
         {
             "number": 5291,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 25 0",
             "init": {
                 "Vr": 0.3757592966419106,
@@ -12001,7 +12003,7 @@
         },
         {
             "number": 5292,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 27 0",
             "init": {
                 "Vr": 0.40606121814192264,
@@ -12015,7 +12017,7 @@
         },
         {
             "number": 5293,
-            "class": "bus",
+            "class": "Bus",
             "name": "JOSHUA 0",
             "init": {
                 "Vr": 0.4672399905188346,
@@ -12029,7 +12031,7 @@
         },
         {
             "number": 5294,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 12 0",
             "init": {
                 "Vr": 0.3207641614405313,
@@ -12043,7 +12045,7 @@
         },
         {
             "number": 5295,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 1 0",
             "init": {
                 "Vr": 0.4622226090684713,
@@ -12057,7 +12059,7 @@
         },
         {
             "number": 5296,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 1 1",
             "init": {
                 "Vr": 0.41731078281748435,
@@ -12071,7 +12073,7 @@
         },
         {
             "number": 5297,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 1 2",
             "init": {
                 "Vr": 0.4622226090684713,
@@ -12085,7 +12087,7 @@
         },
         {
             "number": 5298,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 1 3",
             "init": {
                 "Vr": 0.4758875103475888,
@@ -12099,7 +12101,7 @@
         },
         {
             "number": 5299,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 1 4",
             "init": {
                 "Vr": 0.4901693870417693,
@@ -12113,7 +12115,7 @@
         },
         {
             "number": 5300,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 1 5",
             "init": {
                 "Vr": 0.4854619597671541,
@@ -12127,7 +12129,7 @@
         },
         {
             "number": 5301,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 1 6",
             "init": {
                 "Vr": 0.4900911872292438,
@@ -12141,7 +12143,7 @@
         },
         {
             "number": 5302,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 1 7",
             "init": {
                 "Vr": 0.5441794019482884,
@@ -12155,7 +12157,7 @@
         },
         {
             "number": 5303,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 1 8",
             "init": {
                 "Vr": 0.5267224689535562,
@@ -12169,7 +12171,7 @@
         },
         {
             "number": 5304,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALLEN 1 0",
             "init": {
                 "Vr": 0.4560441754718099,
@@ -12183,7 +12185,7 @@
         },
         {
             "number": 5305,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALLEN 1 1",
             "init": {
                 "Vr": 0.3885496266261702,
@@ -12197,7 +12199,7 @@
         },
         {
             "number": 5306,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALEDO 2 0",
             "init": {
                 "Vr": 0.43595037505752404,
@@ -12211,7 +12213,7 @@
         },
         {
             "number": 5307,
-            "class": "bus",
+            "class": "Bus",
             "name": "THE COLONY 0",
             "init": {
                 "Vr": 0.3490474956011465,
@@ -12225,7 +12227,7 @@
         },
         {
             "number": 5308,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUNNYVALE 0",
             "init": {
                 "Vr": 0.36595031389885313,
@@ -12239,7 +12241,7 @@
         },
         {
             "number": 5309,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 10 0",
             "init": {
                 "Vr": 0.32661718746134544,
@@ -12253,7 +12255,7 @@
         },
         {
             "number": 5310,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 4 0",
             "init": {
                 "Vr": 0.35694468842491445,
@@ -12267,7 +12269,7 @@
         },
         {
             "number": 5311,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 30 0",
             "init": {
                 "Vr": 0.3203448296659742,
@@ -12281,7 +12283,7 @@
         },
         {
             "number": 5312,
-            "class": "bus",
+            "class": "Bus",
             "name": "AZLE 0",
             "init": {
                 "Vr": 0.39636421213978185,
@@ -12295,7 +12297,7 @@
         },
         {
             "number": 5313,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUTCHINS 0",
             "init": {
                 "Vr": 0.39568608410986605,
@@ -12309,7 +12311,7 @@
         },
         {
             "number": 5314,
-            "class": "bus",
+            "class": "Bus",
             "name": "VALLEY MILLS 0",
             "init": {
                 "Vr": 0.5616981091104843,
@@ -12323,7 +12325,7 @@
         },
         {
             "number": 5315,
-            "class": "bus",
+            "class": "Bus",
             "name": "DENTON 6 0",
             "init": {
                 "Vr": 0.36991432425055587,
@@ -12337,7 +12339,7 @@
         },
         {
             "number": 5316,
-            "class": "bus",
+            "class": "Bus",
             "name": "MESQUITE 3 0",
             "init": {
                 "Vr": 0.3443278808428762,
@@ -12351,7 +12353,7 @@
         },
         {
             "number": 5317,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 1 0",
             "init": {
                 "Vr": 0.5819696335927508,
@@ -12365,7 +12367,7 @@
         },
         {
             "number": 5318,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 1 1",
             "init": {
                 "Vr": 0.5338434537629516,
@@ -12379,7 +12381,7 @@
         },
         {
             "number": 5319,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 1 2",
             "init": {
                 "Vr": 0.5947158006816784,
@@ -12393,7 +12395,7 @@
         },
         {
             "number": 5320,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 1 3",
             "init": {
                 "Vr": 0.5819696335927508,
@@ -12407,7 +12409,7 @@
         },
         {
             "number": 5321,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 1 4",
             "init": {
                 "Vr": 0.594190084904836,
@@ -12421,7 +12423,7 @@
         },
         {
             "number": 5322,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 2 0",
             "init": {
                 "Vr": 0.4529550429260813,
@@ -12435,7 +12437,7 @@
         },
         {
             "number": 5323,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 2 1",
             "init": {
                 "Vr": 0.3800811158402799,
@@ -12449,7 +12451,7 @@
         },
         {
             "number": 5324,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 2 2",
             "init": {
                 "Vr": 0.5162292194159278,
@@ -12463,7 +12465,7 @@
         },
         {
             "number": 5325,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 2 3",
             "init": {
                 "Vr": 0.5162615457082338,
@@ -12477,7 +12479,7 @@
         },
         {
             "number": 5326,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 2 4",
             "init": {
                 "Vr": 0.4750912787051446,
@@ -12491,7 +12493,7 @@
         },
         {
             "number": 5327,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT CALM 0",
             "init": {
                 "Vr": 0.5498917076219048,
@@ -12505,7 +12507,7 @@
         },
         {
             "number": 5328,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIESEL 2 0",
             "init": {
                 "Vr": 0.5375567951217537,
@@ -12519,7 +12521,7 @@
         },
         {
             "number": 5329,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 17 0",
             "init": {
                 "Vr": 0.3406803488503164,
@@ -12533,7 +12535,7 @@
         },
         {
             "number": 5330,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 4 0",
             "init": {
                 "Vr": 0.3761616235311975,
@@ -12547,7 +12549,7 @@
         },
         {
             "number": 5331,
-            "class": "bus",
+            "class": "Bus",
             "name": "CELINA 0",
             "init": {
                 "Vr": 0.36819976121333364,
@@ -12561,7 +12563,7 @@
         },
         {
             "number": 5332,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 16 0",
             "init": {
                 "Vr": 0.3625521332250858,
@@ -12575,7 +12577,7 @@
         },
         {
             "number": 5333,
-            "class": "bus",
+            "class": "Bus",
             "name": "RED OAK 0",
             "init": {
                 "Vr": 0.3609062342016126,
@@ -12589,7 +12591,7 @@
         },
         {
             "number": 5334,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLYDE 0",
             "init": {
                 "Vr": 0.7601167543834862,
@@ -12603,7 +12605,7 @@
         },
         {
             "number": 5335,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRVING 2 0",
             "init": {
                 "Vr": 0.3254442819143658,
@@ -12617,7 +12619,7 @@
         },
         {
             "number": 5336,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROWLETT 1 0",
             "init": {
                 "Vr": 0.36961583615622157,
@@ -12631,7 +12633,7 @@
         },
         {
             "number": 5337,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSBORO 2 0",
             "init": {
                 "Vr": 0.5786357657842441,
@@ -12645,7 +12647,7 @@
         },
         {
             "number": 5338,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 3 0",
             "init": {
                 "Vr": 0.4209811995462858,
@@ -12659,7 +12661,7 @@
         },
         {
             "number": 5339,
-            "class": "bus",
+            "class": "Bus",
             "name": "SOUTHLAKE 0",
             "init": {
                 "Vr": 0.3461711625029254,
@@ -12673,7 +12675,7 @@
         },
         {
             "number": 5340,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 29 0",
             "init": {
                 "Vr": 0.3319612264362901,
@@ -12687,7 +12689,7 @@
         },
         {
             "number": 5341,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEWISVILLE 1 0",
             "init": {
                 "Vr": 0.36200216685297143,
@@ -12701,7 +12703,7 @@
         },
         {
             "number": 5342,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEWISVILLE 1 1",
             "init": {
                 "Vr": 0.3840727762553543,
@@ -12715,7 +12717,7 @@
         },
         {
             "number": 5343,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEWISVILLE 1 2",
             "init": {
                 "Vr": 0.4612265858430245,
@@ -12729,7 +12731,7 @@
         },
         {
             "number": 5344,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 36 0",
             "init": {
                 "Vr": 0.31791940428749704,
@@ -12743,7 +12745,7 @@
         },
         {
             "number": 5345,
-            "class": "bus",
+            "class": "Bus",
             "name": "HILLSBORO 0",
             "init": {
                 "Vr": 0.4659354166961669,
@@ -12757,7 +12759,7 @@
         },
         {
             "number": 5346,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 15 0",
             "init": {
                 "Vr": 0.37768605876320177,
@@ -12771,7 +12773,7 @@
         },
         {
             "number": 5347,
-            "class": "bus",
+            "class": "Bus",
             "name": "CISCO 0",
             "init": {
                 "Vr": 0.7234345242481646,
@@ -12785,7 +12787,7 @@
         },
         {
             "number": 5348,
-            "class": "bus",
+            "class": "Bus",
             "name": "ITASCA 0",
             "init": {
                 "Vr": 0.4323532072532573,
@@ -12799,7 +12801,7 @@
         },
         {
             "number": 5349,
-            "class": "bus",
+            "class": "Bus",
             "name": "LANCASTER 2 0",
             "init": {
                 "Vr": 0.3610729178467882,
@@ -12813,7 +12815,7 @@
         },
         {
             "number": 5350,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARLAND 1 0",
             "init": {
                 "Vr": 0.4409365425849663,
@@ -12827,7 +12829,7 @@
         },
         {
             "number": 5351,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARLAND 1 1",
             "init": {
                 "Vr": 0.38687407022278225,
@@ -12841,7 +12843,7 @@
         },
         {
             "number": 5352,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 9 0",
             "init": {
                 "Vr": 0.3492224627123975,
@@ -12855,7 +12857,7 @@
         },
         {
             "number": 5353,
-            "class": "bus",
+            "class": "Bus",
             "name": "DUNCANVILLE 2 0",
             "init": {
                 "Vr": 0.37048179774391127,
@@ -12869,7 +12871,7 @@
         },
         {
             "number": 5354,
-            "class": "bus",
+            "class": "Bus",
             "name": "MESQUITE 1 0",
             "init": {
                 "Vr": 0.3313171050592144,
@@ -12883,7 +12885,7 @@
         },
         {
             "number": 5355,
-            "class": "bus",
+            "class": "Bus",
             "name": "MAYPEARL 0",
             "init": {
                 "Vr": 0.4223943472284584,
@@ -12897,7 +12899,7 @@
         },
         {
             "number": 5356,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARLAND 3 0",
             "init": {
                 "Vr": 0.33886386755765574,
@@ -12911,7 +12913,7 @@
         },
         {
             "number": 5357,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALLEN 2 0",
             "init": {
                 "Vr": 0.36244929890781374,
@@ -12925,7 +12927,7 @@
         },
         {
             "number": 5358,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIESEL 1 0",
             "init": {
                 "Vr": 0.6585384309271167,
@@ -12939,7 +12941,7 @@
         },
         {
             "number": 5359,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIESEL 1 1",
             "init": {
                 "Vr": 0.6240338732984809,
@@ -12953,7 +12955,7 @@
         },
         {
             "number": 5360,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIESEL 1 2",
             "init": {
                 "Vr": 0.7332183907685864,
@@ -12967,7 +12969,7 @@
         },
         {
             "number": 5361,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGEPORT 0",
             "init": {
                 "Vr": 0.5642109003329477,
@@ -12981,7 +12983,7 @@
         },
         {
             "number": 5362,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGEPORT 1",
             "init": {
                 "Vr": 0.549046435644006,
@@ -12995,7 +12997,7 @@
         },
         {
             "number": 5363,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGEPORT 2",
             "init": {
                 "Vr": 0.5668474936885787,
@@ -13009,7 +13011,7 @@
         },
         {
             "number": 5364,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGEPORT 3",
             "init": {
                 "Vr": 0.5795411965770034,
@@ -13023,7 +13025,7 @@
         },
         {
             "number": 5365,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGEPORT 4",
             "init": {
                 "Vr": 0.596806236022514,
@@ -13037,7 +13039,7 @@
         },
         {
             "number": 5366,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGEPORT 5",
             "init": {
                 "Vr": 0.6014213408985012,
@@ -13051,7 +13053,7 @@
         },
         {
             "number": 5367,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGEPORT 6",
             "init": {
                 "Vr": 0.6002947109627367,
@@ -13065,7 +13067,7 @@
         },
         {
             "number": 5368,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGEPORT 7",
             "init": {
                 "Vr": 0.5878513768193756,
@@ -13079,7 +13081,7 @@
         },
         {
             "number": 5369,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGEPORT 8",
             "init": {
                 "Vr": 0.6034218996331185,
@@ -13093,7 +13095,7 @@
         },
         {
             "number": 5370,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEWISVILLE 2 0",
             "init": {
                 "Vr": 0.3719746394878371,
@@ -13107,7 +13109,7 @@
         },
         {
             "number": 5371,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEAGOVILLE 0",
             "init": {
                 "Vr": 0.3883385891557249,
@@ -13121,7 +13123,7 @@
         },
         {
             "number": 5372,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 31 0",
             "init": {
                 "Vr": 0.3224162459114176,
@@ -13135,7 +13137,7 @@
         },
         {
             "number": 5373,
-            "class": "bus",
+            "class": "Bus",
             "name": "HALTOM CITY 0",
             "init": {
                 "Vr": 0.3255938982235295,
@@ -13149,7 +13151,7 @@
         },
         {
             "number": 5374,
-            "class": "bus",
+            "class": "Bus",
             "name": "BALCH SPRINGS 0",
             "init": {
                 "Vr": 0.3806117798289187,
@@ -13163,7 +13165,7 @@
         },
         {
             "number": 5375,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 13 0",
             "init": {
                 "Vr": 0.37597963035482496,
@@ -13177,7 +13179,7 @@
         },
         {
             "number": 5376,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 43 0",
             "init": {
                 "Vr": 0.3702766166321716,
@@ -13191,7 +13193,7 @@
         },
         {
             "number": 5377,
-            "class": "bus",
+            "class": "Bus",
             "name": "KILLEEN 2 0",
             "init": {
                 "Vr": 0.5643609863120547,
@@ -13205,7 +13207,7 @@
         },
         {
             "number": 5378,
-            "class": "bus",
+            "class": "Bus",
             "name": "WACO 5 0",
             "init": {
                 "Vr": 0.5560381970608058,
@@ -13219,7 +13221,7 @@
         },
         {
             "number": 5379,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 9 0",
             "init": {
                 "Vr": 0.3484150768760631,
@@ -13233,7 +13235,7 @@
         },
         {
             "number": 5380,
-            "class": "bus",
+            "class": "Bus",
             "name": "ENNIS 0",
             "init": {
                 "Vr": 0.5032366721706291,
@@ -13247,7 +13249,7 @@
         },
         {
             "number": 5381,
-            "class": "bus",
+            "class": "Bus",
             "name": "ENNIS 1",
             "init": {
                 "Vr": 0.4750046557921781,
@@ -13261,7 +13263,7 @@
         },
         {
             "number": 5382,
-            "class": "bus",
+            "class": "Bus",
             "name": "ENNIS 2",
             "init": {
                 "Vr": 0.5182082432184429,
@@ -13275,7 +13277,7 @@
         },
         {
             "number": 5383,
-            "class": "bus",
+            "class": "Bus",
             "name": "ENNIS 3",
             "init": {
                 "Vr": 0.5202766788074853,
@@ -13289,7 +13291,7 @@
         },
         {
             "number": 5384,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 3 0",
             "init": {
                 "Vr": 0.4421229535795754,
@@ -13303,7 +13305,7 @@
         },
         {
             "number": 5385,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 3 1",
             "init": {
                 "Vr": 0.3999843452528148,
@@ -13317,7 +13319,7 @@
         },
         {
             "number": 5386,
-            "class": "bus",
+            "class": "Bus",
             "name": "RICHARDSON 1 0",
             "init": {
                 "Vr": 0.3451251308189326,
@@ -13331,7 +13333,7 @@
         },
         {
             "number": 5387,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 21 0",
             "init": {
                 "Vr": 0.3504862145240593,
@@ -13345,7 +13347,7 @@
         },
         {
             "number": 5388,
-            "class": "bus",
+            "class": "Bus",
             "name": "WACO 2 0",
             "init": {
                 "Vr": 0.5956178365343239,
@@ -13359,7 +13361,7 @@
         },
         {
             "number": 5389,
-            "class": "bus",
+            "class": "Bus",
             "name": "WACO 2 1",
             "init": {
                 "Vr": 0.574306896411321,
@@ -13373,7 +13375,7 @@
         },
         {
             "number": 5390,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROGERS 0",
             "init": {
                 "Vr": 0.6055591522642008,
@@ -13387,7 +13389,7 @@
         },
         {
             "number": 5391,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROGERS 1",
             "init": {
                 "Vr": 0.5855470505540326,
@@ -13401,7 +13403,7 @@
         },
         {
             "number": 5392,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROGERS 2",
             "init": {
                 "Vr": 0.5624182614390881,
@@ -13415,7 +13417,7 @@
         },
         {
             "number": 5393,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHINA SPRING 0",
             "init": {
                 "Vr": 0.5406906250101664,
@@ -13429,7 +13431,7 @@
         },
         {
             "number": 5394,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALBANY 1 0",
             "init": {
                 "Vr": 0.7839204443020193,
@@ -13443,7 +13445,7 @@
         },
         {
             "number": 5395,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALBANY 1 1",
             "init": {
                 "Vr": 0.8066754633525279,
@@ -13457,7 +13459,7 @@
         },
         {
             "number": 5396,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALBANY 1 2",
             "init": {
                 "Vr": 0.7712655955286135,
@@ -13471,7 +13473,7 @@
         },
         {
             "number": 5397,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALBANY 1 3",
             "init": {
                 "Vr": 0.7866739805463926,
@@ -13485,7 +13487,7 @@
         },
         {
             "number": 5398,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALBANY 1 4",
             "init": {
                 "Vr": 0.7866739805463926,
@@ -13499,7 +13501,7 @@
         },
         {
             "number": 5399,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALBANY 1 5",
             "init": {
                 "Vr": 0.7950109769417474,
@@ -13513,7 +13515,7 @@
         },
         {
             "number": 5400,
-            "class": "bus",
+            "class": "Bus",
             "name": "MCKINNEY 2 0",
             "init": {
                 "Vr": 0.38833325819370945,
@@ -13527,7 +13529,7 @@
         },
         {
             "number": 5401,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 2 0",
             "init": {
                 "Vr": 0.5714178939227164,
@@ -13541,7 +13543,7 @@
         },
         {
             "number": 5402,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 2 1",
             "init": {
                 "Vr": 0.51504695927269,
@@ -13555,7 +13557,7 @@
         },
         {
             "number": 5403,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 2 2",
             "init": {
                 "Vr": 0.600063109182978,
@@ -13569,7 +13571,7 @@
         },
         {
             "number": 5404,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 2 3",
             "init": {
                 "Vr": 0.5889794132759387,
@@ -13583,7 +13585,7 @@
         },
         {
             "number": 5405,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 2 4",
             "init": {
                 "Vr": 0.5903751299364842,
@@ -13597,7 +13599,7 @@
         },
         {
             "number": 5406,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANBURY 2 5",
             "init": {
                 "Vr": 0.5992004523083443,
@@ -13611,7 +13613,7 @@
         },
         {
             "number": 5407,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLIFTON 2 0",
             "init": {
                 "Vr": 0.5458953674274699,
@@ -13625,7 +13627,7 @@
         },
         {
             "number": 5408,
-            "class": "bus",
+            "class": "Bus",
             "name": "FARMERSVILLE 0",
             "init": {
                 "Vr": 0.39335462049826936,
@@ -13639,7 +13641,7 @@
         },
         {
             "number": 5409,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 10 0",
             "init": {
                 "Vr": 0.3581094842699412,
@@ -13653,7 +13655,7 @@
         },
         {
             "number": 5410,
-            "class": "bus",
+            "class": "Bus",
             "name": "KILLEEN 3 0",
             "init": {
                 "Vr": 0.6435426556654071,
@@ -13667,7 +13669,7 @@
         },
         {
             "number": 5411,
-            "class": "bus",
+            "class": "Bus",
             "name": "KILLEEN 3 1",
             "init": {
                 "Vr": 0.6034691139112213,
@@ -13681,7 +13683,7 @@
         },
         {
             "number": 5412,
-            "class": "bus",
+            "class": "Bus",
             "name": "WYLIE 0",
             "init": {
                 "Vr": 0.3567230971920274,
@@ -13695,7 +13697,7 @@
         },
         {
             "number": 5413,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALO PINTO 1 0",
             "init": {
                 "Vr": 0.6294935675766336,
@@ -13709,7 +13711,7 @@
         },
         {
             "number": 5414,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALO PINTO 1 1",
             "init": {
                 "Vr": 0.6201663955604245,
@@ -13723,7 +13725,7 @@
         },
         {
             "number": 5415,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALO PINTO 1 2",
             "init": {
                 "Vr": 0.6562928280886317,
@@ -13737,7 +13739,7 @@
         },
         {
             "number": 5416,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALO PINTO 1 3",
             "init": {
                 "Vr": 0.6565027463490574,
@@ -13751,7 +13753,7 @@
         },
         {
             "number": 5417,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALO PINTO 1 4",
             "init": {
                 "Vr": 0.6533510241026517,
@@ -13765,7 +13767,7 @@
         },
         {
             "number": 5418,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALO PINTO 1 5",
             "init": {
                 "Vr": 0.6523054387951429,
@@ -13779,7 +13781,7 @@
         },
         {
             "number": 5419,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALO PINTO 1 6",
             "init": {
                 "Vr": 0.6429870827665233,
@@ -13793,7 +13795,7 @@
         },
         {
             "number": 5420,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 10 0",
             "init": {
                 "Vr": 0.3942576662037365,
@@ -13807,7 +13809,7 @@
         },
         {
             "number": 5421,
-            "class": "bus",
+            "class": "Bus",
             "name": "JOSEPHINE 0",
             "init": {
                 "Vr": 0.39047173382480543,
@@ -13821,7 +13823,7 @@
         },
         {
             "number": 5422,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEWSIVILLE 0",
             "init": {
                 "Vr": 0.3506809361390555,
@@ -13835,7 +13837,7 @@
         },
         {
             "number": 5423,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEWSIVILLE 1",
             "init": {
                 "Vr": 0.3614518258128486,
@@ -13849,7 +13851,7 @@
         },
         {
             "number": 5424,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEWSIVILLE 2",
             "init": {
                 "Vr": 0.3506809361390555,
@@ -13863,7 +13865,7 @@
         },
         {
             "number": 5425,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 40 0",
             "init": {
                 "Vr": 0.3482792601011158,
@@ -13877,7 +13879,7 @@
         },
         {
             "number": 5426,
-            "class": "bus",
+            "class": "Bus",
             "name": "KEMP 0",
             "init": {
                 "Vr": 0.41923777613399676,
@@ -13891,7 +13893,7 @@
         },
         {
             "number": 5427,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAXAHACHIE 2 0",
             "init": {
                 "Vr": 0.3982641289135889,
@@ -13905,7 +13907,7 @@
         },
         {
             "number": 5428,
-            "class": "bus",
+            "class": "Bus",
             "name": "HURST 0",
             "init": {
                 "Vr": 0.377295692893975,
@@ -13919,7 +13921,7 @@
         },
         {
             "number": 5429,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 18 0",
             "init": {
                 "Vr": 0.3549845526776861,
@@ -13933,7 +13935,7 @@
         },
         {
             "number": 5430,
-            "class": "bus",
+            "class": "Bus",
             "name": "WEATHERFORD 2 0",
             "init": {
                 "Vr": 0.43250692310007516,
@@ -13947,7 +13949,7 @@
         },
         {
             "number": 5431,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKWALL 2 0",
             "init": {
                 "Vr": 0.35186105767757375,
@@ -13961,7 +13963,7 @@
         },
         {
             "number": 5432,
-            "class": "bus",
+            "class": "Bus",
             "name": "WEATHERFORD 3 0",
             "init": {
                 "Vr": 0.45072964194910325,
@@ -13975,7 +13977,7 @@
         },
         {
             "number": 5433,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 3 0",
             "init": {
                 "Vr": 0.34392633902466185,
@@ -13989,7 +13991,7 @@
         },
         {
             "number": 5434,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEWARK 0",
             "init": {
                 "Vr": 0.3984638672610144,
@@ -14003,7 +14005,7 @@
         },
         {
             "number": 5435,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTO 0",
             "init": {
                 "Vr": 0.5925641061961147,
@@ -14017,7 +14019,7 @@
         },
         {
             "number": 5436,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 18 0",
             "init": {
                 "Vr": 0.3294814865578594,
@@ -14031,7 +14033,7 @@
         },
         {
             "number": 5437,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELM MOTT 0",
             "init": {
                 "Vr": 0.5245076031250161,
@@ -14045,7 +14047,7 @@
         },
         {
             "number": 5438,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 17 0",
             "init": {
                 "Vr": 0.36702978603118364,
@@ -14059,7 +14061,7 @@
         },
         {
             "number": 5439,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAXAHACHIE 1 0",
             "init": {
                 "Vr": 0.45196630571219243,
@@ -14073,7 +14075,7 @@
         },
         {
             "number": 5440,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 3 0",
             "init": {
                 "Vr": 0.3440309029573947,
@@ -14087,7 +14089,7 @@
         },
         {
             "number": 5441,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 20 0",
             "init": {
                 "Vr": 0.3968518805821053,
@@ -14101,7 +14103,7 @@
         },
         {
             "number": 5442,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 7 0",
             "init": {
                 "Vr": 0.3597768569616728,
@@ -14115,7 +14117,7 @@
         },
         {
             "number": 5443,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 11 0",
             "init": {
                 "Vr": 0.371520206774676,
@@ -14129,7 +14131,7 @@
         },
         {
             "number": 5444,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDLOTHIAN 1 0",
             "init": {
                 "Vr": 0.5110291449686444,
@@ -14143,7 +14145,7 @@
         },
         {
             "number": 5445,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDLOTHIAN 1 1",
             "init": {
                 "Vr": 0.44684922241788594,
@@ -14157,7 +14159,7 @@
         },
         {
             "number": 5446,
-            "class": "bus",
+            "class": "Bus",
             "name": "HEWITT 0",
             "init": {
                 "Vr": 0.535988450628013,
@@ -14171,7 +14173,7 @@
         },
         {
             "number": 5447,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARLINGTON 11 0",
             "init": {
                 "Vr": 0.3708179620576649,
@@ -14185,7 +14187,7 @@
         },
         {
             "number": 5448,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAND PRAIRIE 3 0",
             "init": {
                 "Vr": 0.44941804730324775,
@@ -14199,7 +14201,7 @@
         },
         {
             "number": 5449,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAND PRAIRIE 3 1",
             "init": {
                 "Vr": 0.3955660543439448,
@@ -14213,7 +14215,7 @@
         },
         {
             "number": 5450,
-            "class": "bus",
+            "class": "Bus",
             "name": "MELISSA 0",
             "init": {
                 "Vr": 0.3759609368376991,
@@ -14227,7 +14229,7 @@
         },
         {
             "number": 5451,
-            "class": "bus",
+            "class": "Bus",
             "name": "COPPERAS COVE 0",
             "init": {
                 "Vr": 0.6443961740293653,
@@ -14241,7 +14243,7 @@
         },
         {
             "number": 5452,
-            "class": "bus",
+            "class": "Bus",
             "name": "COPPERAS COVE 1",
             "init": {
                 "Vr": 0.6231665180705982,
@@ -14255,7 +14257,7 @@
         },
         {
             "number": 5453,
-            "class": "bus",
+            "class": "Bus",
             "name": "CLEBURNE 1 0",
             "init": {
                 "Vr": 0.41684507296082424,
@@ -14269,7 +14271,7 @@
         },
         {
             "number": 5454,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREENVILLE 2 0",
             "init": {
                 "Vr": 0.4129549532374426,
@@ -14283,7 +14285,7 @@
         },
         {
             "number": 5455,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALVORD 0",
             "init": {
                 "Vr": 0.4781540114340181,
@@ -14297,7 +14299,7 @@
         },
         {
             "number": 5456,
-            "class": "bus",
+            "class": "Bus",
             "name": "GORMAN 0",
             "init": {
                 "Vr": 0.6810834706519515,
@@ -14311,7 +14313,7 @@
         },
         {
             "number": 5457,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLLEYVILLE 0",
             "init": {
                 "Vr": 0.35225399612657277,
@@ -14325,7 +14327,7 @@
         },
         {
             "number": 5458,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOLLAND 0",
             "init": {
                 "Vr": 0.5996629394503573,
@@ -14339,7 +14341,7 @@
         },
         {
             "number": 5459,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOLLAND 1",
             "init": {
                 "Vr": 0.5790920694740554,
@@ -14353,7 +14355,7 @@
         },
         {
             "number": 5460,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOLLAND 2",
             "init": {
                 "Vr": 0.528936968610299,
@@ -14367,7 +14369,7 @@
         },
         {
             "number": 5461,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEMPLE 3 0",
             "init": {
                 "Vr": 0.6015991558979444,
@@ -14381,7 +14383,7 @@
         },
         {
             "number": 5462,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 34 0",
             "init": {
                 "Vr": 0.35077601470745023,
@@ -14395,7 +14397,7 @@
         },
         {
             "number": 5463,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRVING 4 0",
             "init": {
                 "Vr": 0.33159713820755343,
@@ -14409,7 +14411,7 @@
         },
         {
             "number": 5464,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRISCO 2 0",
             "init": {
                 "Vr": 0.44566412218233936,
@@ -14423,7 +14425,7 @@
         },
         {
             "number": 5465,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRISCO 2 1",
             "init": {
                 "Vr": 0.3860129717380377,
@@ -14437,7 +14439,7 @@
         },
         {
             "number": 5466,
-            "class": "bus",
+            "class": "Bus",
             "name": "GATESVILLE 3 0",
             "init": {
                 "Vr": 0.5579859552786302,
@@ -14451,7 +14453,7 @@
         },
         {
             "number": 5467,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 25 0",
             "init": {
                 "Vr": 0.33143874247223515,
@@ -14465,7 +14467,7 @@
         },
         {
             "number": 5468,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 37 0",
             "init": {
                 "Vr": 0.3481537137341037,
@@ -14479,7 +14481,7 @@
         },
         {
             "number": 5469,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 19 0",
             "init": {
                 "Vr": 0.3632334436335756,
@@ -14493,7 +14495,7 @@
         },
         {
             "number": 5470,
-            "class": "bus",
+            "class": "Bus",
             "name": "WOODWAY 0",
             "init": {
                 "Vr": 0.5435430920995881,
@@ -14507,7 +14509,7 @@
         },
         {
             "number": 5471,
-            "class": "bus",
+            "class": "Bus",
             "name": "MINGUS 0",
             "init": {
                 "Vr": 0.6094039760724168,
@@ -14521,7 +14523,7 @@
         },
         {
             "number": 5472,
-            "class": "bus",
+            "class": "Bus",
             "name": "THROCKMORTON 0",
             "init": {
                 "Vr": 0.6970942700385511,
@@ -14535,7 +14537,7 @@
         },
         {
             "number": 5473,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEMO 0",
             "init": {
                 "Vr": 0.5032090391994785,
@@ -14549,7 +14551,7 @@
         },
         {
             "number": 5474,
-            "class": "bus",
+            "class": "Bus",
             "name": "ABBOTT 0",
             "init": {
                 "Vr": 0.5035337773533803,
@@ -14563,7 +14565,7 @@
         },
         {
             "number": 5475,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALVARADO 0",
             "init": {
                 "Vr": 0.37359327792501157,
@@ -14577,7 +14579,7 @@
         },
         {
             "number": 5476,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORSICANA 1 0",
             "init": {
                 "Vr": 0.4606896446805515,
@@ -14591,7 +14593,7 @@
         },
         {
             "number": 5477,
-            "class": "bus",
+            "class": "Bus",
             "name": "HARKER HEIGHTS 0",
             "init": {
                 "Vr": 0.5760116504526047,
@@ -14605,7 +14607,7 @@
         },
         {
             "number": 5478,
-            "class": "bus",
+            "class": "Bus",
             "name": "IRVING 3 0",
             "init": {
                 "Vr": 0.34233826799482847,
@@ -14619,7 +14621,7 @@
         },
         {
             "number": 5479,
-            "class": "bus",
+            "class": "Bus",
             "name": "BURLESON 0",
             "init": {
                 "Vr": 0.4765778021779308,
@@ -14633,7 +14635,7 @@
         },
         {
             "number": 5480,
-            "class": "bus",
+            "class": "Bus",
             "name": "BURLESON 1",
             "init": {
                 "Vr": 0.41708614159224294,
@@ -14647,7 +14649,7 @@
         },
         {
             "number": 5481,
-            "class": "bus",
+            "class": "Bus",
             "name": "FORT WORTH 28 0",
             "init": {
                 "Vr": 0.3932184846853994,
@@ -14661,7 +14663,7 @@
         },
         {
             "number": 5482,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLAS 23 0",
             "init": {
                 "Vr": 0.32185543413324763,
@@ -14675,7 +14677,7 @@
         },
         {
             "number": 5483,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORTH RICHLAND HILLS 1 0",
             "init": {
                 "Vr": 0.37798407443766613,
@@ -14689,7 +14691,7 @@
         },
         {
             "number": 5484,
-            "class": "bus",
+            "class": "Bus",
             "name": "CROSS PLAINS 0",
             "init": {
                 "Vr": 0.7305958671739708,
@@ -14703,7 +14705,7 @@
         },
         {
             "number": 5485,
-            "class": "bus",
+            "class": "Bus",
             "name": "BLOOMING GROVE 0",
             "init": {
                 "Vr": 0.5066352661349691,
@@ -14717,7 +14719,7 @@
         },
         {
             "number": 6001,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONVERSE 0",
             "init": {
                 "Vr": 0.5626523341044591,
@@ -14731,7 +14733,7 @@
         },
         {
             "number": 6002,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 46 0",
             "init": {
                 "Vr": 0.5524802234004446,
@@ -14745,7 +14747,7 @@
         },
         {
             "number": 6003,
-            "class": "bus",
+            "class": "Bus",
             "name": "BASTROP 0",
             "init": {
                 "Vr": 0.7126946928584476,
@@ -14759,7 +14761,7 @@
         },
         {
             "number": 6004,
-            "class": "bus",
+            "class": "Bus",
             "name": "BASTROP 1",
             "init": {
                 "Vr": 0.7487617785316744,
@@ -14773,7 +14775,7 @@
         },
         {
             "number": 6005,
-            "class": "bus",
+            "class": "Bus",
             "name": "BASTROP 2",
             "init": {
                 "Vr": 0.7111402573897795,
@@ -14787,7 +14789,7 @@
         },
         {
             "number": 6006,
-            "class": "bus",
+            "class": "Bus",
             "name": "BASTROP 3",
             "init": {
                 "Vr": 0.7365649132937511,
@@ -14801,7 +14803,7 @@
         },
         {
             "number": 6007,
-            "class": "bus",
+            "class": "Bus",
             "name": "BASTROP 4",
             "init": {
                 "Vr": 0.7126946928584476,
@@ -14815,7 +14817,7 @@
         },
         {
             "number": 6008,
-            "class": "bus",
+            "class": "Bus",
             "name": "BASTROP 5",
             "init": {
                 "Vr": 0.7381162731985279,
@@ -14829,7 +14831,7 @@
         },
         {
             "number": 6009,
-            "class": "bus",
+            "class": "Bus",
             "name": "BASTROP 6",
             "init": {
                 "Vr": 0.7511385510454045,
@@ -14843,7 +14845,7 @@
         },
         {
             "number": 6010,
-            "class": "bus",
+            "class": "Bus",
             "name": "BASTROP 7",
             "init": {
                 "Vr": 0.7412854652283107,
@@ -14857,7 +14859,7 @@
         },
         {
             "number": 6011,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 2 0",
             "init": {
                 "Vr": 0.6186724694395878,
@@ -14871,7 +14873,7 @@
         },
         {
             "number": 6012,
-            "class": "bus",
+            "class": "Bus",
             "name": "PAIGE 0",
             "init": {
                 "Vr": 0.6653124749566796,
@@ -14885,7 +14887,7 @@
         },
         {
             "number": 6013,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 42 0",
             "init": {
                 "Vr": 0.5290850040910943,
@@ -14899,7 +14901,7 @@
         },
         {
             "number": 6014,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAELDER 0",
             "init": {
                 "Vr": 0.6312487479595763,
@@ -14913,7 +14915,7 @@
         },
         {
             "number": 6015,
-            "class": "bus",
+            "class": "Bus",
             "name": "ATASCOSA 0",
             "init": {
                 "Vr": 0.5616233925368106,
@@ -14927,7 +14929,7 @@
         },
         {
             "number": 6016,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 40 0",
             "init": {
                 "Vr": 0.5516237765025738,
@@ -14941,7 +14943,7 @@
         },
         {
             "number": 6017,
-            "class": "bus",
+            "class": "Bus",
             "name": "CIBOLO 0",
             "init": {
                 "Vr": 0.5746055186220365,
@@ -14955,7 +14957,7 @@
         },
         {
             "number": 6018,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 6 0",
             "init": {
                 "Vr": 0.5467873006690928,
@@ -14969,7 +14971,7 @@
         },
         {
             "number": 6019,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 25 0",
             "init": {
                 "Vr": 0.5367051877499235,
@@ -14983,7 +14985,7 @@
         },
         {
             "number": 6020,
-            "class": "bus",
+            "class": "Bus",
             "name": "HORSESHOE BAY 0",
             "init": {
                 "Vr": 0.6333435933837118,
@@ -14997,7 +14999,7 @@
         },
         {
             "number": 6021,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEANDER 1 0",
             "init": {
                 "Vr": 0.6741836891392204,
@@ -15011,7 +15013,7 @@
         },
         {
             "number": 6022,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEANDER 1 1",
             "init": {
                 "Vr": 0.6300679968081355,
@@ -15025,7 +15027,7 @@
         },
         {
             "number": 6023,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEANDER 1 2",
             "init": {
                 "Vr": 0.567260573992657,
@@ -15039,7 +15041,7 @@
         },
         {
             "number": 6024,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 10 0",
             "init": {
                 "Vr": 0.5267282472013961,
@@ -15053,7 +15055,7 @@
         },
         {
             "number": 6025,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 31 0",
             "init": {
                 "Vr": 0.5577371719563403,
@@ -15067,7 +15069,7 @@
         },
         {
             "number": 6026,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 49 0",
             "init": {
                 "Vr": 0.5599077918192119,
@@ -15081,7 +15083,7 @@
         },
         {
             "number": 6027,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELGIN 0",
             "init": {
                 "Vr": 0.6202793659545227,
@@ -15095,7 +15097,7 @@
         },
         {
             "number": 6028,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 31 0",
             "init": {
                 "Vr": 0.5399052377568093,
@@ -15109,7 +15111,7 @@
         },
         {
             "number": 6029,
-            "class": "bus",
+            "class": "Bus",
             "name": "RUNGE 0",
             "init": {
                 "Vr": 0.7012650907205038,
@@ -15123,7 +15125,7 @@
         },
         {
             "number": 6030,
-            "class": "bus",
+            "class": "Bus",
             "name": "YOAKUM 0",
             "init": {
                 "Vr": 0.8234450518916651,
@@ -15137,7 +15139,7 @@
         },
         {
             "number": 6031,
-            "class": "bus",
+            "class": "Bus",
             "name": "YOAKUM 1",
             "init": {
                 "Vr": 0.7918250046705663,
@@ -15151,7 +15153,7 @@
         },
         {
             "number": 6032,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 37 0",
             "init": {
                 "Vr": 0.5050125205473452,
@@ -15165,7 +15167,7 @@
         },
         {
             "number": 6033,
-            "class": "bus",
+            "class": "Bus",
             "name": "PFLUGERVILLE 0",
             "init": {
                 "Vr": 0.6437774080023911,
@@ -15179,7 +15181,7 @@
         },
         {
             "number": 6034,
-            "class": "bus",
+            "class": "Bus",
             "name": "PFLUGERVILLE 1",
             "init": {
                 "Vr": 0.6073292385126982,
@@ -15193,7 +15195,7 @@
         },
         {
             "number": 6035,
-            "class": "bus",
+            "class": "Bus",
             "name": "PFLUGERVILLE 2",
             "init": {
                 "Vr": 0.5580322744829176,
@@ -15207,7 +15209,7 @@
         },
         {
             "number": 6036,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 12 0",
             "init": {
                 "Vr": 0.6268730833087107,
@@ -15221,7 +15223,7 @@
         },
         {
             "number": 6037,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 12 1",
             "init": {
                 "Vr": 0.5864859216147916,
@@ -15235,7 +15237,7 @@
         },
         {
             "number": 6038,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 3 0",
             "init": {
                 "Vr": 0.6690167160009508,
@@ -15249,7 +15251,7 @@
         },
         {
             "number": 6039,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 3 1",
             "init": {
                 "Vr": 0.6043235226754762,
@@ -15263,7 +15265,7 @@
         },
         {
             "number": 6040,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 3 2",
             "init": {
                 "Vr": 0.5409736145345253,
@@ -15277,7 +15279,7 @@
         },
         {
             "number": 6041,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 3 3",
             "init": {
                 "Vr": 0.6715617883010625,
@@ -15291,7 +15293,7 @@
         },
         {
             "number": 6042,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 3 4",
             "init": {
                 "Vr": 0.678115478400683,
@@ -15305,7 +15307,7 @@
         },
         {
             "number": 6043,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 48 0",
             "init": {
                 "Vr": 0.5657304921751598,
@@ -15319,7 +15321,7 @@
         },
         {
             "number": 6044,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 19 0",
             "init": {
                 "Vr": 0.5463494319724717,
@@ -15333,7 +15335,7 @@
         },
         {
             "number": 6045,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 0",
             "init": {
                 "Vr": 0.6740689182771579,
@@ -15347,7 +15349,7 @@
         },
         {
             "number": 6046,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 1",
             "init": {
                 "Vr": 0.6275546183380697,
@@ -15361,7 +15363,7 @@
         },
         {
             "number": 6047,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 2",
             "init": {
                 "Vr": 0.5596658927651827,
@@ -15375,7 +15377,7 @@
         },
         {
             "number": 6048,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 3",
             "init": {
                 "Vr": 0.6740689182771579,
@@ -15389,7 +15391,7 @@
         },
         {
             "number": 6049,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 4",
             "init": {
                 "Vr": 0.6740689182771579,
@@ -15403,7 +15405,7 @@
         },
         {
             "number": 6050,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 5",
             "init": {
                 "Vr": 0.6740689182771579,
@@ -15417,7 +15419,7 @@
         },
         {
             "number": 6051,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 6",
             "init": {
                 "Vr": 0.6893964365950261,
@@ -15431,7 +15433,7 @@
         },
         {
             "number": 6052,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 7",
             "init": {
                 "Vr": 0.6740689182771579,
@@ -15445,7 +15447,7 @@
         },
         {
             "number": 6053,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 8",
             "init": {
                 "Vr": 0.6916557791069026,
@@ -15459,7 +15461,7 @@
         },
         {
             "number": 6054,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 2 9",
             "init": {
                 "Vr": 0.7061785269302624,
@@ -15473,7 +15475,7 @@
         },
         {
             "number": 6055,
-            "class": "bus",
+            "class": "Bus",
             "name": "BERGHEIM 0",
             "init": {
                 "Vr": 0.5314141484374006,
@@ -15487,7 +15489,7 @@
         },
         {
             "number": 6056,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 2 0",
             "init": {
                 "Vr": 0.7048303366206898,
@@ -15501,7 +15503,7 @@
         },
         {
             "number": 6057,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 2 1",
             "init": {
                 "Vr": 0.6634777078507467,
@@ -15515,7 +15517,7 @@
         },
         {
             "number": 6058,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 2 2",
             "init": {
                 "Vr": 0.6269025885704308,
@@ -15529,7 +15531,7 @@
         },
         {
             "number": 6059,
-            "class": "bus",
+            "class": "Bus",
             "name": "D HANIS 0",
             "init": {
                 "Vr": 0.5821774436939718,
@@ -15543,7 +15545,7 @@
         },
         {
             "number": 6060,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 24 0",
             "init": {
                 "Vr": 0.5360191812526601,
@@ -15557,7 +15559,7 @@
         },
         {
             "number": 6061,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 7 0",
             "init": {
                 "Vr": 0.5278420360348783,
@@ -15571,7 +15573,7 @@
         },
         {
             "number": 6062,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRENHAM 0",
             "init": {
                 "Vr": 0.8487386261809926,
@@ -15585,7 +15587,7 @@
         },
         {
             "number": 6063,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRENHAM 1",
             "init": {
                 "Vr": 0.8152306496869232,
@@ -15599,7 +15601,7 @@
         },
         {
             "number": 6064,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRENHAM 2",
             "init": {
                 "Vr": 0.7747569352865192,
@@ -15613,7 +15615,7 @@
         },
         {
             "number": 6065,
-            "class": "bus",
+            "class": "Bus",
             "name": "BERTRAM 0",
             "init": {
                 "Vr": 0.5464252861941404,
@@ -15627,7 +15629,7 @@
         },
         {
             "number": 6066,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 1 0",
             "init": {
                 "Vr": 0.6979671889093103,
@@ -15641,7 +15643,7 @@
         },
         {
             "number": 6067,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 1 1",
             "init": {
                 "Vr": 0.662863855328617,
@@ -15655,7 +15657,7 @@
         },
         {
             "number": 6068,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 1 2",
             "init": {
                 "Vr": 0.6053588411618033,
@@ -15669,7 +15671,7 @@
         },
         {
             "number": 6069,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 1 3",
             "init": {
                 "Vr": 0.71117911745885,
@@ -15683,7 +15685,7 @@
         },
         {
             "number": 6070,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 1 4",
             "init": {
                 "Vr": 0.727654374673758,
@@ -15697,7 +15699,7 @@
         },
         {
             "number": 6071,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 1 5",
             "init": {
                 "Vr": 0.7077767598700562,
@@ -15711,7 +15713,7 @@
         },
         {
             "number": 6072,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 1 6",
             "init": {
                 "Vr": 0.6979671889093103,
@@ -15725,7 +15727,7 @@
         },
         {
             "number": 6073,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 1 7",
             "init": {
                 "Vr": 0.7155257079902048,
@@ -15739,7 +15741,7 @@
         },
         {
             "number": 6074,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARION 1 8",
             "init": {
                 "Vr": 0.7153820168623626,
@@ -15753,7 +15755,7 @@
         },
         {
             "number": 6075,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA GRANGE 0",
             "init": {
                 "Vr": 0.8643793744290006,
@@ -15767,7 +15769,7 @@
         },
         {
             "number": 6076,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA GRANGE 1",
             "init": {
                 "Vr": 0.8437705573203503,
@@ -15781,7 +15783,7 @@
         },
         {
             "number": 6077,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA GRANGE 2",
             "init": {
                 "Vr": 0.8220376092354171,
@@ -15795,7 +15797,7 @@
         },
         {
             "number": 6078,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA GRANGE 3",
             "init": {
                 "Vr": 0.884781476850928,
@@ -15809,7 +15811,7 @@
         },
         {
             "number": 6079,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA GRANGE 4",
             "init": {
                 "Vr": 0.8705746036941726,
@@ -15823,7 +15825,7 @@
         },
         {
             "number": 6080,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA GRANGE 5",
             "init": {
                 "Vr": 0.8725708174407678,
@@ -15837,7 +15839,7 @@
         },
         {
             "number": 6081,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 1 0",
             "init": {
                 "Vr": 0.6483039822066573,
@@ -15851,7 +15853,7 @@
         },
         {
             "number": 6082,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 1 1",
             "init": {
                 "Vr": 0.6941750545303209,
@@ -15865,7 +15867,7 @@
         },
         {
             "number": 6083,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 1 2",
             "init": {
                 "Vr": 0.7755538970154191,
@@ -15879,7 +15881,7 @@
         },
         {
             "number": 6084,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 1 0",
             "init": {
                 "Vr": 0.5731440826945933,
@@ -15893,7 +15895,7 @@
         },
         {
             "number": 6085,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 1 1",
             "init": {
                 "Vr": 0.5770825589966044,
@@ -15907,7 +15909,7 @@
         },
         {
             "number": 6086,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 1 2",
             "init": {
                 "Vr": 0.6117546387047114,
@@ -15921,7 +15923,7 @@
         },
         {
             "number": 6087,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 1 3",
             "init": {
                 "Vr": 0.5731440826945933,
@@ -15935,7 +15937,7 @@
         },
         {
             "number": 6088,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 1 4",
             "init": {
                 "Vr": 0.5793827449935409,
@@ -15949,7 +15951,7 @@
         },
         {
             "number": 6089,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 1 5",
             "init": {
                 "Vr": 0.5949287593932495,
@@ -15963,7 +15965,7 @@
         },
         {
             "number": 6090,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 1 6",
             "init": {
                 "Vr": 0.5977063238273417,
@@ -15977,7 +15979,7 @@
         },
         {
             "number": 6091,
-            "class": "bus",
+            "class": "Bus",
             "name": "WIMBERLEY 0",
             "init": {
                 "Vr": 0.5277136910523343,
@@ -15991,7 +15993,7 @@
         },
         {
             "number": 6092,
-            "class": "bus",
+            "class": "Bus",
             "name": "GONZALES 0",
             "init": {
                 "Vr": 0.6889234612090659,
@@ -16005,7 +16007,7 @@
         },
         {
             "number": 6093,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 11 0",
             "init": {
                 "Vr": 0.5589200713887994,
@@ -16019,7 +16021,7 @@
         },
         {
             "number": 6094,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 14 0",
             "init": {
                 "Vr": 0.5699029014046924,
@@ -16033,7 +16035,7 @@
         },
         {
             "number": 6095,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUTTO 0",
             "init": {
                 "Vr": 0.5393847574886899,
@@ -16047,7 +16049,7 @@
         },
         {
             "number": 6096,
-            "class": "bus",
+            "class": "Bus",
             "name": "LULING 0",
             "init": {
                 "Vr": 0.6150904449851043,
@@ -16061,7 +16063,7 @@
         },
         {
             "number": 6097,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 21 0",
             "init": {
                 "Vr": 0.5499337921016815,
@@ -16075,7 +16077,7 @@
         },
         {
             "number": 6098,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 12 0",
             "init": {
                 "Vr": 0.5174068651908666,
@@ -16089,7 +16091,7 @@
         },
         {
             "number": 6099,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 15 0",
             "init": {
                 "Vr": 0.5474819765905606,
@@ -16103,7 +16105,7 @@
         },
         {
             "number": 6100,
-            "class": "bus",
+            "class": "Bus",
             "name": "ADKINS 0",
             "init": {
                 "Vr": 0.5469879651187438,
@@ -16117,7 +16119,7 @@
         },
         {
             "number": 6101,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINCHESTER 0",
             "init": {
                 "Vr": 0.8570740962282734,
@@ -16131,7 +16133,7 @@
         },
         {
             "number": 6102,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINCHESTER 1",
             "init": {
                 "Vr": 0.8239994720188677,
@@ -16145,7 +16147,7 @@
         },
         {
             "number": 6103,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINCHESTER 2",
             "init": {
                 "Vr": 0.7657751913540218,
@@ -16159,7 +16161,7 @@
         },
         {
             "number": 6104,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINCHESTER 3",
             "init": {
                 "Vr": 0.8708803725109638,
@@ -16173,7 +16175,7 @@
         },
         {
             "number": 6105,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINCHESTER 4",
             "init": {
                 "Vr": 0.8790431149321886,
@@ -16187,7 +16189,7 @@
         },
         {
             "number": 6106,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINCHESTER 5",
             "init": {
                 "Vr": 0.8681202721222522,
@@ -16201,7 +16203,7 @@
         },
         {
             "number": 6107,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKDALE 1 0",
             "init": {
                 "Vr": 0.6919954507957702,
@@ -16215,7 +16217,7 @@
         },
         {
             "number": 6108,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKDALE 1 1",
             "init": {
                 "Vr": 0.6786259001716118,
@@ -16229,7 +16231,7 @@
         },
         {
             "number": 6109,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKDALE 1 2",
             "init": {
                 "Vr": 0.6371584740939078,
@@ -16243,7 +16245,7 @@
         },
         {
             "number": 6110,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKDALE 1 3",
             "init": {
                 "Vr": 0.7210572893060202,
@@ -16257,7 +16259,7 @@
         },
         {
             "number": 6111,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKDALE 1 4",
             "init": {
                 "Vr": 0.720287152983295,
@@ -16271,7 +16273,7 @@
         },
         {
             "number": 6112,
-            "class": "bus",
+            "class": "Bus",
             "name": "NATALIA 0",
             "init": {
                 "Vr": 0.5749117201584538,
@@ -16285,7 +16287,7 @@
         },
         {
             "number": 6113,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 20 0",
             "init": {
                 "Vr": 0.5293563987226987,
@@ -16299,7 +16301,7 @@
         },
         {
             "number": 6114,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 43 0",
             "init": {
                 "Vr": 0.5200760236522192,
@@ -16313,7 +16315,7 @@
         },
         {
             "number": 6115,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 5 0",
             "init": {
                 "Vr": 0.5427004673847221,
@@ -16327,7 +16329,7 @@
         },
         {
             "number": 6116,
-            "class": "bus",
+            "class": "Bus",
             "name": "TAYLOR 0",
             "init": {
                 "Vr": 0.5266539219504169,
@@ -16341,7 +16343,7 @@
         },
         {
             "number": 6117,
-            "class": "bus",
+            "class": "Bus",
             "name": "SMITHVILLE 0",
             "init": {
                 "Vr": 0.732692746333333,
@@ -16355,7 +16357,7 @@
         },
         {
             "number": 6118,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR PARK 0",
             "init": {
                 "Vr": 0.6678563399749137,
@@ -16369,7 +16371,7 @@
         },
         {
             "number": 6119,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR PARK 1",
             "init": {
                 "Vr": 0.6088218606630664,
@@ -16383,7 +16385,7 @@
         },
         {
             "number": 6120,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR PARK 2",
             "init": {
                 "Vr": 0.5563206592363196,
@@ -16397,7 +16399,7 @@
         },
         {
             "number": 6121,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 25 0",
             "init": {
                 "Vr": 0.5537426952009179,
@@ -16411,7 +16413,7 @@
         },
         {
             "number": 6122,
-            "class": "bus",
+            "class": "Bus",
             "name": "HALLETTSVILLE 0",
             "init": {
                 "Vr": 0.7818302475869052,
@@ -16425,7 +16427,7 @@
         },
         {
             "number": 6123,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 5 0",
             "init": {
                 "Vr": 0.5293334258876958,
@@ -16439,7 +16441,7 @@
         },
         {
             "number": 6124,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 3 0",
             "init": {
                 "Vr": 0.5926142234914814,
@@ -16453,7 +16455,7 @@
         },
         {
             "number": 6125,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUTHERLAND SPRINGS 0",
             "init": {
                 "Vr": 0.5855672863412974,
@@ -16467,7 +16469,7 @@
         },
         {
             "number": 6126,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 34 0",
             "init": {
                 "Vr": 0.5409314372338295,
@@ -16481,7 +16483,7 @@
         },
         {
             "number": 6127,
-            "class": "bus",
+            "class": "Bus",
             "name": "CAMERON 0",
             "init": {
                 "Vr": 0.6070493711714398,
@@ -16495,7 +16497,7 @@
         },
         {
             "number": 6128,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 35 0",
             "init": {
                 "Vr": 0.5221217282615327,
@@ -16509,7 +16511,7 @@
         },
         {
             "number": 6129,
-            "class": "bus",
+            "class": "Bus",
             "name": "MEDINA 0",
             "init": {
                 "Vr": 0.5426231130980488,
@@ -16523,7 +16525,7 @@
         },
         {
             "number": 6130,
-            "class": "bus",
+            "class": "Bus",
             "name": "MANCHACA 0",
             "init": {
                 "Vr": 0.5464993679263481,
@@ -16537,7 +16539,7 @@
         },
         {
             "number": 6131,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING BRANCH 0",
             "init": {
                 "Vr": 0.5369288720020812,
@@ -16551,7 +16553,7 @@
         },
         {
             "number": 6132,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 19 0",
             "init": {
                 "Vr": 0.5130049280231845,
@@ -16565,7 +16567,7 @@
         },
         {
             "number": 6133,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLATONIA 0",
             "init": {
                 "Vr": 0.656666471553499,
@@ -16579,7 +16581,7 @@
         },
         {
             "number": 6134,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRANGER 0",
             "init": {
                 "Vr": 0.5505376203733485,
@@ -16593,7 +16595,7 @@
         },
         {
             "number": 6135,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAYETTEVILLE 0",
             "init": {
                 "Vr": 0.7963505259074288,
@@ -16607,7 +16609,7 @@
         },
         {
             "number": 6136,
-            "class": "bus",
+            "class": "Bus",
             "name": "GEORGETOWN 2 0",
             "init": {
                 "Vr": 0.5441134289629115,
@@ -16621,7 +16623,7 @@
         },
         {
             "number": 6137,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 35 0",
             "init": {
                 "Vr": 0.4988954525535484,
@@ -16635,7 +16637,7 @@
         },
         {
             "number": 6138,
-            "class": "bus",
+            "class": "Bus",
             "name": "PIPE CREEK 0",
             "init": {
                 "Vr": 0.5194370103269934,
@@ -16649,7 +16651,7 @@
         },
         {
             "number": 6139,
-            "class": "bus",
+            "class": "Bus",
             "name": "RED ROCK 0",
             "init": {
                 "Vr": 0.6139644487220692,
@@ -16663,7 +16665,7 @@
         },
         {
             "number": 6140,
-            "class": "bus",
+            "class": "Bus",
             "name": "JARRELL 0",
             "init": {
                 "Vr": 0.5622827523578173,
@@ -16677,7 +16679,7 @@
         },
         {
             "number": 6141,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 1 0",
             "init": {
                 "Vr": 0.7100851792951394,
@@ -16691,7 +16693,7 @@
         },
         {
             "number": 6142,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 1 1",
             "init": {
                 "Vr": 0.6585531882615777,
@@ -16705,7 +16707,7 @@
         },
         {
             "number": 6143,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 1 2",
             "init": {
                 "Vr": 0.608591760485934,
@@ -16719,7 +16721,7 @@
         },
         {
             "number": 6144,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 1 3",
             "init": {
                 "Vr": 0.7100851792951394,
@@ -16733,7 +16735,7 @@
         },
         {
             "number": 6145,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 1 4",
             "init": {
                 "Vr": 0.7522580664714559,
@@ -16747,7 +16749,7 @@
         },
         {
             "number": 6146,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 1 5",
             "init": {
                 "Vr": 0.7508398581166738,
@@ -16761,7 +16763,7 @@
         },
         {
             "number": 6147,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 1 6",
             "init": {
                 "Vr": 0.7418966153818746,
@@ -16775,7 +16777,7 @@
         },
         {
             "number": 6148,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 1 7",
             "init": {
                 "Vr": 0.7100851792951394,
@@ -16789,7 +16791,7 @@
         },
         {
             "number": 6149,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 1 8",
             "init": {
                 "Vr": 0.720016939584221,
@@ -16803,7 +16805,7 @@
         },
         {
             "number": 6150,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 36 0",
             "init": {
                 "Vr": 0.5451749858797853,
@@ -16817,7 +16819,7 @@
         },
         {
             "number": 6151,
-            "class": "bus",
+            "class": "Bus",
             "name": "SCHULENBURG 0",
             "init": {
                 "Vr": 0.7517155354551943,
@@ -16831,7 +16833,7 @@
         },
         {
             "number": 6152,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 22 0",
             "init": {
                 "Vr": 0.6147665632467351,
@@ -16845,7 +16847,7 @@
         },
         {
             "number": 6153,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 22 1",
             "init": {
                 "Vr": 0.5718106299255099,
@@ -16859,7 +16861,7 @@
         },
         {
             "number": 6154,
-            "class": "bus",
+            "class": "Bus",
             "name": "DRIPPING SPRINGS 0",
             "init": {
                 "Vr": 0.5564675258247227,
@@ -16873,7 +16875,7 @@
         },
         {
             "number": 6155,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 26 0",
             "init": {
                 "Vr": 0.5565513076298998,
@@ -16887,7 +16889,7 @@
         },
         {
             "number": 6156,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 3 0",
             "init": {
                 "Vr": 0.6319677737724702,
@@ -16901,7 +16903,7 @@
         },
         {
             "number": 6157,
-            "class": "bus",
+            "class": "Bus",
             "name": "BOERNE 1 0",
             "init": {
                 "Vr": 0.5201164005760269,
@@ -16915,7 +16917,7 @@
         },
         {
             "number": 6158,
-            "class": "bus",
+            "class": "Bus",
             "name": "WASHINGTON 0",
             "init": {
                 "Vr": 0.7507761229895419,
@@ -16929,7 +16931,7 @@
         },
         {
             "number": 6159,
-            "class": "bus",
+            "class": "Bus",
             "name": "SCHERTZ 0",
             "init": {
                 "Vr": 0.561450823456352,
@@ -16943,7 +16945,7 @@
         },
         {
             "number": 6160,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 8 0",
             "init": {
                 "Vr": 0.534339154573895,
@@ -16957,7 +16959,7 @@
         },
         {
             "number": 6161,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEGUIN 1 0",
             "init": {
                 "Vr": 0.7210058335473325,
@@ -16971,7 +16973,7 @@
         },
         {
             "number": 6162,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEGUIN 1 1",
             "init": {
                 "Vr": 0.6716787652336875,
@@ -16985,7 +16987,7 @@
         },
         {
             "number": 6163,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEGUIN 1 2",
             "init": {
                 "Vr": 0.6332879474852887,
@@ -16999,7 +17001,7 @@
         },
         {
             "number": 6164,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEGUIN 1 3",
             "init": {
                 "Vr": 0.7322082292847831,
@@ -17013,7 +17015,7 @@
         },
         {
             "number": 6165,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEGUIN 1 4",
             "init": {
                 "Vr": 0.7331186872202482,
@@ -17027,7 +17029,7 @@
         },
         {
             "number": 6166,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEGUIN 1 5",
             "init": {
                 "Vr": 0.7278962023199173,
@@ -17041,7 +17043,7 @@
         },
         {
             "number": 6167,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEGUIN 1 6",
             "init": {
                 "Vr": 0.7312017259135671,
@@ -17055,7 +17057,7 @@
         },
         {
             "number": 6168,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 45 0",
             "init": {
                 "Vr": 0.5305410667624667,
@@ -17069,7 +17071,7 @@
         },
         {
             "number": 6169,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 52 0",
             "init": {
                 "Vr": 0.7163665508525248,
@@ -17083,7 +17085,7 @@
         },
         {
             "number": 6170,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 52 1",
             "init": {
                 "Vr": 0.6567261767333274,
@@ -17097,7 +17099,7 @@
         },
         {
             "number": 6171,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 52 2",
             "init": {
                 "Vr": 0.6042098094660622,
@@ -17111,7 +17113,7 @@
         },
         {
             "number": 6172,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 2 0",
             "init": {
                 "Vr": 0.8134140096671338,
@@ -17125,7 +17127,7 @@
         },
         {
             "number": 6173,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 2 1",
             "init": {
                 "Vr": 0.7901388442603735,
@@ -17139,7 +17141,7 @@
         },
         {
             "number": 6174,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 10 0",
             "init": {
                 "Vr": 0.5485306114372449,
@@ -17153,7 +17155,7 @@
         },
         {
             "number": 6175,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 16 0",
             "init": {
                 "Vr": 0.5273942078341005,
@@ -17167,7 +17169,7 @@
         },
         {
             "number": 6176,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 39 0",
             "init": {
                 "Vr": 0.5533378727858365,
@@ -17181,7 +17183,7 @@
         },
         {
             "number": 6177,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 51 0",
             "init": {
                 "Vr": 0.6345720460111924,
@@ -17195,7 +17197,7 @@
         },
         {
             "number": 6178,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 51 1",
             "init": {
                 "Vr": 0.5813959091966052,
@@ -17209,7 +17211,7 @@
         },
         {
             "number": 6179,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 41 0",
             "init": {
                 "Vr": 0.5529431918768872,
@@ -17223,7 +17225,7 @@
         },
         {
             "number": 6180,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA VERNIA 0",
             "init": {
                 "Vr": 0.5654485788145663,
@@ -17237,7 +17239,7 @@
         },
         {
             "number": 6181,
-            "class": "bus",
+            "class": "Bus",
             "name": "MANOR 0",
             "init": {
                 "Vr": 0.5533684902567574,
@@ -17251,7 +17253,7 @@
         },
         {
             "number": 6182,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 38 0",
             "init": {
                 "Vr": 0.5255431706442121,
@@ -17265,7 +17267,7 @@
         },
         {
             "number": 6183,
-            "class": "bus",
+            "class": "Bus",
             "name": "GIDDINGS 0",
             "init": {
                 "Vr": 0.7381915884935389,
@@ -17279,7 +17281,7 @@
         },
         {
             "number": 6184,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 32 0",
             "init": {
                 "Vr": 0.5147225307296779,
@@ -17293,7 +17295,7 @@
         },
         {
             "number": 6185,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 38 0",
             "init": {
                 "Vr": 0.5190008740023972,
@@ -17307,7 +17309,7 @@
         },
         {
             "number": 6186,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 30 0",
             "init": {
                 "Vr": 0.5451571474507912,
@@ -17321,7 +17323,7 @@
         },
         {
             "number": 6187,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 28 0",
             "init": {
                 "Vr": 0.5354643151151396,
@@ -17335,7 +17337,7 @@
         },
         {
             "number": 6188,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLUMBUS 0",
             "init": {
                 "Vr": 0.8476666035639404,
@@ -17349,7 +17351,7 @@
         },
         {
             "number": 6189,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLUMBUS 1",
             "init": {
                 "Vr": 0.8182861601679876,
@@ -17363,7 +17365,7 @@
         },
         {
             "number": 6190,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHINER 0",
             "init": {
                 "Vr": 0.6966725704237191,
@@ -17377,7 +17379,7 @@
         },
         {
             "number": 6191,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 3 0",
             "init": {
                 "Vr": 0.5594172710094364,
@@ -17391,7 +17393,7 @@
         },
         {
             "number": 6192,
-            "class": "bus",
+            "class": "Bus",
             "name": "CALDWELL 0",
             "init": {
                 "Vr": 0.7362123404161303,
@@ -17405,7 +17407,7 @@
         },
         {
             "number": 6193,
-            "class": "bus",
+            "class": "Bus",
             "name": "CALDWELL 1",
             "init": {
                 "Vr": 0.7110721516235149,
@@ -17419,7 +17421,7 @@
         },
         {
             "number": 6194,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 18 0",
             "init": {
                 "Vr": 0.549274891217428,
@@ -17433,7 +17435,7 @@
         },
         {
             "number": 6195,
-            "class": "bus",
+            "class": "Bus",
             "name": "INDUSTRY 0",
             "init": {
                 "Vr": 0.770200489839878,
@@ -17447,7 +17449,7 @@
         },
         {
             "number": 6196,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALE 0",
             "init": {
                 "Vr": 0.5714573114427439,
@@ -17461,7 +17463,7 @@
         },
         {
             "number": 6197,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 37 0",
             "init": {
                 "Vr": 0.6782691100311617,
@@ -17475,7 +17477,7 @@
         },
         {
             "number": 6198,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 37 1",
             "init": {
                 "Vr": 0.610341572208597,
@@ -17489,7 +17491,7 @@
         },
         {
             "number": 6199,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 37 2",
             "init": {
                 "Vr": 0.5694856556436243,
@@ -17503,7 +17505,7 @@
         },
         {
             "number": 6200,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 18 0",
             "init": {
                 "Vr": 0.5393836322563048,
@@ -17517,7 +17519,7 @@
         },
         {
             "number": 6201,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 33 0",
             "init": {
                 "Vr": 0.5284029765989231,
@@ -17531,7 +17533,7 @@
         },
         {
             "number": 6202,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARTINDALE 0",
             "init": {
                 "Vr": 0.6202949836116937,
@@ -17545,7 +17547,7 @@
         },
         {
             "number": 6203,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 17 0",
             "init": {
                 "Vr": 0.5321943273076524,
@@ -17559,7 +17561,7 @@
         },
         {
             "number": 6204,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 23 0",
             "init": {
                 "Vr": 0.5451868370452947,
@@ -17573,7 +17575,7 @@
         },
         {
             "number": 6205,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 29 0",
             "init": {
                 "Vr": 0.5377169127877272,
@@ -17587,7 +17589,7 @@
         },
         {
             "number": 6206,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEXINGTON 0",
             "init": {
                 "Vr": 0.7187558434194633,
@@ -17601,7 +17603,7 @@
         },
         {
             "number": 6207,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEANDER 2 0",
             "init": {
                 "Vr": 0.5424286594611439,
@@ -17615,7 +17617,7 @@
         },
         {
             "number": 6208,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 15 0",
             "init": {
                 "Vr": 0.5168340790875032,
@@ -17629,7 +17631,7 @@
         },
         {
             "number": 6209,
-            "class": "bus",
+            "class": "Bus",
             "name": "MICO 0",
             "init": {
                 "Vr": 0.5669990744269402,
@@ -17643,7 +17645,7 @@
         },
         {
             "number": 6210,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 2 0",
             "init": {
                 "Vr": 0.7153488908519324,
@@ -17657,7 +17659,7 @@
         },
         {
             "number": 6211,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 2 1",
             "init": {
                 "Vr": 0.6852827623661882,
@@ -17671,7 +17673,7 @@
         },
         {
             "number": 6212,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 2 2",
             "init": {
                 "Vr": 0.6453992549108418,
@@ -17685,7 +17687,7 @@
         },
         {
             "number": 6213,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 2 3",
             "init": {
                 "Vr": 0.7725269211096164,
@@ -17699,7 +17701,7 @@
         },
         {
             "number": 6214,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 2 4",
             "init": {
                 "Vr": 0.817901475953999,
@@ -17713,7 +17715,7 @@
         },
         {
             "number": 6215,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 2 5",
             "init": {
                 "Vr": 0.7457922416710474,
@@ -17727,7 +17729,7 @@
         },
         {
             "number": 6216,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARBLE FALLS 2 6",
             "init": {
                 "Vr": 0.77800963522461,
@@ -17741,7 +17743,7 @@
         },
         {
             "number": 6217,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 36 0",
             "init": {
                 "Vr": 0.4952319412203687,
@@ -17755,7 +17757,7 @@
         },
         {
             "number": 6218,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOCKHART 0",
             "init": {
                 "Vr": 0.548317548839927,
@@ -17769,7 +17771,7 @@
         },
         {
             "number": 6219,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 17 0",
             "init": {
                 "Vr": 0.5218489430614744,
@@ -17783,7 +17785,7 @@
         },
         {
             "number": 6220,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 13 0",
             "init": {
                 "Vr": 0.5668049310164316,
@@ -17797,7 +17799,7 @@
         },
         {
             "number": 6221,
-            "class": "bus",
+            "class": "Bus",
             "name": "FALLS CITY 0",
             "init": {
                 "Vr": 0.6658254331072576,
@@ -17811,7 +17813,7 @@
         },
         {
             "number": 6222,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 27 0",
             "init": {
                 "Vr": 0.59288668976078,
@@ -17825,7 +17827,7 @@
         },
         {
             "number": 6223,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 27 1",
             "init": {
                 "Vr": 0.5513982017785323,
@@ -17839,7 +17841,7 @@
         },
         {
             "number": 6224,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 23 0",
             "init": {
                 "Vr": 0.5169824611840785,
@@ -17853,7 +17855,7 @@
         },
         {
             "number": 6225,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 27 0",
             "init": {
                 "Vr": 0.5377207957832438,
@@ -17867,7 +17869,7 @@
         },
         {
             "number": 6226,
-            "class": "bus",
+            "class": "Bus",
             "name": "BLANCO 0",
             "init": {
                 "Vr": 0.5047194412932896,
@@ -17881,7 +17883,7 @@
         },
         {
             "number": 6227,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 24 0",
             "init": {
                 "Vr": 0.5281538812598904,
@@ -17895,7 +17897,7 @@
         },
         {
             "number": 6228,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN MARCOS 0",
             "init": {
                 "Vr": 0.6944560505698418,
@@ -17909,7 +17911,7 @@
         },
         {
             "number": 6229,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN MARCOS 1",
             "init": {
                 "Vr": 0.6426201721701708,
@@ -17923,7 +17925,7 @@
         },
         {
             "number": 6230,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN MARCOS 2",
             "init": {
                 "Vr": 0.5737675434150497,
@@ -17937,7 +17939,7 @@
         },
         {
             "number": 6231,
-            "class": "bus",
+            "class": "Bus",
             "name": "BUDA 0",
             "init": {
                 "Vr": 0.5384824926487457,
@@ -17951,7 +17953,7 @@
         },
         {
             "number": 6232,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEL VALLE 0",
             "init": {
                 "Vr": 0.5850334126614684,
@@ -17965,7 +17967,7 @@
         },
         {
             "number": 6233,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 4 0",
             "init": {
                 "Vr": 0.5236984829765512,
@@ -17979,7 +17981,7 @@
         },
         {
             "number": 6234,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 50 0",
             "init": {
                 "Vr": 0.6687204867212644,
@@ -17993,7 +17995,7 @@
         },
         {
             "number": 6235,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 50 1",
             "init": {
                 "Vr": 0.6472147005362239,
@@ -18007,7 +18009,7 @@
         },
         {
             "number": 6236,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 50 2",
             "init": {
                 "Vr": 0.5805568309338145,
@@ -18021,7 +18023,7 @@
         },
         {
             "number": 6237,
-            "class": "bus",
+            "class": "Bus",
             "name": "BURLINGTON 0",
             "init": {
                 "Vr": 0.6055452699408191,
@@ -18035,7 +18037,7 @@
         },
         {
             "number": 6238,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 13 0",
             "init": {
                 "Vr": 0.5184817669586573,
@@ -18049,7 +18051,7 @@
         },
         {
             "number": 6239,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 0",
             "init": {
                 "Vr": 0.7426559144665541,
@@ -18063,7 +18065,7 @@
         },
         {
             "number": 6240,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 1",
             "init": {
                 "Vr": 0.6748759030514596,
@@ -18077,7 +18079,7 @@
         },
         {
             "number": 6241,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 2",
             "init": {
                 "Vr": 0.5953724600070666,
@@ -18091,7 +18093,7 @@
         },
         {
             "number": 6242,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 3",
             "init": {
                 "Vr": 0.7666657414872176,
@@ -18105,7 +18107,7 @@
         },
         {
             "number": 6243,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 4",
             "init": {
                 "Vr": 0.7709671783351723,
@@ -18119,7 +18121,7 @@
         },
         {
             "number": 6244,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 5",
             "init": {
                 "Vr": 0.7795765773690408,
@@ -18133,7 +18135,7 @@
         },
         {
             "number": 6245,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 6",
             "init": {
                 "Vr": 0.7747163366325427,
@@ -18147,7 +18149,7 @@
         },
         {
             "number": 6246,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 7",
             "init": {
                 "Vr": 0.7616818682680593,
@@ -18161,7 +18163,7 @@
         },
         {
             "number": 6247,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 8",
             "init": {
                 "Vr": 0.7581900711647879,
@@ -18175,7 +18177,7 @@
         },
         {
             "number": 6248,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 9",
             "init": {
                 "Vr": 0.7688165828236432,
@@ -18189,7 +18191,7 @@
         },
         {
             "number": 6249,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELMENDORF 10",
             "init": {
                 "Vr": 0.7780367617516772,
@@ -18203,7 +18205,7 @@
         },
         {
             "number": 6250,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 6 0",
             "init": {
                 "Vr": 0.538965054862463,
@@ -18217,7 +18219,7 @@
         },
         {
             "number": 6251,
-            "class": "bus",
+            "class": "Bus",
             "name": "CANYON LAKE 0",
             "init": {
                 "Vr": 0.5170612296854642,
@@ -18231,7 +18233,7 @@
         },
         {
             "number": 6252,
-            "class": "bus",
+            "class": "Bus",
             "name": "JOHNSON CITY 0",
             "init": {
                 "Vr": 0.6038753042095168,
@@ -18245,7 +18247,7 @@
         },
         {
             "number": 6253,
-            "class": "bus",
+            "class": "Bus",
             "name": "YORKTOWN 0",
             "init": {
                 "Vr": 0.7566084373565771,
@@ -18259,7 +18261,7 @@
         },
         {
             "number": 6254,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 2 0",
             "init": {
                 "Vr": 0.6738686534402756,
@@ -18273,7 +18275,7 @@
         },
         {
             "number": 6255,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 2 1",
             "init": {
                 "Vr": 0.6399173105628835,
@@ -18287,7 +18289,7 @@
         },
         {
             "number": 6256,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 2 2",
             "init": {
                 "Vr": 0.5644656598208768,
@@ -18301,7 +18303,7 @@
         },
         {
             "number": 6257,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 2 3",
             "init": {
                 "Vr": 0.6772780454860906,
@@ -18315,7 +18317,7 @@
         },
         {
             "number": 6258,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 2 4",
             "init": {
                 "Vr": 0.6892217284881739,
@@ -18329,7 +18331,7 @@
         },
         {
             "number": 6259,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 2 5",
             "init": {
                 "Vr": 0.6738686534402756,
@@ -18343,7 +18345,7 @@
         },
         {
             "number": 6260,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 2 6",
             "init": {
                 "Vr": 0.6781361395801185,
@@ -18357,7 +18359,7 @@
         },
         {
             "number": 6261,
-            "class": "bus",
+            "class": "Bus",
             "name": "LACKLAND A F B 0",
             "init": {
                 "Vr": 0.526543343425748,
@@ -18371,7 +18373,7 @@
         },
         {
             "number": 6262,
-            "class": "bus",
+            "class": "Bus",
             "name": "LIBERTY HILL 0",
             "init": {
                 "Vr": 0.5507111792500117,
@@ -18385,7 +18387,7 @@
         },
         {
             "number": 6263,
-            "class": "bus",
+            "class": "Bus",
             "name": "KENEDY 0",
             "init": {
                 "Vr": 0.7484569822353527,
@@ -18399,7 +18401,7 @@
         },
         {
             "number": 6264,
-            "class": "bus",
+            "class": "Bus",
             "name": "KENEDY 1",
             "init": {
                 "Vr": 0.7275858015868643,
@@ -18413,7 +18415,7 @@
         },
         {
             "number": 6265,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 0",
             "init": {
                 "Vr": 0.7845068727871012,
@@ -18427,7 +18429,7 @@
         },
         {
             "number": 6266,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 1",
             "init": {
                 "Vr": 0.7944793247009078,
@@ -18441,7 +18443,7 @@
         },
         {
             "number": 6267,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 2",
             "init": {
                 "Vr": 0.8202084751646503,
@@ -18455,7 +18457,7 @@
         },
         {
             "number": 6268,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 3",
             "init": {
                 "Vr": 0.7918165003914235,
@@ -18469,7 +18471,7 @@
         },
         {
             "number": 6269,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 4",
             "init": {
                 "Vr": 0.8225988463521946,
@@ -18483,7 +18485,7 @@
         },
         {
             "number": 6270,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 5",
             "init": {
                 "Vr": 0.7845068727871012,
@@ -18497,7 +18499,7 @@
         },
         {
             "number": 6271,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 6",
             "init": {
                 "Vr": 0.7845068727871012,
@@ -18511,7 +18513,7 @@
         },
         {
             "number": 6272,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 7",
             "init": {
                 "Vr": 0.7845068727871012,
@@ -18525,7 +18527,7 @@
         },
         {
             "number": 6273,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 8",
             "init": {
                 "Vr": 0.7845068727871012,
@@ -18539,7 +18541,7 @@
         },
         {
             "number": 6274,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUERO 1 9",
             "init": {
                 "Vr": 0.8159681648001834,
@@ -18553,7 +18555,7 @@
         },
         {
             "number": 6275,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 20 0",
             "init": {
                 "Vr": 0.5383847189364042,
@@ -18567,7 +18569,7 @@
         },
         {
             "number": 6276,
-            "class": "bus",
+            "class": "Bus",
             "name": "VON ORMY 0",
             "init": {
                 "Vr": 0.5245696518626585,
@@ -18581,7 +18583,7 @@
         },
         {
             "number": 6277,
-            "class": "bus",
+            "class": "Bus",
             "name": "KYLE 0",
             "init": {
                 "Vr": 0.6300950330118947,
@@ -18595,7 +18597,7 @@
         },
         {
             "number": 6278,
-            "class": "bus",
+            "class": "Bus",
             "name": "KYLE 1",
             "init": {
                 "Vr": 0.5751005825236172,
@@ -18609,7 +18611,7 @@
         },
         {
             "number": 6279,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEGUIN 2 0",
             "init": {
                 "Vr": 0.6665899205912867,
@@ -18623,7 +18625,7 @@
         },
         {
             "number": 6280,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEGUIN 2 1",
             "init": {
                 "Vr": 0.6271987488585407,
@@ -18637,7 +18639,7 @@
         },
         {
             "number": 6281,
-            "class": "bus",
+            "class": "Bus",
             "name": "UNIVERSAL CITY 0",
             "init": {
                 "Vr": 0.5580592636806079,
@@ -18651,7 +18653,7 @@
         },
         {
             "number": 6282,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPICEWOOD 0",
             "init": {
                 "Vr": 0.5759697267887472,
@@ -18665,7 +18667,7 @@
         },
         {
             "number": 6283,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAINT HEDWIG 0",
             "init": {
                 "Vr": 0.5541895232090753,
@@ -18679,7 +18681,7 @@
         },
         {
             "number": 6284,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 16 0",
             "init": {
                 "Vr": 0.563316569619428,
@@ -18693,7 +18695,7 @@
         },
         {
             "number": 6285,
-            "class": "bus",
+            "class": "Bus",
             "name": "BOERNE 2 0",
             "init": {
                 "Vr": 0.5790646980549571,
@@ -18707,7 +18709,7 @@
         },
         {
             "number": 6286,
-            "class": "bus",
+            "class": "Bus",
             "name": "BOERNE 2 1",
             "init": {
                 "Vr": 0.5462388457490573,
@@ -18721,7 +18723,7 @@
         },
         {
             "number": 6287,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 32 0",
             "init": {
                 "Vr": 0.6159032642463896,
@@ -18735,7 +18737,7 @@
         },
         {
             "number": 6288,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 32 1",
             "init": {
                 "Vr": 0.5494695322003504,
@@ -18749,7 +18751,7 @@
         },
         {
             "number": 6289,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 26 0",
             "init": {
                 "Vr": 0.5221916023614814,
@@ -18763,7 +18765,7 @@
         },
         {
             "number": 6290,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 21 0",
             "init": {
                 "Vr": 0.5318325840568733,
@@ -18777,7 +18779,7 @@
         },
         {
             "number": 6291,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 44 0",
             "init": {
                 "Vr": 0.5551792500347389,
@@ -18791,7 +18793,7 @@
         },
         {
             "number": 6292,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR CREEK 1 0",
             "init": {
                 "Vr": 0.6840835962295229,
@@ -18805,7 +18807,7 @@
         },
         {
             "number": 6293,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR CREEK 1 1",
             "init": {
                 "Vr": 0.6363483842438642,
@@ -18819,7 +18821,7 @@
         },
         {
             "number": 6294,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR CREEK 1 2",
             "init": {
                 "Vr": 0.5976966342344555,
@@ -18833,7 +18835,7 @@
         },
         {
             "number": 6295,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR CREEK 1 3",
             "init": {
                 "Vr": 0.6869022956199896,
@@ -18847,7 +18849,7 @@
         },
         {
             "number": 6296,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR CREEK 1 4",
             "init": {
                 "Vr": 0.6864872919994643,
@@ -18861,7 +18863,7 @@
         },
         {
             "number": 6297,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR CREEK 1 5",
             "init": {
                 "Vr": 0.6906046622850534,
@@ -18875,7 +18877,7 @@
         },
         {
             "number": 6298,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 1 0",
             "init": {
                 "Vr": 0.7054634360362878,
@@ -18889,7 +18891,7 @@
         },
         {
             "number": 6299,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 1 1",
             "init": {
                 "Vr": 0.6763704158966373,
@@ -18903,7 +18905,7 @@
         },
         {
             "number": 6300,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 1 2",
             "init": {
                 "Vr": 0.6384593523676365,
@@ -18917,7 +18919,7 @@
         },
         {
             "number": 6301,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 1 3",
             "init": {
                 "Vr": 0.7054634360362878,
@@ -18931,7 +18933,7 @@
         },
         {
             "number": 6302,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 1 4",
             "init": {
                 "Vr": 0.7378689107173743,
@@ -18945,7 +18947,7 @@
         },
         {
             "number": 6303,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 1 5",
             "init": {
                 "Vr": 0.7152063976252726,
@@ -18959,7 +18961,7 @@
         },
         {
             "number": 6304,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 1 6",
             "init": {
                 "Vr": 0.7329681359136836,
@@ -18973,7 +18975,7 @@
         },
         {
             "number": 6305,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW BRAUNFELS 1 7",
             "init": {
                 "Vr": 0.7383778306545478,
@@ -18987,7 +18989,7 @@
         },
         {
             "number": 6306,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 11 0",
             "init": {
                 "Vr": 0.5340545395655463,
@@ -19001,7 +19003,7 @@
         },
         {
             "number": 6307,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 39 0",
             "init": {
                 "Vr": 0.5397930108631986,
@@ -19015,7 +19017,7 @@
         },
         {
             "number": 6308,
-            "class": "bus",
+            "class": "Bus",
             "name": "HONDO 0",
             "init": {
                 "Vr": 0.6393623551023434,
@@ -19029,7 +19031,7 @@
         },
         {
             "number": 6309,
-            "class": "bus",
+            "class": "Bus",
             "name": "HONDO 1",
             "init": {
                 "Vr": 0.582932648936729,
@@ -19043,7 +19045,7 @@
         },
         {
             "number": 6310,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 4 0",
             "init": {
                 "Vr": 0.5737091962726438,
@@ -19057,7 +19059,7 @@
         },
         {
             "number": 6311,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW ULM 0",
             "init": {
                 "Vr": 0.7961663141379497,
@@ -19071,7 +19073,7 @@
         },
         {
             "number": 6312,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 8 0",
             "init": {
                 "Vr": 0.5880591830781754,
@@ -19085,7 +19087,7 @@
         },
         {
             "number": 6313,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 33 0",
             "init": {
                 "Vr": 0.5319194653940379,
@@ -19099,7 +19101,7 @@
         },
         {
             "number": 6314,
-            "class": "bus",
+            "class": "Bus",
             "name": "BULVERDE 0",
             "init": {
                 "Vr": 0.5439037910732029,
@@ -19113,7 +19115,7 @@
         },
         {
             "number": 6315,
-            "class": "bus",
+            "class": "Bus",
             "name": "GEORGETOWN 3 0",
             "init": {
                 "Vr": 0.6161614707362264,
@@ -19127,7 +19129,7 @@
         },
         {
             "number": 6316,
-            "class": "bus",
+            "class": "Bus",
             "name": "GEORGETOWN 3 1",
             "init": {
                 "Vr": 0.6072798022955571,
@@ -19141,7 +19143,7 @@
         },
         {
             "number": 6317,
-            "class": "bus",
+            "class": "Bus",
             "name": "GEORGETOWN 3 2",
             "init": {
                 "Vr": 0.5806316124222598,
@@ -19155,7 +19157,7 @@
         },
         {
             "number": 6318,
-            "class": "bus",
+            "class": "Bus",
             "name": "GEORGETOWN 3 3",
             "init": {
                 "Vr": 0.5491700924316907,
@@ -19169,7 +19171,7 @@
         },
         {
             "number": 6319,
-            "class": "bus",
+            "class": "Bus",
             "name": "GEORGETOWN 3 4",
             "init": {
                 "Vr": 0.5262676533040499,
@@ -19183,7 +19185,7 @@
         },
         {
             "number": 6320,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 9 0",
             "init": {
                 "Vr": 0.5751571652830639,
@@ -19197,7 +19199,7 @@
         },
         {
             "number": 6321,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLORESVILLE 0",
             "init": {
                 "Vr": 0.6880603965312551,
@@ -19211,7 +19213,7 @@
         },
         {
             "number": 6322,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLORESVILLE 1",
             "init": {
                 "Vr": 0.6522856623898592,
@@ -19225,7 +19227,7 @@
         },
         {
             "number": 6323,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 29 0",
             "init": {
                 "Vr": 0.5473307035216156,
@@ -19239,7 +19241,7 @@
         },
         {
             "number": 6324,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 7 0",
             "init": {
                 "Vr": 0.554584351972287,
@@ -19253,7 +19255,7 @@
         },
         {
             "number": 6325,
-            "class": "bus",
+            "class": "Bus",
             "name": "BUCKHOLTS 0",
             "init": {
                 "Vr": 0.5922464577369138,
@@ -19267,7 +19269,7 @@
         },
         {
             "number": 6326,
-            "class": "bus",
+            "class": "Bus",
             "name": "SOMERVILLE 0",
             "init": {
                 "Vr": 0.6927644694098942,
@@ -19281,7 +19283,7 @@
         },
         {
             "number": 6327,
-            "class": "bus",
+            "class": "Bus",
             "name": "WEIMAR 0",
             "init": {
                 "Vr": 0.7825175848621337,
@@ -19295,7 +19297,7 @@
         },
         {
             "number": 6328,
-            "class": "bus",
+            "class": "Bus",
             "name": "COMFORT 0",
             "init": {
                 "Vr": 0.5229353398294444,
@@ -19309,7 +19311,7 @@
         },
         {
             "number": 6329,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORDHEIM 0",
             "init": {
                 "Vr": 0.7311251440032107,
@@ -19323,7 +19325,7 @@
         },
         {
             "number": 6330,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 9 0",
             "init": {
                 "Vr": 0.5110008290955046,
@@ -19337,7 +19339,7 @@
         },
         {
             "number": 6331,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 22 0",
             "init": {
                 "Vr": 0.5231545215984479,
@@ -19351,7 +19353,7 @@
         },
         {
             "number": 6332,
-            "class": "bus",
+            "class": "Bus",
             "name": "HELOTES 0",
             "init": {
                 "Vr": 0.5591280579482956,
@@ -19365,7 +19367,7 @@
         },
         {
             "number": 6333,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 47 0",
             "init": {
                 "Vr": 0.67497615294046,
@@ -19379,7 +19381,7 @@
         },
         {
             "number": 6334,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 47 1",
             "init": {
                 "Vr": 0.6383790225354148,
@@ -19393,7 +19395,7 @@
         },
         {
             "number": 6335,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 47 2",
             "init": {
                 "Vr": 0.5688796117633048,
@@ -19407,7 +19409,7 @@
         },
         {
             "number": 6336,
-            "class": "bus",
+            "class": "Bus",
             "name": "BANDERA 0",
             "init": {
                 "Vr": 0.5226709557380322,
@@ -19421,7 +19423,7 @@
         },
         {
             "number": 6337,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 30 0",
             "init": {
                 "Vr": 0.5575260451738704,
@@ -19435,7 +19437,7 @@
         },
         {
             "number": 6338,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROCKDALE 2 0",
             "init": {
                 "Vr": 0.6037442747691147,
@@ -19449,7 +19451,7 @@
         },
         {
             "number": 6339,
-            "class": "bus",
+            "class": "Bus",
             "name": "CEDAR CREEK 2 0",
             "init": {
                 "Vr": 0.5932413037630409,
@@ -19463,7 +19465,7 @@
         },
         {
             "number": 6340,
-            "class": "bus",
+            "class": "Bus",
             "name": "NIXON 0",
             "init": {
                 "Vr": 0.6334426411905897,
@@ -19477,7 +19479,7 @@
         },
         {
             "number": 6341,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHAPPELL HILL 0",
             "init": {
                 "Vr": 0.7520794127825302,
@@ -19491,7 +19493,7 @@
         },
         {
             "number": 6342,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 3 0",
             "init": {
                 "Vr": 0.6406418431236017,
@@ -19505,7 +19507,7 @@
         },
         {
             "number": 6343,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 3 1",
             "init": {
                 "Vr": 0.6025103162333609,
@@ -19519,7 +19521,7 @@
         },
         {
             "number": 6344,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 3 2",
             "init": {
                 "Vr": 0.570507764317953,
@@ -19533,7 +19535,7 @@
         },
         {
             "number": 6345,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 14 0",
             "init": {
                 "Vr": 0.5236381582907673,
@@ -19547,7 +19549,7 @@
         },
         {
             "number": 6346,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEMING 0",
             "init": {
                 "Vr": 0.6066613084402974,
@@ -19561,7 +19563,7 @@
         },
         {
             "number": 6349,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 1 0",
             "init": {
                 "Vr": 0.6696953790478931,
@@ -19575,7 +19577,7 @@
         },
         {
             "number": 6350,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 1 1",
             "init": {
                 "Vr": 0.631997980740403,
@@ -19589,7 +19591,7 @@
         },
         {
             "number": 6351,
-            "class": "bus",
+            "class": "Bus",
             "name": "AUSTIN 1 2",
             "init": {
                 "Vr": 0.5576229326049614,
@@ -19603,7 +19605,7 @@
         },
         {
             "number": 6352,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 28 0",
             "init": {
                 "Vr": 0.5586481026952945,
@@ -19617,7 +19619,7 @@
         },
         {
             "number": 6353,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 2 0",
             "init": {
                 "Vr": 0.551625380955376,
@@ -19631,7 +19633,7 @@
         },
         {
             "number": 6354,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 4 0",
             "init": {
                 "Vr": 0.5977493772826888,
@@ -19645,7 +19647,7 @@
         },
         {
             "number": 6355,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND ROCK 4 1",
             "init": {
                 "Vr": 0.5756549651761853,
@@ -19659,7 +19661,7 @@
         },
         {
             "number": 6356,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN ANTONIO 34 0",
             "init": {
                 "Vr": 0.5443844170933223,
@@ -19673,7 +19675,7 @@
         },
         {
             "number": 6357,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEVINE 0",
             "init": {
                 "Vr": 0.5986604382964011,
@@ -19687,7 +19689,7 @@
         },
         {
             "number": 6358,
-            "class": "bus",
+            "class": "Bus",
             "name": "GEORGETOWN 1 0",
             "init": {
                 "Vr": 0.5393451252898745,
@@ -19701,7 +19703,7 @@
         },
         {
             "number": 6359,
-            "class": "bus",
+            "class": "Bus",
             "name": "BURNET 0",
             "init": {
                 "Vr": 0.6667628470135857,
@@ -19715,7 +19717,7 @@
         },
         {
             "number": 6360,
-            "class": "bus",
+            "class": "Bus",
             "name": "BURNET 1",
             "init": {
                 "Vr": 0.6488785186402672,
@@ -19729,7 +19731,7 @@
         },
         {
             "number": 7001,
-            "class": "bus",
+            "class": "Bus",
             "name": "INEZ 0",
             "init": {
                 "Vr": 0.8136617965512439,
@@ -19743,7 +19745,7 @@
         },
         {
             "number": 7002,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 2 0",
             "init": {
                 "Vr": 0.9340972389755242,
@@ -19757,7 +19759,7 @@
         },
         {
             "number": 7003,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 2 1",
             "init": {
                 "Vr": 0.8864062668017552,
@@ -19771,7 +19773,7 @@
         },
         {
             "number": 7004,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 2 2",
             "init": {
                 "Vr": 0.8379233917452584,
@@ -19785,7 +19787,7 @@
         },
         {
             "number": 7005,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 2 3",
             "init": {
                 "Vr": 0.9576272000136998,
@@ -19799,7 +19801,7 @@
         },
         {
             "number": 7006,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 2 4",
             "init": {
                 "Vr": 0.9509121957090224,
@@ -19813,7 +19815,7 @@
         },
         {
             "number": 7007,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 2 5",
             "init": {
                 "Vr": 0.9554139217578026,
@@ -19827,7 +19829,7 @@
         },
         {
             "number": 7008,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 2 6",
             "init": {
                 "Vr": 0.9560848510080425,
@@ -19841,7 +19843,7 @@
         },
         {
             "number": 7009,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 2 7",
             "init": {
                 "Vr": 0.9576545078207482,
@@ -19855,7 +19857,7 @@
         },
         {
             "number": 7010,
-            "class": "bus",
+            "class": "Bus",
             "name": "PRAIRIE VIEW 0",
             "init": {
                 "Vr": 0.727654184896847,
@@ -19869,7 +19871,7 @@
         },
         {
             "number": 7011,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONROE 1 0",
             "init": {
                 "Vr": 0.7578729729194966,
@@ -19883,7 +19885,7 @@
         },
         {
             "number": 7012,
-            "class": "bus",
+            "class": "Bus",
             "name": "SIMONTON 0",
             "init": {
                 "Vr": 0.7654051955159642,
@@ -19897,7 +19899,7 @@
         },
         {
             "number": 7013,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 80 0",
             "init": {
                 "Vr": 0.7584131131774744,
@@ -19911,7 +19913,7 @@
         },
         {
             "number": 7014,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 1 0",
             "init": {
                 "Vr": 0.7784826697391248,
@@ -19925,7 +19927,7 @@
         },
         {
             "number": 7015,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 1 1",
             "init": {
                 "Vr": 0.7784826697391248,
@@ -19939,7 +19941,7 @@
         },
         {
             "number": 7016,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 9 0",
             "init": {
                 "Vr": 0.8174429559451122,
@@ -19953,7 +19955,7 @@
         },
         {
             "number": 7017,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 73 0",
             "init": {
                 "Vr": 0.7714020181860674,
@@ -19967,7 +19969,7 @@
         },
         {
             "number": 7018,
-            "class": "bus",
+            "class": "Bus",
             "name": "NURSERY 0",
             "init": {
                 "Vr": 0.8622096264436624,
@@ -19981,7 +19983,7 @@
         },
         {
             "number": 7019,
-            "class": "bus",
+            "class": "Bus",
             "name": "NURSERY 1",
             "init": {
                 "Vr": 0.8465533080036456,
@@ -19995,7 +19997,7 @@
         },
         {
             "number": 7020,
-            "class": "bus",
+            "class": "Bus",
             "name": "NURSERY 2",
             "init": {
                 "Vr": 0.8153285765894664,
@@ -20009,7 +20011,7 @@
         },
         {
             "number": 7021,
-            "class": "bus",
+            "class": "Bus",
             "name": "NURSERY 3",
             "init": {
                 "Vr": 0.8734060014658616,
@@ -20023,7 +20025,7 @@
         },
         {
             "number": 7022,
-            "class": "bus",
+            "class": "Bus",
             "name": "NURSERY 4",
             "init": {
                 "Vr": 0.8870571514739278,
@@ -20037,7 +20039,7 @@
         },
         {
             "number": 7023,
-            "class": "bus",
+            "class": "Bus",
             "name": "NURSERY 5",
             "init": {
                 "Vr": 0.8776888942466208,
@@ -20051,7 +20053,7 @@
         },
         {
             "number": 7024,
-            "class": "bus",
+            "class": "Bus",
             "name": "NURSERY 6",
             "init": {
                 "Vr": 0.8726228647340603,
@@ -20065,7 +20067,7 @@
         },
         {
             "number": 7025,
-            "class": "bus",
+            "class": "Bus",
             "name": "NURSERY 7",
             "init": {
                 "Vr": 0.8622096264436624,
@@ -20079,7 +20081,7 @@
         },
         {
             "number": 7026,
-            "class": "bus",
+            "class": "Bus",
             "name": "BACLIFF 0",
             "init": {
                 "Vr": 0.8262249110370257,
@@ -20093,7 +20095,7 @@
         },
         {
             "number": 7027,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 1 0",
             "init": {
                 "Vr": 0.7661070241529683,
@@ -20107,7 +20109,7 @@
         },
         {
             "number": 7028,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 72 0",
             "init": {
                 "Vr": 0.7905036447240487,
@@ -20121,7 +20123,7 @@
         },
         {
             "number": 7029,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT LAVACA 0",
             "init": {
                 "Vr": 0.8607262472374595,
@@ -20135,7 +20137,7 @@
         },
         {
             "number": 7030,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT LAVACA 1",
             "init": {
                 "Vr": 0.822362421735465,
@@ -20149,7 +20151,7 @@
         },
         {
             "number": 7031,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT LAVACA 2",
             "init": {
                 "Vr": 0.88769876332903,
@@ -20163,7 +20165,7 @@
         },
         {
             "number": 7032,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT LAVACA 3",
             "init": {
                 "Vr": 0.8700373965159399,
@@ -20177,7 +20179,7 @@
         },
         {
             "number": 7033,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT LAVACA 4",
             "init": {
                 "Vr": 0.8692998074947641,
@@ -20191,7 +20193,7 @@
         },
         {
             "number": 7034,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT LAVACA 5",
             "init": {
                 "Vr": 0.8607262472374595,
@@ -20205,7 +20207,7 @@
         },
         {
             "number": 7035,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONROE 5 0",
             "init": {
                 "Vr": 0.8108794071902907,
@@ -20219,7 +20221,7 @@
         },
         {
             "number": 7036,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONROE 5 1",
             "init": {
                 "Vr": 0.7747964183957214,
@@ -20233,7 +20235,7 @@
         },
         {
             "number": 7037,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUGAR LAND 3 0",
             "init": {
                 "Vr": 0.8748877245594662,
@@ -20247,7 +20249,7 @@
         },
         {
             "number": 7038,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUGAR LAND 3 1",
             "init": {
                 "Vr": 0.8500899105453875,
@@ -20261,7 +20263,7 @@
         },
         {
             "number": 7039,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUGAR LAND 3 2",
             "init": {
                 "Vr": 0.7995440525487607,
@@ -20275,7 +20277,7 @@
         },
         {
             "number": 7040,
-            "class": "bus",
+            "class": "Bus",
             "name": "DAYTON 0",
             "init": {
                 "Vr": 0.8707954586657924,
@@ -20289,7 +20291,7 @@
         },
         {
             "number": 7041,
-            "class": "bus",
+            "class": "Bus",
             "name": "DAYTON 1",
             "init": {
                 "Vr": 0.8277202244318456,
@@ -20303,7 +20305,7 @@
         },
         {
             "number": 7042,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 2 0",
             "init": {
                 "Vr": 0.873662850942589,
@@ -20317,7 +20319,7 @@
         },
         {
             "number": 7043,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 2 1",
             "init": {
                 "Vr": 0.8570472319815812,
@@ -20331,7 +20333,7 @@
         },
         {
             "number": 7044,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 2 2",
             "init": {
                 "Vr": 0.8144248998863058,
@@ -20345,7 +20347,7 @@
         },
         {
             "number": 7045,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 2 3",
             "init": {
                 "Vr": 0.8965578237996706,
@@ -20359,7 +20361,7 @@
         },
         {
             "number": 7046,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 2 4",
             "init": {
                 "Vr": 0.8869095651552998,
@@ -20373,7 +20375,7 @@
         },
         {
             "number": 7047,
-            "class": "bus",
+            "class": "Bus",
             "name": "KATY 1 0",
             "init": {
                 "Vr": 0.8696066940439603,
@@ -20387,7 +20389,7 @@
         },
         {
             "number": 7048,
-            "class": "bus",
+            "class": "Bus",
             "name": "KATY 1 1",
             "init": {
                 "Vr": 0.8411781750467269,
@@ -20401,7 +20403,7 @@
         },
         {
             "number": 7049,
-            "class": "bus",
+            "class": "Bus",
             "name": "KATY 1 2",
             "init": {
                 "Vr": 0.7891016396871517,
@@ -20415,7 +20417,7 @@
         },
         {
             "number": 7050,
-            "class": "bus",
+            "class": "Bus",
             "name": "MAGNOLIA 2 0",
             "init": {
                 "Vr": 0.7311469356098341,
@@ -20429,7 +20431,7 @@
         },
         {
             "number": 7051,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 29 0",
             "init": {
                 "Vr": 0.771562725969607,
@@ -20443,7 +20445,7 @@
         },
         {
             "number": 7052,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSOURI CITY 1 0",
             "init": {
                 "Vr": 0.7921194182058708,
@@ -20457,7 +20459,7 @@
         },
         {
             "number": 7053,
-            "class": "bus",
+            "class": "Bus",
             "name": "RICHMOND 1 0",
             "init": {
                 "Vr": 0.8462142402706255,
@@ -20471,7 +20473,7 @@
         },
         {
             "number": 7054,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 11 0",
             "init": {
                 "Vr": 0.7642416969628405,
@@ -20485,7 +20487,7 @@
         },
         {
             "number": 7055,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 33 0",
             "init": {
                 "Vr": 0.7965821473247929,
@@ -20499,7 +20501,7 @@
         },
         {
             "number": 7056,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 8 0",
             "init": {
                 "Vr": 0.8137737008716597,
@@ -20513,7 +20515,7 @@
         },
         {
             "number": 7057,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 8 1",
             "init": {
                 "Vr": 0.7501568548646537,
@@ -20527,7 +20529,7 @@
         },
         {
             "number": 7058,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 2 0",
             "init": {
                 "Vr": 0.8970052121517302,
@@ -20541,7 +20543,7 @@
         },
         {
             "number": 7059,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 2 1",
             "init": {
                 "Vr": 0.8856612778349846,
@@ -20555,7 +20557,7 @@
         },
         {
             "number": 7060,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 2 2",
             "init": {
                 "Vr": 0.8688742687503069,
@@ -20569,7 +20571,7 @@
         },
         {
             "number": 7061,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 2 3",
             "init": {
                 "Vr": 0.901944163144591,
@@ -20583,7 +20585,7 @@
         },
         {
             "number": 7062,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 2 4",
             "init": {
                 "Vr": 0.9015554265675634,
@@ -20597,7 +20599,7 @@
         },
         {
             "number": 7063,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 2 5",
             "init": {
                 "Vr": 0.901942548497898,
@@ -20611,7 +20613,7 @@
         },
         {
             "number": 7064,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 2 6",
             "init": {
                 "Vr": 0.9020901643968904,
@@ -20625,7 +20627,7 @@
         },
         {
             "number": 7065,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 2 7",
             "init": {
                 "Vr": 0.9026690507020662,
@@ -20639,7 +20641,7 @@
         },
         {
             "number": 7066,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 2 8",
             "init": {
                 "Vr": 0.9015615013204715,
@@ -20653,7 +20655,7 @@
         },
         {
             "number": 7067,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 28 0",
             "init": {
                 "Vr": 0.7373294532127737,
@@ -20667,7 +20669,7 @@
         },
         {
             "number": 7068,
-            "class": "bus",
+            "class": "Bus",
             "name": "EL CAMPO 0",
             "init": {
                 "Vr": 0.8793502023686769,
@@ -20681,7 +20683,7 @@
         },
         {
             "number": 7069,
-            "class": "bus",
+            "class": "Bus",
             "name": "EL CAMPO 1",
             "init": {
                 "Vr": 0.8341425762835759,
@@ -20695,7 +20697,7 @@
         },
         {
             "number": 7070,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 12 0",
             "init": {
                 "Vr": 0.7987092533466785,
@@ -20709,7 +20711,7 @@
         },
         {
             "number": 7071,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT O CONNOR 0",
             "init": {
                 "Vr": 0.8463701875406593,
@@ -20723,7 +20725,7 @@
         },
         {
             "number": 7072,
-            "class": "bus",
+            "class": "Bus",
             "name": "DICKINSON 0",
             "init": {
                 "Vr": 0.8266449757707772,
@@ -20737,7 +20739,7 @@
         },
         {
             "number": 7073,
-            "class": "bus",
+            "class": "Bus",
             "name": "GALVESTON 1 0",
             "init": {
                 "Vr": 0.8703787238831256,
@@ -20751,7 +20753,7 @@
         },
         {
             "number": 7074,
-            "class": "bus",
+            "class": "Bus",
             "name": "GALVESTON 1 1",
             "init": {
                 "Vr": 0.8436911236865157,
@@ -20765,7 +20767,7 @@
         },
         {
             "number": 7075,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 10 0",
             "init": {
                 "Vr": 0.8299695130509073,
@@ -20779,7 +20781,7 @@
         },
         {
             "number": 7076,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 2 0",
             "init": {
                 "Vr": 0.9356248312053765,
@@ -20793,7 +20795,7 @@
         },
         {
             "number": 7077,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 2 1",
             "init": {
                 "Vr": 0.9107799856556211,
@@ -20807,7 +20809,7 @@
         },
         {
             "number": 7078,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 2 2",
             "init": {
                 "Vr": 0.8617542711620803,
@@ -20821,7 +20823,7 @@
         },
         {
             "number": 7079,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 2 3",
             "init": {
                 "Vr": 0.9514055664568588,
@@ -20835,7 +20837,7 @@
         },
         {
             "number": 7080,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 2 4",
             "init": {
                 "Vr": 0.9547871732479517,
@@ -20849,7 +20851,7 @@
         },
         {
             "number": 7081,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 2 5",
             "init": {
                 "Vr": 0.95491455737465,
@@ -20863,7 +20865,7 @@
         },
         {
             "number": 7082,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 2 6",
             "init": {
                 "Vr": 0.9520528862030478,
@@ -20877,7 +20879,7 @@
         },
         {
             "number": 7083,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEAGUE CITY 0",
             "init": {
                 "Vr": 0.87769612563254,
@@ -20891,7 +20893,7 @@
         },
         {
             "number": 7084,
-            "class": "bus",
+            "class": "Bus",
             "name": "LEAGUE CITY 1",
             "init": {
                 "Vr": 0.8393702770402459,
@@ -20905,7 +20907,7 @@
         },
         {
             "number": 7085,
-            "class": "bus",
+            "class": "Bus",
             "name": "LIVERPOOL 0",
             "init": {
                 "Vr": 0.8187951100299926,
@@ -20919,7 +20921,7 @@
         },
         {
             "number": 7086,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 16 0",
             "init": {
                 "Vr": 0.7888638848867615,
@@ -20933,7 +20935,7 @@
         },
         {
             "number": 7087,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUGAR LAND 1 0",
             "init": {
                 "Vr": 0.8101238297436192,
@@ -20947,7 +20949,7 @@
         },
         {
             "number": 7088,
-            "class": "bus",
+            "class": "Bus",
             "name": "RICHMOND 2 0",
             "init": {
                 "Vr": 0.7492917903961184,
@@ -20961,7 +20963,7 @@
         },
         {
             "number": 7089,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 82 0",
             "init": {
                 "Vr": 0.7751797350706935,
@@ -20975,7 +20977,7 @@
         },
         {
             "number": 7090,
-            "class": "bus",
+            "class": "Bus",
             "name": "PINEHURST 0",
             "init": {
                 "Vr": 0.7382043896209369,
@@ -20989,7 +20991,7 @@
         },
         {
             "number": 7091,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARLAND 2 0",
             "init": {
                 "Vr": 0.7902902974692502,
@@ -21003,7 +21005,7 @@
         },
         {
             "number": 7092,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 47 0",
             "init": {
                 "Vr": 0.776079723782822,
@@ -21017,7 +21019,7 @@
         },
         {
             "number": 7093,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 79 0",
             "init": {
                 "Vr": 0.7646293772529351,
@@ -21031,7 +21033,7 @@
         },
         {
             "number": 7094,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 49 0",
             "init": {
                 "Vr": 0.7684212853130771,
@@ -21045,7 +21047,7 @@
         },
         {
             "number": 7095,
-            "class": "bus",
+            "class": "Bus",
             "name": "WADSWORTH 0",
             "init": {
                 "Vr": 0.9387445024366234,
@@ -21059,7 +21061,7 @@
         },
         {
             "number": 7096,
-            "class": "bus",
+            "class": "Bus",
             "name": "WADSWORTH 1",
             "init": {
                 "Vr": 0.9293807920564755,
@@ -21073,7 +21075,7 @@
         },
         {
             "number": 7097,
-            "class": "bus",
+            "class": "Bus",
             "name": "WADSWORTH 2",
             "init": {
                 "Vr": 0.917017455657558,
@@ -21087,7 +21089,7 @@
         },
         {
             "number": 7098,
-            "class": "bus",
+            "class": "Bus",
             "name": "WADSWORTH 3",
             "init": {
                 "Vr": 1.0,
@@ -21101,7 +21103,7 @@
         },
         {
             "number": 7099,
-            "class": "bus",
+            "class": "Bus",
             "name": "WADSWORTH 4",
             "init": {
                 "Vr": 0.9743997221806158,
@@ -21115,7 +21117,7 @@
         },
         {
             "number": 7100,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 18 0",
             "init": {
                 "Vr": 0.7920079701587809,
@@ -21129,7 +21131,7 @@
         },
         {
             "number": 7101,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 88 0",
             "init": {
                 "Vr": 0.7854287082422277,
@@ -21143,7 +21145,7 @@
         },
         {
             "number": 7102,
-            "class": "bus",
+            "class": "Bus",
             "name": "TOMBALL 1 0",
             "init": {
                 "Vr": 0.7471645903423321,
@@ -21157,7 +21159,7 @@
         },
         {
             "number": 7103,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 22 0",
             "init": {
                 "Vr": 0.7889613614581344,
@@ -21171,7 +21173,7 @@
         },
         {
             "number": 7104,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 0",
             "init": {
                 "Vr": 0.9377740476346232,
@@ -21185,7 +21187,7 @@
         },
         {
             "number": 7105,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 1",
             "init": {
                 "Vr": 0.8896748710963116,
@@ -21199,7 +21201,7 @@
         },
         {
             "number": 7106,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 2",
             "init": {
                 "Vr": 0.8458082771779496,
@@ -21213,7 +21215,7 @@
         },
         {
             "number": 7107,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 3",
             "init": {
                 "Vr": 0.9506251504802703,
@@ -21227,7 +21229,7 @@
         },
         {
             "number": 7108,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 4",
             "init": {
                 "Vr": 0.954271782437956,
@@ -21241,7 +21243,7 @@
         },
         {
             "number": 7109,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 5",
             "init": {
                 "Vr": 0.9527645953784303,
@@ -21255,7 +21257,7 @@
         },
         {
             "number": 7110,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 6",
             "init": {
                 "Vr": 0.9595823190181174,
@@ -21269,7 +21271,7 @@
         },
         {
             "number": 7111,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 7",
             "init": {
                 "Vr": 0.9599228580475077,
@@ -21283,7 +21285,7 @@
         },
         {
             "number": 7112,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 8",
             "init": {
                 "Vr": 0.9542269985795914,
@@ -21297,7 +21299,7 @@
         },
         {
             "number": 7113,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 9",
             "init": {
                 "Vr": 0.962287218852497,
@@ -21311,7 +21313,7 @@
         },
         {
             "number": 7114,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 10",
             "init": {
                 "Vr": 0.9536372931051668,
@@ -21325,7 +21327,7 @@
         },
         {
             "number": 7115,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEER PARK 11",
             "init": {
                 "Vr": 0.9536429616871389,
@@ -21339,7 +21341,7 @@
         },
         {
             "number": 7116,
-            "class": "bus",
+            "class": "Bus",
             "name": "WALLIS 0",
             "init": {
                 "Vr": 0.7573842004903785,
@@ -21353,7 +21355,7 @@
         },
         {
             "number": 7117,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 67 0",
             "init": {
                 "Vr": 0.7709704936518924,
@@ -21367,7 +21369,7 @@
         },
         {
             "number": 7118,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 4 0",
             "init": {
                 "Vr": 0.7519165718875218,
@@ -21381,7 +21383,7 @@
         },
         {
             "number": 7119,
-            "class": "bus",
+            "class": "Bus",
             "name": "SOUTH HOUSTON 0",
             "init": {
                 "Vr": 0.7935552556183699,
@@ -21395,7 +21397,7 @@
         },
         {
             "number": 7120,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 3 0",
             "init": {
                 "Vr": 0.7510014857862144,
@@ -21409,7 +21411,7 @@
         },
         {
             "number": 7121,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 3 1",
             "init": {
                 "Vr": 0.7510014857862144,
@@ -21423,7 +21425,7 @@
         },
         {
             "number": 7122,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 3 2",
             "init": {
                 "Vr": 0.7510014857862144,
@@ -21437,7 +21439,7 @@
         },
         {
             "number": 7123,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEADRIFT 0",
             "init": {
                 "Vr": 0.8501222739643394,
@@ -21451,7 +21453,7 @@
         },
         {
             "number": 7124,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 34 0",
             "init": {
                 "Vr": 0.776271764874617,
@@ -21465,7 +21467,7 @@
         },
         {
             "number": 7125,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUGAR LAND 2 0",
             "init": {
                 "Vr": 0.9277430056740931,
@@ -21479,7 +21481,7 @@
         },
         {
             "number": 7126,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUGAR LAND 2 1",
             "init": {
                 "Vr": 0.8602127729924081,
@@ -21493,7 +21495,7 @@
         },
         {
             "number": 7127,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUGAR LAND 2 2",
             "init": {
                 "Vr": 0.831045728751214,
@@ -21507,7 +21509,7 @@
         },
         {
             "number": 7128,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONROE 7 0",
             "init": {
                 "Vr": 0.770001535982076,
@@ -21521,7 +21523,7 @@
         },
         {
             "number": 7129,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOLITA 0",
             "init": {
                 "Vr": 0.8474548590673889,
@@ -21535,7 +21537,7 @@
         },
         {
             "number": 7130,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 0",
             "init": {
                 "Vr": 0.9371916710612659,
@@ -21549,7 +21551,7 @@
         },
         {
             "number": 7131,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 1",
             "init": {
                 "Vr": 0.8869647826107433,
@@ -21563,7 +21565,7 @@
         },
         {
             "number": 7132,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 2",
             "init": {
                 "Vr": 0.8425393800930268,
@@ -21577,7 +21579,7 @@
         },
         {
             "number": 7133,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 3",
             "init": {
                 "Vr": 0.9398316556416391,
@@ -21591,7 +21593,7 @@
         },
         {
             "number": 7134,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 4",
             "init": {
                 "Vr": 0.9453134452898824,
@@ -21605,7 +21607,7 @@
         },
         {
             "number": 7135,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 5",
             "init": {
                 "Vr": 0.9471594097872269,
@@ -21619,7 +21621,7 @@
         },
         {
             "number": 7136,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 6",
             "init": {
                 "Vr": 0.9480083823926174,
@@ -21633,7 +21635,7 @@
         },
         {
             "number": 7137,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 7",
             "init": {
                 "Vr": 0.9486835916870631,
@@ -21647,7 +21649,7 @@
         },
         {
             "number": 7138,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 8",
             "init": {
                 "Vr": 0.9449545857069653,
@@ -21661,7 +21663,7 @@
         },
         {
             "number": 7139,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 9",
             "init": {
                 "Vr": 0.9453938747755916,
@@ -21675,7 +21677,7 @@
         },
         {
             "number": 7140,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 10",
             "init": {
                 "Vr": 0.9439785949260747,
@@ -21689,7 +21691,7 @@
         },
         {
             "number": 7141,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 11",
             "init": {
                 "Vr": 0.941797534732503,
@@ -21703,7 +21705,7 @@
         },
         {
             "number": 7142,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAPORTE 12",
             "init": {
                 "Vr": 0.9431704648760364,
@@ -21717,7 +21719,7 @@
         },
         {
             "number": 7143,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEW CANEY 0",
             "init": {
                 "Vr": 0.754405509077777,
@@ -21731,7 +21733,7 @@
         },
         {
             "number": 7144,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 14 0",
             "init": {
                 "Vr": 0.8004041416280162,
@@ -21745,7 +21747,7 @@
         },
         {
             "number": 7145,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 2 0",
             "init": {
                 "Vr": 0.7768392973839788,
@@ -21759,7 +21761,7 @@
         },
         {
             "number": 7146,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 2 1",
             "init": {
                 "Vr": 0.788923598526552,
@@ -21773,7 +21775,7 @@
         },
         {
             "number": 7147,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 78 0",
             "init": {
                 "Vr": 0.7893089139577969,
@@ -21787,7 +21789,7 @@
         },
         {
             "number": 7148,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 40 0",
             "init": {
                 "Vr": 0.756985812906537,
@@ -21801,7 +21803,7 @@
         },
         {
             "number": 7149,
-            "class": "bus",
+            "class": "Bus",
             "name": "BLOOMINGTON 0",
             "init": {
                 "Vr": 0.8233486407546609,
@@ -21815,7 +21817,7 @@
         },
         {
             "number": 7150,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILLIS 2 0",
             "init": {
                 "Vr": 0.8072689035106329,
@@ -21829,7 +21831,7 @@
         },
         {
             "number": 7151,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILLIS 2 1",
             "init": {
                 "Vr": 0.773197090605594,
@@ -21843,7 +21845,7 @@
         },
         {
             "number": 7152,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 51 0",
             "init": {
                 "Vr": 0.7824366977859696,
@@ -21857,7 +21859,7 @@
         },
         {
             "number": 7153,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALACIOS 0",
             "init": {
                 "Vr": 0.8794476119064288,
@@ -21871,7 +21873,7 @@
         },
         {
             "number": 7154,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONROE 4 0",
             "init": {
                 "Vr": 0.7608875751927628,
@@ -21885,7 +21887,7 @@
         },
         {
             "number": 7155,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 52 0",
             "init": {
                 "Vr": 0.7732835349138036,
@@ -21899,7 +21901,7 @@
         },
         {
             "number": 7156,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 2 0",
             "init": {
                 "Vr": 0.8196288063911705,
@@ -21913,7 +21915,7 @@
         },
         {
             "number": 7157,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 2 1",
             "init": {
                 "Vr": 0.7801039308931146,
@@ -21927,7 +21929,7 @@
         },
         {
             "number": 7158,
-            "class": "bus",
+            "class": "Bus",
             "name": "KINGWOOD 1 0",
             "init": {
                 "Vr": 0.7590809582804482,
@@ -21941,7 +21943,7 @@
         },
         {
             "number": 7159,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 0",
             "init": {
                 "Vr": 0.8782362694652964,
@@ -21955,7 +21957,7 @@
         },
         {
             "number": 7160,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 1",
             "init": {
                 "Vr": 0.8461886550197937,
@@ -21969,7 +21971,7 @@
         },
         {
             "number": 7161,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 2",
             "init": {
                 "Vr": 0.804492468033181,
@@ -21983,7 +21985,7 @@
         },
         {
             "number": 7162,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 3",
             "init": {
                 "Vr": 0.8945089340897707,
@@ -21997,7 +21999,7 @@
         },
         {
             "number": 7163,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 4",
             "init": {
                 "Vr": 0.9025293342092213,
@@ -22011,7 +22013,7 @@
         },
         {
             "number": 7164,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 5",
             "init": {
                 "Vr": 0.8964578975163399,
@@ -22025,7 +22027,7 @@
         },
         {
             "number": 7165,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 6",
             "init": {
                 "Vr": 0.8946846242181057,
@@ -22039,7 +22041,7 @@
         },
         {
             "number": 7166,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 7",
             "init": {
                 "Vr": 0.9047601497755637,
@@ -22053,7 +22055,7 @@
         },
         {
             "number": 7167,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 8",
             "init": {
                 "Vr": 0.9080546842213362,
@@ -22067,7 +22069,7 @@
         },
         {
             "number": 7168,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 9",
             "init": {
                 "Vr": 0.897039853054888,
@@ -22081,7 +22083,7 @@
         },
         {
             "number": 7169,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 10",
             "init": {
                 "Vr": 0.8936252529022184,
@@ -22095,7 +22097,7 @@
         },
         {
             "number": 7170,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 5 11",
             "init": {
                 "Vr": 0.9092298329226508,
@@ -22109,7 +22111,7 @@
         },
         {
             "number": 7171,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEXAS CITY 1 0",
             "init": {
                 "Vr": 0.8663618468486721,
@@ -22123,7 +22125,7 @@
         },
         {
             "number": 7172,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEXAS CITY 1 1",
             "init": {
                 "Vr": 0.848261837583672,
@@ -22137,7 +22139,7 @@
         },
         {
             "number": 7173,
-            "class": "bus",
+            "class": "Bus",
             "name": "KINGWOOD 2 0",
             "init": {
                 "Vr": 0.7483261976535798,
@@ -22151,7 +22153,7 @@
         },
         {
             "number": 7174,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 8 0",
             "init": {
                 "Vr": 0.8041124962679798,
@@ -22165,7 +22167,7 @@
         },
         {
             "number": 7175,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 7 0",
             "init": {
                 "Vr": 0.8662813321733098,
@@ -22179,7 +22181,7 @@
         },
         {
             "number": 7176,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 7 1",
             "init": {
                 "Vr": 0.8312325021955405,
@@ -22193,7 +22195,7 @@
         },
         {
             "number": 7177,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 7 2",
             "init": {
                 "Vr": 0.7636695012508268,
@@ -22207,7 +22209,7 @@
         },
         {
             "number": 7178,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 41 0",
             "init": {
                 "Vr": 0.7500303506162976,
@@ -22221,7 +22223,7 @@
         },
         {
             "number": 7179,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRESNO 0",
             "init": {
                 "Vr": 0.7870727720110405,
@@ -22235,7 +22237,7 @@
         },
         {
             "number": 7180,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 48 0",
             "init": {
                 "Vr": 0.771704264964419,
@@ -22249,7 +22251,7 @@
         },
         {
             "number": 7181,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 58 0",
             "init": {
                 "Vr": 0.750894179718482,
@@ -22263,7 +22265,7 @@
         },
         {
             "number": 7182,
-            "class": "bus",
+            "class": "Bus",
             "name": "PATTISON 0",
             "init": {
                 "Vr": 0.7526934226243317,
@@ -22277,7 +22279,7 @@
         },
         {
             "number": 7183,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 77 0",
             "init": {
                 "Vr": 0.7886227292961784,
@@ -22291,7 +22293,7 @@
         },
         {
             "number": 7184,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSOURI CITY 2 0",
             "init": {
                 "Vr": 0.8947393726213928,
@@ -22305,7 +22307,7 @@
         },
         {
             "number": 7185,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSOURI CITY 2 1",
             "init": {
                 "Vr": 0.8639311543946063,
@@ -22319,7 +22321,7 @@
         },
         {
             "number": 7186,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 0",
             "init": {
                 "Vr": 0.9140459943956839,
@@ -22333,7 +22335,7 @@
         },
         {
             "number": 7187,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 1",
             "init": {
                 "Vr": 0.8644111134778265,
@@ -22347,7 +22349,7 @@
         },
         {
             "number": 7188,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 2",
             "init": {
                 "Vr": 0.8068098949710343,
@@ -22361,7 +22363,7 @@
         },
         {
             "number": 7189,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 3",
             "init": {
                 "Vr": 0.9166352701307879,
@@ -22375,7 +22377,7 @@
         },
         {
             "number": 7190,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 4",
             "init": {
                 "Vr": 0.9305460730507695,
@@ -22389,7 +22391,7 @@
         },
         {
             "number": 7191,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 5",
             "init": {
                 "Vr": 0.9140459943956839,
@@ -22403,7 +22405,7 @@
         },
         {
             "number": 7192,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 6",
             "init": {
                 "Vr": 0.9251020589946565,
@@ -22417,7 +22419,7 @@
         },
         {
             "number": 7193,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 7",
             "init": {
                 "Vr": 0.915860466691528,
@@ -22431,7 +22433,7 @@
         },
         {
             "number": 7194,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 8",
             "init": {
                 "Vr": 0.9343336961764412,
@@ -22445,7 +22447,7 @@
         },
         {
             "number": 7195,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 9",
             "init": {
                 "Vr": 0.936585779829078,
@@ -22459,7 +22461,7 @@
         },
         {
             "number": 7196,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 10",
             "init": {
                 "Vr": 0.9288818696005302,
@@ -22473,7 +22475,7 @@
         },
         {
             "number": 7197,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 4 11",
             "init": {
                 "Vr": 0.925592110467409,
@@ -22487,7 +22489,7 @@
         },
         {
             "number": 7198,
-            "class": "bus",
+            "class": "Bus",
             "name": "TOMBALL 2 0",
             "init": {
                 "Vr": 0.7895286684399462,
@@ -22501,7 +22503,7 @@
         },
         {
             "number": 7199,
-            "class": "bus",
+            "class": "Bus",
             "name": "CYPRESS 1 0",
             "init": {
                 "Vr": 0.8747134678976409,
@@ -22515,7 +22517,7 @@
         },
         {
             "number": 7200,
-            "class": "bus",
+            "class": "Bus",
             "name": "CYPRESS 1 1",
             "init": {
                 "Vr": 0.8259726096635829,
@@ -22529,7 +22531,7 @@
         },
         {
             "number": 7201,
-            "class": "bus",
+            "class": "Bus",
             "name": "CYPRESS 1 2",
             "init": {
                 "Vr": 0.786607958916029,
@@ -22543,7 +22545,7 @@
         },
         {
             "number": 7202,
-            "class": "bus",
+            "class": "Bus",
             "name": "HEMPSTEAD 0",
             "init": {
                 "Vr": 0.7281076471117748,
@@ -22557,7 +22559,7 @@
         },
         {
             "number": 7203,
-            "class": "bus",
+            "class": "Bus",
             "name": "WEST COLUMBIA 0",
             "init": {
                 "Vr": 0.826373436534644,
@@ -22571,7 +22573,7 @@
         },
         {
             "number": 7204,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 1 0",
             "init": {
                 "Vr": 0.9414030949657463,
@@ -22585,7 +22587,7 @@
         },
         {
             "number": 7205,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 1 1",
             "init": {
                 "Vr": 0.9092408750342246,
@@ -22599,7 +22601,7 @@
         },
         {
             "number": 7206,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 1 2",
             "init": {
                 "Vr": 0.871657061654558,
@@ -22613,7 +22615,7 @@
         },
         {
             "number": 7207,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 1 3",
             "init": {
                 "Vr": 0.9414030949657463,
@@ -22627,7 +22629,7 @@
         },
         {
             "number": 7208,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 1 4",
             "init": {
                 "Vr": 0.9727683427375879,
@@ -22641,7 +22643,7 @@
         },
         {
             "number": 7209,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 1 5",
             "init": {
                 "Vr": 0.9651610230306565,
@@ -22655,7 +22657,7 @@
         },
         {
             "number": 7210,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 1 6",
             "init": {
                 "Vr": 0.9615685981689295,
@@ -22669,7 +22671,7 @@
         },
         {
             "number": 7211,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 1 7",
             "init": {
                 "Vr": 0.9574964022810994,
@@ -22683,7 +22685,7 @@
         },
         {
             "number": 7212,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 1 8",
             "init": {
                 "Vr": 0.9639829884323486,
@@ -22697,7 +22699,7 @@
         },
         {
             "number": 7213,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA FE 1 0",
             "init": {
                 "Vr": 0.817918977908162,
@@ -22711,7 +22713,7 @@
         },
         {
             "number": 7214,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 27 0",
             "init": {
                 "Vr": 0.78324225991393,
@@ -22725,7 +22727,7 @@
         },
         {
             "number": 7215,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 5 0",
             "init": {
                 "Vr": 0.747181525527613,
@@ -22739,7 +22741,7 @@
         },
         {
             "number": 7216,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 46 0",
             "init": {
                 "Vr": 0.7691291798709479,
@@ -22753,7 +22755,7 @@
         },
         {
             "number": 7217,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 23 0",
             "init": {
                 "Vr": 0.7707316668232042,
@@ -22767,7 +22769,7 @@
         },
         {
             "number": 7218,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONTGOMERY 0",
             "init": {
                 "Vr": 0.729741246104481,
@@ -22781,7 +22783,7 @@
         },
         {
             "number": 7219,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUNGERFORD 0",
             "init": {
                 "Vr": 0.8036131517945171,
@@ -22795,7 +22797,7 @@
         },
         {
             "number": 7220,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 84 0",
             "init": {
                 "Vr": 0.7713448903933383,
@@ -22809,7 +22811,7 @@
         },
         {
             "number": 7221,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 83 0",
             "init": {
                 "Vr": 0.7740621200628036,
@@ -22823,7 +22825,7 @@
         },
         {
             "number": 7222,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 24 0",
             "init": {
                 "Vr": 0.7847124494956016,
@@ -22837,7 +22839,7 @@
         },
         {
             "number": 7223,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 76 0",
             "init": {
                 "Vr": 0.7749482409186271,
@@ -22851,7 +22853,7 @@
         },
         {
             "number": 7224,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 43 0",
             "init": {
                 "Vr": 0.767271310890915,
@@ -22865,7 +22867,7 @@
         },
         {
             "number": 7225,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 81 0",
             "init": {
                 "Vr": 0.746321152502037,
@@ -22879,7 +22881,7 @@
         },
         {
             "number": 7226,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 35 0",
             "init": {
                 "Vr": 0.7816114474224543,
@@ -22893,7 +22895,7 @@
         },
         {
             "number": 7227,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 90 0",
             "init": {
                 "Vr": 0.8913689043183461,
@@ -22907,7 +22909,7 @@
         },
         {
             "number": 7228,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 90 1",
             "init": {
                 "Vr": 0.8405547554589615,
@@ -22921,7 +22923,7 @@
         },
         {
             "number": 7229,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 90 2",
             "init": {
                 "Vr": 0.8114282630765915,
@@ -22935,7 +22937,7 @@
         },
         {
             "number": 7230,
-            "class": "bus",
+            "class": "Bus",
             "name": "BEASLEY 0",
             "init": {
                 "Vr": 0.7908325811016845,
@@ -22949,7 +22951,7 @@
         },
         {
             "number": 7231,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 7 0",
             "init": {
                 "Vr": 0.8203110274304987,
@@ -22963,7 +22965,7 @@
         },
         {
             "number": 7232,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA MARQUE 0",
             "init": {
                 "Vr": 0.8430381172854358,
@@ -22977,7 +22979,7 @@
         },
         {
             "number": 7233,
-            "class": "bus",
+            "class": "Bus",
             "name": "WALLER 0",
             "init": {
                 "Vr": 0.7257420998015462,
@@ -22991,7 +22993,7 @@
         },
         {
             "number": 7234,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORTER 0",
             "init": {
                 "Vr": 0.7564242299854207,
@@ -23005,7 +23007,7 @@
         },
         {
             "number": 7235,
-            "class": "bus",
+            "class": "Bus",
             "name": "CYPRESS 2 0",
             "init": {
                 "Vr": 0.7626733998128014,
@@ -23019,7 +23021,7 @@
         },
         {
             "number": 7236,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 30 0",
             "init": {
                 "Vr": 0.7779454910870103,
@@ -23033,7 +23035,7 @@
         },
         {
             "number": 7237,
-            "class": "bus",
+            "class": "Bus",
             "name": "FULSHEAR 0",
             "init": {
                 "Vr": 0.7704440859234973,
@@ -23047,7 +23049,7 @@
         },
         {
             "number": 7238,
-            "class": "bus",
+            "class": "Bus",
             "name": "LIBERTY 0",
             "init": {
                 "Vr": 0.8220052445684007,
@@ -23061,7 +23063,7 @@
         },
         {
             "number": 7239,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINNIE 0",
             "init": {
                 "Vr": 0.8162250565330406,
@@ -23075,7 +23077,7 @@
         },
         {
             "number": 7240,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 63 0",
             "init": {
                 "Vr": 0.7760366763893076,
@@ -23089,7 +23091,7 @@
         },
         {
             "number": 7241,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 70 0",
             "init": {
                 "Vr": 0.7597064691174581,
@@ -23103,7 +23105,7 @@
         },
         {
             "number": 7242,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 55 0",
             "init": {
                 "Vr": 0.7602606413836572,
@@ -23117,7 +23119,7 @@
         },
         {
             "number": 7243,
-            "class": "bus",
+            "class": "Bus",
             "name": "CROSBY 0",
             "init": {
                 "Vr": 0.78794650380108,
@@ -23131,7 +23133,7 @@
         },
         {
             "number": 7244,
-            "class": "bus",
+            "class": "Bus",
             "name": "MANVEL 0",
             "init": {
                 "Vr": 0.7952679590860817,
@@ -23145,7 +23147,7 @@
         },
         {
             "number": 7245,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 54 0",
             "init": {
                 "Vr": 0.753538264512482,
@@ -23159,7 +23161,7 @@
         },
         {
             "number": 7246,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 89 0",
             "init": {
                 "Vr": 0.7389872178490325,
@@ -23173,7 +23175,7 @@
         },
         {
             "number": 7247,
-            "class": "bus",
+            "class": "Bus",
             "name": "DAMON 0",
             "init": {
                 "Vr": 0.8218526512726526,
@@ -23187,7 +23189,7 @@
         },
         {
             "number": 7248,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 74 0",
             "init": {
                 "Vr": 0.7566202379990854,
@@ -23201,7 +23203,7 @@
         },
         {
             "number": 7249,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 26 0",
             "init": {
                 "Vr": 0.7703391140646083,
@@ -23215,7 +23217,7 @@
         },
         {
             "number": 7250,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 32 0",
             "init": {
                 "Vr": 0.788403717336496,
@@ -23229,7 +23231,7 @@
         },
         {
             "number": 7251,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOCKLEY 0",
             "init": {
                 "Vr": 0.7343975513284013,
@@ -23243,7 +23245,7 @@
         },
         {
             "number": 7252,
-            "class": "bus",
+            "class": "Bus",
             "name": "ANGLETON 0",
             "init": {
                 "Vr": 0.8834911941773151,
@@ -23257,7 +23259,7 @@
         },
         {
             "number": 7253,
-            "class": "bus",
+            "class": "Bus",
             "name": "ANGLETON 1",
             "init": {
                 "Vr": 0.8417738339491565,
@@ -23271,7 +23273,7 @@
         },
         {
             "number": 7254,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONROE 3 0",
             "init": {
                 "Vr": 0.7585482344777438,
@@ -23285,7 +23287,7 @@
         },
         {
             "number": 7255,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 39 0",
             "init": {
                 "Vr": 0.7982358628890354,
@@ -23299,7 +23301,7 @@
         },
         {
             "number": 7256,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 59 0",
             "init": {
                 "Vr": 0.7824172285250247,
@@ -23313,7 +23315,7 @@
         },
         {
             "number": 7257,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARLAND 1 0",
             "init": {
                 "Vr": 0.7929237812142118,
@@ -23327,7 +23329,7 @@
         },
         {
             "number": 7258,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 56 0",
             "init": {
                 "Vr": 0.7829501034324824,
@@ -23341,7 +23343,7 @@
         },
         {
             "number": 7259,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 13 0",
             "init": {
                 "Vr": 0.7935683059644113,
@@ -23355,7 +23357,7 @@
         },
         {
             "number": 7260,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 2 0",
             "init": {
                 "Vr": 0.8123832303973142,
@@ -23369,7 +23371,7 @@
         },
         {
             "number": 7261,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAY CITY 0",
             "init": {
                 "Vr": 0.9143393296793684,
@@ -23383,7 +23385,7 @@
         },
         {
             "number": 7262,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAY CITY 1",
             "init": {
                 "Vr": 0.9045064321548992,
@@ -23397,7 +23399,7 @@
         },
         {
             "number": 7263,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 3 0",
             "init": {
                 "Vr": 0.933898846671271,
@@ -23411,7 +23413,7 @@
         },
         {
             "number": 7264,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 3 1",
             "init": {
                 "Vr": 0.9036485426860351,
@@ -23425,7 +23427,7 @@
         },
         {
             "number": 7265,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 3 2",
             "init": {
                 "Vr": 0.841922594636025,
@@ -23439,7 +23441,7 @@
         },
         {
             "number": 7266,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 3 3",
             "init": {
                 "Vr": 0.9410202994914183,
@@ -23453,7 +23455,7 @@
         },
         {
             "number": 7267,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 3 4",
             "init": {
                 "Vr": 0.9455596319311554,
@@ -23467,7 +23469,7 @@
         },
         {
             "number": 7268,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 3 5",
             "init": {
                 "Vr": 0.9378302416510416,
@@ -23481,7 +23483,7 @@
         },
         {
             "number": 7269,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 3 6",
             "init": {
                 "Vr": 0.9443197889744533,
@@ -23495,7 +23497,7 @@
         },
         {
             "number": 7270,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 3 7",
             "init": {
                 "Vr": 0.940521561330508,
@@ -23509,7 +23511,7 @@
         },
         {
             "number": 7271,
-            "class": "bus",
+            "class": "Bus",
             "name": "BROOKSHIRE 0",
             "init": {
                 "Vr": 0.7534537646927006,
@@ -23523,7 +23525,7 @@
         },
         {
             "number": 7272,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 25 0",
             "init": {
                 "Vr": 0.7877722503280434,
@@ -23537,7 +23539,7 @@
         },
         {
             "number": 7273,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEXAS CITY 2 0",
             "init": {
                 "Vr": 0.8412945218893583,
@@ -23551,7 +23553,7 @@
         },
         {
             "number": 7274,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 3 0",
             "init": {
                 "Vr": 0.8407777290171332,
@@ -23565,7 +23567,7 @@
         },
         {
             "number": 7275,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 3 1",
             "init": {
                 "Vr": 0.8212136320453006,
@@ -23579,7 +23581,7 @@
         },
         {
             "number": 7276,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 36 0",
             "init": {
                 "Vr": 0.7815681725340804,
@@ -23593,7 +23595,7 @@
         },
         {
             "number": 7277,
-            "class": "bus",
+            "class": "Bus",
             "name": "GANADO 0",
             "init": {
                 "Vr": 0.8319168086118763,
@@ -23607,7 +23609,7 @@
         },
         {
             "number": 7278,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONT BELVIEU 0",
             "init": {
                 "Vr": 0.8804632897524184,
@@ -23621,7 +23623,7 @@
         },
         {
             "number": 7279,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONT BELVIEU 1",
             "init": {
                 "Vr": 0.8476385377857597,
@@ -23635,7 +23637,7 @@
         },
         {
             "number": 7280,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONT BELVIEU 2",
             "init": {
                 "Vr": 0.8804632897524184,
@@ -23649,7 +23651,7 @@
         },
         {
             "number": 7281,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONT BELVIEU 3",
             "init": {
                 "Vr": 0.8804632897524184,
@@ -23663,7 +23665,7 @@
         },
         {
             "number": 7282,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 3 0",
             "init": {
                 "Vr": 0.8994418572315763,
@@ -23677,7 +23679,7 @@
         },
         {
             "number": 7283,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 3 1",
             "init": {
                 "Vr": 0.8415664970121703,
@@ -23691,7 +23693,7 @@
         },
         {
             "number": 7284,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 3 2",
             "init": {
                 "Vr": 0.8994418572315763,
@@ -23705,7 +23707,7 @@
         },
         {
             "number": 7285,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 3 3",
             "init": {
                 "Vr": 0.908225637260587,
@@ -23719,7 +23721,7 @@
         },
         {
             "number": 7286,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 3 4",
             "init": {
                 "Vr": 0.9191820657299475,
@@ -23733,7 +23735,7 @@
         },
         {
             "number": 7287,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 3 5",
             "init": {
                 "Vr": 0.9164498159334752,
@@ -23747,7 +23749,7 @@
         },
         {
             "number": 7288,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 3 6",
             "init": {
                 "Vr": 0.9176889900186389,
@@ -23761,7 +23763,7 @@
         },
         {
             "number": 7289,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 3 7",
             "init": {
                 "Vr": 0.9132335592287897,
@@ -23775,7 +23777,7 @@
         },
         {
             "number": 7290,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 6 0",
             "init": {
                 "Vr": 0.7406600823299643,
@@ -23789,7 +23791,7 @@
         },
         {
             "number": 7291,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUMBLE 2 0",
             "init": {
                 "Vr": 0.7384627649967428,
@@ -23803,7 +23805,7 @@
         },
         {
             "number": 7292,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 69 0",
             "init": {
                 "Vr": 0.7899664257364479,
@@ -23817,7 +23819,7 @@
         },
         {
             "number": 7293,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANTA FE 2 0",
             "init": {
                 "Vr": 0.8219370608689824,
@@ -23831,7 +23833,7 @@
         },
         {
             "number": 7294,
-            "class": "bus",
+            "class": "Bus",
             "name": "PORT BOLIVAR 0",
             "init": {
                 "Vr": 0.8617667047592292,
@@ -23845,7 +23847,7 @@
         },
         {
             "number": 7295,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 42 0",
             "init": {
                 "Vr": 0.7589444166375767,
@@ -23859,7 +23861,7 @@
         },
         {
             "number": 7296,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 85 0",
             "init": {
                 "Vr": 0.7484501679535038,
@@ -23873,7 +23875,7 @@
         },
         {
             "number": 7297,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 50 0",
             "init": {
                 "Vr": 0.7732666915665258,
@@ -23887,7 +23889,7 @@
         },
         {
             "number": 7298,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 62 0",
             "init": {
                 "Vr": 0.7621315149125366,
@@ -23901,7 +23903,7 @@
         },
         {
             "number": 7299,
-            "class": "bus",
+            "class": "Bus",
             "name": "EAGLE LAKE 0",
             "init": {
                 "Vr": 0.7875696129126246,
@@ -23915,7 +23917,7 @@
         },
         {
             "number": 7300,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONROE 2 0",
             "init": {
                 "Vr": 0.76610633755522,
@@ -23929,7 +23931,7 @@
         },
         {
             "number": 7301,
-            "class": "bus",
+            "class": "Bus",
             "name": "WEBSTER 0",
             "init": {
                 "Vr": 0.7934786896811828,
@@ -23943,7 +23945,7 @@
         },
         {
             "number": 7302,
-            "class": "bus",
+            "class": "Bus",
             "name": "SWEENY 0",
             "init": {
                 "Vr": 0.8637538315094488,
@@ -23957,7 +23959,7 @@
         },
         {
             "number": 7303,
-            "class": "bus",
+            "class": "Bus",
             "name": "BLESSING 0",
             "init": {
                 "Vr": 0.8398472676487095,
@@ -23971,7 +23973,7 @@
         },
         {
             "number": 7304,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHARTON 1 0",
             "init": {
                 "Vr": 0.9284564978596963,
@@ -23985,7 +23987,7 @@
         },
         {
             "number": 7305,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHARTON 1 1",
             "init": {
                 "Vr": 0.8930526238354584,
@@ -23999,7 +24001,7 @@
         },
         {
             "number": 7306,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHARTON 1 2",
             "init": {
                 "Vr": 0.8423800981087751,
@@ -24013,7 +24015,7 @@
         },
         {
             "number": 7307,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHARTON 1 3",
             "init": {
                 "Vr": 0.946274786099644,
@@ -24027,7 +24029,7 @@
         },
         {
             "number": 7308,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHARTON 1 4",
             "init": {
                 "Vr": 0.9453365707684047,
@@ -24041,7 +24043,7 @@
         },
         {
             "number": 7309,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHARTON 1 5",
             "init": {
                 "Vr": 0.9284564978596963,
@@ -24055,7 +24057,7 @@
         },
         {
             "number": 7310,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHARTON 1 6",
             "init": {
                 "Vr": 0.9585346158393434,
@@ -24069,7 +24071,7 @@
         },
         {
             "number": 7311,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHARTON 1 7",
             "init": {
                 "Vr": 0.9476748726741413,
@@ -24083,7 +24085,7 @@
         },
         {
             "number": 7312,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAKE JACKSON 0",
             "init": {
                 "Vr": 0.8946413939843898,
@@ -24097,7 +24099,7 @@
         },
         {
             "number": 7313,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAKE JACKSON 1",
             "init": {
                 "Vr": 0.8460554532068996,
@@ -24111,7 +24113,7 @@
         },
         {
             "number": 7314,
-            "class": "bus",
+            "class": "Bus",
             "name": "BELLVILLE 0",
             "init": {
                 "Vr": 0.7500982516664763,
@@ -24125,7 +24127,7 @@
         },
         {
             "number": 7315,
-            "class": "bus",
+            "class": "Bus",
             "name": "KATY 4 0",
             "init": {
                 "Vr": 0.7728525913220339,
@@ -24139,7 +24141,7 @@
         },
         {
             "number": 7316,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 38 0",
             "init": {
                 "Vr": 0.7826462570279475,
@@ -24153,7 +24155,7 @@
         },
         {
             "number": 7317,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRIENDSWOOD 0",
             "init": {
                 "Vr": 0.8094662235743033,
@@ -24167,7 +24169,7 @@
         },
         {
             "number": 7318,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 17 0",
             "init": {
                 "Vr": 0.7774791754001694,
@@ -24181,7 +24183,7 @@
         },
         {
             "number": 7319,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 66 0",
             "init": {
                 "Vr": 0.7609411536437025,
@@ -24195,7 +24197,7 @@
         },
         {
             "number": 7320,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 1 0",
             "init": {
                 "Vr": 0.9184060041528296,
@@ -24209,7 +24211,7 @@
         },
         {
             "number": 7321,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 1 1",
             "init": {
                 "Vr": 0.9016291118389159,
@@ -24223,7 +24225,7 @@
         },
         {
             "number": 7322,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 1 2",
             "init": {
                 "Vr": 0.8615915572848887,
@@ -24237,7 +24239,7 @@
         },
         {
             "number": 7323,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 1 3",
             "init": {
                 "Vr": 0.9195488577784617,
@@ -24251,7 +24253,7 @@
         },
         {
             "number": 7324,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 1 4",
             "init": {
                 "Vr": 0.9198577797492788,
@@ -24265,7 +24267,7 @@
         },
         {
             "number": 7325,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 1 5",
             "init": {
                 "Vr": 0.9198563953443695,
@@ -24279,7 +24281,7 @@
         },
         {
             "number": 7326,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 1 6",
             "init": {
                 "Vr": 0.9191497014408848,
@@ -24293,7 +24295,7 @@
         },
         {
             "number": 7327,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEWGULF 0",
             "init": {
                 "Vr": 0.8903631659527479,
@@ -24307,7 +24309,7 @@
         },
         {
             "number": 7328,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEWGULF 1",
             "init": {
                 "Vr": 0.8701085873768982,
@@ -24321,7 +24323,7 @@
         },
         {
             "number": 7329,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEWGULF 2",
             "init": {
                 "Vr": 0.9128172958068159,
@@ -24335,7 +24337,7 @@
         },
         {
             "number": 7330,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 60 0",
             "init": {
                 "Vr": 0.7728401841610417,
@@ -24349,7 +24351,7 @@
         },
         {
             "number": 7331,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 1 0",
             "init": {
                 "Vr": 0.916864199314057,
@@ -24363,7 +24365,7 @@
         },
         {
             "number": 7332,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 1 1",
             "init": {
                 "Vr": 0.8820306174357514,
@@ -24377,7 +24379,7 @@
         },
         {
             "number": 7333,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 1 2",
             "init": {
                 "Vr": 0.8162502784311226,
@@ -24391,7 +24393,7 @@
         },
         {
             "number": 7334,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 1 3",
             "init": {
                 "Vr": 0.916864199314057,
@@ -24405,7 +24407,7 @@
         },
         {
             "number": 7335,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 1 4",
             "init": {
                 "Vr": 0.9336575539334891,
@@ -24419,7 +24421,7 @@
         },
         {
             "number": 7336,
-            "class": "bus",
+            "class": "Bus",
             "name": "STAFFORD 0",
             "init": {
                 "Vr": 0.7983431581410075,
@@ -24433,7 +24435,7 @@
         },
         {
             "number": 7337,
-            "class": "bus",
+            "class": "Bus",
             "name": "EDNA 0",
             "init": {
                 "Vr": 0.8045499240434584,
@@ -24447,7 +24449,7 @@
         },
         {
             "number": 7338,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 21 0",
             "init": {
                 "Vr": 0.7837183888688202,
@@ -24461,7 +24463,7 @@
         },
         {
             "number": 7339,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEEDVILLE 0",
             "init": {
                 "Vr": 0.8392189208644713,
@@ -24475,7 +24477,7 @@
         },
         {
             "number": 7340,
-            "class": "bus",
+            "class": "Bus",
             "name": "SEALY 0",
             "init": {
                 "Vr": 0.7465136641215403,
@@ -24489,7 +24491,7 @@
         },
         {
             "number": 7341,
-            "class": "bus",
+            "class": "Bus",
             "name": "KATY 3 0",
             "init": {
                 "Vr": 0.9042831088747514,
@@ -24503,7 +24505,7 @@
         },
         {
             "number": 7342,
-            "class": "bus",
+            "class": "Bus",
             "name": "KATY 3 1",
             "init": {
                 "Vr": 0.8492305190342644,
@@ -24517,7 +24519,7 @@
         },
         {
             "number": 7343,
-            "class": "bus",
+            "class": "Bus",
             "name": "KATY 3 2",
             "init": {
                 "Vr": 0.7748447608436836,
@@ -24531,7 +24533,7 @@
         },
         {
             "number": 7344,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 37 0",
             "init": {
                 "Vr": 0.7511607157677918,
@@ -24545,7 +24547,7 @@
         },
         {
             "number": 7345,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 19 0",
             "init": {
                 "Vr": 0.7912419727781457,
@@ -24559,7 +24561,7 @@
         },
         {
             "number": 7346,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 0",
             "init": {
                 "Vr": 0.9429861693907116,
@@ -24573,7 +24575,7 @@
         },
         {
             "number": 7347,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 1",
             "init": {
                 "Vr": 0.9033115514224158,
@@ -24587,7 +24589,7 @@
         },
         {
             "number": 7348,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 2",
             "init": {
                 "Vr": 0.863443456932008,
@@ -24601,7 +24603,7 @@
         },
         {
             "number": 7349,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 3",
             "init": {
                 "Vr": 0.9563072455887248,
@@ -24615,7 +24617,7 @@
         },
         {
             "number": 7350,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 4",
             "init": {
                 "Vr": 0.9653787183475834,
@@ -24629,7 +24631,7 @@
         },
         {
             "number": 7351,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 5",
             "init": {
                 "Vr": 0.9702366018697719,
@@ -24643,7 +24645,7 @@
         },
         {
             "number": 7352,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 6",
             "init": {
                 "Vr": 0.9688138298005182,
@@ -24657,7 +24659,7 @@
         },
         {
             "number": 7353,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 7",
             "init": {
                 "Vr": 0.9756252372084371,
@@ -24671,7 +24673,7 @@
         },
         {
             "number": 7354,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 8",
             "init": {
                 "Vr": 0.964508077829569,
@@ -24685,7 +24687,7 @@
         },
         {
             "number": 7355,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 9",
             "init": {
                 "Vr": 0.964636726888056,
@@ -24699,7 +24701,7 @@
         },
         {
             "number": 7356,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 10",
             "init": {
                 "Vr": 0.9631461283562974,
@@ -24713,7 +24715,7 @@
         },
         {
             "number": 7357,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 11",
             "init": {
                 "Vr": 0.9486090811181076,
@@ -24727,7 +24729,7 @@
         },
         {
             "number": 7358,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 12",
             "init": {
                 "Vr": 0.9674200334068384,
@@ -24741,7 +24743,7 @@
         },
         {
             "number": 7359,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 13",
             "init": {
                 "Vr": 0.9573415502801669,
@@ -24755,7 +24757,7 @@
         },
         {
             "number": 7360,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 14",
             "init": {
                 "Vr": 0.9624309901867746,
@@ -24769,7 +24771,7 @@
         },
         {
             "number": 7361,
-            "class": "bus",
+            "class": "Bus",
             "name": "THOMPSONS 15",
             "init": {
                 "Vr": 0.9591911041019757,
@@ -24783,7 +24785,7 @@
         },
         {
             "number": 7362,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 61 0",
             "init": {
                 "Vr": 0.7620168604387461,
@@ -24797,7 +24799,7 @@
         },
         {
             "number": 7363,
-            "class": "bus",
+            "class": "Bus",
             "name": "GALVESTON 3 0",
             "init": {
                 "Vr": 0.8162304313769052,
@@ -24811,7 +24813,7 @@
         },
         {
             "number": 7364,
-            "class": "bus",
+            "class": "Bus",
             "name": "EAST BERNARD 0",
             "init": {
                 "Vr": 0.7693009361559421,
@@ -24825,7 +24827,7 @@
         },
         {
             "number": 7365,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 20 0",
             "init": {
                 "Vr": 0.7771838962992523,
@@ -24839,7 +24841,7 @@
         },
         {
             "number": 7366,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 0",
             "init": {
                 "Vr": 0.9306947192705701,
@@ -24853,7 +24855,7 @@
         },
         {
             "number": 7367,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 1",
             "init": {
                 "Vr": 0.8815552627269232,
@@ -24867,7 +24869,7 @@
         },
         {
             "number": 7368,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 2",
             "init": {
                 "Vr": 0.8281874277943674,
@@ -24881,7 +24883,7 @@
         },
         {
             "number": 7369,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 3",
             "init": {
                 "Vr": 0.9530962782500996,
@@ -24895,7 +24897,7 @@
         },
         {
             "number": 7370,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 4",
             "init": {
                 "Vr": 0.9566975081027663,
@@ -24909,7 +24911,7 @@
         },
         {
             "number": 7371,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 5",
             "init": {
                 "Vr": 0.9537709596428673,
@@ -24923,7 +24925,7 @@
         },
         {
             "number": 7372,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 6",
             "init": {
                 "Vr": 0.9527624785797895,
@@ -24937,7 +24939,7 @@
         },
         {
             "number": 7373,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 7",
             "init": {
                 "Vr": 0.9415438189095582,
@@ -24951,7 +24953,7 @@
         },
         {
             "number": 7374,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 8",
             "init": {
                 "Vr": 0.9501968109345881,
@@ -24965,7 +24967,7 @@
         },
         {
             "number": 7375,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 9",
             "init": {
                 "Vr": 0.9587930730867912,
@@ -24979,7 +24981,7 @@
         },
         {
             "number": 7376,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 10",
             "init": {
                 "Vr": 0.9573496774875462,
@@ -24993,7 +24995,7 @@
         },
         {
             "number": 7377,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 11",
             "init": {
                 "Vr": 0.9531238112114482,
@@ -25007,7 +25009,7 @@
         },
         {
             "number": 7378,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 12",
             "init": {
                 "Vr": 0.9565521094108101,
@@ -25021,7 +25023,7 @@
         },
         {
             "number": 7379,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANNELVIEW 1 13",
             "init": {
                 "Vr": 0.9552812387197309,
@@ -25035,7 +25037,7 @@
         },
         {
             "number": 7380,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 3 0",
             "init": {
                 "Vr": 0.844306930428057,
@@ -25049,7 +25051,7 @@
         },
         {
             "number": 7381,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 15 0",
             "init": {
                 "Vr": 0.7695962066076725,
@@ -25063,7 +25065,7 @@
         },
         {
             "number": 7382,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 31 0",
             "init": {
                 "Vr": 0.7767474849976553,
@@ -25077,7 +25079,7 @@
         },
         {
             "number": 7383,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSHARON 0",
             "init": {
                 "Vr": 0.8254199723182487,
@@ -25091,7 +25093,7 @@
         },
         {
             "number": 7384,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 44 0",
             "init": {
                 "Vr": 0.7681369562557758,
@@ -25105,7 +25107,7 @@
         },
         {
             "number": 7385,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 75 0",
             "init": {
                 "Vr": 0.7554329558694471,
@@ -25119,7 +25121,7 @@
         },
         {
             "number": 7386,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 71 0",
             "init": {
                 "Vr": 0.7703881092405874,
@@ -25133,7 +25135,7 @@
         },
         {
             "number": 7387,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUMBLE 1 0",
             "init": {
                 "Vr": 0.7587235553858885,
@@ -25147,7 +25149,7 @@
         },
         {
             "number": 7388,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 68 0",
             "init": {
                 "Vr": 0.7652097436604939,
@@ -25161,7 +25163,7 @@
         },
         {
             "number": 7389,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILLIS 1 0",
             "init": {
                 "Vr": 0.8542355736445085,
@@ -25175,7 +25177,7 @@
         },
         {
             "number": 7390,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILLIS 1 1",
             "init": {
                 "Vr": 0.8186987391118014,
@@ -25189,7 +25191,7 @@
         },
         {
             "number": 7391,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILLIS 1 2",
             "init": {
                 "Vr": 0.785578316620979,
@@ -25203,7 +25205,7 @@
         },
         {
             "number": 7392,
-            "class": "bus",
+            "class": "Bus",
             "name": "BAYTOWN 4 0",
             "init": {
                 "Vr": 0.8281161068183056,
@@ -25217,7 +25219,7 @@
         },
         {
             "number": 7393,
-            "class": "bus",
+            "class": "Bus",
             "name": "VAN VLECK 0",
             "init": {
                 "Vr": 0.8268347932119045,
@@ -25231,7 +25233,7 @@
         },
         {
             "number": 7394,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUFFMAN 0",
             "init": {
                 "Vr": 0.7736368154028781,
@@ -25245,7 +25247,7 @@
         },
         {
             "number": 7395,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 53 0",
             "init": {
                 "Vr": 0.7648427467356633,
@@ -25259,7 +25261,7 @@
         },
         {
             "number": 7396,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 91 0",
             "init": {
                 "Vr": 0.768763400740786,
@@ -25273,7 +25275,7 @@
         },
         {
             "number": 7397,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROSENBERG 0",
             "init": {
                 "Vr": 0.7799623226670389,
@@ -25287,7 +25289,7 @@
         },
         {
             "number": 7398,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 5 0",
             "init": {
                 "Vr": 0.8092415392904257,
@@ -25301,7 +25303,7 @@
         },
         {
             "number": 7399,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 45 0",
             "init": {
                 "Vr": 0.7898839444829157,
@@ -25315,7 +25317,7 @@
         },
         {
             "number": 7400,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 6 0",
             "init": {
                 "Vr": 0.9226942222272455,
@@ -25329,7 +25331,7 @@
         },
         {
             "number": 7401,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 6 1",
             "init": {
                 "Vr": 0.8889799530193705,
@@ -25343,7 +25345,7 @@
         },
         {
             "number": 7402,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 6 2",
             "init": {
                 "Vr": 0.837483163369663,
@@ -25357,7 +25359,7 @@
         },
         {
             "number": 7403,
-            "class": "bus",
+            "class": "Bus",
             "name": "PASADENA 4 0",
             "init": {
                 "Vr": 0.8129736877116467,
@@ -25371,7 +25373,7 @@
         },
         {
             "number": 7404,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 57 0",
             "init": {
                 "Vr": 0.7479406249429131,
@@ -25385,7 +25387,7 @@
         },
         {
             "number": 7405,
-            "class": "bus",
+            "class": "Bus",
             "name": "GALVESTON 2 0",
             "init": {
                 "Vr": 0.8379220725928197,
@@ -25399,7 +25401,7 @@
         },
         {
             "number": 7406,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 1 0",
             "init": {
                 "Vr": 0.8944409634605636,
@@ -25413,7 +25415,7 @@
         },
         {
             "number": 7407,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 1 1",
             "init": {
                 "Vr": 0.8833162660917812,
@@ -25427,7 +25429,7 @@
         },
         {
             "number": 7408,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT COMFORT 1 2",
             "init": {
                 "Vr": 0.8383487170421113,
@@ -25441,7 +25443,7 @@
         },
         {
             "number": 7409,
-            "class": "bus",
+            "class": "Bus",
             "name": "KATY 2 0",
             "init": {
                 "Vr": 0.8421709449380193,
@@ -25455,7 +25457,7 @@
         },
         {
             "number": 7410,
-            "class": "bus",
+            "class": "Bus",
             "name": "KATY 2 1",
             "init": {
                 "Vr": 0.7811155127632382,
@@ -25469,7 +25471,7 @@
         },
         {
             "number": 7411,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPRING 3 0",
             "init": {
                 "Vr": 0.7470903335113249,
@@ -25483,7 +25485,7 @@
         },
         {
             "number": 7412,
-            "class": "bus",
+            "class": "Bus",
             "name": "DANBURY 0",
             "init": {
                 "Vr": 0.825853088983882,
@@ -25497,7 +25499,7 @@
         },
         {
             "number": 7413,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHARTON 2 0",
             "init": {
                 "Vr": 0.8166697641911265,
@@ -25511,7 +25513,7 @@
         },
         {
             "number": 7414,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 1 0",
             "init": {
                 "Vr": 0.8682511464404765,
@@ -25525,7 +25527,7 @@
         },
         {
             "number": 7415,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 1 1",
             "init": {
                 "Vr": 0.8594190078837345,
@@ -25539,7 +25541,7 @@
         },
         {
             "number": 7416,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORIA 1 2",
             "init": {
                 "Vr": 0.8332585994971741,
@@ -25553,7 +25555,7 @@
         },
         {
             "number": 7417,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 64 0",
             "init": {
                 "Vr": 0.7834313259082448,
@@ -25567,7 +25569,7 @@
         },
         {
             "number": 7418,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 65 0",
             "init": {
                 "Vr": 0.7884896378664624,
@@ -25581,7 +25583,7 @@
         },
         {
             "number": 7419,
-            "class": "bus",
+            "class": "Bus",
             "name": "LA PORTE 0",
             "init": {
                 "Vr": 0.8329838691373062,
@@ -25595,7 +25597,7 @@
         },
         {
             "number": 7420,
-            "class": "bus",
+            "class": "Bus",
             "name": "MAGNOLIA 1 0",
             "init": {
                 "Vr": 0.8089991293082046,
@@ -25609,7 +25611,7 @@
         },
         {
             "number": 7421,
-            "class": "bus",
+            "class": "Bus",
             "name": "MAGNOLIA 1 1",
             "init": {
                 "Vr": 0.7458723104724477,
@@ -25623,7 +25625,7 @@
         },
         {
             "number": 7422,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALVIN 0",
             "init": {
                 "Vr": 0.9225926856342829,
@@ -25637,7 +25639,7 @@
         },
         {
             "number": 7423,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALVIN 1",
             "init": {
                 "Vr": 0.8825437810862171,
@@ -25651,7 +25653,7 @@
         },
         {
             "number": 7424,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALVIN 2",
             "init": {
                 "Vr": 0.8292047517664737,
@@ -25665,7 +25667,7 @@
         },
         {
             "number": 7425,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 86 0",
             "init": {
                 "Vr": 0.746699357218691,
@@ -25679,7 +25681,7 @@
         },
         {
             "number": 7426,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRAZORIA 0",
             "init": {
                 "Vr": 0.8323387409650246,
@@ -25693,7 +25695,7 @@
         },
         {
             "number": 7427,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOUSTON 87 0",
             "init": {
                 "Vr": 0.748497425130226,
@@ -25707,7 +25709,7 @@
         },
         {
             "number": 7428,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 2 0",
             "init": {
                 "Vr": 0.9220654335940798,
@@ -25721,7 +25723,7 @@
         },
         {
             "number": 7429,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 2 1",
             "init": {
                 "Vr": 0.9043559586499954,
@@ -25735,7 +25737,7 @@
         },
         {
             "number": 7430,
-            "class": "bus",
+            "class": "Bus",
             "name": "FREEPORT 2 2",
             "init": {
                 "Vr": 0.8535118067344134,
@@ -25749,7 +25751,7 @@
         },
         {
             "number": 7431,
-            "class": "bus",
+            "class": "Bus",
             "name": "CONROE 6 0",
             "init": {
                 "Vr": 0.760950926706049,
@@ -25763,7 +25765,7 @@
         },
         {
             "number": 7432,
-            "class": "bus",
+            "class": "Bus",
             "name": "MADISONVILLE 0",
             "init": {
                 "Vr": 0.5113724676336874,
@@ -25777,7 +25779,7 @@
         },
         {
             "number": 8001,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORMANGEE 0",
             "init": {
                 "Vr": 0.5485771483123397,
@@ -25791,7 +25793,7 @@
         },
         {
             "number": 8002,
-            "class": "bus",
+            "class": "Bus",
             "name": "ARP 0",
             "init": {
                 "Vr": 0.3375266054601035,
@@ -25805,7 +25807,7 @@
         },
         {
             "number": 8003,
-            "class": "bus",
+            "class": "Bus",
             "name": "CENTERVILLE 0",
             "init": {
                 "Vr": 0.531518365518419,
@@ -25819,7 +25821,7 @@
         },
         {
             "number": 8004,
-            "class": "bus",
+            "class": "Bus",
             "name": "LUFKIN 3 0",
             "init": {
                 "Vr": 0.5388269999258282,
@@ -25833,7 +25835,7 @@
         },
         {
             "number": 8005,
-            "class": "bus",
+            "class": "Bus",
             "name": "LUFKIN 3 1",
             "init": {
                 "Vr": 0.5222255476050982,
@@ -25847,7 +25849,7 @@
         },
         {
             "number": 8006,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLINT 0",
             "init": {
                 "Vr": 0.3908883240964816,
@@ -25861,7 +25863,7 @@
         },
         {
             "number": 8007,
-            "class": "bus",
+            "class": "Bus",
             "name": "BULLARD 0",
             "init": {
                 "Vr": 0.369534954509618,
@@ -25875,7 +25877,7 @@
         },
         {
             "number": 8008,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHANDLER 0",
             "init": {
                 "Vr": 0.31623197986592505,
@@ -25889,7 +25891,7 @@
         },
         {
             "number": 8009,
-            "class": "bus",
+            "class": "Bus",
             "name": "PLANTERSVILLE 0",
             "init": {
                 "Vr": 0.7278679201614586,
@@ -25903,7 +25905,7 @@
         },
         {
             "number": 8010,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARQUEZ 0",
             "init": {
                 "Vr": 0.56602896116914,
@@ -25917,7 +25919,7 @@
         },
         {
             "number": 8011,
-            "class": "bus",
+            "class": "Bus",
             "name": "TENNESSEE COLONY 0",
             "init": {
                 "Vr": 0.4778791678688014,
@@ -25931,7 +25933,7 @@
         },
         {
             "number": 8012,
-            "class": "bus",
+            "class": "Bus",
             "name": "ANDERSON 0",
             "init": {
                 "Vr": 0.7509415834318495,
@@ -25945,7 +25947,7 @@
         },
         {
             "number": 8013,
-            "class": "bus",
+            "class": "Bus",
             "name": "MINEOLA 0",
             "init": {
                 "Vr": 0.3135337051698264,
@@ -25959,7 +25961,7 @@
         },
         {
             "number": 8014,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOVELADY 0",
             "init": {
                 "Vr": 0.4336029506120898,
@@ -25973,7 +25975,7 @@
         },
         {
             "number": 8015,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUNTINGTON 0",
             "init": {
                 "Vr": 0.4416748085845961,
@@ -25987,7 +25989,7 @@
         },
         {
             "number": 8016,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYAN 4 0",
             "init": {
                 "Vr": 0.6922459434966033,
@@ -26001,7 +26003,7 @@
         },
         {
             "number": 8017,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRANKSTON 0",
             "init": {
                 "Vr": 0.3638113665734743,
@@ -26015,7 +26017,7 @@
         },
         {
             "number": 8018,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 4 0",
             "init": {
                 "Vr": 0.44359210344601985,
@@ -26029,7 +26031,7 @@
         },
         {
             "number": 8019,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 4 1",
             "init": {
                 "Vr": 0.3766916869172808,
@@ -26043,7 +26045,7 @@
         },
         {
             "number": 8020,
-            "class": "bus",
+            "class": "Bus",
             "name": "BEN WHEELER 0",
             "init": {
                 "Vr": 0.3261461097188919,
@@ -26057,7 +26059,7 @@
         },
         {
             "number": 8021,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARRISON 0",
             "init": {
                 "Vr": 0.45016483685518527,
@@ -26071,7 +26073,7 @@
         },
         {
             "number": 8022,
-            "class": "bus",
+            "class": "Bus",
             "name": "ETOILE 0",
             "init": {
                 "Vr": 0.4397014003755604,
@@ -26085,7 +26087,7 @@
         },
         {
             "number": 8023,
-            "class": "bus",
+            "class": "Bus",
             "name": "LUFKIN 1 0",
             "init": {
                 "Vr": 0.4980953644034396,
@@ -26099,7 +26101,7 @@
         },
         {
             "number": 8024,
-            "class": "bus",
+            "class": "Bus",
             "name": "LUFKIN 1 1",
             "init": {
                 "Vr": 0.5510410909196249,
@@ -26113,7 +26115,7 @@
         },
         {
             "number": 8025,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALESTINE 1 0",
             "init": {
                 "Vr": 0.40042722963199817,
@@ -26127,7 +26129,7 @@
         },
         {
             "number": 8026,
-            "class": "bus",
+            "class": "Bus",
             "name": "LINDALE 0",
             "init": {
                 "Vr": 0.30383742212950277,
@@ -26141,7 +26143,7 @@
         },
         {
             "number": 8027,
-            "class": "bus",
+            "class": "Bus",
             "name": "WHITEHOUSE 0",
             "init": {
                 "Vr": 0.3794851324090898,
@@ -26155,7 +26157,7 @@
         },
         {
             "number": 8028,
-            "class": "bus",
+            "class": "Bus",
             "name": "OVERTON 0",
             "init": {
                 "Vr": 0.31649444341258,
@@ -26169,7 +26171,7 @@
         },
         {
             "number": 8029,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAND SALINE 0",
             "init": {
                 "Vr": 0.3103388827302578,
@@ -26183,7 +26185,7 @@
         },
         {
             "number": 8030,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHIRO 0",
             "init": {
                 "Vr": 0.8271364574676177,
@@ -26197,7 +26199,7 @@
         },
         {
             "number": 8031,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHIRO 1",
             "init": {
                 "Vr": 0.8145487190905386,
@@ -26211,7 +26213,7 @@
         },
         {
             "number": 8032,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHIRO 2",
             "init": {
                 "Vr": 0.7636145171762072,
@@ -26225,7 +26227,7 @@
         },
         {
             "number": 8033,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHIRO 3",
             "init": {
                 "Vr": 0.8271364574676177,
@@ -26239,7 +26241,7 @@
         },
         {
             "number": 8034,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHIRO 4",
             "init": {
                 "Vr": 0.8271364574676177,
@@ -26253,7 +26255,7 @@
         },
         {
             "number": 8035,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHIRO 5",
             "init": {
                 "Vr": 0.8271364574676177,
@@ -26267,7 +26269,7 @@
         },
         {
             "number": 8036,
-            "class": "bus",
+            "class": "Bus",
             "name": "SHIRO 6",
             "init": {
                 "Vr": 0.8271364574676177,
@@ -26281,7 +26283,7 @@
         },
         {
             "number": 8037,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY 0",
             "init": {
                 "Vr": 0.47487265363386955,
@@ -26295,7 +26297,7 @@
         },
         {
             "number": 8038,
-            "class": "bus",
+            "class": "Bus",
             "name": "SULPHUR SPRINGS 0",
             "init": {
                 "Vr": 0.43384084549139956,
@@ -26309,7 +26311,7 @@
         },
         {
             "number": 8039,
-            "class": "bus",
+            "class": "Bus",
             "name": "VAN 0",
             "init": {
                 "Vr": 0.31591744018252904,
@@ -26323,7 +26325,7 @@
         },
         {
             "number": 8040,
-            "class": "bus",
+            "class": "Bus",
             "name": "MURCHISON 0",
             "init": {
                 "Vr": 0.367274111887015,
@@ -26337,7 +26339,7 @@
         },
         {
             "number": 8041,
-            "class": "bus",
+            "class": "Bus",
             "name": "NACOGDOCHES 2 0",
             "init": {
                 "Vr": 0.4135430364909237,
@@ -26351,7 +26353,7 @@
         },
         {
             "number": 8042,
-            "class": "bus",
+            "class": "Bus",
             "name": "DIBOLL 0",
             "init": {
                 "Vr": 0.43070223905644905,
@@ -26365,7 +26367,7 @@
         },
         {
             "number": 8043,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 1 0",
             "init": {
                 "Vr": 0.5891346747170366,
@@ -26379,7 +26381,7 @@
         },
         {
             "number": 8044,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 1 1",
             "init": {
                 "Vr": 0.5562700569885953,
@@ -26393,7 +26395,7 @@
         },
         {
             "number": 8045,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 1 2",
             "init": {
                 "Vr": 0.5074457110382271,
@@ -26407,7 +26409,7 @@
         },
         {
             "number": 8046,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 1 3",
             "init": {
                 "Vr": 0.6062109587891886,
@@ -26421,7 +26423,7 @@
         },
         {
             "number": 8047,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 1 4",
             "init": {
                 "Vr": 0.5891346747170366,
@@ -26435,7 +26437,7 @@
         },
         {
             "number": 8048,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 1 5",
             "init": {
                 "Vr": 0.6384780795723606,
@@ -26449,7 +26451,7 @@
         },
         {
             "number": 8049,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 1 6",
             "init": {
                 "Vr": 0.6006692300723625,
@@ -26463,7 +26465,7 @@
         },
         {
             "number": 8050,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 1 7",
             "init": {
                 "Vr": 0.5891346747170366,
@@ -26477,7 +26479,7 @@
         },
         {
             "number": 8051,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 1 8",
             "init": {
                 "Vr": 0.5891346747170366,
@@ -26491,7 +26493,7 @@
         },
         {
             "number": 8052,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 8 0",
             "init": {
                 "Vr": 0.35608912760677874,
@@ -26505,7 +26507,7 @@
         },
         {
             "number": 8053,
-            "class": "bus",
+            "class": "Bus",
             "name": "ATHENS 1 0",
             "init": {
                 "Vr": 0.3367656578282332,
@@ -26519,7 +26521,7 @@
         },
         {
             "number": 8054,
-            "class": "bus",
+            "class": "Bus",
             "name": "BUFFALO 0",
             "init": {
                 "Vr": 0.4018788915549782,
@@ -26533,7 +26535,7 @@
         },
         {
             "number": 8055,
-            "class": "bus",
+            "class": "Bus",
             "name": "RUSK 0",
             "init": {
                 "Vr": 0.43329284000273355,
@@ -26547,7 +26549,7 @@
         },
         {
             "number": 8056,
-            "class": "bus",
+            "class": "Bus",
             "name": "WINONA 0",
             "init": {
                 "Vr": 0.34708713794587726,
@@ -26561,7 +26563,7 @@
         },
         {
             "number": 8057,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 2 0",
             "init": {
                 "Vr": 0.5458623880821346,
@@ -26575,7 +26577,7 @@
         },
         {
             "number": 8058,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 2 1",
             "init": {
                 "Vr": 0.5460450905836247,
@@ -26589,7 +26591,7 @@
         },
         {
             "number": 8059,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 2 2",
             "init": {
                 "Vr": 0.5141717834711782,
@@ -26603,7 +26605,7 @@
         },
         {
             "number": 8060,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 2 3",
             "init": {
                 "Vr": 0.5458623880821346,
@@ -26617,7 +26619,7 @@
         },
         {
             "number": 8061,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 2 4",
             "init": {
                 "Vr": 0.5458623880821346,
@@ -26631,7 +26633,7 @@
         },
         {
             "number": 8062,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUSHING 2 0",
             "init": {
                 "Vr": 0.49317052222969926,
@@ -26645,7 +26647,7 @@
         },
         {
             "number": 8063,
-            "class": "bus",
+            "class": "Bus",
             "name": "NACOGDOCHES 3 0",
             "init": {
                 "Vr": 0.3983301131738535,
@@ -26659,7 +26661,7 @@
         },
         {
             "number": 8064,
-            "class": "bus",
+            "class": "Bus",
             "name": "FAIRFIELD 3 0",
             "init": {
                 "Vr": 0.504111234823748,
@@ -26673,7 +26675,7 @@
         },
         {
             "number": 8065,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRINIDAD 2 0",
             "init": {
                 "Vr": 0.4003768817392432,
@@ -26687,7 +26689,7 @@
         },
         {
             "number": 8066,
-            "class": "bus",
+            "class": "Bus",
             "name": "DIKE 0",
             "init": {
                 "Vr": 0.45910690381699,
@@ -26701,7 +26703,7 @@
         },
         {
             "number": 8067,
-            "class": "bus",
+            "class": "Bus",
             "name": "JEWETT 1 0",
             "init": {
                 "Vr": 0.6243308108973055,
@@ -26715,7 +26717,7 @@
         },
         {
             "number": 8068,
-            "class": "bus",
+            "class": "Bus",
             "name": "JEWETT 1 1",
             "init": {
                 "Vr": 0.6165036212324906,
@@ -26729,7 +26731,7 @@
         },
         {
             "number": 8069,
-            "class": "bus",
+            "class": "Bus",
             "name": "JEWETT 1 2",
             "init": {
                 "Vr": 0.5982956907173584,
@@ -26743,7 +26745,7 @@
         },
         {
             "number": 8070,
-            "class": "bus",
+            "class": "Bus",
             "name": "JEWETT 1 3",
             "init": {
                 "Vr": 0.6243308108973055,
@@ -26757,7 +26759,7 @@
         },
         {
             "number": 8071,
-            "class": "bus",
+            "class": "Bus",
             "name": "JEWETT 1 4",
             "init": {
                 "Vr": 0.6886491991997727,
@@ -26771,7 +26773,7 @@
         },
         {
             "number": 8072,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALESTINE 2 0",
             "init": {
                 "Vr": 0.41626595126175686,
@@ -26785,7 +26787,7 @@
         },
         {
             "number": 8073,
-            "class": "bus",
+            "class": "Bus",
             "name": "EMORY 0",
             "init": {
                 "Vr": 0.31707329366652465,
@@ -26799,7 +26801,7 @@
         },
         {
             "number": 8074,
-            "class": "bus",
+            "class": "Bus",
             "name": "MT. ENTERPRISE 0",
             "init": {
                 "Vr": 0.6478000192979132,
@@ -26813,7 +26815,7 @@
         },
         {
             "number": 8075,
-            "class": "bus",
+            "class": "Bus",
             "name": "MT. ENTERPRISE 1",
             "init": {
                 "Vr": 0.602586916190702,
@@ -26827,7 +26829,7 @@
         },
         {
             "number": 8076,
-            "class": "bus",
+            "class": "Bus",
             "name": "MT. ENTERPRISE 2",
             "init": {
                 "Vr": 0.5431974366103995,
@@ -26841,7 +26843,7 @@
         },
         {
             "number": 8077,
-            "class": "bus",
+            "class": "Bus",
             "name": "MT. ENTERPRISE 3",
             "init": {
                 "Vr": 0.6808025506494175,
@@ -26855,7 +26857,7 @@
         },
         {
             "number": 8078,
-            "class": "bus",
+            "class": "Bus",
             "name": "MT. ENTERPRISE 4",
             "init": {
                 "Vr": 0.6825060423685445,
@@ -26869,7 +26871,7 @@
         },
         {
             "number": 8079,
-            "class": "bus",
+            "class": "Bus",
             "name": "MT. ENTERPRISE 5",
             "init": {
                 "Vr": 0.6750735407756184,
@@ -26883,7 +26885,7 @@
         },
         {
             "number": 8080,
-            "class": "bus",
+            "class": "Bus",
             "name": "MT. ENTERPRISE 6",
             "init": {
                 "Vr": 0.6790549850426478,
@@ -26897,7 +26899,7 @@
         },
         {
             "number": 8081,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 9 0",
             "init": {
                 "Vr": 0.3273051897447228,
@@ -26911,7 +26913,7 @@
         },
         {
             "number": 8082,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRANKLIN 0",
             "init": {
                 "Vr": 0.7103342991185909,
@@ -26925,7 +26927,7 @@
         },
         {
             "number": 8083,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRANKLIN 1",
             "init": {
                 "Vr": 0.6694864474658513,
@@ -26939,7 +26941,7 @@
         },
         {
             "number": 8084,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRANKLIN 2",
             "init": {
                 "Vr": 0.6014890766045272,
@@ -26953,7 +26955,7 @@
         },
         {
             "number": 8085,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRANKLIN 3",
             "init": {
                 "Vr": 0.59421524628509,
@@ -26967,7 +26969,7 @@
         },
         {
             "number": 8086,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRANKLIN 4",
             "init": {
                 "Vr": 0.5749679381530775,
@@ -26981,7 +26983,7 @@
         },
         {
             "number": 8087,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRANKLIN 5",
             "init": {
                 "Vr": 0.7103342991185909,
@@ -26995,7 +26997,7 @@
         },
         {
             "number": 8088,
-            "class": "bus",
+            "class": "Bus",
             "name": "FRANKLIN 6",
             "init": {
                 "Vr": 0.7516598118119217,
@@ -27009,7 +27011,7 @@
         },
         {
             "number": 8089,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 3 0",
             "init": {
                 "Vr": 0.35448419537309467,
@@ -27023,7 +27025,7 @@
         },
         {
             "number": 8090,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELKHART 0",
             "init": {
                 "Vr": 0.3866842314419856,
@@ -27037,7 +27039,7 @@
         },
         {
             "number": 8091,
-            "class": "bus",
+            "class": "Bus",
             "name": "WORTHAM 0",
             "init": {
                 "Vr": 0.46407309282809694,
@@ -27051,7 +27053,7 @@
         },
         {
             "number": 8092,
-            "class": "bus",
+            "class": "Bus",
             "name": "OAKWOOD 0",
             "init": {
                 "Vr": 0.3934489157885422,
@@ -27065,7 +27067,7 @@
         },
         {
             "number": 8093,
-            "class": "bus",
+            "class": "Bus",
             "name": "COOKVILLE 0",
             "init": {
                 "Vr": 0.520077282806671,
@@ -27079,7 +27081,7 @@
         },
         {
             "number": 8094,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLLEGE STATION 1 0",
             "init": {
                 "Vr": 0.7384677147531796,
@@ -27093,7 +27095,7 @@
         },
         {
             "number": 8095,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLLEGE STATION 1 1",
             "init": {
                 "Vr": 0.6949427365780573,
@@ -27107,7 +27109,7 @@
         },
         {
             "number": 8096,
-            "class": "bus",
+            "class": "Bus",
             "name": "EDGEWOOD 0",
             "init": {
                 "Vr": 0.3425514705710525,
@@ -27121,7 +27123,7 @@
         },
         {
             "number": 8097,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUSHING 1 0",
             "init": {
                 "Vr": 0.5462604287262063,
@@ -27135,7 +27137,7 @@
         },
         {
             "number": 8098,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUSHING 1 1",
             "init": {
                 "Vr": 0.49020612196154484,
@@ -27149,7 +27151,7 @@
         },
         {
             "number": 8099,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUSHING 1 2",
             "init": {
                 "Vr": 0.6125815790662879,
@@ -27163,7 +27165,7 @@
         },
         {
             "number": 8100,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 2 0",
             "init": {
                 "Vr": 0.3558988386163139,
@@ -27177,7 +27179,7 @@
         },
         {
             "number": 8101,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALTO 0",
             "init": {
                 "Vr": 0.4257820134712075,
@@ -27191,7 +27193,7 @@
         },
         {
             "number": 8102,
-            "class": "bus",
+            "class": "Bus",
             "name": "CALVERT 0",
             "init": {
                 "Vr": 0.6343477574638537,
@@ -27205,7 +27207,7 @@
         },
         {
             "number": 8103,
-            "class": "bus",
+            "class": "Bus",
             "name": "JEWETT 2 0",
             "init": {
                 "Vr": 0.5794769235018635,
@@ -27219,7 +27221,7 @@
         },
         {
             "number": 8104,
-            "class": "bus",
+            "class": "Bus",
             "name": "NAVASOTA 0",
             "init": {
                 "Vr": 0.7351450723215779,
@@ -27233,7 +27235,7 @@
         },
         {
             "number": 8105,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT PLEASANT 2 0",
             "init": {
                 "Vr": 0.5692771015756134,
@@ -27247,7 +27249,7 @@
         },
         {
             "number": 8106,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT PLEASANT 2 1",
             "init": {
                 "Vr": 0.5020233918216924,
@@ -27261,7 +27263,7 @@
         },
         {
             "number": 8107,
-            "class": "bus",
+            "class": "Bus",
             "name": "SCROGGINS 0",
             "init": {
                 "Vr": 0.5019582464935933,
@@ -27275,7 +27277,7 @@
         },
         {
             "number": 8108,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILLS POINT 0",
             "init": {
                 "Vr": 0.3054788957792572,
@@ -27289,7 +27291,7 @@
         },
         {
             "number": 8109,
-            "class": "bus",
+            "class": "Bus",
             "name": "ATHENS 2 0",
             "init": {
                 "Vr": 0.3808068551047181,
@@ -27303,7 +27305,7 @@
         },
         {
             "number": 8110,
-            "class": "bus",
+            "class": "Bus",
             "name": "POINT 0",
             "init": {
                 "Vr": 0.39391301975712706,
@@ -27317,7 +27319,7 @@
         },
         {
             "number": 8111,
-            "class": "bus",
+            "class": "Bus",
             "name": "LUFKIN 2 0",
             "init": {
                 "Vr": 0.45961117474805024,
@@ -27331,7 +27333,7 @@
         },
         {
             "number": 8112,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSONVILLE 1 0",
             "init": {
                 "Vr": 0.5358165502699584,
@@ -27345,7 +27347,7 @@
         },
         {
             "number": 8113,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSONVILLE 1 1",
             "init": {
                 "Vr": 0.5210797804126831,
@@ -27359,7 +27361,7 @@
         },
         {
             "number": 8114,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSONVILLE 1 2",
             "init": {
                 "Vr": 0.4883826198537693,
@@ -27373,7 +27375,7 @@
         },
         {
             "number": 8115,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSONVILLE 1 3",
             "init": {
                 "Vr": 0.5358165502699584,
@@ -27387,7 +27389,7 @@
         },
         {
             "number": 8116,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSONVILLE 1 4",
             "init": {
                 "Vr": 0.5358165502699584,
@@ -27401,7 +27403,7 @@
         },
         {
             "number": 8117,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSONVILLE 1 5",
             "init": {
                 "Vr": 0.5605996344236166,
@@ -27415,7 +27417,7 @@
         },
         {
             "number": 8118,
-            "class": "bus",
+            "class": "Bus",
             "name": "CROCKETT 0",
             "init": {
                 "Vr": 0.404928177474732,
@@ -27429,7 +27431,7 @@
         },
         {
             "number": 8119,
-            "class": "bus",
+            "class": "Bus",
             "name": "HENDERSON 1 0",
             "init": {
                 "Vr": 0.5104808157585645,
@@ -27443,7 +27445,7 @@
         },
         {
             "number": 8120,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYAN 3 0",
             "init": {
                 "Vr": 0.6778997637269331,
@@ -27457,7 +27459,7 @@
         },
         {
             "number": 8121,
-            "class": "bus",
+            "class": "Bus",
             "name": "JACKSONVILLE 2 0",
             "init": {
                 "Vr": 0.42209034541217394,
@@ -27471,7 +27473,7 @@
         },
         {
             "number": 8122,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYAN 5 0",
             "init": {
                 "Vr": 0.6718754014604514,
@@ -27485,7 +27487,7 @@
         },
         {
             "number": 8123,
-            "class": "bus",
+            "class": "Bus",
             "name": "MALAKOFF 0",
             "init": {
                 "Vr": 0.3915217602129387,
@@ -27499,7 +27501,7 @@
         },
         {
             "number": 8124,
-            "class": "bus",
+            "class": "Bus",
             "name": "CUMBY 0",
             "init": {
                 "Vr": 0.4242525866727843,
@@ -27513,7 +27515,7 @@
         },
         {
             "number": 8125,
-            "class": "bus",
+            "class": "Bus",
             "name": "NACOGDOCHES 1 0",
             "init": {
                 "Vr": 0.4116143763020122,
@@ -27527,7 +27529,7 @@
         },
         {
             "number": 8126,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT PLEASANT 1 0",
             "init": {
                 "Vr": 0.6184885209117019,
@@ -27541,7 +27543,7 @@
         },
         {
             "number": 8127,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT PLEASANT 1 1",
             "init": {
                 "Vr": 0.6008007989307175,
@@ -27555,7 +27557,7 @@
         },
         {
             "number": 8128,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT PLEASANT 1 2",
             "init": {
                 "Vr": 0.566721804155769,
@@ -27569,7 +27571,7 @@
         },
         {
             "number": 8129,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT PLEASANT 1 3",
             "init": {
                 "Vr": 0.6417102456545215,
@@ -27583,7 +27585,7 @@
         },
         {
             "number": 8130,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT PLEASANT 1 4",
             "init": {
                 "Vr": 0.677391273575254,
@@ -27597,7 +27599,7 @@
         },
         {
             "number": 8131,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT PLEASANT 1 5",
             "init": {
                 "Vr": 0.6483719232357766,
@@ -27611,7 +27613,7 @@
         },
         {
             "number": 8132,
-            "class": "bus",
+            "class": "Bus",
             "name": "TEAGUE 0",
             "init": {
                 "Vr": 0.4237426006167087,
@@ -27625,7 +27627,7 @@
         },
         {
             "number": 8133,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 7 0",
             "init": {
                 "Vr": 0.4604961357397311,
@@ -27639,7 +27641,7 @@
         },
         {
             "number": 8134,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 7 1",
             "init": {
                 "Vr": 0.4121771280666473,
@@ -27653,7 +27655,7 @@
         },
         {
             "number": 8135,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 6 0",
             "init": {
                 "Vr": 0.3616610885676482,
@@ -27667,7 +27669,7 @@
         },
         {
             "number": 8136,
-            "class": "bus",
+            "class": "Bus",
             "name": "YANTIS 0",
             "init": {
                 "Vr": 0.3515027826573416,
@@ -27681,7 +27683,7 @@
         },
         {
             "number": 8137,
-            "class": "bus",
+            "class": "Bus",
             "name": "POLLOK 0",
             "init": {
                 "Vr": 0.459990628723032,
@@ -27695,7 +27697,7 @@
         },
         {
             "number": 8138,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 1 0",
             "init": {
                 "Vr": 0.34361464757622867,
@@ -27709,7 +27711,7 @@
         },
         {
             "number": 8139,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLLEGE STATION 2 0",
             "init": {
                 "Vr": 0.7275846062108559,
@@ -27723,7 +27725,7 @@
         },
         {
             "number": 8140,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLLEGE STATION 2 1",
             "init": {
                 "Vr": 0.6897273118923838,
@@ -27737,7 +27739,7 @@
         },
         {
             "number": 8141,
-            "class": "bus",
+            "class": "Bus",
             "name": "HEARNE 0",
             "init": {
                 "Vr": 0.6240651026411659,
@@ -27751,7 +27753,7 @@
         },
         {
             "number": 8142,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOUNT VERNON 0",
             "init": {
                 "Vr": 0.4672776611608534,
@@ -27765,7 +27767,7 @@
         },
         {
             "number": 8143,
-            "class": "bus",
+            "class": "Bus",
             "name": "IOLA 0",
             "init": {
                 "Vr": 0.7116159071185831,
@@ -27779,7 +27781,7 @@
         },
         {
             "number": 8144,
-            "class": "bus",
+            "class": "Bus",
             "name": "STREETMAN 0",
             "init": {
                 "Vr": 0.48201047188232793,
@@ -27793,7 +27795,7 @@
         },
         {
             "number": 8145,
-            "class": "bus",
+            "class": "Bus",
             "name": "COMO 0",
             "init": {
                 "Vr": 0.4043786997214211,
@@ -27807,7 +27809,7 @@
         },
         {
             "number": 8146,
-            "class": "bus",
+            "class": "Bus",
             "name": "HENDERSON 2 0",
             "init": {
                 "Vr": 0.30279478245052166,
@@ -27821,7 +27823,7 @@
         },
         {
             "number": 8147,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRINIDAD 1 0",
             "init": {
                 "Vr": 0.5125026382719443,
@@ -27835,7 +27837,7 @@
         },
         {
             "number": 8148,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRINIDAD 1 1",
             "init": {
                 "Vr": 0.4742482906798758,
@@ -27849,7 +27851,7 @@
         },
         {
             "number": 8149,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRINIDAD 1 2",
             "init": {
                 "Vr": 0.404636869838976,
@@ -27863,7 +27865,7 @@
         },
         {
             "number": 8150,
-            "class": "bus",
+            "class": "Bus",
             "name": "ZAVALLA 0",
             "init": {
                 "Vr": 0.4386458731153,
@@ -27877,7 +27879,7 @@
         },
         {
             "number": 8151,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRAPELAND 0",
             "init": {
                 "Vr": 0.3931854233488464,
@@ -27891,7 +27893,7 @@
         },
         {
             "number": 8152,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYAN 2 0",
             "init": {
                 "Vr": 0.7026029705041481,
@@ -27905,7 +27907,7 @@
         },
         {
             "number": 8153,
-            "class": "bus",
+            "class": "Bus",
             "name": "CANTON 0",
             "init": {
                 "Vr": 0.3177786389121214,
@@ -27919,7 +27921,7 @@
         },
         {
             "number": 8154,
-            "class": "bus",
+            "class": "Bus",
             "name": "TYLER 5 0",
             "init": {
                 "Vr": 0.3293628245110838,
@@ -27933,7 +27935,7 @@
         },
         {
             "number": 8155,
-            "class": "bus",
+            "class": "Bus",
             "name": "BREMOND 0",
             "init": {
                 "Vr": 0.6981635777902598,
@@ -27947,7 +27949,7 @@
         },
         {
             "number": 8156,
-            "class": "bus",
+            "class": "Bus",
             "name": "BREMOND 1",
             "init": {
                 "Vr": 0.709436144090219,
@@ -27961,7 +27963,7 @@
         },
         {
             "number": 8157,
-            "class": "bus",
+            "class": "Bus",
             "name": "BREMOND 2",
             "init": {
                 "Vr": 0.6519570422080693,
@@ -27975,7 +27977,7 @@
         },
         {
             "number": 8158,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYAN 1 0",
             "init": {
                 "Vr": 0.8024774212138038,
@@ -27989,7 +27991,7 @@
         },
         {
             "number": 8159,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYAN 1 1",
             "init": {
                 "Vr": 0.7629248912964692,
@@ -28003,7 +28005,7 @@
         },
         {
             "number": 8160,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRYAN 1 2",
             "init": {
                 "Vr": 0.7213092357794039,
@@ -109697,7 +109699,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1004,
                 "speed": 0,
                 "pmech": 1
             },
@@ -109716,7 +109717,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1006,
                 "speed": 2,
                 "pmech": 3
             },
@@ -109735,7 +109735,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1009,
                 "speed": 4,
                 "pmech": 5
             },
@@ -109754,7 +109753,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1011,
                 "speed": 6,
                 "pmech": 7
             },
@@ -109773,7 +109771,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1021,
                 "speed": 8,
                 "pmech": 9
             },
@@ -109792,7 +109789,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1023,
                 "speed": 10,
                 "pmech": 11
             },
@@ -109811,7 +109807,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1026,
                 "speed": 12,
                 "pmech": 13
             },
@@ -109830,7 +109825,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1033,
                 "speed": 14,
                 "pmech": 15
             },
@@ -109849,7 +109843,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1035,
                 "speed": 16,
                 "pmech": 17
             },
@@ -109868,7 +109861,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1039,
                 "speed": 18,
                 "pmech": 19
             },
@@ -109887,7 +109879,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1043,
                 "speed": 20,
                 "pmech": 21
             },
@@ -109906,7 +109897,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1050,
                 "speed": 22,
                 "pmech": 23
             },
@@ -109925,7 +109915,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1051,
                 "speed": 24,
                 "pmech": 25
             },
@@ -109944,7 +109933,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1052,
                 "speed": 26,
                 "pmech": 27
             },
@@ -109963,7 +109951,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1066,
                 "speed": 28,
                 "pmech": 29
             },
@@ -109982,7 +109969,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1070,
                 "speed": 30,
                 "pmech": 31
             },
@@ -110001,7 +109987,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1072,
                 "speed": 32,
                 "pmech": 33
             },
@@ -110020,7 +110005,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1073,
                 "speed": 34,
                 "pmech": 35
             },
@@ -110039,7 +110023,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1074,
                 "speed": 36,
                 "pmech": 37
             },
@@ -110058,7 +110041,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1075,
                 "speed": 38,
                 "pmech": 39
             },
@@ -110077,7 +110059,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1078,
                 "speed": 40,
                 "pmech": 41
             },
@@ -110096,7 +110077,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1079,
                 "speed": 42,
                 "pmech": 43
             },
@@ -110115,7 +110095,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1080,
                 "speed": 44,
                 "pmech": 45
             },
@@ -110134,7 +110113,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1082,
                 "speed": 46,
                 "pmech": 47
             },
@@ -110153,7 +110131,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1084,
                 "speed": 48,
                 "pmech": 49
             },
@@ -110172,7 +110149,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1088,
                 "speed": 50,
                 "pmech": 51
             },
@@ -110191,7 +110167,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1090,
                 "speed": 52,
                 "pmech": 53
             },
@@ -110210,7 +110185,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1090,
                 "speed": 54,
                 "pmech": 55
             },
@@ -110229,7 +110203,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2013,
                 "speed": 56,
                 "pmech": 57
             },
@@ -110248,7 +110221,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2023,
                 "speed": 58,
                 "pmech": 59
             },
@@ -110267,7 +110239,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2024,
                 "speed": 60,
                 "pmech": 61
             },
@@ -110286,7 +110257,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2042,
                 "speed": 62,
                 "pmech": 63
             },
@@ -110305,7 +110275,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2057,
                 "speed": 64,
                 "pmech": 65
             },
@@ -110324,7 +110293,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2059,
                 "speed": 66,
                 "pmech": 67
             },
@@ -110343,7 +110311,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2062,
                 "speed": 68,
                 "pmech": 69
             },
@@ -110362,7 +110329,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2071,
                 "speed": 70,
                 "pmech": 71
             },
@@ -110381,7 +110347,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2076,
                 "speed": 72,
                 "pmech": 73
             },
@@ -110400,7 +110365,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2078,
                 "speed": 74,
                 "pmech": 75
             },
@@ -110419,7 +110383,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2083,
                 "speed": 76,
                 "pmech": 77
             },
@@ -110438,7 +110401,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2089,
                 "speed": 78,
                 "pmech": 79
             },
@@ -110457,7 +110419,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2099,
                 "speed": 80,
                 "pmech": 81
             },
@@ -110476,7 +110437,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2100,
                 "speed": 82,
                 "pmech": 83
             },
@@ -110495,7 +110455,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2115,
                 "speed": 84,
                 "pmech": 85
             },
@@ -110514,7 +110473,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2116,
                 "speed": 86,
                 "pmech": 87
             },
@@ -110533,7 +110491,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2117,
                 "speed": 88,
                 "pmech": 89
             },
@@ -110552,7 +110509,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2118,
                 "speed": 90,
                 "pmech": 91
             },
@@ -110571,7 +110527,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2119,
                 "speed": 92,
                 "pmech": 93
             },
@@ -110590,7 +110545,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2120,
                 "speed": 94,
                 "pmech": 95
             },
@@ -110609,7 +110563,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2123,
                 "speed": 96,
                 "pmech": 97
             },
@@ -110628,7 +110581,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2127,
                 "speed": 98,
                 "pmech": 99
             },
@@ -110647,7 +110599,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3004,
                 "speed": 100,
                 "pmech": 101
             },
@@ -110666,7 +110617,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3017,
                 "speed": 102,
                 "pmech": 103
             },
@@ -110685,7 +110635,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3020,
                 "speed": 104,
                 "pmech": 105
             },
@@ -110704,7 +110653,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3028,
                 "speed": 106,
                 "pmech": 107
             },
@@ -110723,7 +110671,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3034,
                 "speed": 108,
                 "pmech": 109
             },
@@ -110742,7 +110689,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3039,
                 "speed": 110,
                 "pmech": 111
             },
@@ -110761,7 +110707,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3048,
                 "speed": 112,
                 "pmech": 113
             },
@@ -110780,7 +110725,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3055,
                 "speed": 114,
                 "pmech": 115
             },
@@ -110799,7 +110743,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3056,
                 "speed": 116,
                 "pmech": 117
             },
@@ -110818,7 +110761,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3057,
                 "speed": 118,
                 "pmech": 119
             },
@@ -110837,7 +110779,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3060,
                 "speed": 120,
                 "pmech": 121
             },
@@ -110856,7 +110797,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3061,
                 "speed": 122,
                 "pmech": 123
             },
@@ -110875,7 +110815,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3062,
                 "speed": 124,
                 "pmech": 125
             },
@@ -110894,7 +110833,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3063,
                 "speed": 126,
                 "pmech": 127
             },
@@ -110913,7 +110851,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3065,
                 "speed": 128,
                 "pmech": 129
             },
@@ -110932,7 +110869,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3068,
                 "speed": 130,
                 "pmech": 131
             },
@@ -110951,7 +110887,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3071,
                 "speed": 132,
                 "pmech": 133
             },
@@ -110970,7 +110905,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3074,
                 "speed": 134,
                 "pmech": 135
             },
@@ -110989,7 +110923,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3081,
                 "speed": 136,
                 "pmech": 137
             },
@@ -111008,7 +110941,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3084,
                 "speed": 138,
                 "pmech": 139
             },
@@ -111027,7 +110959,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3086,
                 "speed": 140,
                 "pmech": 141
             },
@@ -111046,7 +110977,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3092,
                 "speed": 142,
                 "pmech": 143
             },
@@ -111065,7 +110995,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3095,
                 "speed": 144,
                 "pmech": 145
             },
@@ -111084,7 +111013,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3098,
                 "speed": 146,
                 "pmech": 147
             },
@@ -111103,7 +111031,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3105,
                 "speed": 148,
                 "pmech": 149
             },
@@ -111122,7 +111049,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3110,
                 "speed": 150,
                 "pmech": 151
             },
@@ -111141,7 +111067,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3112,
                 "speed": 152,
                 "pmech": 153
             },
@@ -111160,7 +111085,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3113,
                 "speed": 154,
                 "pmech": 155
             },
@@ -111179,7 +111103,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3117,
                 "speed": 156,
                 "pmech": 157
             },
@@ -111198,7 +111121,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3118,
                 "speed": 158,
                 "pmech": 159
             },
@@ -111217,7 +111139,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3120,
                 "speed": 160,
                 "pmech": 161
             },
@@ -111236,7 +111157,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3122,
                 "speed": 162,
                 "pmech": 163
             },
@@ -111255,7 +111175,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3127,
                 "speed": 164,
                 "pmech": 165
             },
@@ -111274,7 +111193,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3129,
                 "speed": 166,
                 "pmech": 167
             },
@@ -111293,7 +111211,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3131,
                 "speed": 168,
                 "pmech": 169
             },
@@ -111312,7 +111229,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3137,
                 "speed": 170,
                 "pmech": 171
             },
@@ -111331,7 +111247,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3141,
                 "speed": 172,
                 "pmech": 173
             },
@@ -111350,7 +111265,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4010,
                 "speed": 174,
                 "pmech": 175
             },
@@ -111369,7 +111283,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4026,
                 "speed": 176,
                 "pmech": 177
             },
@@ -111388,7 +111301,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4030,
                 "speed": 178,
                 "pmech": 179
             },
@@ -111407,7 +111319,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4050,
                 "speed": 180,
                 "pmech": 181
             },
@@ -111426,7 +111337,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4052,
                 "speed": 182,
                 "pmech": 183
             },
@@ -111445,7 +111355,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4058,
                 "speed": 184,
                 "pmech": 185
             },
@@ -111464,7 +111373,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4059,
                 "speed": 186,
                 "pmech": 187
             },
@@ -111483,7 +111391,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4060,
                 "speed": 188,
                 "pmech": 189
             },
@@ -111502,7 +111409,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4061,
                 "speed": 190,
                 "pmech": 191
             },
@@ -111521,7 +111427,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4062,
                 "speed": 192,
                 "pmech": 193
             },
@@ -111540,7 +111445,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4063,
                 "speed": 194,
                 "pmech": 195
             },
@@ -111559,7 +111463,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4065,
                 "speed": 196,
                 "pmech": 197
             },
@@ -111578,7 +111481,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4076,
                 "speed": 198,
                 "pmech": 199
             },
@@ -111597,7 +111499,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4077,
                 "speed": 200,
                 "pmech": 201
             },
@@ -111616,7 +111517,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4082,
                 "speed": 202,
                 "pmech": 203
             },
@@ -111635,7 +111535,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4083,
                 "speed": 204,
                 "pmech": 205
             },
@@ -111654,7 +111553,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4084,
                 "speed": 206,
                 "pmech": 207
             },
@@ -111673,7 +111571,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4085,
                 "speed": 208,
                 "pmech": 209
             },
@@ -111692,7 +111589,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4091,
                 "speed": 210,
                 "pmech": 211
             },
@@ -111711,7 +111607,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4093,
                 "speed": 212,
                 "pmech": 213
             },
@@ -111730,7 +111625,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4094,
                 "speed": 214,
                 "pmech": 215
             },
@@ -111749,7 +111643,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4095,
                 "speed": 216,
                 "pmech": 217
             },
@@ -111768,7 +111661,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4097,
                 "speed": 218,
                 "pmech": 219
             },
@@ -111787,7 +111679,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4105,
                 "speed": 220,
                 "pmech": 221
             },
@@ -111806,7 +111697,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4115,
                 "speed": 222,
                 "pmech": 223
             },
@@ -111825,7 +111715,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4116,
                 "speed": 224,
                 "pmech": 225
             },
@@ -111844,7 +111733,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4134,
                 "speed": 226,
                 "pmech": 227
             },
@@ -111863,7 +111751,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4135,
                 "speed": 228,
                 "pmech": 229
             },
@@ -111882,7 +111769,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4136,
                 "speed": 230,
                 "pmech": 231
             },
@@ -111901,7 +111787,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4142,
                 "speed": 232,
                 "pmech": 233
             },
@@ -111920,7 +111805,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4153,
                 "speed": 234,
                 "pmech": 235
             },
@@ -111939,7 +111823,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4160,
                 "speed": 236,
                 "pmech": 237
             },
@@ -111958,7 +111841,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4161,
                 "speed": 238,
                 "pmech": 239
             },
@@ -111977,7 +111859,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4162,
                 "speed": 240,
                 "pmech": 241
             },
@@ -111996,7 +111877,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4166,
                 "speed": 242,
                 "pmech": 243
             },
@@ -112015,7 +111895,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4177,
                 "speed": 244,
                 "pmech": 245
             },
@@ -112034,7 +111913,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4181,
                 "speed": 246,
                 "pmech": 247
             },
@@ -112053,7 +111931,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4183,
                 "speed": 248,
                 "pmech": 249
             },
@@ -112072,7 +111949,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4192,
                 "speed": 250,
                 "pmech": 251
             },
@@ -112091,7 +111967,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4192,
                 "speed": 252,
                 "pmech": 253
             },
@@ -112110,7 +111985,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4192,
                 "speed": 254,
                 "pmech": 255
             },
@@ -112129,7 +112003,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4192,
                 "speed": 256,
                 "pmech": 257
             },
@@ -112148,7 +112021,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4192,
                 "speed": 258,
                 "pmech": 259
             },
@@ -112167,7 +112039,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4192,
                 "speed": 260,
                 "pmech": 261
             },
@@ -112186,7 +112057,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4192,
                 "speed": 262,
                 "pmech": 263
             },
@@ -112205,7 +112075,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4192,
                 "speed": 264,
                 "pmech": 265
             },
@@ -112224,7 +112093,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4192,
                 "speed": 266,
                 "pmech": 267
             },
@@ -112243,7 +112111,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4194,
                 "speed": 268,
                 "pmech": 269
             },
@@ -112262,7 +112129,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4195,
                 "speed": 270,
                 "pmech": 271
             },
@@ -112281,7 +112147,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5020,
                 "speed": 272,
                 "pmech": 273
             },
@@ -112300,7 +112165,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5037,
                 "speed": 274,
                 "pmech": 275
             },
@@ -112319,7 +112183,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5038,
                 "speed": 276,
                 "pmech": 277
             },
@@ -112338,7 +112201,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5039,
                 "speed": 278,
                 "pmech": 279
             },
@@ -112357,7 +112219,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5040,
                 "speed": 280,
                 "pmech": 281
             },
@@ -112376,7 +112237,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5041,
                 "speed": 282,
                 "pmech": 283
             },
@@ -112395,7 +112255,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5042,
                 "speed": 284,
                 "pmech": 285
             },
@@ -112414,7 +112273,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5051,
                 "speed": 286,
                 "pmech": 287
             },
@@ -112433,7 +112291,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5058,
                 "speed": 288,
                 "pmech": 289
             },
@@ -112452,7 +112309,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5065,
                 "speed": 290,
                 "pmech": 291
             },
@@ -112471,7 +112327,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5067,
                 "speed": 292,
                 "pmech": 293
             },
@@ -112490,7 +112345,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5068,
                 "speed": 294,
                 "pmech": 295
             },
@@ -112509,7 +112363,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5069,
                 "speed": 296,
                 "pmech": 297
             },
@@ -112528,7 +112381,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5166,
                 "speed": 298,
                 "pmech": 299
             },
@@ -112547,7 +112399,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5167,
                 "speed": 300,
                 "pmech": 301
             },
@@ -112566,7 +112417,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5170,
                 "speed": 302,
                 "pmech": 303
             },
@@ -112585,7 +112435,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5198,
                 "speed": 304,
                 "pmech": 305
             },
@@ -112604,7 +112453,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5206,
                 "speed": 306,
                 "pmech": 307
             },
@@ -112623,7 +112471,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5207,
                 "speed": 308,
                 "pmech": 309
             },
@@ -112642,7 +112489,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5208,
                 "speed": 310,
                 "pmech": 311
             },
@@ -112661,7 +112507,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5238,
                 "speed": 312,
                 "pmech": 313
             },
@@ -112680,7 +112525,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5243,
                 "speed": 314,
                 "pmech": 315
             },
@@ -112699,7 +112543,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5262,
                 "speed": 316,
                 "pmech": 317
             },
@@ -112718,7 +112561,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5263,
                 "speed": 318,
                 "pmech": 319
             },
@@ -112737,7 +112579,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5281,
                 "speed": 320,
                 "pmech": 321
             },
@@ -112756,7 +112597,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5282,
                 "speed": 322,
                 "pmech": 323
             },
@@ -112775,7 +112615,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5298,
                 "speed": 324,
                 "pmech": 325
             },
@@ -112794,7 +112633,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5299,
                 "speed": 326,
                 "pmech": 327
             },
@@ -112813,7 +112651,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5300,
                 "speed": 328,
                 "pmech": 329
             },
@@ -112832,7 +112669,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5301,
                 "speed": 330,
                 "pmech": 331
             },
@@ -112851,7 +112687,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5302,
                 "speed": 332,
                 "pmech": 333
             },
@@ -112870,7 +112705,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5303,
                 "speed": 334,
                 "pmech": 335
             },
@@ -112889,7 +112723,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5319,
                 "speed": 336,
                 "pmech": 337
             },
@@ -112908,7 +112741,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5321,
                 "speed": 338,
                 "pmech": 339
             },
@@ -112927,7 +112759,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5324,
                 "speed": 340,
                 "pmech": 341
             },
@@ -112946,7 +112777,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5325,
                 "speed": 342,
                 "pmech": 343
             },
@@ -112965,7 +112795,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5326,
                 "speed": 344,
                 "pmech": 345
             },
@@ -112984,7 +112813,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5360,
                 "speed": 346,
                 "pmech": 347
             },
@@ -113003,7 +112831,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5363,
                 "speed": 348,
                 "pmech": 349
             },
@@ -113022,7 +112849,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5364,
                 "speed": 350,
                 "pmech": 351
             },
@@ -113041,7 +112867,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5365,
                 "speed": 352,
                 "pmech": 353
             },
@@ -113060,7 +112885,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5366,
                 "speed": 354,
                 "pmech": 355
             },
@@ -113079,7 +112903,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5367,
                 "speed": 356,
                 "pmech": 357
             },
@@ -113098,7 +112921,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5368,
                 "speed": 358,
                 "pmech": 359
             },
@@ -113117,7 +112939,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5369,
                 "speed": 360,
                 "pmech": 361
             },
@@ -113136,7 +112957,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5382,
                 "speed": 362,
                 "pmech": 363
             },
@@ -113155,7 +112975,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5383,
                 "speed": 364,
                 "pmech": 365
             },
@@ -113174,7 +112993,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5399,
                 "speed": 366,
                 "pmech": 367
             },
@@ -113193,7 +113011,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5403,
                 "speed": 368,
                 "pmech": 369
             },
@@ -113212,7 +113029,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5404,
                 "speed": 370,
                 "pmech": 371
             },
@@ -113231,7 +113047,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5405,
                 "speed": 372,
                 "pmech": 373
             },
@@ -113250,7 +113065,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5406,
                 "speed": 374,
                 "pmech": 375
             },
@@ -113269,7 +113083,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5415,
                 "speed": 376,
                 "pmech": 377
             },
@@ -113288,7 +113101,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5416,
                 "speed": 378,
                 "pmech": 379
             },
@@ -113307,7 +113119,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5417,
                 "speed": 380,
                 "pmech": 381
             },
@@ -113326,7 +113137,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5418,
                 "speed": 382,
                 "pmech": 383
             },
@@ -113345,7 +113155,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5419,
                 "speed": 384,
                 "pmech": 385
             },
@@ -113364,7 +113173,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5423,
                 "speed": 386,
                 "pmech": 387
             },
@@ -113383,7 +113191,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5444,
                 "speed": 388,
                 "pmech": 389
             },
@@ -113402,7 +113209,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5444,
                 "speed": 390,
                 "pmech": 391
             },
@@ -113421,7 +113227,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5444,
                 "speed": 392,
                 "pmech": 393
             },
@@ -113440,7 +113245,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 5444,
                 "speed": 394,
                 "pmech": 395
             },
@@ -113459,7 +113263,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6006,
                 "speed": 396,
                 "pmech": 397
             },
@@ -113478,7 +113281,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6008,
                 "speed": 398,
                 "pmech": 399
             },
@@ -113497,7 +113299,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6009,
                 "speed": 400,
                 "pmech": 401
             },
@@ -113516,7 +113317,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6010,
                 "speed": 402,
                 "pmech": 403
             },
@@ -113535,7 +113335,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6051,
                 "speed": 404,
                 "pmech": 405
             },
@@ -113554,7 +113353,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6053,
                 "speed": 406,
                 "pmech": 407
             },
@@ -113573,7 +113371,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6054,
                 "speed": 408,
                 "pmech": 409
             },
@@ -113592,7 +113389,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6069,
                 "speed": 410,
                 "pmech": 411
             },
@@ -113611,7 +113407,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6070,
                 "speed": 412,
                 "pmech": 413
             },
@@ -113630,7 +113425,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6071,
                 "speed": 414,
                 "pmech": 415
             },
@@ -113649,7 +113443,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6073,
                 "speed": 416,
                 "pmech": 417
             },
@@ -113668,7 +113461,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6074,
                 "speed": 418,
                 "pmech": 419
             },
@@ -113687,7 +113479,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6078,
                 "speed": 420,
                 "pmech": 421
             },
@@ -113706,7 +113497,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6079,
                 "speed": 422,
                 "pmech": 423
             },
@@ -113725,7 +113515,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6080,
                 "speed": 424,
                 "pmech": 425
             },
@@ -113744,7 +113533,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6085,
                 "speed": 426,
                 "pmech": 427
             },
@@ -113763,7 +113551,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6086,
                 "speed": 428,
                 "pmech": 429
             },
@@ -113782,7 +113569,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6088,
                 "speed": 430,
                 "pmech": 431
             },
@@ -113801,7 +113587,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6089,
                 "speed": 432,
                 "pmech": 433
             },
@@ -113820,7 +113605,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6090,
                 "speed": 434,
                 "pmech": 435
             },
@@ -113839,7 +113623,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6104,
                 "speed": 436,
                 "pmech": 437
             },
@@ -113858,7 +113641,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6105,
                 "speed": 438,
                 "pmech": 439
             },
@@ -113877,7 +113659,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6106,
                 "speed": 440,
                 "pmech": 441
             },
@@ -113896,7 +113677,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6110,
                 "speed": 442,
                 "pmech": 443
             },
@@ -113915,7 +113695,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6111,
                 "speed": 444,
                 "pmech": 445
             },
@@ -113934,7 +113713,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6145,
                 "speed": 446,
                 "pmech": 447
             },
@@ -113953,7 +113731,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6146,
                 "speed": 448,
                 "pmech": 449
             },
@@ -113972,7 +113749,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6147,
                 "speed": 450,
                 "pmech": 451
             },
@@ -113991,7 +113767,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6149,
                 "speed": 452,
                 "pmech": 453
             },
@@ -114010,7 +113785,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6164,
                 "speed": 454,
                 "pmech": 455
             },
@@ -114029,7 +113803,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6165,
                 "speed": 456,
                 "pmech": 457
             },
@@ -114048,7 +113821,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6166,
                 "speed": 458,
                 "pmech": 459
             },
@@ -114067,7 +113839,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6167,
                 "speed": 460,
                 "pmech": 461
             },
@@ -114086,7 +113857,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6242,
                 "speed": 462,
                 "pmech": 463
             },
@@ -114105,7 +113875,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6243,
                 "speed": 464,
                 "pmech": 465
             },
@@ -114124,7 +113893,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6244,
                 "speed": 466,
                 "pmech": 467
             },
@@ -114143,7 +113911,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6245,
                 "speed": 468,
                 "pmech": 469
             },
@@ -114162,7 +113929,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6246,
                 "speed": 470,
                 "pmech": 471
             },
@@ -114181,7 +113947,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6247,
                 "speed": 472,
                 "pmech": 473
             },
@@ -114200,7 +113965,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6248,
                 "speed": 474,
                 "pmech": 475
             },
@@ -114219,7 +113983,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6249,
                 "speed": 476,
                 "pmech": 477
             },
@@ -114238,7 +114001,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6257,
                 "speed": 478,
                 "pmech": 479
             },
@@ -114257,7 +114019,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6258,
                 "speed": 480,
                 "pmech": 481
             },
@@ -114276,7 +114037,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6260,
                 "speed": 482,
                 "pmech": 483
             },
@@ -114295,7 +114055,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6268,
                 "speed": 484,
                 "pmech": 485
             },
@@ -114314,7 +114073,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6295,
                 "speed": 486,
                 "pmech": 487
             },
@@ -114333,7 +114091,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6296,
                 "speed": 488,
                 "pmech": 489
             },
@@ -114352,7 +114109,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6297,
                 "speed": 490,
                 "pmech": 491
             },
@@ -114371,7 +114127,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6302,
                 "speed": 492,
                 "pmech": 493
             },
@@ -114390,7 +114145,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6303,
                 "speed": 494,
                 "pmech": 495
             },
@@ -114409,7 +114163,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6304,
                 "speed": 496,
                 "pmech": 497
             },
@@ -114428,7 +114181,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6305,
                 "speed": 498,
                 "pmech": 499
             },
@@ -114447,7 +114199,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6349,
                 "speed": 500,
                 "pmech": 501
             },
@@ -114466,7 +114217,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6349,
                 "speed": 502,
                 "pmech": 503
             },
@@ -114485,7 +114235,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 6349,
                 "speed": 504,
                 "pmech": 505
             },
@@ -114504,7 +114253,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7005,
                 "speed": 506,
                 "pmech": 507
             },
@@ -114523,7 +114271,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7006,
                 "speed": 508,
                 "pmech": 509
             },
@@ -114542,7 +114289,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7007,
                 "speed": 510,
                 "pmech": 511
             },
@@ -114561,7 +114307,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7008,
                 "speed": 512,
                 "pmech": 513
             },
@@ -114580,7 +114325,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7009,
                 "speed": 514,
                 "pmech": 515
             },
@@ -114599,7 +114343,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7021,
                 "speed": 516,
                 "pmech": 517
             },
@@ -114618,7 +114361,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7022,
                 "speed": 518,
                 "pmech": 519
             },
@@ -114637,7 +114379,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7023,
                 "speed": 520,
                 "pmech": 521
             },
@@ -114656,7 +114397,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7024,
                 "speed": 522,
                 "pmech": 523
             },
@@ -114675,7 +114415,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7031,
                 "speed": 524,
                 "pmech": 525
             },
@@ -114694,7 +114433,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7032,
                 "speed": 526,
                 "pmech": 527
             },
@@ -114713,7 +114451,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7033,
                 "speed": 528,
                 "pmech": 529
             },
@@ -114732,7 +114469,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7045,
                 "speed": 530,
                 "pmech": 531
             },
@@ -114751,7 +114487,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7046,
                 "speed": 532,
                 "pmech": 533
             },
@@ -114770,7 +114505,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7061,
                 "speed": 534,
                 "pmech": 535
             },
@@ -114789,7 +114523,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7062,
                 "speed": 536,
                 "pmech": 537
             },
@@ -114808,7 +114541,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7063,
                 "speed": 538,
                 "pmech": 539
             },
@@ -114827,7 +114559,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7064,
                 "speed": 540,
                 "pmech": 541
             },
@@ -114846,7 +114577,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7065,
                 "speed": 542,
                 "pmech": 543
             },
@@ -114865,7 +114595,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7066,
                 "speed": 544,
                 "pmech": 545
             },
@@ -114884,7 +114613,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7079,
                 "speed": 546,
                 "pmech": 547
             },
@@ -114903,7 +114631,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7080,
                 "speed": 548,
                 "pmech": 549
             },
@@ -114922,7 +114649,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7081,
                 "speed": 550,
                 "pmech": 551
             },
@@ -114941,7 +114667,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7082,
                 "speed": 552,
                 "pmech": 553
             },
@@ -114960,7 +114685,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7098,
                 "speed": 554,
                 "pmech": 555
             },
@@ -114979,7 +114703,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7099,
                 "speed": 556,
                 "pmech": 557
             },
@@ -114998,7 +114721,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7107,
                 "speed": 558,
                 "pmech": 559
             },
@@ -115017,7 +114739,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7108,
                 "speed": 560,
                 "pmech": 561
             },
@@ -115036,7 +114757,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7109,
                 "speed": 562,
                 "pmech": 563
             },
@@ -115055,7 +114775,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7110,
                 "speed": 564,
                 "pmech": 565
             },
@@ -115074,7 +114793,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7111,
                 "speed": 566,
                 "pmech": 567
             },
@@ -115093,7 +114811,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7112,
                 "speed": 568,
                 "pmech": 569
             },
@@ -115112,7 +114829,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7113,
                 "speed": 570,
                 "pmech": 571
             },
@@ -115131,7 +114847,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7114,
                 "speed": 572,
                 "pmech": 573
             },
@@ -115150,7 +114865,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7115,
                 "speed": 574,
                 "pmech": 575
             },
@@ -115169,7 +114883,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7133,
                 "speed": 576,
                 "pmech": 577
             },
@@ -115188,7 +114901,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7134,
                 "speed": 578,
                 "pmech": 579
             },
@@ -115207,7 +114919,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7135,
                 "speed": 580,
                 "pmech": 581
             },
@@ -115226,7 +114937,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7136,
                 "speed": 582,
                 "pmech": 583
             },
@@ -115245,7 +114955,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7137,
                 "speed": 584,
                 "pmech": 585
             },
@@ -115264,7 +114973,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7138,
                 "speed": 586,
                 "pmech": 587
             },
@@ -115283,7 +114991,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7139,
                 "speed": 588,
                 "pmech": 589
             },
@@ -115302,7 +115009,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7140,
                 "speed": 590,
                 "pmech": 591
             },
@@ -115321,7 +115027,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7141,
                 "speed": 592,
                 "pmech": 593
             },
@@ -115340,7 +115045,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7142,
                 "speed": 594,
                 "pmech": 595
             },
@@ -115359,7 +115063,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7146,
                 "speed": 596,
                 "pmech": 597
             },
@@ -115378,7 +115081,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7162,
                 "speed": 598,
                 "pmech": 599
             },
@@ -115397,7 +115099,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7163,
                 "speed": 600,
                 "pmech": 601
             },
@@ -115416,7 +115117,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7164,
                 "speed": 602,
                 "pmech": 603
             },
@@ -115435,7 +115135,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7165,
                 "speed": 604,
                 "pmech": 605
             },
@@ -115454,7 +115153,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7166,
                 "speed": 606,
                 "pmech": 607
             },
@@ -115473,7 +115171,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7167,
                 "speed": 608,
                 "pmech": 609
             },
@@ -115492,7 +115189,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7168,
                 "speed": 610,
                 "pmech": 611
             },
@@ -115511,7 +115207,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7169,
                 "speed": 612,
                 "pmech": 613
             },
@@ -115530,7 +115225,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7170,
                 "speed": 614,
                 "pmech": 615
             },
@@ -115549,7 +115243,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7189,
                 "speed": 616,
                 "pmech": 617
             },
@@ -115568,7 +115261,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7190,
                 "speed": 618,
                 "pmech": 619
             },
@@ -115587,7 +115279,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7192,
                 "speed": 620,
                 "pmech": 621
             },
@@ -115606,7 +115297,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7193,
                 "speed": 622,
                 "pmech": 623
             },
@@ -115625,7 +115315,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7194,
                 "speed": 624,
                 "pmech": 625
             },
@@ -115644,7 +115333,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7195,
                 "speed": 626,
                 "pmech": 627
             },
@@ -115663,7 +115351,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7196,
                 "speed": 628,
                 "pmech": 629
             },
@@ -115682,7 +115369,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7197,
                 "speed": 630,
                 "pmech": 631
             },
@@ -115701,7 +115387,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7208,
                 "speed": 632,
                 "pmech": 633
             },
@@ -115720,7 +115405,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7209,
                 "speed": 634,
                 "pmech": 635
             },
@@ -115739,7 +115423,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7210,
                 "speed": 636,
                 "pmech": 637
             },
@@ -115758,7 +115441,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7211,
                 "speed": 638,
                 "pmech": 639
             },
@@ -115777,7 +115459,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7212,
                 "speed": 640,
                 "pmech": 641
             },
@@ -115796,7 +115477,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7266,
                 "speed": 642,
                 "pmech": 643
             },
@@ -115815,7 +115495,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7267,
                 "speed": 644,
                 "pmech": 645
             },
@@ -115834,7 +115513,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7268,
                 "speed": 646,
                 "pmech": 647
             },
@@ -115853,7 +115531,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7269,
                 "speed": 648,
                 "pmech": 649
             },
@@ -115872,7 +115549,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7270,
                 "speed": 650,
                 "pmech": 651
             },
@@ -115891,7 +115567,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7285,
                 "speed": 652,
                 "pmech": 653
             },
@@ -115910,7 +115585,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7286,
                 "speed": 654,
                 "pmech": 655
             },
@@ -115929,7 +115603,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7287,
                 "speed": 656,
                 "pmech": 657
             },
@@ -115948,7 +115621,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7288,
                 "speed": 658,
                 "pmech": 659
             },
@@ -115967,7 +115639,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7289,
                 "speed": 660,
                 "pmech": 661
             },
@@ -115986,7 +115657,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7307,
                 "speed": 662,
                 "pmech": 663
             },
@@ -116005,7 +115675,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7308,
                 "speed": 664,
                 "pmech": 665
             },
@@ -116024,7 +115693,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7310,
                 "speed": 666,
                 "pmech": 667
             },
@@ -116043,7 +115711,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7311,
                 "speed": 668,
                 "pmech": 669
             },
@@ -116062,7 +115729,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7323,
                 "speed": 670,
                 "pmech": 671
             },
@@ -116081,7 +115747,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7324,
                 "speed": 672,
                 "pmech": 673
             },
@@ -116100,7 +115765,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7325,
                 "speed": 674,
                 "pmech": 675
             },
@@ -116119,7 +115783,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7326,
                 "speed": 676,
                 "pmech": 677
             },
@@ -116138,7 +115801,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7329,
                 "speed": 678,
                 "pmech": 679
             },
@@ -116157,7 +115819,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7335,
                 "speed": 680,
                 "pmech": 681
             },
@@ -116176,7 +115837,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7349,
                 "speed": 682,
                 "pmech": 683
             },
@@ -116195,7 +115855,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7350,
                 "speed": 684,
                 "pmech": 685
             },
@@ -116214,7 +115873,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7351,
                 "speed": 686,
                 "pmech": 687
             },
@@ -116233,7 +115891,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7352,
                 "speed": 688,
                 "pmech": 689
             },
@@ -116252,7 +115909,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7353,
                 "speed": 690,
                 "pmech": 691
             },
@@ -116271,7 +115927,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7354,
                 "speed": 692,
                 "pmech": 693
             },
@@ -116290,7 +115945,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7355,
                 "speed": 694,
                 "pmech": 695
             },
@@ -116309,7 +115963,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7356,
                 "speed": 696,
                 "pmech": 697
             },
@@ -116328,7 +115981,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7357,
                 "speed": 698,
                 "pmech": 699
             },
@@ -116347,7 +115999,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7358,
                 "speed": 700,
                 "pmech": 701
             },
@@ -116366,7 +116017,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7359,
                 "speed": 702,
                 "pmech": 703
             },
@@ -116385,7 +116035,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7360,
                 "speed": 704,
                 "pmech": 705
             },
@@ -116404,7 +116053,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7361,
                 "speed": 706,
                 "pmech": 707
             },
@@ -116423,7 +116071,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7369,
                 "speed": 708,
                 "pmech": 709
             },
@@ -116442,7 +116089,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7370,
                 "speed": 710,
                 "pmech": 711
             },
@@ -116461,7 +116107,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7371,
                 "speed": 712,
                 "pmech": 713
             },
@@ -116480,7 +116125,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7372,
                 "speed": 714,
                 "pmech": 715
             },
@@ -116499,7 +116143,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7373,
                 "speed": 716,
                 "pmech": 717
             },
@@ -116518,7 +116161,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7374,
                 "speed": 718,
                 "pmech": 719
             },
@@ -116537,7 +116179,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7375,
                 "speed": 720,
                 "pmech": 721
             },
@@ -116556,7 +116197,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7376,
                 "speed": 722,
                 "pmech": 723
             },
@@ -116575,7 +116215,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7377,
                 "speed": 724,
                 "pmech": 725
             },
@@ -116594,7 +116233,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7378,
                 "speed": 726,
                 "pmech": 727
             },
@@ -116613,7 +116251,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7379,
                 "speed": 728,
                 "pmech": 729
             },
@@ -116632,7 +116269,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7389,
                 "speed": 730,
                 "pmech": 731
             },
@@ -116651,7 +116287,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7400,
                 "speed": 732,
                 "pmech": 733
             },
@@ -116670,7 +116305,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7400,
                 "speed": 734,
                 "pmech": 735
             },
@@ -116689,7 +116323,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7400,
                 "speed": 736,
                 "pmech": 737
             },
@@ -116708,7 +116341,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7400,
                 "speed": 738,
                 "pmech": 739
             },
@@ -116727,7 +116359,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7400,
                 "speed": 740,
                 "pmech": 741
             },
@@ -116746,7 +116377,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7400,
                 "speed": 742,
                 "pmech": 743
             },
@@ -116765,7 +116395,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7406,
                 "speed": 744,
                 "pmech": 745
             },
@@ -116784,7 +116413,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7406,
                 "speed": 746,
                 "pmech": 747
             },
@@ -116803,7 +116431,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7414,
                 "speed": 748,
                 "pmech": 749
             },
@@ -116822,7 +116449,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7419,
                 "speed": 750,
                 "pmech": 751
             },
@@ -116841,7 +116467,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7419,
                 "speed": 752,
                 "pmech": 753
             },
@@ -116860,7 +116485,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 754,
                 "pmech": 755
             },
@@ -116879,7 +116503,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 756,
                 "pmech": 757
             },
@@ -116898,7 +116521,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 758,
                 "pmech": 759
             },
@@ -116917,7 +116539,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 760,
                 "pmech": 761
             },
@@ -116936,7 +116557,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 762,
                 "pmech": 763
             },
@@ -116955,7 +116575,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 764,
                 "pmech": 765
             },
@@ -116974,7 +116593,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 766,
                 "pmech": 767
             },
@@ -116993,7 +116611,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 768,
                 "pmech": 769
             },
@@ -117012,7 +116629,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 770,
                 "pmech": 771
             },
@@ -117031,7 +116647,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 772,
                 "pmech": 773
             },
@@ -117050,7 +116665,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7422,
                 "speed": 774,
                 "pmech": 775
             },
@@ -117069,7 +116683,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 776,
                 "pmech": 777
             },
@@ -117088,7 +116701,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 778,
                 "pmech": 779
             },
@@ -117107,7 +116719,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 780,
                 "pmech": 781
             },
@@ -117126,7 +116737,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 782,
                 "pmech": 783
             },
@@ -117145,7 +116755,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 784,
                 "pmech": 785
             },
@@ -117164,7 +116773,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 786,
                 "pmech": 787
             },
@@ -117183,7 +116791,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 788,
                 "pmech": 789
             },
@@ -117202,7 +116809,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 790,
                 "pmech": 791
             },
@@ -117221,7 +116827,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 792,
                 "pmech": 793
             },
@@ -117240,7 +116845,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 7428,
                 "speed": 794,
                 "pmech": 795
             },
@@ -117259,7 +116863,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8024,
                 "speed": 796,
                 "pmech": 797
             },
@@ -117278,7 +116881,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8046,
                 "speed": 798,
                 "pmech": 799
             },
@@ -117297,7 +116899,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8048,
                 "speed": 800,
                 "pmech": 801
             },
@@ -117316,7 +116917,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8049,
                 "speed": 802,
                 "pmech": 803
             },
@@ -117335,7 +116935,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8071,
                 "speed": 804,
                 "pmech": 805
             },
@@ -117354,7 +116953,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8077,
                 "speed": 806,
                 "pmech": 807
             },
@@ -117373,7 +116971,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8078,
                 "speed": 808,
                 "pmech": 809
             },
@@ -117392,7 +116989,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8079,
                 "speed": 810,
                 "pmech": 811
             },
@@ -117411,7 +117007,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8080,
                 "speed": 812,
                 "pmech": 813
             },
@@ -117430,7 +117025,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8088,
                 "speed": 814,
                 "pmech": 815
             },
@@ -117449,7 +117043,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8099,
                 "speed": 816,
                 "pmech": 817
             },
@@ -117468,7 +117061,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8117,
                 "speed": 818,
                 "pmech": 819
             },
@@ -117487,7 +117079,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8129,
                 "speed": 820,
                 "pmech": 821
             },
@@ -117506,7 +117097,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8130,
                 "speed": 822,
                 "pmech": 823
             },
@@ -117525,7 +117115,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8131,
                 "speed": 824,
                 "pmech": 825
             },
@@ -117544,7 +117133,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 8155,
                 "speed": 826,
                 "pmech": 827
             },

--- a/examples/PhasorDynamics/Large/WECC/wecc.case.json
+++ b/examples/PhasorDynamics/Large/WECC/wecc.case.json
@@ -1,17 +1,19 @@
 {
     "header": {
-        "format_version": 0.1,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "WECC",
         "case_description": "",
-        "case_comments": "",
+        "case_comments": ""
+    },
+    "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
     "buses": [
         {
             "number": 1001,
-            "class": "bus",
+            "class": "Bus",
             "name": "FOURCORN",
             "init": {
                 "Vr": 1.0291466289885092,
@@ -25,7 +27,7 @@
         },
         {
             "number": 1002,
-            "class": "bus",
+            "class": "Bus",
             "name": "FOURCORN",
             "init": {
                 "Vr": 1.0032473274593743,
@@ -39,7 +41,7 @@
         },
         {
             "number": 1003,
-            "class": "bus",
+            "class": "Bus",
             "name": "FOURCORN",
             "init": {
                 "Vr": 0.9731671773810331,
@@ -53,7 +55,7 @@
         },
         {
             "number": 1004,
-            "class": "bus",
+            "class": "Bus",
             "name": "SAN JUAN",
             "init": {
                 "Vr": 0.9750905539848131,
@@ -67,7 +69,7 @@
         },
         {
             "number": 1032,
-            "class": "bus",
+            "class": "Bus",
             "name": "FCNGN4CC",
             "init": {
                 "Vr": 1.0016025293432642,
@@ -81,7 +83,7 @@
         },
         {
             "number": 1034,
-            "class": "bus",
+            "class": "Bus",
             "name": "SJUAN G4",
             "init": {
                 "Vr": 0.9685246905974173,
@@ -95,7 +97,7 @@
         },
         {
             "number": 1101,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORONADO",
             "init": {
                 "Vr": 0.9816588086167465,
@@ -109,7 +111,7 @@
         },
         {
             "number": 1102,
-            "class": "bus",
+            "class": "Bus",
             "name": "CHOLLA",
             "init": {
                 "Vr": 0.9911535229164995,
@@ -123,7 +125,7 @@
         },
         {
             "number": 1131,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORONADO",
             "init": {
                 "Vr": 0.984072847499644,
@@ -137,7 +139,7 @@
         },
         {
             "number": 1201,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOENKOPI",
             "init": {
                 "Vr": 1.0840475191470649,
@@ -151,7 +153,7 @@
         },
         {
             "number": 1202,
-            "class": "bus",
+            "class": "Bus",
             "name": "NAVAJO",
             "init": {
                 "Vr": 1.0775172088362486,
@@ -165,7 +167,7 @@
         },
         {
             "number": 1232,
-            "class": "bus",
+            "class": "Bus",
             "name": "NAVAJO 2",
             "init": {
                 "Vr": 1.078360777641177,
@@ -179,7 +181,7 @@
         },
         {
             "number": 1301,
-            "class": "bus",
+            "class": "Bus",
             "name": "MEAD",
             "init": {
                 "Vr": 1.0294848702778479,
@@ -193,7 +195,7 @@
         },
         {
             "number": 1302,
-            "class": "bus",
+            "class": "Bus",
             "name": "H ALLEN",
             "init": {
                 "Vr": 1.0031102501183398,
@@ -207,7 +209,7 @@
         },
         {
             "number": 1303,
-            "class": "bus",
+            "class": "Bus",
             "name": "H ALLEN",
             "init": {
                 "Vr": 0.9696170242023398,
@@ -221,7 +223,7 @@
         },
         {
             "number": 1331,
-            "class": "bus",
+            "class": "Bus",
             "name": "HOOVER",
             "init": {
                 "Vr": 1.0327382064230135,
@@ -235,7 +237,7 @@
         },
         {
             "number": 1333,
-            "class": "bus",
+            "class": "Bus",
             "name": "H ALLEN",
             "init": {
                 "Vr": 0.9788488012911469,
@@ -249,7 +251,7 @@
         },
         {
             "number": 1401,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALOVRDE",
             "init": {
                 "Vr": 1.0006619844038074,
@@ -263,7 +265,7 @@
         },
         {
             "number": 1402,
-            "class": "bus",
+            "class": "Bus",
             "name": "WESTWING",
             "init": {
                 "Vr": 0.9926913526533575,
@@ -277,7 +279,7 @@
         },
         {
             "number": 1403,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARKER",
             "init": {
                 "Vr": 1.002636418924378,
@@ -291,7 +293,7 @@
         },
         {
             "number": 1431,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALOVRD2",
             "init": {
                 "Vr": 1.0155897351487866,
@@ -305,7 +307,7 @@
         },
         {
             "number": 2000,
-            "class": "bus",
+            "class": "Bus",
             "name": "MEXICO",
             "init": {
                 "Vr": 0.9573563608151822,
@@ -319,7 +321,7 @@
         },
         {
             "number": 2030,
-            "class": "bus",
+            "class": "Bus",
             "name": "MEXICO",
             "init": {
                 "Vr": 0.962127203284071,
@@ -333,7 +335,7 @@
         },
         {
             "number": 2100,
-            "class": "bus",
+            "class": "Bus",
             "name": "IMPERIAL",
             "init": {
                 "Vr": 1.0105814268017232,
@@ -347,7 +349,7 @@
         },
         {
             "number": 2130,
-            "class": "bus",
+            "class": "Bus",
             "name": "IMPERIAL",
             "init": {
                 "Vr": 1.0124715974631084,
@@ -361,7 +363,7 @@
         },
         {
             "number": 2201,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIGUEL",
             "init": {
                 "Vr": 0.8890871589849977,
@@ -375,7 +377,7 @@
         },
         {
             "number": 2202,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIGUEL",
             "init": {
                 "Vr": 0.8769607872022306,
@@ -389,7 +391,7 @@
         },
         {
             "number": 2203,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION",
             "init": {
                 "Vr": 0.8878082289029842,
@@ -403,7 +405,7 @@
         },
         {
             "number": 2233,
-            "class": "bus",
+            "class": "Bus",
             "name": "MISSION",
             "init": {
                 "Vr": 0.8917539463136887,
@@ -417,7 +419,7 @@
         },
         {
             "number": 2301,
-            "class": "bus",
+            "class": "Bus",
             "name": "IMPRLVLY",
             "init": {
                 "Vr": 1.0003265347798895,
@@ -431,7 +433,7 @@
         },
         {
             "number": 2302,
-            "class": "bus",
+            "class": "Bus",
             "name": "IMPRLVLY",
             "init": {
                 "Vr": 1.004674006929104,
@@ -445,7 +447,7 @@
         },
         {
             "number": 2332,
-            "class": "bus",
+            "class": "Bus",
             "name": "IMPRLVLY",
             "init": {
                 "Vr": 1.0058740984236978,
@@ -459,7 +461,7 @@
         },
         {
             "number": 2400,
-            "class": "bus",
+            "class": "Bus",
             "name": "DEVERS",
             "init": {
                 "Vr": 0.9686677018365756,
@@ -473,7 +475,7 @@
         },
         {
             "number": 2401,
-            "class": "bus",
+            "class": "Bus",
             "name": "LUGO",
             "init": {
                 "Vr": 1.0201142388690945,
@@ -487,7 +489,7 @@
         },
         {
             "number": 2402,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIRALOMA",
             "init": {
                 "Vr": 0.9811514709203086,
@@ -501,7 +503,7 @@
         },
         {
             "number": 2403,
-            "class": "bus",
+            "class": "Bus",
             "name": "VALLEY",
             "init": {
                 "Vr": 0.9495294494720706,
@@ -515,7 +517,7 @@
         },
         {
             "number": 2404,
-            "class": "bus",
+            "class": "Bus",
             "name": "VINCENT",
             "init": {
                 "Vr": 1.0235317739456062,
@@ -529,7 +531,7 @@
         },
         {
             "number": 2405,
-            "class": "bus",
+            "class": "Bus",
             "name": "SYLMAR S",
             "init": {
                 "Vr": 0.9926730669624063,
@@ -543,7 +545,7 @@
         },
         {
             "number": 2406,
-            "class": "bus",
+            "class": "Bus",
             "name": "EAGLROCK",
             "init": {
                 "Vr": 0.9735157068301625,
@@ -557,7 +559,7 @@
         },
         {
             "number": 2407,
-            "class": "bus",
+            "class": "Bus",
             "name": "LITEHIPE",
             "init": {
                 "Vr": 0.9106775654857185,
@@ -571,7 +573,7 @@
         },
         {
             "number": 2408,
-            "class": "bus",
+            "class": "Bus",
             "name": "MESA CAL",
             "init": {
                 "Vr": 0.9960375520788632,
@@ -585,7 +587,7 @@
         },
         {
             "number": 2409,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIRALOMA",
             "init": {
                 "Vr": 0.9656154166672628,
@@ -599,7 +601,7 @@
         },
         {
             "number": 2410,
-            "class": "bus",
+            "class": "Bus",
             "name": "PARDEE",
             "init": {
                 "Vr": 0.9740857347695497,
@@ -613,7 +615,7 @@
         },
         {
             "number": 2411,
-            "class": "bus",
+            "class": "Bus",
             "name": "VINCENT",
             "init": {
                 "Vr": 1.0000879564679523,
@@ -627,7 +629,7 @@
         },
         {
             "number": 2431,
-            "class": "bus",
+            "class": "Bus",
             "name": "LUGO",
             "init": {
                 "Vr": 1.0201855324720284,
@@ -641,7 +643,7 @@
         },
         {
             "number": 2434,
-            "class": "bus",
+            "class": "Bus",
             "name": "VINCENT",
             "init": {
                 "Vr": 0.9998610711787467,
@@ -655,7 +657,7 @@
         },
         {
             "number": 2438,
-            "class": "bus",
+            "class": "Bus",
             "name": "MESA CAL",
             "init": {
                 "Vr": 1.0005346742025203,
@@ -669,7 +671,7 @@
         },
         {
             "number": 2439,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIRALOMA",
             "init": {
                 "Vr": 0.9657061083281868,
@@ -683,7 +685,7 @@
         },
         {
             "number": 2501,
-            "class": "bus",
+            "class": "Bus",
             "name": "SERRANO",
             "init": {
                 "Vr": 0.9632392366839512,
@@ -697,7 +699,7 @@
         },
         {
             "number": 2502,
-            "class": "bus",
+            "class": "Bus",
             "name": "SERRANO",
             "init": {
                 "Vr": 0.9512104097787043,
@@ -711,7 +713,7 @@
         },
         {
             "number": 2503,
-            "class": "bus",
+            "class": "Bus",
             "name": "S.ONOFRE",
             "init": {
                 "Vr": 0.9246982850202976,
@@ -725,7 +727,7 @@
         },
         {
             "number": 2533,
-            "class": "bus",
+            "class": "Bus",
             "name": "S.ONOFRE",
             "init": {
                 "Vr": 0.9289638822595822,
@@ -739,7 +741,7 @@
         },
         {
             "number": 2600,
-            "class": "bus",
+            "class": "Bus",
             "name": "ADELANTO",
             "init": {
                 "Vr": 1.0416664033141128,
@@ -753,7 +755,7 @@
         },
         {
             "number": 2601,
-            "class": "bus",
+            "class": "Bus",
             "name": "RINALDI",
             "init": {
                 "Vr": 1.0325531966502695,
@@ -767,7 +769,7 @@
         },
         {
             "number": 2602,
-            "class": "bus",
+            "class": "Bus",
             "name": "STA E",
             "init": {
                 "Vr": 1.0086414897598246,
@@ -781,7 +783,7 @@
         },
         {
             "number": 2603,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORVL",
             "init": {
                 "Vr": 1.0403867019879436,
@@ -795,7 +797,7 @@
         },
         {
             "number": 2604,
-            "class": "bus",
+            "class": "Bus",
             "name": "INTERMT",
             "init": {
                 "Vr": 1.0281874791724415,
@@ -809,7 +811,7 @@
         },
         {
             "number": 2605,
-            "class": "bus",
+            "class": "Bus",
             "name": "STA B1",
             "init": {
                 "Vr": 1.012781982392856,
@@ -823,7 +825,7 @@
         },
         {
             "number": 2606,
-            "class": "bus",
+            "class": "Bus",
             "name": "STA B2",
             "init": {
                 "Vr": 1.012781982392856,
@@ -837,7 +839,7 @@
         },
         {
             "number": 2607,
-            "class": "bus",
+            "class": "Bus",
             "name": "VICTORVL",
             "init": {
                 "Vr": 1.0341155960129134,
@@ -851,7 +853,7 @@
         },
         {
             "number": 2608,
-            "class": "bus",
+            "class": "Bus",
             "name": "CASTAIC",
             "init": {
                 "Vr": 1.0012144391172937,
@@ -865,7 +867,7 @@
         },
         {
             "number": 2609,
-            "class": "bus",
+            "class": "Bus",
             "name": "GLENDAL",
             "init": {
                 "Vr": 0.9906155869439697,
@@ -879,7 +881,7 @@
         },
         {
             "number": 2610,
-            "class": "bus",
+            "class": "Bus",
             "name": "HAYNES",
             "init": {
                 "Vr": 0.9976616726348186,
@@ -893,7 +895,7 @@
         },
         {
             "number": 2611,
-            "class": "bus",
+            "class": "Bus",
             "name": "OLIVE",
             "init": {
                 "Vr": 1.0006465478842197,
@@ -907,7 +909,7 @@
         },
         {
             "number": 2612,
-            "class": "bus",
+            "class": "Bus",
             "name": "RINALDI",
             "init": {
                 "Vr": 0.9981314814982941,
@@ -921,7 +923,7 @@
         },
         {
             "number": 2613,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIVER",
             "init": {
                 "Vr": 0.9920507009050489,
@@ -935,7 +937,7 @@
         },
         {
             "number": 2614,
-            "class": "bus",
+            "class": "Bus",
             "name": "STA BLD",
             "init": {
                 "Vr": 0.9969952293066526,
@@ -949,7 +951,7 @@
         },
         {
             "number": 2615,
-            "class": "bus",
+            "class": "Bus",
             "name": "STA E",
             "init": {
                 "Vr": 0.992564620778635,
@@ -963,7 +965,7 @@
         },
         {
             "number": 2616,
-            "class": "bus",
+            "class": "Bus",
             "name": "STA F",
             "init": {
                 "Vr": 0.9935243389653521,
@@ -977,7 +979,7 @@
         },
         {
             "number": 2617,
-            "class": "bus",
+            "class": "Bus",
             "name": "STA G",
             "init": {
                 "Vr": 0.9916653652761533,
@@ -991,7 +993,7 @@
         },
         {
             "number": 2618,
-            "class": "bus",
+            "class": "Bus",
             "name": "STA J",
             "init": {
                 "Vr": 0.9925039278007112,
@@ -1005,7 +1007,7 @@
         },
         {
             "number": 2619,
-            "class": "bus",
+            "class": "Bus",
             "name": "SYLMARLA",
             "init": {
                 "Vr": 0.9980314018742489,
@@ -1019,7 +1021,7 @@
         },
         {
             "number": 2620,
-            "class": "bus",
+            "class": "Bus",
             "name": "VALLEY",
             "init": {
                 "Vr": 0.9937414145114053,
@@ -1033,7 +1035,7 @@
         },
         {
             "number": 2621,
-            "class": "bus",
+            "class": "Bus",
             "name": "STA B",
             "init": {
                 "Vr": 1.005399914523277,
@@ -1047,7 +1049,7 @@
         },
         {
             "number": 2630,
-            "class": "bus",
+            "class": "Bus",
             "name": "HAYNES3G",
             "init": {
                 "Vr": 0.9971748859135611,
@@ -1061,7 +1063,7 @@
         },
         {
             "number": 2631,
-            "class": "bus",
+            "class": "Bus",
             "name": "OLIVE",
             "init": {
                 "Vr": 1.0009927061276438,
@@ -1075,7 +1077,7 @@
         },
         {
             "number": 2634,
-            "class": "bus",
+            "class": "Bus",
             "name": "INTERM1G",
             "init": {
                 "Vr": 1.0284840467271332,
@@ -1089,7 +1091,7 @@
         },
         {
             "number": 2637,
-            "class": "bus",
+            "class": "Bus",
             "name": "OWENS G",
             "init": {
                 "Vr": 0.9983990169102167,
@@ -1103,7 +1105,7 @@
         },
         {
             "number": 2638,
-            "class": "bus",
+            "class": "Bus",
             "name": "CASTAI4G",
             "init": {
                 "Vr": 1.0014131240403334,
@@ -1117,7 +1119,7 @@
         },
         {
             "number": 2901,
-            "class": "bus",
+            "class": "Bus",
             "name": "ELDORADO",
             "init": {
                 "Vr": 1.0905332810230042,
@@ -1131,7 +1133,7 @@
         },
         {
             "number": 2902,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOHAVE",
             "init": {
                 "Vr": 1.096090314117727,
@@ -1145,7 +1147,7 @@
         },
         {
             "number": 3101,
-            "class": "bus",
+            "class": "Bus",
             "name": "EMBRCDRD",
             "init": {
                 "Vr": 0.9722787675171465,
@@ -1159,7 +1161,7 @@
         },
         {
             "number": 3102,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARTIN",
             "init": {
                 "Vr": 0.9794141550652612,
@@ -1173,7 +1175,7 @@
         },
         {
             "number": 3103,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANMATEO",
             "init": {
                 "Vr": 0.9896506407883032,
@@ -1187,7 +1189,7 @@
         },
         {
             "number": 3104,
-            "class": "bus",
+            "class": "Bus",
             "name": "MARTIN",
             "init": {
                 "Vr": 0.966012119171973,
@@ -1201,7 +1203,7 @@
         },
         {
             "number": 3105,
-            "class": "bus",
+            "class": "Bus",
             "name": "POTRERO",
             "init": {
                 "Vr": 0.9798837604121561,
@@ -1215,7 +1217,7 @@
         },
         {
             "number": 3133,
-            "class": "bus",
+            "class": "Bus",
             "name": "SANMATEO",
             "init": {
                 "Vr": 0.9896001687756142,
@@ -1229,7 +1231,7 @@
         },
         {
             "number": 3135,
-            "class": "bus",
+            "class": "Bus",
             "name": "POTRERO",
             "init": {
                 "Vr": 0.9805210974851748,
@@ -1243,7 +1245,7 @@
         },
         {
             "number": 3201,
-            "class": "bus",
+            "class": "Bus",
             "name": "C.COSTA",
             "init": {
                 "Vr": 1.0004020002639695,
@@ -1257,7 +1259,7 @@
         },
         {
             "number": 3202,
-            "class": "bus",
+            "class": "Bus",
             "name": "MORAGA",
             "init": {
                 "Vr": 0.9996931986521757,
@@ -1271,7 +1273,7 @@
         },
         {
             "number": 3203,
-            "class": "bus",
+            "class": "Bus",
             "name": "NEWARK",
             "init": {
                 "Vr": 0.997821672298632,
@@ -1285,7 +1287,7 @@
         },
         {
             "number": 3204,
-            "class": "bus",
+            "class": "Bus",
             "name": "PITSBURG",
             "init": {
                 "Vr": 1.0099970428966683,
@@ -1299,7 +1301,7 @@
         },
         {
             "number": 3205,
-            "class": "bus",
+            "class": "Bus",
             "name": "SOBRANTE",
             "init": {
                 "Vr": 0.9998394737339775,
@@ -1313,7 +1315,7 @@
         },
         {
             "number": 3234,
-            "class": "bus",
+            "class": "Bus",
             "name": "PITSBURG",
             "init": {
                 "Vr": 1.0118280166590294,
@@ -1327,7 +1329,7 @@
         },
         {
             "number": 3301,
-            "class": "bus",
+            "class": "Bus",
             "name": "METCALF",
             "init": {
                 "Vr": 1.0078525781046732,
@@ -1341,7 +1343,7 @@
         },
         {
             "number": 3302,
-            "class": "bus",
+            "class": "Bus",
             "name": "JEFFERSN",
             "init": {
                 "Vr": 0.9754762000923262,
@@ -1355,7 +1357,7 @@
         },
         {
             "number": 3303,
-            "class": "bus",
+            "class": "Bus",
             "name": "METCALF",
             "init": {
                 "Vr": 0.9954176615916132,
@@ -1369,7 +1371,7 @@
         },
         {
             "number": 3304,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONTAVIS",
             "init": {
                 "Vr": 0.9823729914843256,
@@ -1383,7 +1385,7 @@
         },
         {
             "number": 3305,
-            "class": "bus",
+            "class": "Bus",
             "name": "RAVENSWD",
             "init": {
                 "Vr": 0.9914663871855712,
@@ -1397,7 +1399,7 @@
         },
         {
             "number": 3333,
-            "class": "bus",
+            "class": "Bus",
             "name": "METCALF",
             "init": {
                 "Vr": 0.9966023945451874,
@@ -1411,7 +1413,7 @@
         },
         {
             "number": 3401,
-            "class": "bus",
+            "class": "Bus",
             "name": "GREGG",
             "init": {
                 "Vr": 0.9385106763063653,
@@ -1425,7 +1427,7 @@
         },
         {
             "number": 3402,
-            "class": "bus",
+            "class": "Bus",
             "name": "HELMS PP",
             "init": {
                 "Vr": 0.940525362113976,
@@ -1439,7 +1441,7 @@
         },
         {
             "number": 3403,
-            "class": "bus",
+            "class": "Bus",
             "name": "MC CALL",
             "init": {
                 "Vr": 0.9996320493015209,
@@ -1453,7 +1455,7 @@
         },
         {
             "number": 3404,
-            "class": "bus",
+            "class": "Bus",
             "name": "PANOCHE",
             "init": {
                 "Vr": 0.977058716366943,
@@ -1467,7 +1469,7 @@
         },
         {
             "number": 3405,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILSON",
             "init": {
                 "Vr": 0.9267027581428218,
@@ -1481,7 +1483,7 @@
         },
         {
             "number": 3432,
-            "class": "bus",
+            "class": "Bus",
             "name": "HELMS PP",
             "init": {
                 "Vr": 0.940525362113976,
@@ -1495,7 +1497,7 @@
         },
         {
             "number": 3433,
-            "class": "bus",
+            "class": "Bus",
             "name": "MC CALL",
             "init": {
                 "Vr": 1.000018305257258,
@@ -1509,7 +1511,7 @@
         },
         {
             "number": 3501,
-            "class": "bus",
+            "class": "Bus",
             "name": "FULTON",
             "init": {
                 "Vr": 0.9996057072629682,
@@ -1523,7 +1525,7 @@
         },
         {
             "number": 3531,
-            "class": "bus",
+            "class": "Bus",
             "name": "FULTON",
             "init": {
                 "Vr": 0.9997975637408305,
@@ -1537,7 +1539,7 @@
         },
         {
             "number": 3601,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUMBOLDT",
             "init": {
                 "Vr": 1.0125718786784759,
@@ -1551,7 +1553,7 @@
         },
         {
             "number": 3631,
-            "class": "bus",
+            "class": "Bus",
             "name": "HUMBOLDT",
             "init": {
                 "Vr": 1.012373248318211,
@@ -1565,7 +1567,7 @@
         },
         {
             "number": 3701,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUMMIT",
             "init": {
                 "Vr": 0.9414776476282241,
@@ -1579,7 +1581,7 @@
         },
         {
             "number": 3731,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUMMIT",
             "init": {
                 "Vr": 0.9413043872984699,
@@ -1593,7 +1595,7 @@
         },
         {
             "number": 3801,
-            "class": "bus",
+            "class": "Bus",
             "name": "DIABLO",
             "init": {
                 "Vr": 1.0489927570535271,
@@ -1607,7 +1609,7 @@
         },
         {
             "number": 3802,
-            "class": "bus",
+            "class": "Bus",
             "name": "GATES",
             "init": {
                 "Vr": 1.0318510687118039,
@@ -1621,7 +1623,7 @@
         },
         {
             "number": 3803,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY",
             "init": {
                 "Vr": 1.0380724489642617,
@@ -1635,7 +1637,7 @@
         },
         {
             "number": 3804,
-            "class": "bus",
+            "class": "Bus",
             "name": "GATES",
             "init": {
                 "Vr": 0.9945631732828706,
@@ -1649,7 +1651,7 @@
         },
         {
             "number": 3805,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY",
             "init": {
                 "Vr": 1.0279899525424085,
@@ -1663,7 +1665,7 @@
         },
         {
             "number": 3806,
-            "class": "bus",
+            "class": "Bus",
             "name": "MORROBAY",
             "init": {
                 "Vr": 1.0170550686812594,
@@ -1677,7 +1679,7 @@
         },
         {
             "number": 3831,
-            "class": "bus",
+            "class": "Bus",
             "name": "DIABLO1",
             "init": {
                 "Vr": 1.0486659020632656,
@@ -1691,7 +1693,7 @@
         },
         {
             "number": 3835,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY",
             "init": {
                 "Vr": 1.0284764086876332,
@@ -1705,7 +1707,7 @@
         },
         {
             "number": 3836,
-            "class": "bus",
+            "class": "Bus",
             "name": "MORROBAY",
             "init": {
                 "Vr": 1.0172172040369767,
@@ -1719,7 +1721,7 @@
         },
         {
             "number": 3891,
-            "class": "bus",
+            "class": "Bus",
             "name": "GATES1",
             "init": {
                 "Vr": 1.0384532135976612,
@@ -1733,7 +1735,7 @@
         },
         {
             "number": 3892,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY1",
             "init": {
                 "Vr": 1.0362785350581156,
@@ -1747,7 +1749,7 @@
         },
         {
             "number": 3893,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY2",
             "init": {
                 "Vr": 1.0063510208297626,
@@ -1761,7 +1763,7 @@
         },
         {
             "number": 3894,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY3",
             "init": {
                 "Vr": 1.0361387813136547,
@@ -1775,7 +1777,7 @@
         },
         {
             "number": 3895,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY4",
             "init": {
                 "Vr": 1.0064556735070977,
@@ -1789,7 +1791,7 @@
         },
         {
             "number": 3896,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY5",
             "init": {
                 "Vr": 1.0367171098759727,
@@ -1803,7 +1805,7 @@
         },
         {
             "number": 3897,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDWAY6",
             "init": {
                 "Vr": 1.008975900594003,
@@ -1817,7 +1819,7 @@
         },
         {
             "number": 3901,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOSBANOS",
             "init": {
                 "Vr": 1.0242087734225898,
@@ -1831,7 +1833,7 @@
         },
         {
             "number": 3902,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOSSLAND",
             "init": {
                 "Vr": 0.9992115471789931,
@@ -1845,7 +1847,7 @@
         },
         {
             "number": 3903,
-            "class": "bus",
+            "class": "Bus",
             "name": "TESLA",
             "init": {
                 "Vr": 1.0302299886192652,
@@ -1859,7 +1861,7 @@
         },
         {
             "number": 3904,
-            "class": "bus",
+            "class": "Bus",
             "name": "VACA-DIX",
             "init": {
                 "Vr": 1.0294245545129779,
@@ -1873,7 +1875,7 @@
         },
         {
             "number": 3905,
-            "class": "bus",
+            "class": "Bus",
             "name": "TABLE MT",
             "init": {
                 "Vr": 1.0430836110243549,
@@ -1887,7 +1889,7 @@
         },
         {
             "number": 3906,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND MT",
             "init": {
                 "Vr": 1.064933267977804,
@@ -1901,7 +1903,7 @@
         },
         {
             "number": 3907,
-            "class": "bus",
+            "class": "Bus",
             "name": "BELLOTA",
             "init": {
                 "Vr": 0.941851965966272,
@@ -1915,7 +1917,7 @@
         },
         {
             "number": 3908,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIGHTON",
             "init": {
                 "Vr": 0.9344874641880455,
@@ -1929,7 +1931,7 @@
         },
         {
             "number": 3909,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLGATE",
             "init": {
                 "Vr": 0.9402903253932633,
@@ -1943,7 +1945,7 @@
         },
         {
             "number": 3910,
-            "class": "bus",
+            "class": "Bus",
             "name": "CORTINA",
             "init": {
                 "Vr": 0.9544597331917197,
@@ -1957,7 +1959,7 @@
         },
         {
             "number": 3911,
-            "class": "bus",
+            "class": "Bus",
             "name": "COTWDPGE",
             "init": {
                 "Vr": 1.0402970108674507,
@@ -1971,7 +1973,7 @@
         },
         {
             "number": 3912,
-            "class": "bus",
+            "class": "Bus",
             "name": "GLENN",
             "init": {
                 "Vr": 1.0082822777162115,
@@ -1985,7 +1987,7 @@
         },
         {
             "number": 3913,
-            "class": "bus",
+            "class": "Bus",
             "name": "GOLDHILL",
             "init": {
                 "Vr": 0.9637646735261063,
@@ -1999,7 +2001,7 @@
         },
         {
             "number": 3914,
-            "class": "bus",
+            "class": "Bus",
             "name": "IGNACIO",
             "init": {
                 "Vr": 0.9906614183700735,
@@ -2013,7 +2015,7 @@
         },
         {
             "number": 3915,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAKEVILE",
             "init": {
                 "Vr": 0.9952684608450031,
@@ -2027,7 +2029,7 @@
         },
         {
             "number": 3916,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOGAN CR",
             "init": {
                 "Vr": 1.0067546253478934,
@@ -2041,7 +2043,7 @@
         },
         {
             "number": 3917,
-            "class": "bus",
+            "class": "Bus",
             "name": "LOSBANOS",
             "init": {
                 "Vr": 0.9994134712276752,
@@ -2055,7 +2057,7 @@
         },
         {
             "number": 3918,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOSSLAND",
             "init": {
                 "Vr": 0.9883262088268351,
@@ -2069,7 +2071,7 @@
         },
         {
             "number": 3919,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALERMO",
             "init": {
                 "Vr": 0.9550547035686098,
@@ -2083,7 +2085,7 @@
         },
         {
             "number": 3920,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIO OSO",
             "init": {
                 "Vr": 0.9503777078193959,
@@ -2097,7 +2099,7 @@
         },
         {
             "number": 3921,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND MT",
             "init": {
                 "Vr": 1.0696441340161758,
@@ -2111,7 +2113,7 @@
         },
         {
             "number": 3922,
-            "class": "bus",
+            "class": "Bus",
             "name": "TABLE MT",
             "init": {
                 "Vr": 0.9912487763628958,
@@ -2125,7 +2127,7 @@
         },
         {
             "number": 3923,
-            "class": "bus",
+            "class": "Bus",
             "name": "TESLA",
             "init": {
                 "Vr": 1.0174439240600766,
@@ -2139,7 +2141,7 @@
         },
         {
             "number": 3924,
-            "class": "bus",
+            "class": "Bus",
             "name": "VACA-DIX",
             "init": {
                 "Vr": 1.0049008159106407,
@@ -2153,7 +2155,7 @@
         },
         {
             "number": 3925,
-            "class": "bus",
+            "class": "Bus",
             "name": "COTWDPGE",
             "init": {
                 "Vr": 1.0272660694953977,
@@ -2167,7 +2169,7 @@
         },
         {
             "number": 3926,
-            "class": "bus",
+            "class": "Bus",
             "name": "RIO OSO",
             "init": {
                 "Vr": 0.9401758837714785,
@@ -2181,7 +2183,7 @@
         },
         {
             "number": 3931,
-            "class": "bus",
+            "class": "Bus",
             "name": "ROUND MT",
             "init": {
                 "Vr": 1.0701051072572718,
@@ -2195,7 +2197,7 @@
         },
         {
             "number": 3932,
-            "class": "bus",
+            "class": "Bus",
             "name": "MOSSLAND",
             "init": {
                 "Vr": 0.9982215271217232,
@@ -2209,7 +2211,7 @@
         },
         {
             "number": 3933,
-            "class": "bus",
+            "class": "Bus",
             "name": "TESLA",
             "init": {
                 "Vr": 1.0199999809265137,
@@ -2223,7 +2225,7 @@
         },
         {
             "number": 4001,
-            "class": "bus",
+            "class": "Bus",
             "name": "MALIN",
             "init": {
                 "Vr": 1.0741622851771058,
@@ -2237,7 +2239,7 @@
         },
         {
             "number": 4002,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUMMER L",
             "init": {
                 "Vr": 1.1117677023694128,
@@ -2251,7 +2253,7 @@
         },
         {
             "number": 4003,
-            "class": "bus",
+            "class": "Bus",
             "name": "BURNS",
             "init": {
                 "Vr": 1.125665205763732,
@@ -2265,7 +2267,7 @@
         },
         {
             "number": 4004,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRIZZLY",
             "init": {
                 "Vr": 1.0957812146604506,
@@ -2279,7 +2281,7 @@
         },
         {
             "number": 4005,
-            "class": "bus",
+            "class": "Bus",
             "name": "JOHN DAY",
             "init": {
                 "Vr": 1.0752484647575837,
@@ -2293,7 +2295,7 @@
         },
         {
             "number": 4006,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG EDDY",
             "init": {
                 "Vr": 1.0627128291750094,
@@ -2307,7 +2309,7 @@
         },
         {
             "number": 4007,
-            "class": "bus",
+            "class": "Bus",
             "name": "CELILOCA",
             "init": {
                 "Vr": 1.0622045208946733,
@@ -2321,7 +2323,7 @@
         },
         {
             "number": 4008,
-            "class": "bus",
+            "class": "Bus",
             "name": "MALIN",
             "init": {
                 "Vr": 1.0692418779487243,
@@ -2335,7 +2337,7 @@
         },
         {
             "number": 4009,
-            "class": "bus",
+            "class": "Bus",
             "name": "BIG EDDY",
             "init": {
                 "Vr": 1.0584367491548898,
@@ -2349,7 +2351,7 @@
         },
         {
             "number": 4010,
-            "class": "bus",
+            "class": "Bus",
             "name": "CELILO",
             "init": {
                 "Vr": 1.0562579539373358,
@@ -2363,7 +2365,7 @@
         },
         {
             "number": 4031,
-            "class": "bus",
+            "class": "Bus",
             "name": "MALIN",
             "init": {
                 "Vr": 1.0717490395344864,
@@ -2377,7 +2379,7 @@
         },
         {
             "number": 4035,
-            "class": "bus",
+            "class": "Bus",
             "name": "JOHN DAY",
             "init": {
                 "Vr": 1.0738706270108667,
@@ -2391,7 +2393,7 @@
         },
         {
             "number": 4039,
-            "class": "bus",
+            "class": "Bus",
             "name": "DALLES21",
             "init": {
                 "Vr": 1.0643068861369407,
@@ -2405,7 +2407,7 @@
         },
         {
             "number": 4090,
-            "class": "bus",
+            "class": "Bus",
             "name": "MALIN1",
             "init": {
                 "Vr": 1.107927005657545,
@@ -2419,7 +2421,7 @@
         },
         {
             "number": 4091,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRIZZLY1",
             "init": {
                 "Vr": 1.1065342937987306,
@@ -2433,7 +2435,7 @@
         },
         {
             "number": 4092,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRIZZLY2",
             "init": {
                 "Vr": 1.088171966574024,
@@ -2447,7 +2449,7 @@
         },
         {
             "number": 4093,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRIZZLY3",
             "init": {
                 "Vr": 1.0863425851844155,
@@ -2461,7 +2463,7 @@
         },
         {
             "number": 4094,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRIZZLY4",
             "init": {
                 "Vr": 1.100345473859454,
@@ -2475,7 +2477,7 @@
         },
         {
             "number": 4095,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRIZZLY5",
             "init": {
                 "Vr": 1.0864876402426793,
@@ -2489,7 +2491,7 @@
         },
         {
             "number": 4096,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRIZZLY6",
             "init": {
                 "Vr": 1.084441010567787,
@@ -2503,7 +2505,7 @@
         },
         {
             "number": 4097,
-            "class": "bus",
+            "class": "Bus",
             "name": "GRIZZLY7",
             "init": {
                 "Vr": 1.100106826657524,
@@ -2517,7 +2519,7 @@
         },
         {
             "number": 4101,
-            "class": "bus",
+            "class": "Bus",
             "name": "COULEE",
             "init": {
                 "Vr": 1.1063961479749795,
@@ -2531,7 +2533,7 @@
         },
         {
             "number": 4102,
-            "class": "bus",
+            "class": "Bus",
             "name": "HANFORD",
             "init": {
                 "Vr": 1.0933785682775603,
@@ -2545,7 +2547,7 @@
         },
         {
             "number": 4103,
-            "class": "bus",
+            "class": "Bus",
             "name": "BELL",
             "init": {
                 "Vr": 1.07849822686903,
@@ -2559,7 +2561,7 @@
         },
         {
             "number": 4104,
-            "class": "bus",
+            "class": "Bus",
             "name": "BELL",
             "init": {
                 "Vr": 1.0171706995360488,
@@ -2573,7 +2575,7 @@
         },
         {
             "number": 4131,
-            "class": "bus",
+            "class": "Bus",
             "name": "COULEE",
             "init": {
                 "Vr": 1.101449246524323,
@@ -2587,7 +2589,7 @@
         },
         {
             "number": 4132,
-            "class": "bus",
+            "class": "Bus",
             "name": "HANFORD",
             "init": {
                 "Vr": 1.0912778951059916,
@@ -2601,7 +2603,7 @@
         },
         {
             "number": 4201,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORTH",
             "init": {
                 "Vr": 1.1172000284886705,
@@ -2615,7 +2617,7 @@
         },
         {
             "number": 4202,
-            "class": "bus",
+            "class": "Bus",
             "name": "WCASCADE",
             "init": {
                 "Vr": 1.0489425214153374,
@@ -2629,7 +2631,7 @@
         },
         {
             "number": 4203,
-            "class": "bus",
+            "class": "Bus",
             "name": "WILLAMET",
             "init": {
                 "Vr": 1.0085432656736182,
@@ -2643,7 +2645,7 @@
         },
         {
             "number": 4204,
-            "class": "bus",
+            "class": "Bus",
             "name": "MERIDIAN",
             "init": {
                 "Vr": 1.0521354682222321,
@@ -2657,7 +2659,7 @@
         },
         {
             "number": 4231,
-            "class": "bus",
+            "class": "Bus",
             "name": "NORTH G3",
             "init": {
                 "Vr": 1.1220740013157733,
@@ -2671,7 +2673,7 @@
         },
         {
             "number": 4232,
-            "class": "bus",
+            "class": "Bus",
             "name": "WCASCADE",
             "init": {
                 "Vr": 1.0494790604244124,
@@ -2685,7 +2687,7 @@
         },
         {
             "number": 5001,
-            "class": "bus",
+            "class": "Bus",
             "name": "CANADA",
             "init": {
                 "Vr": 1.044633378493421,
@@ -2699,7 +2701,7 @@
         },
         {
             "number": 5002,
-            "class": "bus",
+            "class": "Bus",
             "name": "CANALB",
             "init": {
                 "Vr": 1.0471190075320949,
@@ -2713,7 +2715,7 @@
         },
         {
             "number": 5003,
-            "class": "bus",
+            "class": "Bus",
             "name": "CA230TO",
             "init": {
                 "Vr": 1.036090017536494,
@@ -2727,7 +2729,7 @@
         },
         {
             "number": 5004,
-            "class": "bus",
+            "class": "Bus",
             "name": "CA230",
             "init": {
                 "Vr": 1.060371720701631,
@@ -2741,7 +2743,7 @@
         },
         {
             "number": 5031,
-            "class": "bus",
+            "class": "Bus",
             "name": "CANAD G1",
             "init": {
                 "Vr": 1.0519628321419958,
@@ -2755,7 +2757,7 @@
         },
         {
             "number": 5032,
-            "class": "bus",
+            "class": "Bus",
             "name": "CMAIN GM",
             "init": {
                 "Vr": 1.057994203253784,
@@ -2769,7 +2771,7 @@
         },
         {
             "number": 6101,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDPOINT",
             "init": {
                 "Vr": 1.035247306721843,
@@ -2783,7 +2785,7 @@
         },
         {
             "number": 6102,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDPOINT",
             "init": {
                 "Vr": 0.9869794129963294,
@@ -2797,7 +2799,7 @@
         },
         {
             "number": 6103,
-            "class": "bus",
+            "class": "Bus",
             "name": "BORAH",
             "init": {
                 "Vr": 0.9817652896086463,
@@ -2811,7 +2813,7 @@
         },
         {
             "number": 6104,
-            "class": "bus",
+            "class": "Bus",
             "name": "BORAH",
             "init": {
                 "Vr": 1.0113851718658269,
@@ -2825,7 +2827,7 @@
         },
         {
             "number": 6132,
-            "class": "bus",
+            "class": "Bus",
             "name": "MIDPOINT",
             "init": {
                 "Vr": 0.9775365161402827,
@@ -2839,7 +2841,7 @@
         },
         {
             "number": 6201,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLSTRP",
             "init": {
                 "Vr": 1.0513823577640673,
@@ -2853,7 +2855,7 @@
         },
         {
             "number": 6202,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARRISON",
             "init": {
                 "Vr": 1.093658511428057,
@@ -2867,7 +2869,7 @@
         },
         {
             "number": 6203,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLSTRP",
             "init": {
                 "Vr": 0.999764491229505,
@@ -2881,7 +2883,7 @@
         },
         {
             "number": 6204,
-            "class": "bus",
+            "class": "Bus",
             "name": "GARRISON",
             "init": {
                 "Vr": 1.0505201536195254,
@@ -2895,7 +2897,7 @@
         },
         {
             "number": 6205,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONTANA",
             "init": {
                 "Vr": 1.0233013230224504,
@@ -2909,7 +2911,7 @@
         },
         {
             "number": 6231,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLSTRP",
             "init": {
                 "Vr": 1.049979958664284,
@@ -2923,7 +2925,7 @@
         },
         {
             "number": 6235,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONTA G1",
             "init": {
                 "Vr": 1.0224390898248412,
@@ -2937,7 +2939,7 @@
         },
         {
             "number": 6301,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGER",
             "init": {
                 "Vr": 0.9777519359370199,
@@ -2951,7 +2953,7 @@
         },
         {
             "number": 6302,
-            "class": "bus",
+            "class": "Bus",
             "name": "LARAMIE",
             "init": {
                 "Vr": 0.8515618538112251,
@@ -2965,7 +2967,7 @@
         },
         {
             "number": 6303,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGER2",
             "init": {
                 "Vr": 0.8969294909002588,
@@ -2979,7 +2981,7 @@
         },
         {
             "number": 6304,
-            "class": "bus",
+            "class": "Bus",
             "name": "LARAMIE",
             "init": {
                 "Vr": 0.9391038107381421,
@@ -2993,7 +2995,7 @@
         },
         {
             "number": 6305,
-            "class": "bus",
+            "class": "Bus",
             "name": "NAUGHTON",
             "init": {
                 "Vr": 0.9187725144165042,
@@ -3007,7 +3009,7 @@
         },
         {
             "number": 6333,
-            "class": "bus",
+            "class": "Bus",
             "name": "BRIDGER",
             "init": {
                 "Vr": 0.8904576042351704,
@@ -3021,7 +3023,7 @@
         },
         {
             "number": 6335,
-            "class": "bus",
+            "class": "Bus",
             "name": "NAUGHT",
             "init": {
                 "Vr": 0.9151467016312164,
@@ -3035,7 +3037,7 @@
         },
         {
             "number": 6401,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRACYSPP",
             "init": {
                 "Vr": 1.0128316304704426,
@@ -3049,7 +3051,7 @@
         },
         {
             "number": 6402,
-            "class": "bus",
+            "class": "Bus",
             "name": "SUMITSPP",
             "init": {
                 "Vr": 0.966812652449819,
@@ -3063,7 +3065,7 @@
         },
         {
             "number": 6403,
-            "class": "bus",
+            "class": "Bus",
             "name": "VALMY",
             "init": {
                 "Vr": 1.1073533784186766,
@@ -3077,7 +3079,7 @@
         },
         {
             "number": 6404,
-            "class": "bus",
+            "class": "Bus",
             "name": "GONDER",
             "init": {
                 "Vr": 1.0791704423576842,
@@ -3091,7 +3093,7 @@
         },
         {
             "number": 6433,
-            "class": "bus",
+            "class": "Bus",
             "name": "VALMY",
             "init": {
                 "Vr": 1.1080673530152034,
@@ -3105,7 +3107,7 @@
         },
         {
             "number": 6501,
-            "class": "bus",
+            "class": "Bus",
             "name": "BENLOMND",
             "init": {
                 "Vr": 1.0222612175527113,
@@ -3119,7 +3121,7 @@
         },
         {
             "number": 6502,
-            "class": "bus",
+            "class": "Bus",
             "name": "CAMP WIL",
             "init": {
                 "Vr": 1.0200065690105058,
@@ -3133,7 +3135,7 @@
         },
         {
             "number": 6503,
-            "class": "bus",
+            "class": "Bus",
             "name": "EMERY",
             "init": {
                 "Vr": 1.0482894541021806,
@@ -3147,7 +3149,7 @@
         },
         {
             "number": 6504,
-            "class": "bus",
+            "class": "Bus",
             "name": "MONA",
             "init": {
                 "Vr": 1.0225581126043477,
@@ -3161,7 +3163,7 @@
         },
         {
             "number": 6505,
-            "class": "bus",
+            "class": "Bus",
             "name": "PINTO",
             "init": {
                 "Vr": 1.0587525319802276,
@@ -3175,7 +3177,7 @@
         },
         {
             "number": 6506,
-            "class": "bus",
+            "class": "Bus",
             "name": "PINTO PS",
             "init": {
                 "Vr": 1.0471253161861365,
@@ -3189,7 +3191,7 @@
         },
         {
             "number": 6507,
-            "class": "bus",
+            "class": "Bus",
             "name": "SIGURD",
             "init": {
                 "Vr": 1.0513530573285206,
@@ -3203,7 +3205,7 @@
         },
         {
             "number": 6508,
-            "class": "bus",
+            "class": "Bus",
             "name": "SPAN FRK",
             "init": {
                 "Vr": 1.0278770168183777,
@@ -3217,7 +3219,7 @@
         },
         {
             "number": 6509,
-            "class": "bus",
+            "class": "Bus",
             "name": "TERMINAL",
             "init": {
                 "Vr": 1.0207603288880465,
@@ -3231,7 +3233,7 @@
         },
         {
             "number": 6510,
-            "class": "bus",
+            "class": "Bus",
             "name": "BENLOMND",
             "init": {
                 "Vr": 0.9885392998727536,
@@ -3245,7 +3247,7 @@
         },
         {
             "number": 6533,
-            "class": "bus",
+            "class": "Bus",
             "name": "EMERY",
             "init": {
                 "Vr": 1.0468199407967484,
@@ -3259,7 +3261,7 @@
         },
         {
             "number": 7001,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLOEAST",
             "init": {
                 "Vr": 0.8475933578231597,
@@ -3273,7 +3275,7 @@
         },
         {
             "number": 7002,
-            "class": "bus",
+            "class": "Bus",
             "name": "CRAIG",
             "init": {
                 "Vr": 0.8731966002522802,
@@ -3287,7 +3289,7 @@
         },
         {
             "number": 7031,
-            "class": "bus",
+            "class": "Bus",
             "name": "COLOEAST",
             "init": {
                 "Vr": 0.8649863113272928,
@@ -3301,7 +3303,7 @@
         },
         {
             "number": 7032,
-            "class": "bus",
+            "class": "Bus",
             "name": "CRAIG",
             "init": {
                 "Vr": 0.8802883650638654,
@@ -3315,7 +3317,7 @@
         },
         {
             "number": 8001,
-            "class": "bus",
+            "class": "Bus",
             "name": "OLINDA",
             "init": {
                 "Vr": 1.0588410693269101,
@@ -3329,7 +3331,7 @@
         },
         {
             "number": 8002,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRACY",
             "init": {
                 "Vr": 1.0324629905380864,
@@ -3343,7 +3345,7 @@
         },
         {
             "number": 8003,
-            "class": "bus",
+            "class": "Bus",
             "name": "COTWDWAP",
             "init": {
                 "Vr": 1.0729949831527752,
@@ -3357,7 +3359,7 @@
         },
         {
             "number": 8004,
-            "class": "bus",
+            "class": "Bus",
             "name": "RNCHSECO",
             "init": {
                 "Vr": 0.9790789203521542,
@@ -3371,7 +3373,7 @@
         },
         {
             "number": 8005,
-            "class": "bus",
+            "class": "Bus",
             "name": "TRACYPMP",
             "init": {
                 "Vr": 0.9755708179875415,
@@ -3385,7 +3387,7 @@
         },
         {
             "number": 8033,
-            "class": "bus",
+            "class": "Bus",
             "name": "COTWDWAP",
             "init": {
                 "Vr": 1.074508137859625,
@@ -3399,7 +3401,7 @@
         },
         {
             "number": 8034,
-            "class": "bus",
+            "class": "Bus",
             "name": "RNCHSECO",
             "init": {
                 "Vr": 0.9845748440903827,

--- a/examples/PhasorDynamics/Medium/Hawaii/hawaii.case.json
+++ b/examples/PhasorDynamics/Medium/Hawaii/hawaii.case.json
@@ -1,10 +1,12 @@
 {
     "header": {
-        "format_version": 0.1,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "Hawaii",
         "case_description": "A modified Hawaii 37 Bus Case that only has synchronous machines.",
-        "case_comments": "No Case Comments",
+        "case_comments": "No Case Comments"
+    },
+    "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
@@ -17,7 +19,7 @@
     "buses": [
         {
             "number": 1,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALOHA138",
             "init": {
                 "Vr": 0.9933554848330083,
@@ -31,7 +33,7 @@
         },
         {
             "number": 2,
-            "class": "bus",
+            "class": "Bus",
             "name": "ALOHA69",
             "init": {
                 "Vr": 0.9888972890393228,
@@ -45,7 +47,7 @@
         },
         {
             "number": 3,
-            "class": "bus",
+            "class": "Bus",
             "name": "FLOWER69",
             "init": {
                 "Vr": 0.9811930004560111,
@@ -59,7 +61,7 @@
         },
         {
             "number": 4,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAVE69",
             "init": {
                 "Vr": 0.973882121818533,
@@ -73,7 +75,7 @@
         },
         {
             "number": 5,
-            "class": "bus",
+            "class": "Bus",
             "name": "HONOLULU138",
             "init": {
                 "Vr": 0.9883394508774866,
@@ -87,7 +89,7 @@
         },
         {
             "number": 6,
-            "class": "bus",
+            "class": "Bus",
             "name": "HONOLULU69",
             "init": {
                 "Vr": 0.9766427916739501,
@@ -101,7 +103,7 @@
         },
         {
             "number": 7,
-            "class": "bus",
+            "class": "Bus",
             "name": "SURF69",
             "init": {
                 "Vr": 0.9757827875915684,
@@ -115,7 +117,7 @@
         },
         {
             "number": 8,
-            "class": "bus",
+            "class": "Bus",
             "name": "KANEOHE69",
             "init": {
                 "Vr": 0.9737759184819345,
@@ -129,7 +131,7 @@
         },
         {
             "number": 9,
-            "class": "bus",
+            "class": "Bus",
             "name": "TURTLE138",
             "init": {
                 "Vr": 0.9857919157353446,
@@ -143,7 +145,7 @@
         },
         {
             "number": 10,
-            "class": "bus",
+            "class": "Bus",
             "name": "TURTLE69",
             "init": {
                 "Vr": 0.9761721215093908,
@@ -157,7 +159,7 @@
         },
         {
             "number": 11,
-            "class": "bus",
+            "class": "Bus",
             "name": "MAHALO69",
             "init": {
                 "Vr": 0.9686003345219932,
@@ -171,7 +173,7 @@
         },
         {
             "number": 12,
-            "class": "bus",
+            "class": "Bus",
             "name": "LYCHEE69",
             "init": {
                 "Vr": 0.9716135420181101,
@@ -185,7 +187,7 @@
         },
         {
             "number": 13,
-            "class": "bus",
+            "class": "Bus",
             "name": "COCONUT69",
             "init": {
                 "Vr": 0.9734195116664179,
@@ -199,7 +201,7 @@
         },
         {
             "number": 14,
-            "class": "bus",
+            "class": "Bus",
             "name": "KAILUA138",
             "init": {
                 "Vr": 0.9822907352895506,
@@ -213,7 +215,7 @@
         },
         {
             "number": 15,
-            "class": "bus",
+            "class": "Bus",
             "name": "KAILUA69",
             "init": {
                 "Vr": 0.9732168267136281,
@@ -227,7 +229,7 @@
         },
         {
             "number": 16,
-            "class": "bus",
+            "class": "Bus",
             "name": "PALM69",
             "init": {
                 "Vr": 0.9759580386148334,
@@ -241,7 +243,7 @@
         },
         {
             "number": 17,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAIMANALO69",
             "init": {
                 "Vr": 0.9682619523875232,
@@ -255,7 +257,7 @@
         },
         {
             "number": 18,
-            "class": "bus",
+            "class": "Bus",
             "name": "VOLCANO69",
             "init": {
                 "Vr": 0.9684321205816101,
@@ -269,7 +271,7 @@
         },
         {
             "number": 19,
-            "class": "bus",
+            "class": "Bus",
             "name": "PEARL CITY69",
             "init": {
                 "Vr": 0.9894399665466365,
@@ -283,7 +285,7 @@
         },
         {
             "number": 20,
-            "class": "bus",
+            "class": "Bus",
             "name": "MILILANI69",
             "init": {
                 "Vr": 0.9890789809125838,
@@ -297,7 +299,7 @@
         },
         {
             "number": 21,
-            "class": "bus",
+            "class": "Bus",
             "name": "AIEA69",
             "init": {
                 "Vr": 0.9758027869300845,
@@ -311,7 +313,7 @@
         },
         {
             "number": 22,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAIPAHU138",
             "init": {
                 "Vr": 0.9962891675055405,
@@ -325,7 +327,7 @@
         },
         {
             "number": 23,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAIPAHU69",
             "init": {
                 "Vr": 0.9993245410953303,
@@ -339,7 +341,7 @@
         },
         {
             "number": 24,
-            "class": "bus",
+            "class": "Bus",
             "name": "KAPOLEI69",
             "init": {
                 "Vr": 0.991323659034225,
@@ -353,7 +355,7 @@
         },
         {
             "number": 25,
-            "class": "bus",
+            "class": "Bus",
             "name": "EWA BEACH138",
             "init": {
                 "Vr": 0.9965716303889519,
@@ -367,7 +369,7 @@
         },
         {
             "number": 26,
-            "class": "bus",
+            "class": "Bus",
             "name": "EWA BEACH69",
             "init": {
                 "Vr": 0.9931443749906678,
@@ -381,7 +383,7 @@
         },
         {
             "number": 27,
-            "class": "bus",
+            "class": "Bus",
             "name": "KAHUKU69",
             "init": {
                 "Vr": 1.0031325897695496,
@@ -395,7 +397,7 @@
         },
         {
             "number": 28,
-            "class": "bus",
+            "class": "Bus",
             "name": "HALEIWA69",
             "init": {
                 "Vr": 0.9999916562514691,
@@ -409,7 +411,7 @@
         },
         {
             "number": 29,
-            "class": "bus",
+            "class": "Bus",
             "name": "LAIE69",
             "init": {
                 "Vr": 0.9953819154880136,
@@ -423,7 +425,7 @@
         },
         {
             "number": 30,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAHIAWA69",
             "init": {
                 "Vr": 0.9957712762493851,
@@ -437,7 +439,7 @@
         },
         {
             "number": 31,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAIALUA69",
             "init": {
                 "Vr": 0.994545466811905,
@@ -451,7 +453,7 @@
         },
         {
             "number": 32,
-            "class": "bus",
+            "class": "Bus",
             "name": "HAUULA69",
             "init": {
                 "Vr": 0.990953188522265,
@@ -465,7 +467,7 @@
         },
         {
             "number": 33,
-            "class": "bus",
+            "class": "Bus",
             "name": "WAIANAE69",
             "init": {
                 "Vr": 0.9942413119251227,
@@ -479,7 +481,7 @@
         },
         {
             "number": 34,
-            "class": "bus",
+            "class": "Bus",
             "name": "SCHOFIELD69",
             "init": {
                 "Vr": 0.9993384407366903,
@@ -493,7 +495,7 @@
         },
         {
             "number": 35,
-            "class": "bus",
+            "class": "Bus",
             "name": "KALAELOA138",
             "init": {
                 "Vr": 0.9999784225857238,
@@ -507,7 +509,7 @@
         },
         {
             "number": 36,
-            "class": "bus",
+            "class": "Bus",
             "name": "COGEN69",
             "init": {
                 "Vr": 0.9946436699675367,
@@ -521,7 +523,7 @@
         },
         {
             "number": 37,
-            "class": "bus",
+            "class": "Bus",
             "name": "KAHE138",
             "init": {
                 "Vr": 0.9999903715081334,
@@ -3927,7 +3929,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2,
                 "speed": 0,
                 "pmech": 1
             },
@@ -3946,7 +3947,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2,
                 "speed": 2,
                 "pmech": 3
             },
@@ -3965,7 +3965,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2,
                 "speed": 4,
                 "pmech": 5
             },
@@ -3984,7 +3983,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2,
                 "speed": 6,
                 "pmech": 7
             },
@@ -4003,7 +4001,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 8,
                 "pmech": 9
             },
@@ -4022,7 +4019,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 10,
                 "pmech": 11
             },
@@ -4041,7 +4037,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 12,
                 "pmech": 13
             },
@@ -4060,7 +4055,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 14,
                 "pmech": 15
             },
@@ -4079,7 +4073,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 16,
                 "pmech": 17
             },
@@ -4098,7 +4091,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 18,
                 "pmech": 19
             },
@@ -4117,7 +4109,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 20,
                 "pmech": 21
             },
@@ -4136,7 +4127,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 22,
                 "pmech": 23
             },
@@ -4155,7 +4145,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 24,
                 "pmech": 25
             },
@@ -4174,7 +4163,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 23,
                 "speed": 26,
                 "pmech": 27
             },
@@ -4193,7 +4181,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 26,
                 "speed": 28,
                 "pmech": 29
             },
@@ -4212,7 +4199,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 26,
                 "speed": 30,
                 "pmech": 31
             },
@@ -4231,7 +4217,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 27,
                 "speed": 32,
                 "pmech": 33
             },
@@ -4250,7 +4235,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 27,
                 "speed": 34,
                 "pmech": 35
             },
@@ -4269,7 +4253,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 28,
                 "speed": 36,
                 "pmech": 37
             },
@@ -4288,7 +4271,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 28,
                 "speed": 38,
                 "pmech": 39
             },
@@ -4307,7 +4289,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 33,
                 "speed": 40,
                 "pmech": 41
             },
@@ -4326,7 +4307,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 34,
                 "speed": 42,
                 "pmech": 43
             },
@@ -4345,7 +4325,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 34,
                 "speed": 44,
                 "pmech": 45
             },
@@ -4364,7 +4343,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 34,
                 "speed": 46,
                 "pmech": 47
             },
@@ -4383,7 +4361,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 34,
                 "speed": 48,
                 "pmech": 49
             },
@@ -4402,7 +4379,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 34,
                 "speed": 50,
                 "pmech": 51
             },
@@ -4421,7 +4397,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 34,
                 "speed": 52,
                 "pmech": 53
             },
@@ -4440,7 +4415,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 35,
                 "speed": 54,
                 "pmech": 55
             },
@@ -4459,7 +4433,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 35,
                 "speed": 56,
                 "pmech": 57
             },
@@ -4478,7 +4451,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 35,
                 "speed": 58,
                 "pmech": 59
             },
@@ -4497,7 +4469,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 35,
                 "speed": 60,
                 "pmech": 61
             },
@@ -4516,7 +4487,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 35,
                 "speed": 62,
                 "pmech": 63
             },
@@ -4535,7 +4505,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 35,
                 "speed": 64,
                 "pmech": 65
             },
@@ -4554,7 +4523,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 36,
                 "speed": 66,
                 "pmech": 67
             },
@@ -4573,7 +4541,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 36,
                 "speed": 68,
                 "pmech": 69
             },
@@ -4592,7 +4559,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 36,
                 "speed": 70,
                 "pmech": 71
             },
@@ -4611,7 +4577,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 36,
                 "speed": 72,
                 "pmech": 73
             },
@@ -4630,7 +4595,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 37,
                 "speed": 74,
                 "pmech": 75
             },
@@ -4649,7 +4613,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 37,
                 "speed": 76,
                 "pmech": 77
             },

--- a/examples/PhasorDynamics/Medium/NewEngland/newengland.case.json
+++ b/examples/PhasorDynamics/Medium/NewEngland/newengland.case.json
@@ -1,17 +1,19 @@
 {
   "header": {
-    "format_version": 0.1,
-    "format_revision": 1,
+    "format_version": 0.2,
+    "format_revision": 0,
     "case_name": "IEEE New England Case",
     "case_description": "",
-    "case_comments": "",
+    "case_comments": ""
+  },
+  "params": {
     "freq_base": 60.0,
     "va_base": 100000000.0
   },
   "buses": [
     {
       "number": 1,
-      "class": "bus",
+      "class": "Bus",
       "name": "1",
       "init": {
         "Vr": 1.0256813460172247,
@@ -25,7 +27,7 @@
     },
     {
       "number": 2,
-      "class": "bus",
+      "class": "Bus",
       "name": "2",
       "init": {
         "Vr": 1.0188787195207465,
@@ -39,7 +41,7 @@
     },
     {
       "number": 3,
-      "class": "bus",
+      "class": "Bus",
       "name": "3",
       "init": {
         "Vr": 0.9913039321884629,
@@ -53,7 +55,7 @@
     },
     {
       "number": 4,
-      "class": "bus",
+      "class": "Bus",
       "name": "4",
       "init": {
         "Vr": 0.9663907241937241,
@@ -67,7 +69,7 @@
     },
     {
       "number": 5,
-      "class": "bus",
+      "class": "Bus",
       "name": "5",
       "init": {
         "Vr": 0.9704642321383364,
@@ -81,7 +83,7 @@
     },
     {
       "number": 6,
-      "class": "bus",
+      "class": "Bus",
       "name": "6",
       "init": {
         "Vr": 0.9696596442920445,
@@ -95,7 +97,7 @@
     },
     {
       "number": 7,
-      "class": "bus",
+      "class": "Bus",
       "name": "7",
       "init": {
         "Vr": 0.9557173654544806,
@@ -109,7 +111,7 @@
     },
     {
       "number": 8,
-      "class": "bus",
+      "class": "Bus",
       "name": "8",
       "init": {
         "Vr": 0.95470823926118,
@@ -123,7 +125,7 @@
     },
     {
       "number": 9,
-      "class": "bus",
+      "class": "Bus",
       "name": "9",
       "init": {
         "Vr": 1.0006780824979387,
@@ -137,7 +139,7 @@
     },
     {
       "number": 10,
-      "class": "bus",
+      "class": "Bus",
       "name": "10",
       "init": {
         "Vr": 0.9741244811425748,
@@ -151,7 +153,7 @@
     },
     {
       "number": 11,
-      "class": "bus",
+      "class": "Bus",
       "name": "11",
       "init": {
         "Vr": 0.9715211727712043,
@@ -165,7 +167,7 @@
     },
     {
       "number": 12,
-      "class": "bus",
+      "class": "Bus",
       "name": "12",
       "init": {
         "Vr": 0.9517452124960469,
@@ -179,7 +181,7 @@
     },
     {
       "number": 13,
-      "class": "bus",
+      "class": "Bus",
       "name": "13",
       "init": {
         "Vr": 0.9720425289020881,
@@ -193,7 +195,7 @@
     },
     {
       "number": 14,
-      "class": "bus",
+      "class": "Bus",
       "name": "14",
       "init": {
         "Vr": 0.9708017788417259,
@@ -207,7 +209,7 @@
     },
     {
       "number": 15,
-      "class": "bus",
+      "class": "Bus",
       "name": "15",
       "init": {
         "Vr": 0.9701462313144,
@@ -221,7 +223,7 @@
     },
     {
       "number": 16,
-      "class": "bus",
+      "class": "Bus",
       "name": "16",
       "init": {
         "Vr": 0.9890299335780378,
@@ -235,7 +237,7 @@
     },
     {
       "number": 17,
-      "class": "bus",
+      "class": "Bus",
       "name": "17",
       "init": {
         "Vr": 0.9915178207250563,
@@ -249,7 +251,7 @@
     },
     {
       "number": 18,
-      "class": "bus",
+      "class": "Bus",
       "name": "18",
       "init": {
         "Vr": 0.9889130169059795,
@@ -263,7 +265,7 @@
     },
     {
       "number": 19,
-      "class": "bus",
+      "class": "Bus",
       "name": "19",
       "init": {
         "Vr": 0.9920557328707976,
@@ -277,7 +279,7 @@
     },
     {
       "number": 20,
-      "class": "bus",
+      "class": "Bus",
       "name": "20",
       "init": {
         "Vr": 0.9877673717238171,
@@ -291,7 +293,7 @@
     },
     {
       "number": 21,
-      "class": "bus",
+      "class": "Bus",
       "name": "21",
       "init": {
         "Vr": 0.9978403620569859,
@@ -305,7 +307,7 @@
     },
     {
       "number": 22,
-      "class": "bus",
+      "class": "Bus",
       "name": "22",
       "init": {
         "Vr": 1.024288343561141,
@@ -319,7 +321,7 @@
     },
     {
       "number": 23,
-      "class": "bus",
+      "class": "Bus",
       "name": "23",
       "init": {
         "Vr": 1.023219433158734,
@@ -333,7 +335,7 @@
     },
     {
       "number": 24,
-      "class": "bus",
+      "class": "Bus",
       "name": "24",
       "init": {
         "Vr": 0.9968636356828063,
@@ -347,7 +349,7 @@
     },
     {
       "number": 25,
-      "class": "bus",
+      "class": "Bus",
       "name": "25",
       "init": {
         "Vr": 1.0288772797094754,
@@ -361,7 +363,7 @@
     },
     {
       "number": 26,
-      "class": "bus",
+      "class": "Bus",
       "name": "26",
       "init": {
         "Vr": 1.017201700583185,
@@ -375,7 +377,7 @@
     },
     {
       "number": 27,
-      "class": "bus",
+      "class": "Bus",
       "name": "27",
       "init": {
         "Vr": 0.9966421233582243,
@@ -389,7 +391,7 @@
     },
     {
       "number": 28,
-      "class": "bus",
+      "class": "Bus",
       "name": "28",
       "init": {
         "Vr": 1.0210929402867615,
@@ -403,7 +405,7 @@
     },
     {
       "number": 29,
-      "class": "bus",
+      "class": "Bus",
       "name": "29",
       "init": {
         "Vr": 1.0224833566661076,
@@ -417,7 +419,7 @@
     },
     {
       "number": 30,
-      "class": "bus",
+      "class": "Bus",
       "name": "30",
       "init": {
         "Vr": 1.0458538770326358,
@@ -431,7 +433,7 @@
     },
     {
       "number": 31,
-      "class": "bus",
+      "class": "Bus",
       "name": "31",
       "init": {
         "Vr": 0.9819999933242798,
@@ -445,7 +447,7 @@
     },
     {
       "number": 32,
-      "class": "bus",
+      "class": "Bus",
       "name": "32",
       "init": {
         "Vr": 0.9821658449175024,
@@ -459,7 +461,7 @@
     },
     {
       "number": 33,
-      "class": "bus",
+      "class": "Bus",
       "name": "33",
       "init": {
         "Vr": 0.9941298512997627,
@@ -473,7 +475,7 @@
     },
     {
       "number": 34,
-      "class": "bus",
+      "class": "Bus",
       "name": "34",
       "init": {
         "Vr": 1.0102651143651138,
@@ -487,7 +489,7 @@
     },
     {
       "number": 35,
-      "class": "bus",
+      "class": "Bus",
       "name": "35",
       "init": {
         "Vr": 1.044427614783733,
@@ -501,7 +503,7 @@
     },
     {
       "number": 36,
-      "class": "bus",
+      "class": "Bus",
       "name": "36",
       "init": {
         "Vr": 1.0534356965112757,
@@ -515,7 +517,7 @@
     },
     {
       "number": 37,
-      "class": "bus",
+      "class": "Bus",
       "name": "37",
       "init": {
         "Vr": 1.027242212215458,
@@ -529,7 +531,7 @@
     },
     {
       "number": 38,
-      "class": "bus",
+      "class": "Bus",
       "name": "38",
       "init": {
         "Vr": 1.0174047982434924,
@@ -543,7 +545,7 @@
     },
     {
       "number": 39,
-      "class": "bus",
+      "class": "Bus",
       "name": "39",
       "init": {
         "Vr": 1.0127542562486023,

--- a/examples/PhasorDynamics/Small/TwoArea/twoarea.json
+++ b/examples/PhasorDynamics/Small/TwoArea/twoarea.json
@@ -1,17 +1,19 @@
 {
     "header": {
-        "format_version": 0.1,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "two_area_case",
         "case_description": "None",
-        "case_comments": "No case Ccmments",
+        "case_comments": "No case Ccmments"
+    },
+    "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
     "buses": [
         {
             "number": 1,
-            "class": "bus",
+            "class": "Bus",
             "name": "1",
             "init": {
                 "Vr": 0.8417632907983953,
@@ -25,7 +27,7 @@
         },
         {
             "number": 2,
-            "class": "bus",
+            "class": "Bus",
             "name": "2",
             "init": {
                 "Vr": 0.9305542572926901,
@@ -39,7 +41,7 @@
         },
         {
             "number": 3,
-            "class": "bus",
+            "class": "Bus",
             "name": "12",
             "init": {
                 "Vr": 0.9461473466531829,
@@ -53,7 +55,7 @@
         },
         {
             "number": 4,
-            "class": "bus",
+            "class": "Bus",
             "name": "11",
             "init": {
                 "Vr": 0.7311328197493693,
@@ -67,7 +69,7 @@
         },
         {
             "number": 5,
-            "class": "bus",
+            "class": "Bus",
             "name": "101",
             "init": {
                 "Vr": 0.8685212337220097,
@@ -81,7 +83,7 @@
         },
         {
             "number": 6,
-            "class": "bus",
+            "class": "Bus",
             "name": "102",
             "init": {
                 "Vr": 0.919614611832545,
@@ -95,7 +97,7 @@
         },
         {
             "number": 7,
-            "class": "bus",
+            "class": "Bus",
             "name": "3",
             "init": {
                 "Vr": 0.928670340372285,
@@ -109,7 +111,7 @@
         },
         {
             "number": 8,
-            "class": "bus",
+            "class": "Bus",
             "name": "13",
             "init": {
                 "Vr": 0.8761848072516336,
@@ -123,7 +125,7 @@
         },
         {
             "number": 9,
-            "class": "bus",
+            "class": "Bus",
             "name": "112",
             "init": {
                 "Vr": 0.8866370706078832,
@@ -137,7 +139,7 @@
         },
         {
             "number": 10,
-            "class": "bus",
+            "class": "Bus",
             "name": "111",
             "init": {
                 "Vr": 0.7830220631762669,
@@ -576,7 +578,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 1,
                 "speed": 0,
                 "pmech": 1
             },
@@ -595,7 +596,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 2,
                 "speed": 2,
                 "pmech": 3
             },
@@ -614,7 +614,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 3,
                 "speed": 4,
                 "pmech": 5
             },
@@ -633,7 +632,6 @@
         {
             "class": "Tgov1",
             "ports": {
-                "bus": 4,
                 "speed": 6,
                 "pmech": 7
             },

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.case.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Basic/ThreeBusBasic.case.json
@@ -1,10 +1,12 @@
 {
     "header": {
-        "format_version": 0.1,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "ThreeBusExample",
         "case_description": "None",
-        "case_comments": "None",
+        "case_comments": "None"
+    },
+    "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
@@ -17,7 +19,7 @@
     "buses": [
         {
             "number": 0,
-            "class": "infinite_bus",
+            "class": "BusInfinite",
             "name": "1",
             "init": {
                 "Vr": 1.06,
@@ -30,7 +32,7 @@
         },
         {
             "number": 1,
-            "class": "bus",
+            "class": "Bus",
             "name": "2",
             "init": {
                 "Vr": 1.0599558398065716,
@@ -43,7 +45,7 @@
         },
         {
             "number": 2,
-            "class": "bus",
+            "class": "Bus",
             "name": "3",
             "init": {
                 "Vr": 0.9610827543495831,

--- a/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.case.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/Classical/ThreeBusClassical.case.json
@@ -1,17 +1,19 @@
 {
     "header": {
-        "format_version": 0.1,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "ThreeBusExample_Classical",
         "case_description": "None",
-        "case_comments": "None",
+        "case_comments": "None"
+    },
+    "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
     "buses": [
         {
             "number": 0,
-            "class": "infinite_bus",
+            "class": "BusInfinite",
             "name": "1",
             "init": {
                 "Vr": 1.06,
@@ -21,7 +23,7 @@
         },
         {
             "number": 1,
-            "class": "bus",
+            "class": "Bus",
             "name": "2",
             "init": {
                 "Vr": 1.0599558398065716,
@@ -32,7 +34,7 @@
         },
         {
             "number": 2,
-            "class": "bus",
+            "class": "Bus",
             "name": "3",
             "init": {
                 "Vr": 0.9610827543495831,

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.case.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ConstantSource/ThreeBusConstantSource.case.json
@@ -1,17 +1,19 @@
 {
     "header": {
-        "format_version": 0,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "ThreeBusConstantSource",
         "case_description": "3-bus test case with constant signal sources",
-        "case_comments": "None",
+        "case_comments": "None"
+    },
+    "params": {
         "freq_base": 60.0,
-        "va_base": 100e6
+        "va_base": 100000000.0
     },
     "buses": [
         {
             "number": 1,
-            "class": "infinite_bus",
+            "class": "BusInfinite",
             "name": "1",
             "init": {
                 "Vr": 1.06,
@@ -24,7 +26,7 @@
         },
         {
             "number": 2,
-            "class": "bus",
+            "class": "Bus",
             "name": "2",
             "init": {
                 "Vr": 1.0599558398065716,
@@ -37,7 +39,7 @@
         },
         {
             "number": 3,
-            "class": "bus",
+            "class": "Bus",
             "name": "3",
             "init": {
                 "Vr": 0.9610827543495831,
@@ -153,13 +155,13 @@
             "class": "BusToSignalAdapter",
             "ports": {"bus":1, "ir":1, "ii":2},
             "id": "adapt3",
-            "params": []
+            "params": {}
         },
         {
             "class": "ConstantSignalSource",
             "ports": {"sr":1, "si":2},
             "id": "const_source_1",
-            "params": []
+            "params": {}
         }
     ]
 }

--- a/examples/PhasorDynamics/Tiny/ThreeBus/ZipLoad/ThreeBusZipLoad.case.json
+++ b/examples/PhasorDynamics/Tiny/ThreeBus/ZipLoad/ThreeBusZipLoad.case.json
@@ -1,17 +1,19 @@
 {
     "header": {
-        "format_version": 0.1,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "ThreeBusExample_ZipLoad",
         "case_description": "None",
-        "case_comments": "None",
+        "case_comments": "None"
+    },
+    "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
     "buses": [
         {
             "number": 0,
-            "class": "infinite_bus",
+            "class": "BusInfinite",
             "name": "1",
             "init": {
                 "Vr": 1.06,
@@ -21,7 +23,7 @@
         },
         {
             "number": 1,
-            "class": "bus",
+            "class": "Bus",
             "name": "2",
             "init": {
                 "Vr": 1.0599558398065716,
@@ -32,7 +34,7 @@
         },
         {
             "number": 2,
-            "class": "bus",
+            "class": "Bus",
             "name": "3",
             "init": {
                 "Vr": 0.9610827543495831,

--- a/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.case.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Basic/TwoBusBasic.case.json
@@ -1,12 +1,14 @@
 {
     "header": {
-        "format_version": 0,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "Basic 2-bus test case",
         "case_description": "A two-bus test case for demonstrating the dynamics format",
-        "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
+        "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed"
+    },
+    "params": {
         "freq_base": 60.0,
-        "va_base": 100e6
+        "va_base": 100000000.0
     },
     "monitors": [
         {
@@ -17,7 +19,7 @@
     "buses": [
         { 
             "number": 0,
-            "class": "bus",
+            "class": "Bus",
             "name": "Bus_1",
             "init": {
                 "Vr":0.9949877346411762,
@@ -28,7 +30,7 @@
         },
         { 
             "number": 1,
-            "class": "infinite_bus",
+            "class": "BusInfinite",
             "name": "Bus_2",
             "init": {
                 "Vr":1.0,

--- a/examples/PhasorDynamics/Tiny/TwoBus/Gensal/TwoBusGensal.case.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Gensal/TwoBusGensal.case.json
@@ -1,12 +1,14 @@
 {
     "header": {
-        "format_version": 0,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "GENSAL two-bus validation",
         "case_description": "Two-bus case: GENSAL machine on Bus_1, 100 MW resistive load on Bus_2, lossless tie line X=0.1, bus fault on Bus_2",
-        "case_comments": "Validates GENSAL trajectory against an external (PowerWorld) reference. Monitors machine differential states.",
+        "case_comments": "Validates GENSAL trajectory against an external (PowerWorld) reference. Monitors machine differential states."
+    },
+    "params": {
         "freq_base": 60.0,
-        "va_base": 100e6
+        "va_base": 100000000.0
     },
     "monitors": [
         {
@@ -17,7 +19,7 @@
     "buses": [
         {
             "number": 1,
-            "class": "bus",
+            "class": "Bus",
             "name": "Bus_1",
             "init": {
                 "Vr": 1.0,
@@ -27,7 +29,7 @@
         },
         {
             "number": 2,
-            "class": "bus",
+            "class": "Bus",
             "name": "Bus_2",
             "init": {
                 "Vr": 0.9898978476307575,
@@ -68,7 +70,7 @@
         },
         {
             "class": "Tgov1",
-            "ports": {"bus": 1, "speed": 0, "pmech": 1},
+            "ports": {"speed": 0, "pmech": 1},
             "id": "tgov1_1_1",
             "params": {
                 "Trate": 100.0,

--- a/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.case.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Ieeet1/TwoBusIeeet1.case.json
@@ -1,12 +1,14 @@
 {
     "header": {
-        "format_version": 0,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "2-bus test case with governor and exciter",
         "case_description": "A two-bus test case for demonstrating the dynamics format",
-        "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
+        "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed"
+    },
+    "params": {
         "freq_base": 60.0,
-        "va_base": 100e6
+        "va_base": 100000000.0
     },
     "monitors": [
         {
@@ -17,7 +19,7 @@
     "buses": [
         { 
             "number": 0,
-            "class": "bus",
+            "class": "Bus",
             "name": "Bus 1",
             "init": {
                 "Vr":0.9949877346411762,
@@ -28,7 +30,7 @@
         },
         { 
             "number": 1,
-            "class": "infinite_bus",
+            "class": "BusInfinite",
             "name": "Bus 2",
             "init": {
                 "Vr":1.0,
@@ -78,7 +80,7 @@
         },
         {
             "class": "Tgov1",
-            "ports": {"bus":0, "speed": 0, "pmech":1},
+            "ports": {"speed": 0, "pmech":1},
             "id": "DV2",
             "params": {
                 "Trate": 100.0,

--- a/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.case.json
+++ b/examples/PhasorDynamics/Tiny/TwoBus/Tgov1/TwoBusTgov1.case.json
@@ -1,12 +1,14 @@
 {
     "header": {
-        "format_version": 0,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "Two-bus test case with governor",
         "case_description": "A two-bus test case for demonstrating the dynamics format",
-        "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
+        "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed"
+    },
+    "params": {
         "freq_base": 60.0,
-        "va_base": 100e6
+        "va_base": 100000000.0
     },
     "monitors": [
         {
@@ -17,7 +19,7 @@
     "buses": [
         { 
             "number": 0,
-            "class": "bus",
+            "class": "Bus",
             "name": "Bus 1",
             "init": {
                 "Vr":0.9949877346411762,
@@ -28,7 +30,7 @@
         },
         { 
             "number": 1,
-            "class": "infinite_bus",
+            "class": "BusInfinite",
             "name": "Bus 2",
             "init": {
                 "Vr":1.0,
@@ -77,7 +79,7 @@
         },
         {
             "class": "Tgov1",
-            "ports": {"bus":0, "speed": 0, "pmech":1},
+            "ports": {"speed": 0, "pmech":1},
             "id": "DV2",
             "params": {"Trate": 100.0, "R":0.05, "T1":0.5, "T2":2.5, "T3":7.5, "Pvmin":0.0, "Pvmax":1.0, "Dt":0.0}
         },

--- a/tests/IntegrationTests/PhasorDynamics/PDIntegrationTests.hpp
+++ b/tests/IntegrationTests/PhasorDynamics/PDIntegrationTests.hpp
@@ -134,7 +134,6 @@ namespace GridKit
           const auto& ag = a.gov[i];
           const auto& bg = b.gov[i];
 
-          success *= ag.buses.at(Tgov1Buses::bus) == bg.buses.at(Tgov1Buses::bus);
           success *= ag.signal_inputs.count(SignalIn::speed) == bg.signal_inputs.count(SignalIn::speed);
           if (ag.signal_inputs.count(SignalIn::speed))
           {
@@ -407,7 +406,6 @@ namespace GridKit
         set_data.genrou[0].monitored_variables.insert(GenrouVar::speed);
 
         set_data.gov.resize(1);
-        set_data.gov[0].buses[Tgov1Buses::bus]                    = 0;
         set_data.gov[0].signal_inputs[Tgov1SignalInputs::speed]   = 0;
         set_data.gov[0].signal_outputs[Tgov1SignalOutputs::pmech] = 1;
         set_data.gov[0].parameters[Tgov1Parameters::Trate]        = 100.0;
@@ -514,7 +512,6 @@ namespace GridKit
         set_data.genrou[0].monitored_variables.insert(GenrouVar::speed);
 
         set_data.gov.resize(1);
-        set_data.gov[0].buses[Tgov1Buses::bus]                    = 0;
         set_data.gov[0].signal_inputs[Tgov1SignalInputs::speed]   = 0;
         set_data.gov[0].signal_outputs[Tgov1SignalOutputs::pmech] = 1;
         set_data.gov[0].parameters[Tgov1Parameters::Trate]        = 100.0;

--- a/tests/UnitTests/PhasorDynamics/ThreeBusBasicBad.json
+++ b/tests/UnitTests/PhasorDynamics/ThreeBusBasicBad.json
@@ -1,17 +1,19 @@
 {
     "header": {
-        "format_version": 0.1,
-        "format_revision": 1,
+        "format_version": 0.2,
+        "format_revision": 0,
         "case_name": "ThreeBusExample",
         "case_description": "None",
-        "case_comments": "None",
+        "case_comments": "None"
+    },
+    "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
     "buses": [
         {
             "number": 0,
-            "class": "infinite_bus",
+            "class": "BusInfinite",
             "name": "1",
             "init": {
                 "Vr": 1.06,
@@ -25,7 +27,7 @@
         },
         {
             "number": 1,
-            "class": "bus",
+            "class": "Bus",
             "name": "2",
             "init": {
                 "Vr": 1.0599558398065716,
@@ -39,7 +41,7 @@
         },
         {
             "number": 2,
-            "class": "bus",
+            "class": "Bus",
             "name": "3",
             "init": {
                 "Vr": 0.9610827543495831,

--- a/tests/UnitTests/Utilities/CaseFormatTests.hpp
+++ b/tests/UnitTests/Utilities/CaseFormatTests.hpp
@@ -41,13 +41,15 @@ namespace GridKit
         const char data[] =
             R"({
                "header": {
-                   "format_version": 0,
-                   "format_revision": 1,
+                   "format_version": 0.2,
+                   "format_revision": 0,
                    "case_name": "Two-bus test case 1",
                    "case_description": "A two-bus test case for demonstrating the dynamics format",
-                   "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
-                   "freq_base": 60.0,
-                   "va_base": 100e6
+                   "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed"
+               },
+               "params": {
+                   "freq_base": 50.0,
+                   "va_base": 50000000.0
                },
                "monitors": [
                    {
@@ -60,8 +62,8 @@ namespace GridKit
                    }
                ],
                "buses": [
-                   { "number": 1, "class": "bus", "name": "Bus 1", "init": {"Vr":0.994988, "Vi":0.099997}, "params": {"kv": 115.0}, "mon": ["Vr", "Vi"] },
-                   { "number": 2, "class": "infinite_bus", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "params": {"kv": 115.0} }
+                   { "number": 1, "class": "Bus", "name": "Bus 1", "init": {"Vr":0.994988, "Vi":0.099997}, "params": {"kv": 115.0}, "mon": ["Vr", "Vi"] },
+                   { "number": 2, "class": "BusInfinite", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "params": {"kv": 115.0} }
                ],
                "devices": [
                    { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0, "tap":1.05, "phase":0.1} },
@@ -77,14 +79,14 @@ namespace GridKit
         TestStatus                   success = true;
         SystemModelData<RealT, IdxT> result  = json::parse(data);
 
-        success *= result.format_version == 0;
-        success *= result.format_revision == 1;
+        success *= result.format_version == 0.2;
+        success *= result.format_revision == 0;
         success *= result.case_name == "Two-bus test case 1";
         success *= result.case_date_time == std::nullopt;
         success *= result.case_description == "A two-bus test case for demonstrating the dynamics format";
         success *= result.case_comments == "This case is set up to monitor the voltage at both buses and the machine angle and speed";
-        success *= result.freq_base == 60.0;
-        success *= result.va_base == 100.0e6;
+        success *= result.freq_base == 50.0;
+        success *= result.va_base == 50.0e6;
 
         success *= result.monitor_sink[0].file_name == "mon.csv";
         success *= result.monitor_sink[0].format == VariableMonitorFormat::CSV;
@@ -191,17 +193,19 @@ namespace GridKit
         const char data[] =
             R"({
                "header": {
-                   "format_version": 0,
-                   "format_revision": 1,
+                   "format_version": 0.2,
+                   "format_revision": 0,
                    "case_name": "Two-bus test case 2",
                    "case_description": "A two-bus test case for demonstrating the dynamics format",
-                   "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed",
+                   "case_comments": "This case is set up to monitor the voltage at both buses and the machine angle and speed"
+               },
+               "params": {
                    "freq_base": 60.0,
-                   "va_base": 100e6
+                   "va_base": 100000000.0
                },
                "buses": [
-                   { "number": 1, "class": "bus", "name": "Bus 1", "init": {"Vr":0.994988, "Vi":0.099997}, "params": {"kv": 115.0}, "mon": ["Vr", "Vi"] },
-                   { "number": 2, "class": "infinite_bus", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "params": {"kv": 115.0} }
+                   { "number": 1, "class": "Bus", "name": "Bus 1", "init": {"Vr":0.994988, "Vi":0.099997}, "params": {"kv": 115.0}, "mon": ["Vr", "Vi"] },
+                   { "number": 2, "class": "BusInfinite", "name": "Bus 2", "init": {"Vr":1.0, "Vi":0.0}, "params": {"kv": 115.0} }
                ],
                "signals": [
                    { "signal_id": 1, "name": "Machine Speed Deviation"},
@@ -214,7 +218,7 @@ namespace GridKit
                "devices": [
                    { "class": "Branch", "ports": {"bus1":1, "bus2":2}, "id": "BR1", "params": {"R":0.0, "X":0.1, "G":0.0, "B":0.0, "tap":1.05, "phase":0.1} },
                    { "class": "Genrou", "ports": {"bus":1, "speed": 1, "pmech":2, "efd":3}, "id": "DV1", "params": {"p0":1.0, "q0":0.05013, "H":3.0, "D":0.0, "Ra":0.0, "Tdop":7.0, "Tdopp":0.04, "Tqopp":0.05, "Tqop":0.75, "Xd":2.1, "Xdp":0.2, "Xdpp":0.18, "Xq":0.5, "Xqp": 0.0, "Xqpp":0.18, "Xl":0.15, "S10":0.0, "S12":0.0}, "mon": ["delta", "omega"] },
-                   { "class": "Tgov1", "ports": {"bus":1, "speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0.0, "Pvmin":1.0, "Dt":0.0}},
+                   { "class": "Tgov1", "ports": {"speed": 1, "pmech":2}, "id": "DV2", "params": {"R":0.05, "T1":0.5,"T2":2.5, "T3":7.5, "Pvmax":0.0, "Pvmin":1.0, "Dt":0.0}},
                    { "class": "Esdc1a", "ports": {"bus":1, "speed":1, "vref":4, "vs":5, "vuel":6, "efd":3}, "id": "DV5", "params": {"Tr":0.0, "Ka":40.0, "Ta":0.1, "Tb":0.0, "Tc":0.0, "Vrmax":1.0, "Vrmin":-1.0, "Ke":0.1, "Te":0.5, "Kf":0.05, "Tf1":0.7, "Spdmlt":false, "E1":2.8, "Se1":0.08, "E2":3.7, "Se2":0.33, "UEL":0, "exclim":true}, "mon": ["efd", "vc", "vr", "vf", "se", "vfe"] },
                    { "class": "Ieeet1", "ports": {"bus":1, "speed": 1, "efd":3}, "id": "DV3", "params": {"Tr":0.0, "Ka":50.0, "Ta":0.04, "Ke":-0.06, "Te":0.6, "Kf":0.09, "Tf":1.46, "Vrmin":-1.0, "Vrmax":1.0, "E1":2.8, "E2":3.373, "Se1":0.04, "Se2":0.33, "Ispdlim":0.0}},
                    { "class": "SexsPti", "ports": {"bus":1, "efd":3}, "id": "DV4", "params": {"Ta":0.1, "Tb":0.5, "Te":0.8, "K":10.0, "Efdmax":5.0, "Efdmin":-5.0}},
@@ -225,8 +229,8 @@ namespace GridKit
         TestStatus                   success = true;
         SystemModelData<RealT, IdxT> result  = json::parse(data);
 
-        success *= result.format_version == 0;
-        success *= result.format_revision == 1;
+        success *= result.format_version == 0.2;
+        success *= result.format_revision == 0;
         success *= result.case_name == "Two-bus test case 2";
         success *= result.case_date_time == std::nullopt;
         success *= result.case_description == "A two-bus test case for demonstrating the dynamics format";
@@ -317,7 +321,6 @@ namespace GridKit
         success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Pvmax]) == 0;
         success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Pvmin]) == 1;
         success *= std::get<RealT>(result.gov[0].parameters[Governor::Tgov1Parameters::Dt]) == 0;
-        success *= result.gov[0].buses[Governor::Tgov1Buses::bus] == 1;
         success *= result.gov[0].signal_inputs[Governor::Tgov1SignalInputs::speed] == 1;
         success *= result.gov[0].signal_outputs[Governor::Tgov1SignalOutputs::pmech] == 2;
         success *= result.gov[0].disambiguation_string == "DV2";


### PR DESCRIPTION
## Description

Closes #503

Moves the system frequency and power bases out of the case header and into a top-level `params` object. This keeps the header focused on case information and gives `SystemModel` a consistent place for system-level parameters.

The case format is now version `0.2`, revision `0`.

## Proposed changes

- Move `freq_base` and `va_base` from `header` to `params`.
- Update all tracked PhasorDynamics cases to format `0.2`, revision `0`.
- Rename the bus classes to `Bus` and `BusInfinite` for consistency with device class names.
- Remove unused bus-level base overrides.
- Remove the unused TGOV1 bus port.
- Update the parser, tests, and input format documentation.

## Checklist

- [x] Relevant tests pass with `UtilitiesCaseFormatTest` and `PhasorDynamicsIntegrationTest`.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- N/A. The case format has not been released yet.

## Further comments

The TGOV1 `bus` port was an artifact from the early implementation and was not used by the model.

I would prefer to address #405 partially and move the load/gen fields like `p0`/`q0` into an `init` section for these devices, which would make it more consistent with how `Bus` works. not strictly necessary so I left out.