### PR TITLE
Add simple one-sided co-sim example taking constant current over zmq

### DIFF
--- a/GridKit/Model/PhasorDynamics/SystemModelData.cpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.cpp
@@ -32,5 +32,18 @@ namespace GridKit
       }
       return parseSystemModelData(stream);
     }
+
+    SystemModelData<double, size_t> parseSystemModelData(const std::string& fileName)
+    {
+      auto stream = std::ifstream(fileName);
+      if (!stream)
+      {
+        std::stringstream ss;
+        ss << "Could not open file: " << fileName;
+        Log::error() << ss.str() << std::endl;
+        throw std::runtime_error(ss.str());
+      }
+      return parseSystemModelData(stream);
+    }
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SystemModelData.cpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.cpp
@@ -32,18 +32,5 @@ namespace GridKit
       }
       return parseSystemModelData(stream);
     }
-
-    SystemModelData<double, size_t> parseSystemModelData(const std::string& fileName)
-    {
-      auto stream = std::ifstream(fileName);
-      if (!stream)
-      {
-        std::stringstream ss;
-        ss << "Could not open file: " << fileName;
-        Log::error() << ss.str() << std::endl;
-        throw std::runtime_error(ss.str());
-      }
-      return parseSystemModelData(stream);
-    }
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SystemModelData.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.hpp
@@ -135,6 +135,5 @@ namespace GridKit
     SystemModelData<double, size_t> parseSystemModelData(std::istream& stream);
     SystemModelData<double, size_t> parseSystemModelData(std::istream&& stream);
     SystemModelData<double, size_t> parseSystemModelData(const std::filesystem::path& filePath);
-    SystemModelData<double, size_t> parseSystemModelData(const std::string& fileName);
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SystemModelData.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelData.hpp
@@ -135,5 +135,6 @@ namespace GridKit
     SystemModelData<double, size_t> parseSystemModelData(std::istream& stream);
     SystemModelData<double, size_t> parseSystemModelData(std::istream&& stream);
     SystemModelData<double, size_t> parseSystemModelData(const std::filesystem::path& filePath);
+    SystemModelData<double, size_t> parseSystemModelData(const std::string& fileName);
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -56,6 +56,7 @@ add_subdirectory(Experimental)
 
 if(TARGET SUNDIALS::idas)
   add_subdirectory(PhasorDynamics)
+  add_subdirectory(Network)
 endif()
 
 add_subdirectory(Consumer)

--- a/examples/Network/CMakeLists.txt
+++ b/examples/Network/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(GRIDKIT_ENABLE_ZMQ)
+  add_subdirectory(ThreeBusCoSim)
+endif()

