### PR TITLE
Use std::once_flag and std::call_once for time constant warnings.

### DIFF
--- a/GridKit/Model/PhasorDynamics/Controller/REECB/Reecb.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REECB/Reecb.hpp
@@ -196,6 +196,8 @@ namespace GridKit
         ScalarT& Vi();
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
+        static void logTimeConstantWarning();
+
         static constexpr RealT VMEAS_MINIMUM         = static_cast<RealT>(0.01);
 
         BusT* bus_{nullptr};

--- a/GridKit/Model/PhasorDynamics/Controller/REECB/Reecb.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REECB/Reecb.hpp
@@ -196,9 +196,9 @@ namespace GridKit
         ScalarT& Vi();
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
-        static void logTimeConstantWarning();
+        static void            logTimeConstantWarning();
 
-        static constexpr RealT VMEAS_MINIMUM         = static_cast<RealT>(0.01);
+        static constexpr RealT VMEAS_MINIMUM = static_cast<RealT>(0.01);
 
         BusT* bus_{nullptr};
 

--- a/GridKit/Model/PhasorDynamics/Controller/REECB/ReecbImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REECB/ReecbImpl.hpp
@@ -1433,7 +1433,7 @@ namespace GridKit
        * @brief Static method to log time constant warnings
        *
        * @note Used in combination with static std:once_flag and std:call_once,
-       *       to reduce the number of times the warning is printed. 
+       *       to reduce the number of times the warning is printed.
        */
       template <typename scalar_type, typename index_type>
       void Reecb<scalar_type, index_type>::logTimeConstantWarning()

--- a/GridKit/Model/PhasorDynamics/Controller/REECB/ReecbImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REECB/ReecbImpl.hpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <cassert>
 #include <limits>
+#include <mutex>
 #include <numbers>
 #include <numeric>
 #include <variant>
@@ -1428,6 +1429,14 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(ReecbInternalVariables::PMEAS)]; });
       }
 
+      template <typename scalar_type, typename index_type>
+      void Reecb<scalar_type, index_type>::logTimeConstantWarning()
+      {
+        Log::warning() << "Reecb: any of Trv, Tp, Tiq, or Tpord below "
+                       << TIME_CONSTANT_MINIMUM
+                       << " s is raised to that floor to keep the controller lags well posed\n";
+      }
+
       /**
        * @brief Resolve parameter-derived constants and selector masks
        *
@@ -1447,9 +1456,9 @@ namespace GridKit
 
         if (floor_warning)
         {
-          Log::warning() << "Reecb: any of Trv, Tp, Tiq, or Tpord below "
-                         << TIME_CONSTANT_MINIMUM
-                         << " s is raised to that floor to keep the controller lags well posed\n";
+          static std::once_flag time_constant_warning_flag_;
+          std::call_once(time_constant_warning_flag_,
+                         &logTimeConstantWarning);
         }
 
         va_component_base_ = mva_base_ * static_cast<RealT>(1.0e6);

--- a/GridKit/Model/PhasorDynamics/Controller/REECB/ReecbImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REECB/ReecbImpl.hpp
@@ -1429,6 +1429,12 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(ReecbInternalVariables::PMEAS)]; });
       }
 
+      /**
+       * @brief Static method to log time constant warnings
+       *
+       * @note Used in combination with static std:once_flag and std:call_once,
+       *       to reduce the number of times the warning is printed. 
+       */
       template <typename scalar_type, typename index_type>
       void Reecb<scalar_type, index_type>::logTimeConstantWarning()
       {

--- a/GridKit/Model/PhasorDynamics/Controller/REPCA/Repca.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REPCA/Repca.hpp
@@ -161,7 +161,7 @@ namespace GridKit
         ScalarT& Vi();
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
-        static void logTimeConstantWarning();
+        static void            logTimeConstantWarning();
 
         static constexpr RealT INITIALIZATION_LIMIT_OFFSET = static_cast<RealT>(0.1);
 

--- a/GridKit/Model/PhasorDynamics/Controller/REPCA/Repca.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REPCA/Repca.hpp
@@ -161,6 +161,7 @@ namespace GridKit
         ScalarT& Vi();
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
+        static void logTimeConstantWarning();
 
         static constexpr RealT INITIALIZATION_LIMIT_OFFSET = static_cast<RealT>(0.1);
 

--- a/GridKit/Model/PhasorDynamics/Controller/REPCA/RepcaImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REPCA/RepcaImpl.hpp
@@ -988,7 +988,7 @@ namespace GridKit
        * @brief Static method to log time constant warnings
        *
        * @note Used in combination with static std:once_flag and std:call_once,
-       *       to reduce the number of times the warning is printed. 
+       *       to reduce the number of times the warning is printed.
        */
       template <typename scalar_type, typename index_type>
       void Repca<scalar_type, index_type>::logTimeConstantWarning()

--- a/GridKit/Model/PhasorDynamics/Controller/REPCA/RepcaImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REPCA/RepcaImpl.hpp
@@ -984,6 +984,12 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(RepcaInternalVariables::PMEAS)]; });
       }
 
