### PR TITLE
Fix Rosenbrock MINUS_ONE bug

### DIFF
--- a/GridKit/Model/Evaluator.hpp
+++ b/GridKit/Model/Evaluator.hpp
@@ -36,8 +36,23 @@ namespace GridKit
       {
       }
 
+      /**
+       * @brief Allocate all internal memory used by the model.
+       *
+       * @post Changing the model by changing its internal topology (i.e. \ref size(), \ref nnz(), sparsity pattern
+       * in \ref getCsrJacobian(), etc.) may invalidate the model until `allocate()` is called again. Calling any
+       * function that requires `allocate()` to be called in between modifying the model and reallocating may invoke
+       * undefined behaviour.
+       */
       virtual int allocate()                          = 0;
       virtual int initialize()                        = 0;
+      /**
+       * @brief Fill the \ref tag() vector with proper indicators.
+       *
+       * @note For some models, this may be a no-op, and the vector returned by \ref tag() will still be empty.
+       *
+       * @pre \ref allocate() must have been called.
+       */
       virtual int tagDifferentiable()                 = 0;
       /**
        * @brief Compute the absolute tolerance for each variable in the model
@@ -50,16 +65,35 @@ namespace GridKit
        * error cannot be used.
        */
       virtual int setAbsoluteTolerance(RealT rel_tol) = 0;
-      virtual int evaluateResidual()                  = 0;
-      virtual int evaluateJacobian()                  = 0;
-      virtual int evaluateIntegrand()                 = 0;
+
+      /**
+       * @brief Evaluate the model's residual function.
+       *
+       * For models which can be appropriately modeled in semi-explicit form, this will evaluate
+       * \f[F(t, y, \dot{y}) = f(t,y) - M \dot{y},\f]
+       * where \f(M\f) is the mass matrix. For models which can be modeled in Hessenberg form,
+       * \f(M\f) should be a simple indicator function for if the variable is differential
+       * (if \f(\dot{y}\f) appears in its equation). This indicator should be given by \ref tag().
+       */
+      virtual int evaluateResidual()  = 0;
+      virtual int evaluateJacobian()  = 0;
+      virtual int evaluateIntegrand() = 0;
 
       virtual int initializeAdjoint()        = 0;
       virtual int evaluateAdjointResidual()  = 0;
       // virtual int evaluateAdjointJacobian() = 0;
       virtual int evaluateAdjointIntegrand() = 0;
 
+      /// How many variables exist in the model
       virtual IdxT size() = 0;