--- a/examples/Network/ThreeBusCoSim/CMakeLists.txt
+++ b/examples/Network/ThreeBusCoSim/CMakeLists.txt
@@ -1,0 +1,18 @@
+gridkit_example_add_file(ThreeBusCoSimClient.case.json)
+gridkit_example_add_file(ThreeBusCoSimServer.case.json)
+gridkit_example_add_file(run_cosim.sh)
+
+add_executable(CoSimClient ThreeBusCoSimClient.cpp)
+target_link_libraries(
+  CoSimClient
+  PUBLIC GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn ZMQ)
+
+add_executable(CoSimServer ThreeBusCoSimServer.cpp)
+target_link_libraries(
+  CoSimServer
+  PUBLIC GridKit::phasor_dynamics_systemmodel GridKit::solvers_dyn ZMQ)
+
+add_test(
+  NAME CoSimExample
+  COMMAND bash run_cosim.sh
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/Network/ThreeBusCoSim/CoSim.hpp
+++ b/examples/Network/ThreeBusCoSim/CoSim.hpp
@@ -4,6 +4,17 @@ namespace GridKit
 {
   namespace CoSim
   {
+    /*
+     * The following is meant to be used to communicate driver information over
+     * the network. It is crude, but it at least gives language in the code that
+     * expresses the meaning of the intent.
+     *
+     * - STEP is used to initiate (and continue) the co-simulation (take a step)
+     * - END is used to end the co-simulation
+     *
+     * Both of these are sent by the client to keep the server in step.
+     */
+
     using StatusT = int;
 
     inline constexpr StatusT STEP = 1;

--- a/examples/Network/ThreeBusCoSim/CoSim.hpp
+++ b/examples/Network/ThreeBusCoSim/CoSim.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace GridKit
+{
+  namespace CoSim
+  {
+    using StatusT = int;
+
+    inline constexpr StatusT STEP = 1;
+    inline constexpr StatusT END  = 0;
+  } // namespace CoSim
+} // namespace GridKit

--- a/examples/Network/ThreeBusCoSim/README.md
+++ b/examples/Network/ThreeBusCoSim/README.md
@@ -1,0 +1,10 @@
+# Three-bus co-simulation example case with constant signal source
+
+This example duplicates the behavior of the ThreeBusConstantSource example, but
+with the `ConstantSignalSource` component removed and its behavior reproduced in
+the app (external to the system model) with currents being received over zmq
+from another app.
+
+Note that this example code is temporary and meant simply as an initial step
+towards implementing multi-instance co-simulation with GridKit. It will be
+generalized into an application that can be used for other co-simulation cases.

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.case.json
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.case.json
@@ -2,8 +2,8 @@
     "header": {
         "format_version": 0.2,
         "format_revision": 0,
-        "case_name": "ThreeBusConstantSource",
-        "case_description": "3-bus test case with constant signal sources",
+        "case_name": "ThreeBusCoSimClient",
+        "case_description": "3-bus test case sending voltage and receiving current",
         "case_comments": "None"
     },
     "params": {
@@ -58,8 +58,10 @@
         }
     ],
     "signals": [
-        { "signal_id": 1, "name": "ir1"},
-        { "signal_id": 2, "name": "ir2"}
+        { "signal_id": 1, "name": "vr"},
+        { "signal_id": 2, "name": "vi"},
+        { "signal_id": 3, "name": "ir"},
+        { "signal_id": 4, "name": "ii"}
     ],
     "devices": [
         {
@@ -159,14 +161,8 @@
         },
         {
             "class": "BusToSignalAdapter",
-            "ports": {"bus":1, "ir":1, "ii":2},
+            "ports": {"bus":1, "vr":1, "vi":2, "ir":3, "ii":4},
             "id": "adapt3",
-            "params": {}
-        },
-        {
-            "class": "ConstantSignalSource",
-            "ports": {"sr":1, "si":2},
-            "id": "const_source_1",
             "params": {}
         }
     ]

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.cpp
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.cpp
@@ -1,0 +1,134 @@
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp>
+#include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
+#include <GridKit/Model/PhasorDynamics/SystemModel.hpp>
+#include <GridKit/Model/PhasorDynamics/SystemModelData.hpp>
+#include <GridKit/Solver/Dynamic/Ida.hpp>
+
+#include "CoSim.hpp"
+#include <zmq.hpp>
+
+using namespace GridKit;
+using namespace GridKit::PhasorDynamics;
+using namespace AnalysisManager::Sundials;
+
+template <typename scalar_type, typename index_type>
+class CoSimClient
+{
+public:
+  using ScalarT      = scalar_type;
+  using IdxT         = index_type;
+  using SystemModelT = SystemModel<ScalarT, IdxT>;
+  using SignalT      = typename SystemModelT::SignalT;
+
+  CoSimClient() = delete;
+
+  CoSimClient(SignalT* vr, SignalT* vi, SignalT* ir, SignalT* ii)
+    : vr_signal_(vr),
+      vi_signal_(vi),
+      ir_signal_(ir),
+      ii_signal_(ii),
+      ctx_{},
+      socket_(ctx_, zmq::socket_type::req)
+  {
+    ir_signal_->set(&ir_, &ir_idx_);
+    ii_signal_->set(&ii_, &ii_idx_);
+    socket_.connect("tcp://0.0.0.0:5556");
+  }
+
+  ~CoSimClient()
+  {
+    std::ostringstream oss;
+    oss << CoSim::END << " " << vr_signal_->read() << " " << vi_signal_->read();
+    zmq::message_t s_msg{oss.str().data(), oss.str().size()};
+    socket_.send(s_msg, zmq::send_flags::none);
+
+    zmq::message_t r_msg;
+    auto           recv_result = socket_.recv(r_msg, zmq::recv_flags::none);
+    if (recv_result)
+    {
+    }
+  }
+
+  void exchange()
+  {
+    // 1. Send data
+    std::ostringstream oss;
+    oss << std::scientific << std::setprecision(16);
+    oss << CoSim::STEP << " " << vr_signal_->read() << " " << vi_signal_->read();
+    // std::cout << "[CLIENT] Sending: " << oss.str() << std::endl;
+
+    zmq::message_t s_msg{oss.str().data(), oss.str().size()};
+    socket_.send(s_msg, zmq::send_flags::none);
+
+    // 2. Receive data from DataBroker
+    zmq::message_t r_msg;
+    auto           recv_result = socket_.recv(r_msg, zmq::recv_flags::none);
+    if (recv_result)
+    {
+      std::istringstream iss(r_msg.to_string());
+      // std::cout << "[CLIENT] Received: " << iss.str() << std::endl;
+      iss >> ir_ >> ii_;
+    }
+  }
+
+private:
+  SignalT*       vr_signal_;
+  SignalT*       vi_signal_;
+  SignalT*       ir_signal_;
+  SignalT*       ii_signal_;
+  ScalarT        ir_{};
+  ScalarT        ii_{};
+  IdxT           ir_idx_{GridKit::INVALID_INDEX<IdxT>};
+  IdxT           ii_idx_{GridKit::INVALID_INDEX<IdxT>};
+  zmq::context_t ctx_;
+  zmq::socket_t  socket_;
+};
+
+using ScalarT = double;
+using RealT   = double;
+using IdxT    = std::size_t;
+
+int main()
+{
+  // Instantiate system
+  auto                       data = parseSystemModelData("ThreeBusCoSimClient.case.json");
+  auto                       sys  = SystemModel<ScalarT, IdxT>(data);
+  CoSimClient<ScalarT, IdxT> client(
+      sys.getSignal(1), sys.getSignal(2), sys.getSignal(3), sys.getSignal(4));
+  sys.allocate();
+  client.exchange();
+
+  // Set up simulation
+  Ida<ScalarT, IdxT> ida(&sys);
+  ida.setTolerance(1.0e-7, 1.0e-9);
+  ida.configureSimulation();
+
+  // TODO: Take one step at a time and exchange data between.
+  //       Just use step_callback
+  auto step_cb = [&client](auto)
+  {
+    client.exchange();
+  };
+
+  RealT dt = 1.0 / 4.0 / 60.0;
+
+  // Run for 1s
+  ida.initializeSimulation(0.0);
+  ida.runSimulation(1.0, dt, step_cb);
+
+  // Introduce fault and run for the next 0.1s
+  sys.getBusFault(0)->setStatus(true);
+  ida.initializeSimulation(1.0);
+  ida.runSimulation(1.1, dt, step_cb);
+
+  // Clear the fault and run until t = 10s.
+  sys.getBusFault(0)->setStatus(false);
+  ida.initializeSimulation(1.1);
+  ida.runSimulation(10.0, dt, step_cb);
+
+  return 0;
+}

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.cpp
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.cpp
@@ -7,6 +7,7 @@
 #include <GridKit/Model/PhasorDynamics/SystemModel.hpp>
 #include <GridKit/Model/PhasorDynamics/SystemModelData.hpp>
 #include <GridKit/Solver/Dynamic/Ida.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
 
 #include "CoSim.hpp"
 #include <zmq.hpp>
@@ -14,6 +15,8 @@
 using namespace GridKit;
 using namespace GridKit::PhasorDynamics;
 using namespace AnalysisManager::Sundials;
+
+using Log = GridKit::Utilities::Logger;
 
 /**
  * @brief A simple implementation of the "client" side of a co-simulation pair
@@ -61,6 +64,7 @@ public:
     ir_signal_->set(&ir_, &ir_idx_);
     ii_signal_->set(&ii_, &ii_idx_);
     socket_.connect("tcp://0.0.0.0:5556");
+    Log::summary() << "CLIENT: Established connection with server\n";
   }
 
   /**
@@ -78,6 +82,7 @@ public:
     if (recv_result)
     {
     }
+    Log::summary() << "CLIENT: Ending simulation\n";
   }
 
   /**
@@ -90,7 +95,7 @@ public:
     std::ostringstream oss;
     oss << std::scientific << std::setprecision(16);
     oss << CoSim::STEP << " " << vr_signal_->read() << " " << vi_signal_->read();
-    // std::cout << "[CLIENT] Sending: " << oss.str() << std::endl;
+    Log::misc() << "CLIENT: Sending \"" << oss.str() << "\"\n";
 
     zmq::message_t s_msg{oss.str().data(), oss.str().size()};
     socket_.send(s_msg, zmq::send_flags::none);
@@ -101,7 +106,7 @@ public:
     if (recv_result)
     {
       std::istringstream iss(r_msg.to_string());
-      // std::cout << "[CLIENT] Received: " << iss.str() << std::endl;
+      Log::misc() << "CLIENT: Received \"" << iss.str() << "\"\n";
       iss >> ir_ >> ii_;
     }
   }
@@ -135,6 +140,8 @@ using IdxT    = std::size_t;
 
 int main()
 {
+  Log::setVerbosity(Log::Verbosity::SUMMARY);
+
   // Instantiate system
   auto filepath = std::filesystem::path("ThreeBusCoSimClient.case.json");
   auto data     = parseSystemModelData(filepath);

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.cpp
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.cpp
@@ -95,9 +95,10 @@ using IdxT    = std::size_t;
 int main()
 {
   // Instantiate system
-  auto                       data = parseSystemModelData("ThreeBusCoSimClient.case.json");
-  auto                       sys  = SystemModel<ScalarT, IdxT>(data);
-  CoSimClient<ScalarT, IdxT> client(
+  auto filepath = std::filesystem::path("ThreeBusCoSimClient.case.json");
+  auto data     = parseSystemModelData(filepath);
+  auto sys      = SystemModel<ScalarT, IdxT>(data);
+  auto client   = CoSimClient<ScalarT, IdxT>(
       sys.getSignal(1), sys.getSignal(2), sys.getSignal(3), sys.getSignal(4));
   sys.allocate();
   client.exchange();

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.cpp
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimClient.cpp
@@ -15,17 +15,41 @@ using namespace GridKit;
 using namespace GridKit::PhasorDynamics;
 using namespace AnalysisManager::Sundials;
 
+/**
+ * @brief A simple implementation of the "client" side of a co-simulation pair
+ *
+ * This is a "client" in the sense that it initiates the simulation and triggers
+ * its end.
+ *
+ * @tparam scalar_type scalar parameter type
+ * @tparam index_type  integer parameter type
+ */
 template <typename scalar_type, typename index_type>
 class CoSimClient
 {
 public:
+  /// Type representing a scalar value
   using ScalarT      = scalar_type;
+  /// Type representing an index
   using IdxT         = index_type;
+  /// Alias for SystemModel
   using SystemModelT = SystemModel<ScalarT, IdxT>;
+  /// Alias for SignalNode
   using SignalT      = typename SystemModelT::SignalT;
 
   CoSimClient() = delete;
 
+  /**
+   * @brief Construct with set of signal nodes to connect
+   *
+   * This links the current signal nodes with variables received from server and
+   * connects to the expected tcp port from which to receive.
+   *
+   * @param vr node from which to read real component of voltage to send
+   * @param vi node from which to read imaginary component of voltage to send
+   * @param ir node for communicating received real component of current
+   * @param ii node for communicating received imaginary component of current
+   */
   CoSimClient(SignalT* vr, SignalT* vi, SignalT* ir, SignalT* ii)
     : vr_signal_(vr),
       vi_signal_(vi),
@@ -39,6 +63,9 @@ public:
     socket_.connect("tcp://0.0.0.0:5556");
   }
 
+  /**
+   * @brief Signal the end of the simulation to the server and destruct object
+   */
   ~CoSimClient()
   {
     std::ostringstream oss;
@@ -53,6 +80,10 @@ public:
     }
   }
 
+  /**
+   * @brief Send voltage to and receive current from server-side instance for a
+   * single time step.
+   */
   void exchange()
   {
     // 1. Send data
@@ -76,15 +107,25 @@ public:
   }
 
 private:
+  /// node from which to read real component of voltage to send
   SignalT*       vr_signal_;
+  /// node from which to read imaginary component of voltage to send
   SignalT*       vi_signal_;
+  /// node for communicating received real component of current
   SignalT*       ir_signal_;
+  /// node for communicating received imaginary component of current
   SignalT*       ii_signal_;
+  /// variable for receiving current
   ScalarT        ir_{};
+  /// variable for receiving current
   ScalarT        ii_{};
+  /// dummy index for current signal
   IdxT           ir_idx_{GridKit::INVALID_INDEX<IdxT>};
+  /// dummy index for current signal
   IdxT           ii_idx_{GridKit::INVALID_INDEX<IdxT>};
+  /// ZMQ context
   zmq::context_t ctx_;
+  /// ZMQ socket
   zmq::socket_t  socket_;
 };
 
