### PR TITLE
Refine IDATest::consistentICType test for steady-state initialization

### DIFF
--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -402,7 +402,7 @@ namespace GridKit
         auto* f       = f_.getData();
 
         y[0]       = 0.0;
-        y[1]       = 1.0;                       // Carefully chosen non-zero guess. Initialization will fail with bad initial guesses.
+        y[1]       = 10.0;                      // Initialization will fail with bad initial guesses.
         yp[0]      = steady_state_ ? 0.0 : 2.0; // Purposefully inconsistent guess for non-steady-state case.
         yp[1]      = 0.0;
         tag_       = {true, false};
@@ -577,7 +577,8 @@ namespace GridKit
         TestStatus success = true;
 
         using RealT = typename ScalarTraits<ScalarT>::RealT;
-        static constexpr auto tol = std::numeric_limits<RealT>::epsilon();
+
+        static constexpr auto tol = 100.0 * std::numeric_limits<RealT>::epsilon();
 
         // IdaConsistentICType::YA_YDP with non-steady-state initial guess for the derivatives
         {

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -402,7 +402,7 @@ namespace GridKit
         auto* f       = f_.getData();
 
         y[0]       = 0.0;
-        y[1]       = 10.0; 
+        y[1]       = 10.0;
         yp[0]      = steady_state_ ? 0.0 : 2.0; // Purposefully inconsistent guess for non-steady-state case.
         yp[1]      = 0.0;
         tag_       = {true, false};
@@ -578,7 +578,7 @@ namespace GridKit
 
         using RealT = typename ScalarTraits<ScalarT>::RealT;
 
-        // If the tolerances are too tight, a finite difference approximation to the Jacobian 
+        // If the tolerances are too tight, a finite difference approximation to the Jacobian
         // cannot be generated, and initialization will fail with bad initial guesses.
         static constexpr auto tol = 100.0 * std::numeric_limits<RealT>::epsilon();
 

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -577,7 +577,21 @@ namespace GridKit
         TestStatus success = true;
 
         {
-          Model::ConsistentICTypeEvaluator<ScalarT, IdxT> model;
+          Model::ConsistentICTypeEvaluator<ScalarT, IdxT> model(false);
+
+          Ida<ScalarT, IdxT> ida(&model);
+          ida.setConsistentICType(AnalysisManager::Sundials::IdaConsistentICType::YA_YDP);
+          ida.configureSimulation();
+          ida.initializeSimulation(0.0);
+
+          success *= isEqual(model.yp().getData()[0], 1.0);
+          success *= isEqual(model.yp().getData()[1], 0.0);
+          success *= isEqual(model.y().getData()[0], 0.0);
+          success *= isEqual(model.y().getData()[1], 0.0);
+        }
+
+        {
+          Model::ConsistentICTypeEvaluator<ScalarT, IdxT> model(true);
 
           Ida<ScalarT, IdxT> ida(&model);
           ida.setConsistentICType(AnalysisManager::Sundials::IdaConsistentICType::YA_YDP);

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -577,6 +577,7 @@ namespace GridKit
         TestStatus success = true;
 
         using RealT = typename ScalarTraits<ScalarT>::RealT;
+        static constexpr auto tol = std::numeric_limits<RealT>::epsilon();
 
         // IdaConsistentICType::YA_YDP with non-steady-state initial guess for the derivatives
         {
@@ -584,14 +585,14 @@ namespace GridKit
 
           Ida<ScalarT, IdxT> ida(&model);
           ida.setConsistentICType(AnalysisManager::Sundials::IdaConsistentICType::YA_YDP);
-          ida.setTolerance(std::numeric_limits<RealT>::epsilon());
+          ida.setTolerance(tol);
           ida.configureSimulation();
           ida.initializeSimulation(0.0);
 
-          success *= isEqual(model.yp().getData()[0], 1.0);
-          success *= isEqual(model.yp().getData()[1], 0.0);
-          success *= isEqual(model.y().getData()[0], 0.0);
-          success *= isEqual(model.y().getData()[1], 0.0);
+          success *= isEqual(model.yp().getData()[0], 1.0, tol);
+          success *= isEqual(model.yp().getData()[1], 0.0, tol);
+          success *= isEqual(model.y().getData()[0], 0.0, tol);
+          success *= isEqual(model.y().getData()[1], 0.0, tol);
         }
 
         // IdaConsistentICType::Y with steady-state initial guess for the derivatives
@@ -600,14 +601,14 @@ namespace GridKit
 
           Ida<ScalarT, IdxT> ida(&model);
           ida.setConsistentICType(AnalysisManager::Sundials::IdaConsistentICType::Y);
-          ida.setTolerance(std::numeric_limits<RealT>::epsilon());
+          ida.setTolerance(tol);
           ida.configureSimulation();
           ida.initializeSimulation(0.0);
 
-          success *= isEqual(model.yp().getData()[0], 0.0);
-          success *= isEqual(model.yp().getData()[1], 0.0);
-          success *= isEqual(model.y().getData()[0], 0.5);
-          success *= isEqual(model.y().getData()[1], 0.5);
+          success *= isEqual(model.yp().getData()[0], 0.0, tol);
+          success *= isEqual(model.yp().getData()[1], 0.0, tol);
+          success *= isEqual(model.y().getData()[0], 0.5, tol);
+          success *= isEqual(model.y().getData()[1], 0.5, tol);
         }
 
         {

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -584,8 +584,8 @@ namespace GridKit
           ida.configureSimulation();
           ida.initializeSimulation(0.0);
 
-          success *= (std::abs(model.yp().getData()[0] - 1.0) < 1.0e-10);
-          success *= (std::abs(model.y().getData()[1]) < 1.0e-10);
+          success *= isEqual(model.yp().getData()[0], 1.0);
+          success *= isEqual(model.y().getData()[1], 0.0);
         }
 
         {
@@ -596,7 +596,7 @@ namespace GridKit
           ida.configureSimulation();
           ida.initializeSimulation(0.0);
 
-          success *= (std::abs(model.y().getData()[0]) < 1.0e-10);
+          success *= isEqual(model.y().getData()[0], 0.0);
         }
 
         return success.report(__func__);

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -402,7 +402,7 @@ namespace GridKit
         auto* f       = f_.getData();
 
         y[0]       = 0.0;
-        y[1]       = 10.0;                      // Initialization will fail with bad initial guesses.
+        y[1]       = 10.0; 
         yp[0]      = steady_state_ ? 0.0 : 2.0; // Purposefully inconsistent guess for non-steady-state case.
         yp[1]      = 0.0;
         tag_       = {true, false};
@@ -578,6 +578,8 @@ namespace GridKit
 
         using RealT = typename ScalarTraits<ScalarT>::RealT;
 
+        // If the tolerances are too tight, a finite difference approximation to the Jacobian 
+        // cannot be generated, and initialization will fail with bad initial guesses.
         static constexpr auto tol = 100.0 * std::numeric_limits<RealT>::epsilon();
 
         // IdaConsistentICType::YA_YDP with non-steady-state initial guess for the derivatives

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -384,8 +384,8 @@ namespace GridKit
     public:
       ConsistentICTypeEvaluator() = default;
 
-      explicit ConsistentICTypeEvaluator(bool consistent_derivative)
-        : consistent_derivative_(consistent_derivative)
+      explicit ConsistentICTypeEvaluator(bool steady_state)
+        : steady_state_(steady_state)
       {
       }
 
@@ -402,8 +402,8 @@ namespace GridKit
         auto* f       = f_.getData();
 
         y[0]       = 0.0;
-        y[1]       = 10.0;
-        yp[0]      = consistent_derivative_ ? 1.0 : 0.0;
+        y[1]       = 1.0; // Carefully chosen non-zero guess. Initialization will fail with bad initial guesses.
+        yp[0]      = steady_state_ ? 0.0 : 2.0; // Purposefully inconsistent guess for non-steady-state case.
         yp[1]      = 0.0;
         tag_       = {true, false};
         abs_tol[0] = 0.0;
@@ -428,14 +428,14 @@ namespace GridKit
         const auto* y  = y_.getData();
         const auto* yp = yp_.getData();
 
-        f[0] = yp[0] - 1.0;
+        f[0] = yp[0] + y[0] + y[1] - 1.0;
         f[1] = y[1] - y[0];
         f_.setDataUpdated();
         return 0;
       }
 
     private:
