### PR TITLE
Implement tagDifferentiable in PowerElectronics models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Added `REECB` electrical-control model implementation for PhasorDynamics.
 - Added cases and validation for ACTIVSg10k, ACTIVSg200, ACTIVSg500, and WECC240.
 - Added IDA option to choose the consistent initial condition calculation type.
+- Implemented `tagDifferentiable()` for `PowerElectronics` models.
 
 ## v0.1
 

--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
@@ -49,6 +49,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int Capacitor<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are differentials
+    tag_.resize(size_, true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
@@ -50,7 +50,7 @@ namespace GridKit
   int Capacitor<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are differentials
-    tag_.resize(size_, true);
+    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -137,6 +137,8 @@ namespace GridKit
       f_ext_            = std::make_unique<ScalarT*[]>(size_);
       connection_nodes_ = std::make_unique<IdxT[]>(size_);
 
+      tag_.resize(size_);
+
       if (!allocated_)
       {
         allocateVectors(size_);

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -128,14 +128,14 @@ namespace GridKit
      */
     int allocate() override
     {
-      jacobian_coo_rows_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
-      jacobian_coo_cols_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
-      jacobian_coo_values_ = std::make_unique<RealT[]>(static_cast<size_t>(nnz_));
+      jacobian_coo_rows_   = std::make_unique<IdxT[]>(nnz_);
+      jacobian_coo_cols_   = std::make_unique<IdxT[]>(nnz_);
+      jacobian_coo_values_ = std::make_unique<RealT[]>(nnz_);
 
-      y_ext_            = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
-      yp_ext_           = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
-      f_ext_            = std::make_unique<ScalarT*[]>(static_cast<size_t>(size_));
-      connection_nodes_ = std::make_unique<IdxT[]>(static_cast<size_t>(size_));
+      y_ext_            = std::make_unique<const ScalarT*[]>(size_);
+      yp_ext_           = std::make_unique<const ScalarT*[]>(size_);
+      f_ext_            = std::make_unique<ScalarT*[]>(size_);
+      connection_nodes_ = std::make_unique<IdxT[]>(size_);
 
       if (!allocated_)
       {
@@ -250,7 +250,7 @@ namespace GridKit
     {
       assert(rows.size() == cols.size());
       assert(rows.size() == vals.size());
-      assert(current_jac_size_ + rows.size() <= static_cast<size_t>(nnz_));
+      assert(current_jac_size_ + rows.size() <= nnz_);
 
       for (size_t i = 0; i < rows.size(); i++)
       {
@@ -265,22 +265,22 @@ namespace GridKit
   public:
     IdxT size() final
     {
-      return size_;
+      return static_cast<IdxT>(size_);
     }
 
     IdxT size() const
     {
-      return size_;
+      return static_cast<IdxT>(size_);
     }
 
     IdxT nnz() final
     {
-      return nnz_;
+      return static_cast<IdxT>(nnz_);
     }
 
     IdxT nnz() const
     {
-      return nnz_;
+      return static_cast<IdxT>(nnz_);
     }
 
     IdxT sizeQuadrature() final
@@ -491,11 +491,11 @@ namespace GridKit
 
   protected:
     /// The number of variables in this component. Should be equal to \ref n_extern_ plus \ref n_intern_. \see size()
-    IdxT size_{0};
+    IdxT   size_{0};
     /// The number of nonzero elements in this component's Jacobian. \see nnz()
-    IdxT nnz_{0};
-    IdxT size_quad_{0};
-    IdxT size_opt_{0};
+    size_t nnz_{0};
+    IdxT   size_quad_{0};
+    IdxT   size_opt_{0};
 
     // COO Jacobian buffers
     std::unique_ptr<IdxT[]>  jacobian_coo_rows_;

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -128,16 +128,16 @@ namespace GridKit
      */
     int allocate() override
     {
-      jacobian_coo_rows_   = std::make_unique<IdxT[]>(nnz_);
-      jacobian_coo_cols_   = std::make_unique<IdxT[]>(nnz_);
-      jacobian_coo_values_ = std::make_unique<RealT[]>(nnz_);
+      jacobian_coo_rows_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
+      jacobian_coo_cols_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
+      jacobian_coo_values_ = std::make_unique<RealT[]>(static_cast<size_t>(nnz_));
 
-      y_ext_            = std::make_unique<const ScalarT*[]>(size_);
-      yp_ext_           = std::make_unique<const ScalarT*[]>(size_);
-      f_ext_            = std::make_unique<ScalarT*[]>(size_);
-      connection_nodes_ = std::make_unique<IdxT[]>(size_);
+      y_ext_            = std::make_unique<const ScalarT*[]>(static_cast<IdxT>(size_));
+      yp_ext_           = std::make_unique<const ScalarT*[]>(static_cast<IdxT>(size_));
+      f_ext_            = std::make_unique<ScalarT*[]>(static_cast<IdxT>(size_));
+      connection_nodes_ = std::make_unique<IdxT[]>(static_cast<IdxT>(size_));
 
-      tag_.resize(size_);
+      tag_.resize(static_cast<IdxT>(size_));
 
       if (!allocated_)
       {
@@ -252,7 +252,7 @@ namespace GridKit
     {
       assert(rows.size() == cols.size());
       assert(rows.size() == vals.size());
-      assert(current_jac_size_ + rows.size() <= nnz_);
+      assert(current_jac_size_ + rows.size() <= static_cast<size_t>(nnz_));
 
       for (size_t i = 0; i < rows.size(); i++)
       {
@@ -267,22 +267,22 @@ namespace GridKit
   public:
     IdxT size() final
     {
-      return static_cast<IdxT>(size_);
+      return size_;
     }
 
     IdxT size() const
     {
-      return static_cast<IdxT>(size_);
+      return size_;
     }
 
     IdxT nnz() final
     {
-      return static_cast<IdxT>(nnz_);
+      return nnz_;
     }
 
     IdxT nnz() const
     {
-      return static_cast<IdxT>(nnz_);
+      return nnz_;
     }
 
     IdxT sizeQuadrature() final
@@ -493,11 +493,11 @@ namespace GridKit
 
   protected:
     /// The number of variables in this component. Should be equal to \ref n_extern_ plus \ref n_intern_. \see size()
-    IdxT   size_{0};
+    IdxT size_{0};
     /// The number of nonzero elements in this component's Jacobian. \see nnz()
-    size_t nnz_{0};
-    IdxT   size_quad_{0};
-    IdxT   size_opt_{0};
+    IdxT nnz_{0};
+    IdxT size_quad_{0};
+    IdxT size_opt_{0};
 
     // COO Jacobian buffers
     std::unique_ptr<IdxT[]>  jacobian_coo_rows_;

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -132,10 +132,10 @@ namespace GridKit
       jacobian_coo_cols_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
       jacobian_coo_values_ = std::make_unique<RealT[]>(static_cast<size_t>(nnz_));
 
-      y_ext_            = std::make_unique<const ScalarT*[]>(static_cast<IdxT>(size_));
-      yp_ext_           = std::make_unique<const ScalarT*[]>(static_cast<IdxT>(size_));
-      f_ext_            = std::make_unique<ScalarT*[]>(static_cast<IdxT>(size_));
-      connection_nodes_ = std::make_unique<IdxT[]>(static_cast<IdxT>(size_));
+      y_ext_            = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
+      yp_ext_           = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
+      f_ext_            = std::make_unique<ScalarT*[]>(static_cast<size_t>(size_));
+      connection_nodes_ = std::make_unique<IdxT[]>(static_cast<size_t>(size_));
 
       tag_.resize(static_cast<IdxT>(size_));
 

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -137,7 +137,7 @@ namespace GridKit
       f_ext_            = std::make_unique<ScalarT*[]>(static_cast<size_t>(size_));
       connection_nodes_ = std::make_unique<IdxT[]>(static_cast<size_t>(size_));
 
-      tag_.resize(static_cast<IdxT>(size_));
+      tag_.resize(static_cast<size_t>(size_));
 
       if (!allocated_)
       {

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
@@ -3,7 +3,6 @@
 #include "DistributedGenerator.hpp"
 
 #include <cmath>
-#include <iostream>
 #include <vector>
 
 namespace GridKit
@@ -74,6 +73,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int DistributedGenerator<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are differentials
+    tag_.resize(size_, true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
@@ -74,7 +74,7 @@ namespace GridKit
   int DistributedGenerator<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are differentials
-    tag_.resize(size_, true);
+    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
@@ -60,6 +60,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int InductionMotor<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are differentials
+    tag_.resize(size_, true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
@@ -61,7 +61,7 @@ namespace GridKit
   int InductionMotor<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are differentials
-    tag_.resize(size_, true);
+    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
@@ -49,7 +49,7 @@ namespace GridKit
   int Inductor<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are differentials
-    tag_.resize(size_, true);
+    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
@@ -48,6 +48,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int Inductor<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are differentials
+    tag_.resize(size_, true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
@@ -62,6 +62,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int LinearTransformer<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are differentials
+    tag_.resize(size_, true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
@@ -63,7 +63,7 @@ namespace GridKit
   int LinearTransformer<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are differentials
-    tag_.resize(size_, true);
+    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
@@ -47,9 +47,7 @@ namespace GridKit
     return 0;
   }
 
-  /*
-   * \brief Identify differential variables
-   */
+  /// There are no internal variables in this component, so \ref tag_ can be set arbitrarily.
   template <class ScalarT, typename IdxT>
   int MicrogridBusDQ<ScalarT, IdxT>::tagDifferentiable()
   {
@@ -77,8 +75,6 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridBusDQ<ScalarT, IdxT>::evaluateInternalResidual()
   {
-    // No internal variables - tag doesn't matter.
-    tag_.resize(size_, false);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
@@ -77,6 +77,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridBusDQ<ScalarT, IdxT>::evaluateInternalResidual()
   {
+    // No internal variables - tag doesn't matter.
+    tag_.resize(size_, false);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
@@ -63,7 +63,7 @@ namespace GridKit
   int MicrogridLine<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are differentials
-    tag_.resize(size_, true);
+    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
@@ -62,6 +62,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridLine<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are differentials
+    tag_.resize(size_, true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
@@ -59,7 +59,7 @@ namespace GridKit
   int MicrogridLoad<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are differentials
-    tag_.resize(size_, true);
+    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
@@ -58,6 +58,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int MicrogridLoad<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are differentials
+    tag_.resize(size_, true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/NodeBase.hpp
+++ b/GridKit/Model/PowerElectronics/NodeBase.hpp
@@ -145,7 +145,7 @@ namespace GridKit
           allocateVectors(static_cast<IdxT>(size));
         }
 
-        tag_.resize(size);
+        tag_.resize(size, false);
         variable_indices_.resize(size);
         residual_indices_.resize(size);
 

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
@@ -43,14 +43,10 @@ namespace GridKit
     return 0;
   }
 
-  /*
-   * \brief Identify differential variables
-   */
+  /// There are no internal variables in this component, so \ref tag_ can be set arbitrarily.
   template <class ScalarT, typename IdxT>
   int Resistor<ScalarT, IdxT>::tagDifferentiable()
   {
-    // No internal variables, so these valeus do not matter
-    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
@@ -49,6 +49,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int Resistor<ScalarT, IdxT>::tagDifferentiable()
   {
+    // No internal variables, so these valeus do not matter
+    tag_.resize(size_, true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
@@ -50,7 +50,7 @@ namespace GridKit
   int Resistor<ScalarT, IdxT>::tagDifferentiable()
   {
     // No internal variables, so these valeus do not matter
-    tag_.resize(size_, true);
+    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
@@ -77,6 +77,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int SynchronousMachine<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are differentials
+    tag_.resize(size_, true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
@@ -78,7 +78,7 @@ namespace GridKit
   int SynchronousMachine<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are differentials
-    tag_.resize(size_, true);
+    std::fill(tag_.begin(), tag_.end(), true);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <format>
 #include <vector>
 
 #include <GridKit/Constants.hpp>
@@ -11,6 +12,8 @@
 #include <GridKit/Model/PowerElectronics/CircuitNode.hpp>
 #include <GridKit/Model/PowerElectronics/NodeBase.hpp>
 #include <GridKit/ScalarTraits.hpp>
+
+#include "GridKit/Utilities/Logger/Logger.hpp"
 
 namespace GridKit
 {
@@ -147,8 +150,6 @@ namespace GridKit
         // Component and node offsets can change when topology is modified.
         abs_tol_.setToZero(memory::HOST);
       }
-
-      tag_.resize(size_);
 
       { // Start node internal indexing after all component internals for proper KLU ordering
         size_t node_internal_idx = component_internal_size;
@@ -294,6 +295,38 @@ namespace GridKit
 
     int tagDifferentiable() final
     {
+      for (size_t i = 0; i < components_.size(); i++)
+      {
+        component_type* component = components_[i];
+
+        if (int err = component->tagDifferentiable())
+        {
+          return err;
+        }
+
+        if (component->tag().size() != component->size())
+        {
+          GridKit::Utilities::Logger::error() << std::format("Component {} has an ill-configured tag(). Expected tags for {} variables, got {} instead.\n", i, component->size(), component->tag().size());
+          return 1;
+        }
+      }
+
+      tag_.resize(size_, false);
+
+      size_t idx = 0;
+      for (component_type* comp : components_)
+      {
+        const auto& external_indices = comp->getExternIndices();
+        for (IdxT i = 0; i < comp->size(); i++)
+        {
+          if (!external_indices.contains(i))
+          {
+            tag_[idx] = comp->tag()[i];
+            idx++;
+          }
+        }
+      }
+
       return 0;
     }
 

--- a/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -151,6 +151,8 @@ namespace GridKit
         abs_tol_.setToZero(memory::HOST);
       }
 
+      tag_.resize(size_);
+
       { // Start node internal indexing after all component internals for proper KLU ordering
         size_t node_internal_idx = component_internal_size;
         for (node_type* node : nodes_)
@@ -311,7 +313,7 @@ namespace GridKit
         }
       }
 
-      tag_.resize(size_, false);
+      std::fill(tag_.begin(), tag_.end(), false);
 
       size_t idx = 0;
       for (component_type* comp : components_)

--- a/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -295,35 +295,50 @@ namespace GridKit
       return CircuitComponent<ScalarT, IdxT>::initialize();
     }
 
+    /**
+     * @brief Tags all system variables as differentiable, based on what the
+     * components that own those variables tag them as.
+     *
+     * Starts by asking all components to tag their differentiables. This implementation
+     * assumes all node variables are algebraic, and will not ask nodes to tag their differentiables.
+     * Sets all variables to algebraic (`false`) to start, then loops over all component internal variables.
+     * Re-creates the same internal variable to system variables mapping as in \ref allocate() - all
+     * internal variables from the same component are stored contiguously in a block, and blocks are
+     * stored contiguously in the same order as \ref components_, with node variables at the end.
+     * Each internal variable's tag in the system is set to its tag in the component.
+     */
     int tagDifferentiable() final
     {
+      // Ask all component to tag their differentiables
       for (size_t i = 0; i < components_.size(); i++)
       {
         component_type* component = components_[i];
 
+        // Bubble up errors if necessary
         if (int err = component->tagDifferentiable())
         {
           return err;
         }
-
-        if (component->tag().size() != component->size())
-        {
-          GridKit::Utilities::Logger::error() << std::format("Component {} has an ill-configured tag(). Expected tags for {} variables, got {} instead.\n", i, component->size(), component->tag().size());
-          return 1;
-        }
       }
 
+      // Fill tags with a default value (false) for node variables. Assumed to be algebraic here.
       std::fill(tag_.begin(), tag_.end(), false);
 
+      // Copy tags for internal variables from their components - going in the order as described above
       size_t idx = 0;
       for (component_type* comp : components_)
       {
         const auto& external_indices = comp->getExternIndices();
+
+        // Loop over all component variables - including externals
         for (IdxT i = 0; i < comp->size(); i++)
         {
+          // Discard externals
           if (!external_indices.contains(i))
           {
             tag_[idx] = comp->tag()[i];
+
+            // Ensures internal variables are contiguous, and in the same order as the component
             idx++;
           }
         }

--- a/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
+++ b/GridKit/Model/PowerElectronics/SystemModelPowerElectronics.hpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <format>
 #include <vector>
 
 #include <GridKit/Constants.hpp>
@@ -12,8 +11,6 @@
 #include <GridKit/Model/PowerElectronics/CircuitNode.hpp>
 #include <GridKit/Model/PowerElectronics/NodeBase.hpp>
 #include <GridKit/ScalarTraits.hpp>
-
-#include "GridKit/Utilities/Logger/Logger.hpp"
 
 namespace GridKit
 {

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
@@ -60,6 +60,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int TransmissionLine<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are algebraics
+    tag_.resize(size_, false);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
@@ -61,7 +61,7 @@ namespace GridKit
   int TransmissionLine<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are algebraics
-    tag_.resize(size_, false);
+    std::fill(tag_.begin(), tag_.end(), false);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
@@ -50,7 +50,7 @@ namespace GridKit
   int VoltageSource<ScalarT, IdxT>::tagDifferentiable()
   {
     // All variables are algebraics
-    tag_.resize(size_, false);
+    std::fill(tag_.begin(), tag_.end(), false);
     return 0;
   }
 

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
@@ -49,6 +49,8 @@ namespace GridKit
   template <class ScalarT, typename IdxT>
   int VoltageSource<ScalarT, IdxT>::tagDifferentiable()
   {
+    // All variables are algebraics
+    tag_.resize(size_, false);
     return 0;
   }
 

--- a/examples/PowerElectronics/Microgrid/Microgrid.cpp
+++ b/examples/PowerElectronics/Microgrid/Microgrid.cpp
@@ -228,23 +228,27 @@ int main(int /* argc */, char const** /* argv */)
   bool all_internal_diff = true;
   bool all_external_alg  = true;
 
-  const size_t num_node_vars = 4 * 2 + 1;
+  const size_t num_node_vars = bus1.size() + bus2.size() + bus3.size() + bus4.size() + dg_signal.size();
 
   for (size_t i = 0; i < sysmodel->size() - num_node_vars; i++)
   {
     all_internal_diff = all_internal_diff && sysmodel->tag()[i];
     if (!sysmodel->tag()[i])
     {
-      std::cout << "Broken on " << i << '\n';
+      std::cout << "Unexepected algebraic-tagged internal variable found in index " << i << '\n';
     }
   }
 
   for (size_t i = sysmodel->size() - num_node_vars; i < sysmodel->size(); i++)
   {
     all_external_alg = all_external_alg && !sysmodel->tag()[i];
+    if (sysmodel->tag()[i])
+    {
+      std::cout << "Unexepected differential-tagged external variable found in index " << i << '\n';
+    }
   }
 
-  std::cout << "Verify all internal variables are differential: " << all_internal_diff << ", and all external variabels are algebraic: " << all_external_alg << '\n';
+  std::cout << "Verify all internal variables are differential: " << all_internal_diff << ", and all external variables are algebraic: " << all_external_alg << '\n';
 
   // Create numerical integrator and configure it for the generator model
   auto* idas = new AnalysisManager::Sundials::Ida<double, size_t>(sysmodel);

--- a/examples/PowerElectronics/Microgrid/Microgrid.cpp
+++ b/examples/PowerElectronics/Microgrid/Microgrid.cpp
@@ -223,6 +223,29 @@ int main(int /* argc */, char const** /* argv */)
     sysmodel->getCsrJacobian()->print();
   }
 
+  sysmodel->tagDifferentiable();
+
+  bool all_internal_diff = true;
+  bool all_external_alg  = true;
+
+  const size_t num_node_vars = 4 * 2 + 1;
+
+  for (size_t i = 0; i < sysmodel->size() - num_node_vars; i++)
+  {
+    all_internal_diff = all_internal_diff && sysmodel->tag()[i];
+    if (!sysmodel->tag()[i])
+    {
+      std::cout << "Broken on " << i << '\n';
+    }
+  }
+
+  for (size_t i = sysmodel->size() - num_node_vars; i < sysmodel->size(); i++)
+  {
+    all_external_alg = all_external_alg && !sysmodel->tag()[i];
+  }
+
+  std::cout << "Verify all internal variables are differential: " << all_internal_diff << ", and all external variabels are algebraic: " << all_external_alg << '\n';
+
   // Create numerical integrator and configure it for the generator model
   auto* idas = new AnalysisManager::Sundials::Ida<double, size_t>(sysmodel);
 


### PR DESCRIPTION
## Description
 
Implemented `tagDifferentiable()` in `PowerElectronics` models, so that they can be used for scaling testing of `Rosenbrock`.
 
 ## Proposed changes

 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [ ] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
 