@@ -109,7 +150,7 @@ int main()
   ida.configureSimulation();
 
   // TODO: Take one step at a time and exchange data between.
-  //       Just use step_callback
+  //       Use step_callback for now.
   auto step_cb = [&client](auto)
   {
     client.exchange();

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.case.json
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.case.json
@@ -2,20 +2,14 @@
     "header": {
         "format_version": 0.2,
         "format_revision": 0,
-        "case_name": "ThreeBusConstantSource",
-        "case_description": "3-bus test case with constant signal sources",
+        "case_name": "ThreeBusCoSimServer",
+        "case_description": "3-bus test case receiving voltage and sending current",
         "case_comments": "None"
     },
     "params": {
         "freq_base": 60.0,
         "va_base": 100000000.0
     },
-    "monitors": [
-        {
-            "file_name": "mon.csv",
-            "format":"csv"
-        }
-    ],
     "buses": [
         {
             "number": 1,
@@ -167,7 +161,7 @@
             "class": "ConstantSignalSource",
             "ports": {"sr":1, "si":2},
             "id": "const_source_1",
-            "params": {}
+            "params": {"Sr":0.0, "Si":0.0}
         }
     ]
 }

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.cpp
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.cpp
@@ -1,0 +1,83 @@
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
+#include <GridKit/Model/PhasorDynamics/SystemModel.hpp>
+#include <GridKit/Model/PhasorDynamics/SystemModelData.hpp>
+
+#include "CoSim.hpp"
+#include <zmq.hpp>
+
+using ScalarT = double;
+using IdxT    = std::size_t;
+
+using namespace GridKit;
+using namespace GridKit::PhasorDynamics;
+
+template <typename scalar_type, typename index_type>
+class CoSimServer
+{
+public:
+  using ScalarT      = scalar_type;
+  using IdxT         = index_type;
+  using SystemModelT = GridKit::PhasorDynamics::SystemModel<ScalarT, IdxT>;
+  using SignalT      = typename SystemModelT::SignalT;
+
+  CoSimServer() = delete;
+
+  CoSimServer(SignalT* ir, SignalT* ii)
+    : ir_signal_(ir),
+      ii_signal_(ii),
+      ctx_{},
+      socket_(ctx_, zmq::socket_type::rep)
+  {
+    socket_.bind("tcp://0.0.0.0:5556");
+  }
+
+  void start()
+  {
+    CoSim::StatusT status;
+    ScalarT        d1, d2;
+    do
+    {
+      // 1. Receive data
+      zmq::message_t msg;
+      auto           recv_result = socket_.recv(msg, zmq::recv_flags::none);
+      if (recv_result)
+      {
+        std::istringstream(msg.to_string()) >> status >> d1 >> d2;
+        // std::cout << "[SERVER] Received: " << msg.to_string_view() << std::endl;
+      }
+
+      // 2. Respond with new data
+      std::ostringstream oss;
+      oss << std::scientific << std::setprecision(16);
+      oss << ir_signal_->read() << " " << ii_signal_->read();
+      // std::cout << "[SERVER] Sending: " << oss.str() << std::endl;
+
+      zmq::message_t reply{oss.str().data(), oss.str().size()};
+      socket_.send(reply, zmq::send_flags::none);
+    } while (status == CoSim::STEP);
+  }
+
+private:
+  SignalT*       ir_signal_;
+  SignalT*       ii_signal_;
+  zmq::context_t ctx_;
+  zmq::socket_t  socket_;
+};
+
+int main()
+{
+  // Instantiate system
+  auto data = parseSystemModelData("ThreeBusCoSimServer.case.json");
+  auto sys  = SystemModel<ScalarT, IdxT>(data);
+  sys.allocate();
+
+  // Set up cosim
+  CoSimServer<ScalarT, IdxT> server(sys.getSignal(1), sys.getSignal(2));
+  server.start();
+
+  return 0;
+}

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.cpp
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.cpp
@@ -15,17 +15,39 @@ using IdxT    = std::size_t;
 using namespace GridKit;
 using namespace GridKit::PhasorDynamics;
 