+      /**
+       * @brief How many non-zero elements are in this model's Jacobian.
+       *
+       * This knowledge may be needed to allocate the buffers for the model's Jacobian, so it
+       * it should not depend on \ref allocate() having been called.
+       *
+       * @see getCsrJacobian()
+       */
       virtual IdxT nnz()  = 0;
 
       /**
@@ -102,7 +136,7 @@ namespace GridKit
       /**
        * @brief Return a pointer to the CSR Jacobian
        *
-       * @todo Remove this and use CsrMatrix for jac_
+       * @pre \ref allocate() must have been called.
        */
       virtual CsrMatrixT* getCsrJacobian() const
       {
@@ -144,6 +178,14 @@ namespace GridKit
       virtual VectorT&       yp()       = 0;
       virtual const VectorT& yp() const = 0;
 
+      /**
+       * @brief An indicator for which variables in the model are differential (true) or algebraic (false).
+       *
+       * This information may be required for certain integrator features (such as the \ref AnalysisManager::NativeDynamicSolver::Rosenbrock
+       * integrator), but is not required to be set. A reference to an empty vector may be returned.
+       *
+       * @pre \ref tagDifferentiable() must have been called.
+       */
       virtual std::vector<bool>&       tag()       = 0;
       virtual const std::vector<bool>& tag() const = 0;
 

--- a/GridKit/Solver/Dynamic/Rosenbrock.cpp
+++ b/GridKit/Solver/Dynamic/Rosenbrock.cpp
@@ -641,6 +641,7 @@ namespace AnalysisManager
     int Rosenbrock<ScalarT, IdxT>::timeStep(RealT t0, RealT dt)
     {
       constexpr RealT ZERO      = GridKit::ZERO<RealT>;
+      constexpr RealT ONE       = GridKit::ONE<RealT>;
       constexpr RealT MINUS_ONE = GridKit::MINUS_ONE<RealT>;
 
       // A flag to keep track of if y0 (stored in y_cur_) has been copied in to the model already, to avoid double-copying
@@ -657,7 +658,7 @@ namespace AnalysisManager
 
         // GridKit, like IDA, expects to evaluate the Jacobian J = df/dy + alpha * df/dy',
         // so we need a negative here since df/dy' = M.
-        model_->updateTime(t0, MINUS_ONE / (dt * tab_.gamma_));
+        model_->updateTime(t0, ONE / (dt * tab_.gamma_));
         BUBBLE_FAIL(model_->evaluateJacobian());
         BUBBLE_FAIL(lin_solver_.setupSolver(workspace_.jacobian_analyzed_));
         workspace_.jacobian_analyzed_ = true;

--- a/GridKit/Solver/Dynamic/Rosenbrock.cpp
+++ b/GridKit/Solver/Dynamic/Rosenbrock.cpp
@@ -317,7 +317,8 @@ namespace AnalysisManager
      *
      * - Sets the simulation time to `t0` and copies the initial condition from \ref model_.
      * - Analyzes \ref model_ Jacobian sparsity and runs the preconditioner
-     * - Generates the mass matrix from \ref GridKit::Model::Evaluator::tag(). If the tag is not properly set, then initialization will fail.
+     * - Generates the mass matrix from \ref GridKit::Model::Evaluator::tag() as described in the class description.
+     *   If the tag is not properly set, then initialization will fail.
      * - Resets \ref stats_.
      *
      * @note This method can fail.
@@ -617,6 +618,10 @@ namespace AnalysisManager
      * - \ref jacobian_analyzed_ keeps track of whether the Jacobian has been factored in a previous call to `timeStep()`. If so, then it can be re-factored
      * in a faster way. The first factor must be done on actual data, so it cannot be performed pre-simulation.
      *
+     * @remark <b>On evaluating the Jacobian:</b> GridKit, like IDA, expects to evaluate the Jacobian \f(D = \frac{\partial F}{\partial y} + \alpha \frac{\partial F}{\partial \dot{y}}\f). As seen above,
+     * we need to evaluate \f(J - \frac{1}{h\gamma} M\f), where \f(J = \frac{\partial F}{\partial y}\f). Since, in the implicit form, \f(F = f(t, y) - M\dot{y}\f), then
+     * \f(M = - \frac{\partial F}{\partial \dot{y}}\f). So evaluating \f(D\f) with \f(\alpha = \frac{1}{h\gamma}\f) will get us what we want.
+     *
      * @pre Must call \ref initializeSimulation() beforehand.
      *
      * @note This method can fail.
@@ -656,8 +661,7 @@ namespace AnalysisManager
         BUBBLE_FAIL(y_cur_->copyToExternal(model_->y().getData(), memspace_, memspace_));
         y0_copied = true;
 
-        // GridKit, like IDA, expects to evaluate the Jacobian J = df/dy + alpha * df/dy',
-        // so we need a negative here since df/dy' = M.
+        // See remark on evaluating Jacobian for why this constant is correct.
         model_->updateTime(t0, ONE / (dt * tab_.gamma_));
         BUBBLE_FAIL(model_->evaluateJacobian());
         BUBBLE_FAIL(lin_solver_.setupSolver(workspace_.jacobian_analyzed_));

--- a/GridKit/Solver/Dynamic/Rosenbrock.hpp
+++ b/GridKit/Solver/Dynamic/Rosenbrock.hpp
@@ -27,6 +27,17 @@ namespace AnalysisManager
      *        boast a large amount of customization to simulating a given model.
      *
      *        For the list of available Rosenbrock methods, see `Rosenbrock::Tableau`.
+     *
+     *        The Rosenbrock integrator is built to integrate DAEs in semi-explicit form with
+     *        (optional) mass matrix \f(M\f) given by
+     *        \f[M\dot{y} = f(t, y),\f]
+     *        where \f(M\f) is constant and can be singular (\f(M\f) is non-singular only for ODEs).
+     *        GridKit models equations in this semi-explicit form, but evaluates the implicit equation
+     *        \f[F(t, y, \dot{y}) = f(t, y) - M\dot{y}\f]
+     *        whenever \ref GridKit::Model::Evaluator::evaluateResidual() is called. Also, all models currently use
+     *        a diagonal mass matrix with values of only 1 or 0, as indicated by \ref GridKit::Model::Evaluator::tag().
+     *        We can use this by evaluating \f(F(t, y, 0) = f(t,y)\f) and constructing the mass matrix
+     *        based on the tag.
      */
     template <class ScalarT, typename IdxT>
     class Rosenbrock

--- a/tests/UnitTests/Solver/Dynamic/RosenbrockTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/RosenbrockTests.hpp
@@ -142,13 +142,14 @@ namespace GridKit
 
       int evaluateResidual() override
       {
-        const auto* y = y_.getData();
-        auto*       f = f_.getData();
+        const auto* y  = y_.getData();
+        const auto* yp = yp_.getData();
+        auto*       f  = f_.getData();
 
         ScalarT y02 = y[0] * y[0];
         ScalarT y12 = y[1] * y[1];
 
-        f[0] = y02 / (y[1] * std::sqrt(std::pow(y[0] / y[1], 2) - 1));
+        f[0] = -yp[0] + y02 / (y[1] * std::sqrt(std::pow(y[0] / y[1], 2) - 1));
         f[1] = y12 + 1 / (1 + y02) - (y02 / y12 - y02);
 
         f_.setDataUpdated();
@@ -174,7 +175,7 @@ namespace GridKit
         ScalarT tmp  = std::pow(y12 / y22 - 1, 1.5);
         ScalarT tmp2 = std::pow(y12 + 1, 2);
 
-        vals[0] = static_cast<RealT>(alpha_ + -(-y13 + 2 * y1 * y22) / (y23 * tmp));
+        vals[0] = static_cast<RealT>(-alpha_ + -(-y13 + 2 * y1 * y22) / (y23 * tmp));
         vals[1] = static_cast<RealT>(y12 / (y22 * tmp));
         vals[2] = static_cast<RealT>(-2 * y1 * (1 / y22 - 1) - (2 * y1) / tmp2);
         vals[3] = static_cast<RealT>((2 * (y12 + y24)) / y23);


### PR DESCRIPTION
## Description
 
Rosenbrock was using wrong value of `alpha` when evaluating model Jacobian - there was an extra minus sign. This wasn't caught by the test because the test was also incorrectly using alpha in its own Jacobian - there was a missing minus sign. These cancelled out and cause correct behavior when Rosenbrock was applied to the test problem.

Some documentation has been added to assist with understanding the issue.
 
 ## Proposed changes
 
The `MINUS_ONE` in Rosenbrock's model Jacobian evaluation has been changed to a `ONE`, and the test has been updated to compute its Jacobian in a way that agrees with the rest of GridKit.
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [ ] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.

This is a fix to the rosenbrock integrator, which is already included in the changelog
 
 ## Further comments

 