+      /**
+       * @brief Static method to log time constant warnings
+       *
+       * @note Used in combination with static std:once_flag and std:call_once,
+       *       to reduce the number of times the warning is printed. 
+       */
       template <typename scalar_type, typename index_type>
       void Repca<scalar_type, index_type>::logTimeConstantWarning()
       {

--- a/GridKit/Model/PhasorDynamics/Controller/REPCA/RepcaImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Controller/REPCA/RepcaImpl.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <algorithm>
+#include <mutex>
 #include <variant>
 
 #include <GridKit/Model/PhasorDynamics/BusBase.hpp>
@@ -983,6 +984,14 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(RepcaInternalVariables::PMEAS)]; });
       }
 
+      template <typename scalar_type, typename index_type>
+      void Repca<scalar_type, index_type>::logTimeConstantWarning()
+      {
+        Log::warning() << "Repca: Tfltr, Tfv, Tp, and Tlag below "
+                       << TIME_CONSTANT_MINIMUM
+                       << " s are raised to that floor to keep the controller lags well posed\n";
+      }
+
       /**
        * @brief Resolve parameter-derived constants
        *
@@ -1012,9 +1021,9 @@ namespace GridKit
         if (Tfltr_ < TIME_CONSTANT_MINIMUM || Tfv_ < TIME_CONSTANT_MINIMUM
             || Tp_ < TIME_CONSTANT_MINIMUM || Tlag_ < TIME_CONSTANT_MINIMUM)
         {
-          Log::warning() << "Repca: Tfltr, Tfv, Tp, and Tlag below "
-                         << TIME_CONSTANT_MINIMUM
-                         << " s are raised to that floor to keep the controller lags well posed\n";
+          static std::once_flag time_constant_warning_flag_;
+          std::call_once(time_constant_warning_flag_,
+                         &logTimeConstantWarning);
         }
 
         Tfltr_ = std::max(Tfltr_, TIME_CONSTANT_MINIMUM);

--- a/GridKit/Model/PhasorDynamics/Converter/REGCA/Regca.hpp
+++ b/GridKit/Model/PhasorDynamics/Converter/REGCA/Regca.hpp
@@ -203,7 +203,7 @@ namespace GridKit
         ScalarT& Ii();
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
-        static void logTimeConstantWarning();
+        static void            logTimeConstantWarning();
 
         BusT* bus_{nullptr};
 

--- a/GridKit/Model/PhasorDynamics/Converter/REGCA/Regca.hpp
+++ b/GridKit/Model/PhasorDynamics/Converter/REGCA/Regca.hpp
@@ -203,6 +203,7 @@ namespace GridKit
         ScalarT& Ii();
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
+        static void logTimeConstantWarning();
 
         BusT* bus_{nullptr};
 

--- a/GridKit/Model/PhasorDynamics/Converter/REGCA/RegcaImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Converter/REGCA/RegcaImpl.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <algorithm>
+#include <mutex>
 #include <variant>
 
 #include <GridKit/Model/PhasorDynamics/BusBase.hpp>
@@ -60,6 +61,14 @@ namespace GridKit
       {
       }
 
+      template <typename scalar_type, typename index_type>
+      void Regca<scalar_type, index_type>::logTimeConstantWarning()
+      {
+        Log::warning() << "Regca: Tg and TM below " << TIME_CONSTANT_MINIMUM
+                       << " s are raised to that floor to keep the current-control "
+                       << "and voltage-sensor lags well posed\n";
+      }
+
       /**
        * @brief Resolve parameter-derived constants and limiter selections.
        *
@@ -72,9 +81,9 @@ namespace GridKit
       {
         if (Tg_ < TIME_CONSTANT_MINIMUM || TM_ < TIME_CONSTANT_MINIMUM)
         {
-          Log::warning() << "Regca: Tg and TM below " << TIME_CONSTANT_MINIMUM
-                         << " s are raised to that floor to keep the current-control "
-                         << "and voltage-sensor lags well posed\n";
+          static std::once_flag time_constant_warning_flag_;
+          std::call_once(time_constant_warning_flag_,
+                         &logTimeConstantWarning);
         }
 
         Tg_          = std::max(Tg_, TIME_CONSTANT_MINIMUM);

--- a/GridKit/Model/PhasorDynamics/Converter/REGCA/RegcaImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Converter/REGCA/RegcaImpl.hpp
@@ -65,7 +65,7 @@ namespace GridKit
        * @brief Static method to log time constant warnings
        *
        * @note Used in combination with static std:once_flag and std:call_once,
-       *       to reduce the number of times the warning is printed. 
+       *       to reduce the number of times the warning is printed.
        */
       template <typename scalar_type, typename index_type>
       void Regca<scalar_type, index_type>::logTimeConstantWarning()