+/**
+ * @brief A simple implementation of the "server" side of a co-simulation pair
+ *
+ * This is a "server" in the sense that it waits for a request from the "client"
+ * to initiate each step in the simulation and to trigger when to stop the
+ * simulation.
+ *
+ * @tparam scalar_type scalar parameter type
+ * @tparam index_type  integer parameter type
+ */
 template <typename scalar_type, typename index_type>
 class CoSimServer
 {
 public:
+  /// Type representing a scalar value
   using ScalarT      = scalar_type;
+  /// Type representing an index
   using IdxT         = index_type;
-  using SystemModelT = GridKit::PhasorDynamics::SystemModel<ScalarT, IdxT>;
+  /// Alias for SystemModel
+  using SystemModelT = SystemModel<ScalarT, IdxT>;
+  /// Alias for SignalNode
   using SignalT      = typename SystemModelT::SignalT;
 
   CoSimServer() = delete;
 
+  /**
+   * @brief Construct with set of signal nodes to connect
+   *
+   * This also binds the tcp port to which the client is expected to connect
+   *
+   * @param ir node from which to read real component of current to send
+   * @param ii node from which to read imaginary component of current to send
+   */
   CoSimServer(SignalT* ir, SignalT* ii)
     : ir_signal_(ir),
       ii_signal_(ii),
@@ -35,6 +57,18 @@ public:
     socket_.bind("tcp://0.0.0.0:5556");
   }
 
