### PR TITLE
Fix broken documentation references

### DIFF
--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -195,16 +195,16 @@ namespace GridKit
     }
 
     /**
-     * @brief Evaluate all of the residuals of internal variables of the component,
-     * modifying \ref f_.
+     * @brief Evaluate all residuals for the component's internal variables,
+     * writing them through `f_int_`.
      *
      * @return An error code, or 0 if successful.
      */
     virtual int evaluateInternalResidual() = 0;
 
     /**
-     * @brief Evaluate all of the residuals of external variables of the component,
-     * modifying \ref f_
+     * @brief Evaluate all residual contributions for the component's external variables,
+     * accumulating them through `f_ext_`.
      *
      * @return An error code, or 0 if successful.
      */
@@ -445,8 +445,8 @@ namespace GridKit
      *
      * Most components do not need state and residual storages. The most notable exception
      * is currently the system, so a separate flag is provided for the system.
-     * Systems still can't directly access \ref y_, \ref yp_, and \ref f_, so they need
-     * their corresponding \ref y_int_, \ref yp_int_, and \ref f_int_ set, since there isn't
+     * Systems still can't directly access `y_`, `yp_`, and `f_`, so they need
+     * their corresponding `y_int_`, `yp_int_`, and `f_int_` set, since there isn't
      * another system above them to set it.
      *
      * @todo This is a weird exception specifically for systems - and in a hierarchical setting
@@ -490,7 +490,7 @@ namespace GridKit
     std::unique_ptr<IdxT[]> connection_nodes_;
 
   protected:
-    /// The number of variables in this component. Should be equal to \ref n_extern_ plus \ref n_intern_ \see getSize()
+    /// The number of variables in this component. Should be equal to `n_extern_` plus `n_intern_`. \see size()
     IdxT size_{0};
     /// The number of nonzero elements in this component's Jacobian. \see nnz()
     IdxT nnz_{0};
@@ -514,7 +514,7 @@ namespace GridKit
 
     /**
      * An array of (input) pointers to state values for external variables.
-     * \note The size of this array is equal to \ref size_, allowing you to index it with the index
+     * \note The size of this array is equal to `size_`, allowing you to index it with the index
      * of the variable in question (i.e. consisten with \ref extern_indices_). Therefore, accessing
      * and dereferencing the pointer in an internal variable index is undefined behavior.
      * \see setExternalConnectionNodes()
@@ -522,7 +522,7 @@ namespace GridKit
     std::unique_ptr<const ScalarT*[]> y_ext_;
     /**
      * An array of (input) pointers to derivative values for external variables.
-     * \note The size of this array is equal to \ref size_, allowing you to index it with the index
+     * \note The size of this array is equal to `size_`, allowing you to index it with the index
      * of the variable in question (i.e. consisten with \ref extern_indices_). Therefore, accessing
      * and dereferencing the pointer in an internal variable index is undefined behavior.
      * \see setExternalConnectionNodes()
@@ -530,7 +530,7 @@ namespace GridKit
     std::unique_ptr<const ScalarT*[]> yp_ext_;
     /**
      * An array of (output) pointers to residuals for external variables.
-     * \note The size of this array is equal to \ref size_, allowing you to index it with the index
+     * \note The size of this array is equal to `size_`, allowing you to index it with the index
      * of the variable in question (i.e. consisten with \ref extern_indices_). Therefore, accessing
      * and dereferencing the pointer in an internal variable index is undefined behavior.
      * \see setExternalConnectionNodes()


### PR DESCRIPTION
## Description

The current Read the Docs build fails during Doxygen generation because `CircuitComponent` contains unresolved `\ref` links to internal data members. Since Doxygen warnings are treated as errors (to ensure we don't accumulate documentation issues), the documentation build stops before Sphinx runs.

This fixes those references and adds a Doxygen build check to the existing pre-commit workflow so these failures are caught before merge. No project dependencies are added.

## Proposed changes

- Replace unresolved member references with inline code formatting.
- Correct the internal and external residual documentation.
- Replace the stale `getSize()` reference with `size()`.
- Build Doxygen in the existing pre-commit workflow.

## Checklist

- [x] Relevant checks pass with `check-yaml` and `doxygen Doxyfile`.
- N/A. No compiled code changed.
- [x] The changes follow GridKit™ style guidelines.
- N/A. No new code requiring unit tests.
- [x] The documentation is updated.
- [x] The feature branch is rebased with respect to the target branch.
- N/A.  no CHANGELOG needed

## Further comments

The new check only builds the Doxygen XML and does not add a full Sphinx or Read the Docs CI build (which would be preferred but is pending.)

EDIT: Doxygen pre-commit has been deferred for another PR.