--- a/GridKit/Model/PhasorDynamics/Converter/REGCA/RegcaImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Converter/REGCA/RegcaImpl.hpp
@@ -61,6 +61,12 @@ namespace GridKit
       {
       }
 
+      /**
+       * @brief Static method to log time constant warnings
+       *
+       * @note Used in combination with static std:once_flag and std:call_once,
+       *       to reduce the number of times the warning is printed. 
+       */
       template <typename scalar_type, typename index_type>
       void Regca<scalar_type, index_type>::logTimeConstantWarning()
       {

--- a/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1a.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1a.hpp
@@ -140,7 +140,7 @@ namespace GridKit
         ScalarT& Vi();
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
-        static void logTimeConstantWarning();
+        static void            logTimeConstantWarning();
 
         BusT* bus_{nullptr};
 

--- a/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1a.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1a.hpp
@@ -140,6 +140,7 @@ namespace GridKit
         ScalarT& Vi();
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
+        static void logTimeConstantWarning();
 
         BusT* bus_{nullptr};
 

--- a/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1aImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1aImpl.hpp
@@ -766,7 +766,7 @@ namespace GridKit
        * @brief Static method to log time constant warnings
        *
        * @note Used in combination with static std:once_flag and std:call_once,
-       *       to reduce the number of times the warning is printed. 
+       *       to reduce the number of times the warning is printed.
        */
       template <typename scalar_type, typename index_type>
       void Esdc1a<scalar_type, index_type>::logTimeConstantWarning()

--- a/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1aImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1aImpl.hpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <mutex>
 #include <variant>
 
 #include <GridKit/Model/PhasorDynamics/BusBase.hpp>
@@ -761,6 +762,14 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(Esdc1aInternalVariables::VFE)]; });
       }
 
+      template <typename scalar_type, typename index_type>
+      void Esdc1a<scalar_type, index_type>::logTimeConstantWarning()
+      {
+        Log::warning() << "Esdc1a: Tr, Ta, Tb, Te, and Tf1 below "
+                       << TIME_CONSTANT_MINIMUM
+                       << " s are raised to that floor to keep the exciter lags well posed\n";
+      }
+
       /**
        * @brief Resolve the parameter-derived constants and selector masks
        *
@@ -796,9 +805,9 @@ namespace GridKit
             || Tb_ < TIME_CONSTANT_MINIMUM || Te_ < TIME_CONSTANT_MINIMUM
             || Tf1_ < TIME_CONSTANT_MINIMUM)
         {
-          Log::warning() << "Esdc1a: Tr, Ta, Tb, Te, and Tf1 below "
-                         << TIME_CONSTANT_MINIMUM
-                         << " s are raised to that floor to keep the exciter lags well posed\n";
+          static std::once_flag time_constant_warning_flag_;
+          std::call_once(time_constant_warning_flag_,
+                         &logTimeConstantWarning);
         }
 
         Tr_  = std::max(Tr_, TIME_CONSTANT_MINIMUM);

--- a/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1aImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/ESDC1A/Esdc1aImpl.hpp
@@ -762,6 +762,12 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(Esdc1aInternalVariables::VFE)]; });
       }
 
+      /**
+       * @brief Static method to log time constant warnings
+       *
+       * @note Used in combination with static std:once_flag and std:call_once,
+       *       to reduce the number of times the warning is printed. 
+       */
       template <typename scalar_type, typename index_type>
       void Esdc1a<scalar_type, index_type>::logTimeConstantWarning()
       {

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -125,6 +125,7 @@ namespace GridKit
 
       private:
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
+        static void logTimeConstantWarning();
 
         // Signal pointers
         BusT* bus_;

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp
@@ -125,7 +125,7 @@ namespace GridKit
 
       private:
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
-        static void logTimeConstantWarning();
+        static void            logTimeConstantWarning();
 
         // Signal pointers
         BusT* bus_;

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <mutex>
 
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
 #include <GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1.hpp>
@@ -491,6 +492,14 @@ namespace GridKit
         setDerivedParameters();
       }
 