+  /**
+   * @brief Start the server
+   *
+   * The server will stay in this function until the end of the simulation is
+   * triggered by the client.
+   *
+   * Each time a voltage message is received, a
+   * step is taken and the resulting currents are sent as a response.
+   *
+   * @note For this initial implementation, no solver step is taken. Constant
+   * current values are sent in response.
+   */
   void start()
   {
     CoSim::StatusT status;
@@ -62,9 +96,13 @@ public:
   }
 
 private:
+  /// node from which to read real component of current to send
   SignalT*       ir_signal_;
+  /// node from which to read imaginary component of current to send
   SignalT*       ii_signal_;
+  /// ZMQ context
   zmq::context_t ctx_;
+  /// ZMQ socket
   zmq::socket_t  socket_;
 };
 

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.cpp
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.cpp
@@ -5,6 +5,7 @@
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
 #include <GridKit/Model/PhasorDynamics/SystemModel.hpp>
 #include <GridKit/Model/PhasorDynamics/SystemModelData.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
 
 #include "CoSim.hpp"
 #include <zmq.hpp>
@@ -14,6 +15,8 @@ using IdxT    = std::size_t;
 
 using namespace GridKit;
 using namespace GridKit::PhasorDynamics;
+
+using Log = GridKit::Utilities::Logger;
 
 /**
  * @brief A simple implementation of the "server" side of a co-simulation pair
@@ -63,14 +66,19 @@ public:
    * The server will stay in this function until the end of the simulation is
    * triggered by the client.
    *
-   * Each time a voltage message is received, a
-   * step is taken and the resulting currents are sent as a response.
+   * Each time a voltage message is received, a step is taken and the resulting
+   * currents are sent as a response.
+   *
+   * Messages received from the client begin with a status token. Stepping will
+   * continue as long as the status received is CoSim::STEP. When CoSim::END is
+   * received the simulation will wrap up.
    *
    * @note For this initial implementation, no solver step is taken. Constant
    * current values are sent in response.
    */
   void start()
   {
+    Log::summary() << "SERVER: Start simulation loop\n";
     CoSim::StatusT status;
     ScalarT        d1, d2;
     do
@@ -81,18 +89,20 @@ public:
       if (recv_result)
       {
         std::istringstream(msg.to_string()) >> status >> d1 >> d2;
-        // std::cout << "[SERVER] Received: " << msg.to_string_view() << std::endl;
+        Log::misc() << "SERVER: Received \"" << msg.to_string_view() << "\"\n";
       }
 
       // 2. Respond with new data
       std::ostringstream oss;
       oss << std::scientific << std::setprecision(16);
       oss << ir_signal_->read() << " " << ii_signal_->read();
-      // std::cout << "[SERVER] Sending: " << oss.str() << std::endl;
+      Log::misc() << "SERVER: Sending \"" << oss.str() << "\"\n";
 
       zmq::message_t reply{oss.str().data(), oss.str().size()};
       socket_.send(reply, zmq::send_flags::none);
     } while (status == CoSim::STEP);