-      bool consistent_derivative_{false};
+      bool steady_state_{false};
     };
   } // namespace Model
 
@@ -576,11 +576,15 @@ namespace GridKit
       {
         TestStatus success = true;
 
+        using RealT = typename ScalarTraits<ScalarT>::RealT;
+
+        // IdaConsistentICType::YA_YDP with non-steady-state initial guess for the derivatives
         {
           Model::ConsistentICTypeEvaluator<ScalarT, IdxT> model(false);
 
           Ida<ScalarT, IdxT> ida(&model);
           ida.setConsistentICType(AnalysisManager::Sundials::IdaConsistentICType::YA_YDP);
+          ida.setTolerance(std::numeric_limits<RealT>::epsilon());
           ida.configureSimulation();
           ida.initializeSimulation(0.0);
 
@@ -590,18 +594,20 @@ namespace GridKit
           success *= isEqual(model.y().getData()[1], 0.0);
         }
 
+        // IdaConsistentICType::Y with steady-state initial guess for the derivatives
         {
           Model::ConsistentICTypeEvaluator<ScalarT, IdxT> model(true);
 
           Ida<ScalarT, IdxT> ida(&model);
-          ida.setConsistentICType(AnalysisManager::Sundials::IdaConsistentICType::YA_YDP);
+          ida.setConsistentICType(AnalysisManager::Sundials::IdaConsistentICType::Y);
+          ida.setTolerance(std::numeric_limits<RealT>::epsilon());
           ida.configureSimulation();
           ida.initializeSimulation(0.0);
 
-          success *= isEqual(model.yp().getData()[0], 1.0);
+          success *= isEqual(model.yp().getData()[0], 0.0);
           success *= isEqual(model.yp().getData()[1], 0.0);
-          success *= isEqual(model.y().getData()[0], 0.0);
-          success *= isEqual(model.y().getData()[1], 0.0);
+          success *= isEqual(model.y().getData()[0], 0.5);
+          success *= isEqual(model.y().getData()[1], 0.5);
         }
 
         {

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -585,6 +585,8 @@ namespace GridKit
           ida.initializeSimulation(0.0);
 
           success *= isEqual(model.yp().getData()[0], 1.0);
+          success *= isEqual(model.yp().getData()[1], 0.0);
+          success *= isEqual(model.y().getData()[0], 0.0);
           success *= isEqual(model.y().getData()[1], 0.0);
         }
 

--- a/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
+++ b/tests/UnitTests/Solver/Dynamic/IdaTests.hpp
@@ -402,7 +402,7 @@ namespace GridKit
         auto* f       = f_.getData();
 
         y[0]       = 0.0;
-        y[1]       = 1.0; // Carefully chosen non-zero guess. Initialization will fail with bad initial guesses.
+        y[1]       = 1.0;                       // Carefully chosen non-zero guess. Initialization will fail with bad initial guesses.
         yp[0]      = steady_state_ ? 0.0 : 2.0; // Purposefully inconsistent guess for non-steady-state case.
         yp[1]      = 0.0;
         tag_       = {true, false};


### PR DESCRIPTION
## Description
 
This modifies the `IDATest::consistentICType` model to something that admits a steady-state solution to exercise both `IdaConsistentICType::Y` and `IdaConsistentICType::YA_YDP`. 

More minor suggestion to tighten the IDA tolerance and use `isEqual` with default criteria.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] The [CHANGELOG.md](/CHANGELOG.md) has been updated to reflect the changes. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments

Feel free to adjust/enhance as you see fit.
 