+      template <typename scalar_type, typename index_type>
+      void Ieeet1<scalar_type, index_type>::logTimeConstantWarning()
+      {
+        Log::warning() << "Ieeet1: Tr, Ta, Te, and Tf below "
+                       << TIME_CONSTANT_MINIMUM
+                       << " s are raised to that floor\n";
+      }
+
       /**
        * @brief Resolve the parameter-derived constants
        */
@@ -500,9 +509,9 @@ namespace GridKit
         if (Tr_ < TIME_CONSTANT_MINIMUM || Ta_ < TIME_CONSTANT_MINIMUM
             || Te_ < TIME_CONSTANT_MINIMUM || Tf_ < TIME_CONSTANT_MINIMUM)
         {
-          Log::warning() << "Ieeet1: Tr, Ta, Te, and Tf below "
-                         << TIME_CONSTANT_MINIMUM
-                         << " s are raised to that floor\n";
+          static std::once_flag time_constant_warning_flag_;
+          std::call_once(time_constant_warning_flag_,
+                         &logTimeConstantWarning);
         }
 
         Tr_ = std::max(Tr_, TIME_CONSTANT_MINIMUM);

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -492,6 +492,12 @@ namespace GridKit
         setDerivedParameters();
       }
 
+      /**
+       * @brief Static method to log time constant warnings
+       *
+       * @note Used in combination with static std:once_flag and std:call_once,
+       *       to reduce the number of times the warning is printed. 
+       */
       template <typename scalar_type, typename index_type>
       void Ieeet1<scalar_type, index_type>::logTimeConstantWarning()
       {

--- a/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Exciter/IEEET1/Ieeet1Impl.hpp
@@ -496,7 +496,7 @@ namespace GridKit
        * @brief Static method to log time constant warnings
        *
        * @note Used in combination with static std:once_flag and std:call_once,
-       *       to reduce the number of times the warning is printed. 
+       *       to reduce the number of times the warning is printed.
        */
       template <typename scalar_type, typename index_type>
       void Ieeet1<scalar_type, index_type>::logTimeConstantWarning()

--- a/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPti.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPti.hpp
@@ -122,6 +122,7 @@ namespace GridKit
         RealT                                     toSystemBase(RealT value) const;
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
+        static void logTimeConstantWarning();
 
         RealT R_{static_cast<RealT>(0.05)};
         RealT T1_{static_cast<RealT>(0.4)};

--- a/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPti.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPti.hpp
@@ -122,7 +122,7 @@ namespace GridKit
         RealT                                     toSystemBase(RealT value) const;
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
-        static void logTimeConstantWarning();
+        static void            logTimeConstantWarning();
 
         RealT R_{static_cast<RealT>(0.05)};
         RealT T1_{static_cast<RealT>(0.4)};

--- a/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPtiImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPtiImpl.hpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <mutex>
 #include <variant>
 
 #include <GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPti.hpp>
@@ -712,6 +713,14 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(GastPtiInternalVariables::VTEMP)]; });
       }
 