+
+    Log::summary() << "SERVER: Simulation stopped\n";
   }
 
 private:
@@ -108,6 +118,8 @@ private:
 
 int main()
 {
+  Log::setVerbosity(Log::Verbosity::SUMMARY);
+
   // Instantiate system
   auto filepath = std::filesystem::path("ThreeBusCoSimServer.case.json");
   auto data     = parseSystemModelData(filepath);

--- a/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.cpp
+++ b/examples/Network/ThreeBusCoSim/ThreeBusCoSimServer.cpp
@@ -71,8 +71,9 @@ private:
 int main()
 {
   // Instantiate system
-  auto data = parseSystemModelData("ThreeBusCoSimServer.case.json");
-  auto sys  = SystemModel<ScalarT, IdxT>(data);
+  auto filepath = std::filesystem::path("ThreeBusCoSimServer.case.json");
+  auto data     = parseSystemModelData(filepath);
+  auto sys      = SystemModel<ScalarT, IdxT>(data);
   sys.allocate();
 
   // Set up cosim

--- a/examples/Network/ThreeBusCoSim/run_cosim.sh
+++ b/examples/Network/ThreeBusCoSim/run_cosim.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./CoSimServer &
+
+./CoSimClient
+
+wait

--- a/examples/Network/ThreeBusCoSim/run_cosim.sh
+++ b/examples/Network/ThreeBusCoSim/run_cosim.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+readonly _cosim_dir=$(dirname $(realpath $0))
+
+cd ${_cosim_dir}
+
 ./CoSimServer &
 
 ./CoSimClient

--- a/examples/Network/ThreeBusCoSim/run_cosim.sh
+++ b/examples/Network/ThreeBusCoSim/run_cosim.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 ./CoSimServer &
 


### PR DESCRIPTION
## Description
 
See #469 

Introduce a minimal example using zmq for communication between GridKit processes.
 
 ## Proposed changes
 
This example duplicates the behavior of the `ThreeBusConstantSource` example, but with the `ConstantSignalSource` component removed and its behavior reproduced in the app (external to the system model) with currents being received over zmq from another app.
 
 ## Checklist
 
- [X] All tests pass.
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows GridKit™ style guidelines.
- [N/A] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
- [N/A] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments

A lot of comments here. :smile: I have numbered them for reference in discussion. 

1. I verified locally that the solution output is equal to that of the `ConstantSignalSource` example.
2. This example code is temporary; longer-term, this will be generalized and moved to the applications directory.
3. This example uses the "step_callback" in `Ida::runSimulation` rather than managing the stepping itself; this is questionable :), since we are intending to remove that.
4. The app implementation is a bit crude because this proof-of-concept (first attempt) was meant to be non-invasive (no modification to the phasor dynamics libraries). In order to move forward with a more general implementation, we will need some other tools.
    1. The immediate next step would be to add a "branch-terminal-adapter" (not sure what to name it) so that bus voltage (coming in over zmq) could be read from outside the system. This would enable a true co-simulation example with two systems solving in step with one another.
    2. Beyond that, the path diverges depending on how often we want to synchronize: just at every time step OR at every call to `evaluateResidual`
        1. Every residual: Use the "IOPorts" PR replacement of `ComponentSignals`. Extend it to make ports configurable...enabling the zmq exchange to be triggered when signals are read from ports.
        2. Every step
            1. Add a modified version of `ConstantSignalSource` that would use zmq to update its "constant" values.
            2. Use "IOPorts" as-is/was to enable this more naturally from outside the system (no new component needed). This would make the most sense from the application perspective because the application input file could simply specify which signals to assign to the network.

I'll add that in either of the "IOPorts" scenarios the co-simulation "manager" could be set up to exchange all necessary variables in one send/recv.