+      template <typename scalar_type, typename index_type>
+      void GastPti<scalar_type, index_type>::logTimeConstantWarning()
+      {
+        Log::warning() << "GastPti: T1, T2, and T3 below "
+                       << TIME_CONSTANT_MINIMUM
+                       << " s are raised to that floor to keep the turbine lags well posed\n";
+      }
+
       /**
        * @brief Resolve the parameter-derived constants
        *
@@ -735,9 +744,9 @@ namespace GridKit
 
         if (floor_warning)
         {
-          Log::warning() << "GastPti: T1, T2, and T3 below "
-                         << TIME_CONSTANT_MINIMUM
-                         << " s are raised to that floor to keep the turbine lags well posed\n";
+          static std::once_flag time_constant_warning_flag_;
+          std::call_once(time_constant_warning_flag_,
+                         &logTimeConstantWarning);
         }
 
         va_component_base_ = ZERO<RealT>;

--- a/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPtiImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPtiImpl.hpp
@@ -713,6 +713,12 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(GastPtiInternalVariables::VTEMP)]; });
       }
 
+      /**
+       * @brief Static method to log time constant warnings
+       *
+       * @note Used in combination with static std:once_flag and std:call_once,
+       *       to reduce the number of times the warning is printed. 
+       */
       template <typename scalar_type, typename index_type>
       void GastPti<scalar_type, index_type>::logTimeConstantWarning()
       {

--- a/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPtiImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/GASTPTI/GastPtiImpl.hpp
@@ -717,7 +717,7 @@ namespace GridKit
        * @brief Static method to log time constant warnings
        *
        * @note Used in combination with static std:once_flag and std:call_once,
-       *       to reduce the number of times the warning is printed. 
+       *       to reduce the number of times the warning is printed.
        */
       template <typename scalar_type, typename index_type>
       void GastPti<scalar_type, index_type>::logTimeConstantWarning()

--- a/GridKit/Model/PhasorDynamics/Governor/HYGOV/Hygov.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/HYGOV/Hygov.hpp
@@ -152,6 +152,7 @@ namespace GridKit
         ScalarT toSystemBase(ScalarT value) const;
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
+        static void logTimeConstantWarning();
 
         /// Accepted seed distance beyond the achievable-power range edge.
         static constexpr RealT INITIALIZATION_TOLERANCE =

--- a/GridKit/Model/PhasorDynamics/Governor/HYGOV/Hygov.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/HYGOV/Hygov.hpp
@@ -152,7 +152,7 @@ namespace GridKit
         ScalarT toSystemBase(ScalarT value) const;
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
-        static void logTimeConstantWarning();
+        static void            logTimeConstantWarning();
 
         /// Accepted seed distance beyond the achievable-power range edge.
         static constexpr RealT INITIALIZATION_TOLERANCE =

--- a/GridKit/Model/PhasorDynamics/Governor/HYGOV/HygovImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/HYGOV/HygovImpl.hpp
@@ -765,6 +765,12 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(HygovInternalVariables::H)]; });
       }
 
+      /**
+       * @brief Static method to log time constant warnings
+       *
+       * @note Used in combination with static std:once_flag and std:call_once,
+       *       to reduce the number of times the warning is printed. 
+       */
       template <typename scalar_type, typename index_type>
       void Hygov<scalar_type, index_type>::logTimeConstantWarning()
       {

--- a/GridKit/Model/PhasorDynamics/Governor/HYGOV/HygovImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/HYGOV/HygovImpl.hpp
@@ -769,7 +769,7 @@ namespace GridKit
        * @brief Static method to log time constant warnings
        *
        * @note Used in combination with static std:once_flag and std:call_once,
-       *       to reduce the number of times the warning is printed. 
+       *       to reduce the number of times the warning is printed.
        */
       template <typename scalar_type, typename index_type>
       void Hygov<scalar_type, index_type>::logTimeConstantWarning()

--- a/GridKit/Model/PhasorDynamics/Governor/HYGOV/HygovImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/HYGOV/HygovImpl.hpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <mutex>
 #include <numeric>
 #include <variant>
 
@@ -764,6 +765,14 @@ namespace GridKit
                       { return y_.getData()[static_cast<size_t>(HygovInternalVariables::H)]; });
       }
 
+      template <typename scalar_type, typename index_type>
+      void Hygov<scalar_type, index_type>::logTimeConstantWarning()
+      {
+        Log::warning() << "Hygov: Tr, Tf, Tg, Tw, and Tnp below "
+                       << TIME_CONSTANT_MINIMUM
+                       << " s are raised to preserve Hessenberg form\n";
+      }
+
       /**
        * @brief Resolve the parameter-derived constants
        *
@@ -816,9 +825,9 @@ namespace GridKit
             || Tg_ < TIME_CONSTANT_MINIMUM || Tw_ < TIME_CONSTANT_MINIMUM
             || Tnp_ < TIME_CONSTANT_MINIMUM)
         {
-          Log::warning() << "Hygov: Tr, Tf, Tg, Tw, and Tnp below "
-                         << TIME_CONSTANT_MINIMUM
-                         << " s are raised to preserve Hessenberg form\n";
+          static std::once_flag time_constant_warning_flag_;
+          std::call_once(time_constant_warning_flag_,
+                         &logTimeConstantWarning);
         }
 
         // HYGOV residuals solve explicitly for the state derivatives to preserve

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -142,6 +142,7 @@ namespace GridKit
         ScalarT toSystemBase(ScalarT value) const;
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
+        static void logTimeConstantWarning();
 
         /* Local copies of signal variables */
         std::vector<ScalarT> ws_;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp
@@ -142,7 +142,7 @@ namespace GridKit
         ScalarT toSystemBase(ScalarT value) const;
 
         static constexpr RealT TIME_CONSTANT_MINIMUM = static_cast<RealT>(1.0e-3);
-        static void logTimeConstantWarning();
+        static void            logTimeConstantWarning();
 
         /* Local copies of signal variables */
         std::vector<ScalarT> ws_;

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <mutex>
 
 #include <GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1.hpp>
 #include <GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Data.hpp>
@@ -129,12 +130,20 @@ namespace GridKit
       }
 
       template <typename scalar_type, typename index_type>
+      void Tgov1<scalar_type, index_type>::logTimeConstantWarning()
+      {
+        Log::warning() << "Tgov1: T1 and T3 below " << TIME_CONSTANT_MINIMUM
+                       << " s are raised to that floor\n";
+      }
+
+      template <typename scalar_type, typename index_type>
       void Tgov1<scalar_type, index_type>::setDerivedParams()
       {
         if (T1_ < TIME_CONSTANT_MINIMUM || T3_ < TIME_CONSTANT_MINIMUM)
         {
-          Log::warning() << "Tgov1: T1 and T3 below " << TIME_CONSTANT_MINIMUM
-                         << " s are raised to that floor\n";
+          static std::once_flag time_constant_warning_flag_;
+          std::call_once(time_constant_warning_flag_,
+                         &logTimeConstantWarning);
         }
 
         T1_ = std::max(T1_, TIME_CONSTANT_MINIMUM);

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -133,7 +133,7 @@ namespace GridKit
        * @brief Static method to log time constant warnings
        *
        * @note Used in combination with static std:once_flag and std:call_once,
-       *       to reduce the number of times the warning is printed. 
+       *       to reduce the number of times the warning is printed.
        */
       template <typename scalar_type, typename index_type>
       void Tgov1<scalar_type, index_type>::logTimeConstantWarning()

--- a/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
+++ b/GridKit/Model/PhasorDynamics/Governor/Tgov1/Tgov1Impl.hpp
@@ -129,6 +129,12 @@ namespace GridKit
         }
       }
 
+      /**
+       * @brief Static method to log time constant warnings
+       *
+       * @note Used in combination with static std:once_flag and std:call_once,
+       *       to reduce the number of times the warning is printed. 
+       */
       template <typename scalar_type, typename index_type>
       void Tgov1<scalar_type, index_type>::logTimeConstantWarning()
       {


### PR DESCRIPTION
## Description
 
This uses `std:once_flag` and `std::call_once` to only warn user about the raised time constants once.
This removes the excessive warnings for this known issue. 
 
 ## Proposed changes
 
- Added `static void logTimeConstantWarning()` to the relevant header files after `TIME_CONSTANT_MINIMUM`
- Moved `Log::Warning()` call to the static method
- Introduced `std:once_flag` and `std::call_once` at the call site, when the warning is warranted.
 
 ## Checklist
 
- [x ] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [N/A] The [CHANGELOG.md](/CHANGELOG.md) has been updated to reflect the changes. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 Will need to better generalize if a similar pattern is needed later.
