### PR TITLE
Cloning Components in PowerElectronics Module

### DIFF
--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
@@ -55,6 +55,25 @@ namespace GridKit
   }
 
   /**
+   * @brief Compute the absolute tolerance for each variable in the model
+   *
+   * @param rel_tol The relative tolerance which can be used to pick the
+   *        absolute tolerance.
+   * @tparam ScalarT Scalar data type
+   * @tparam IdxT Index data type
+   * @return int 0 if successful, non-zero otherwise.
+   *
+   * This represents a "noise" level close to zero for which pure relative
+   * error cannot be used.
+   */
+  template <class ScalarT, typename IdxT>
+  int Capacitor<ScalarT, IdxT>::setAbsoluteTolerance(RealT rel_tol)
+  {
+    abs_tol_.setToConst(static_cast<ScalarT>(rel_tol));
+    return 0;
+  }
+
+  /**
    * @brief Evaluate the resisdual of the Capcitor
    *
    */
@@ -117,6 +136,18 @@ namespace GridKit
   int Capacitor<ScalarT, IdxT>::evaluateAdjointIntegrand()
   {
     return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  bool Capacitor<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* Capacitor<ScalarT, IdxT>::clone() const
+  {
+    return new Capacitor<ScalarT, IdxT>(*this);
   }
 
   // Available template instantiations

--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.cpp
@@ -139,12 +139,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool Capacitor<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* Capacitor<ScalarT, IdxT>::clone() const
   {
     return new Capacitor<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.hpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.hpp
@@ -29,6 +29,7 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::y_int_;
     using CircuitComponent<ScalarT, IdxT>::yp_ext_;
     using CircuitComponent<ScalarT, IdxT>::yp_int_;
+    using CircuitComponent<ScalarT, IdxT>::abs_tol_;
     using CircuitComponent<ScalarT, IdxT>::tag_;
     using CircuitComponent<ScalarT, IdxT>::f_ext_;
     using CircuitComponent<ScalarT, IdxT>::f_int_;
@@ -50,15 +51,19 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
+    int setAbsoluteTolerance(RealT);
     int evaluateInternalResidual() final;
     int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT C_;

--- a/GridKit/Model/PowerElectronics/Capacitor/Capacitor.hpp
+++ b/GridKit/Model/PowerElectronics/Capacitor/Capacitor.hpp
@@ -57,11 +57,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -27,6 +27,138 @@ namespace GridKit
 
     CircuitComponent() = default;
 
+    CircuitComponent(const CircuitComponent& other)
+      : n_extern_(other.n_extern_),
+        n_intern_(other.n_intern_),
+        extern_indices_(other.extern_indices_),
+        size_(other.size_),
+        nnz_(other.nnz_),
+        size_quad_(other.size_quad_),
+        size_opt_(other.size_opt_),
+        current_jac_size_(other.current_jac_size_),
+
+        // These pointers refer to storage supplied by a parent system.
+        // The copied component must be connected to its own storage later.
+        y_int_(nullptr),
+        yp_int_(nullptr),
+        f_int_(nullptr),
+
+        tag_(other.tag_),
+        time_(other.time_),
+        alpha_(other.alpha_),
+        max_steps_(other.max_steps_),
+        idc_(other.idc_),
+        allocated_(other.allocated_)
+    {
+      /*
+       * VectorT disables its normal copy constructor and copy-assignment
+       * operator. Use its provided copyFromExternal() operation to perform
+       * an independent copy of the vector data.
+       */
+      auto copyVector = [](VectorT& destination, const VectorT& source)
+      {
+        const IdxT source_size = source.getSize();
+
+        if (source_size == 0)
+        {
+          return;
+        }
+
+        destination.resize(source_size);
+        destination.copyFromExternal(source);
+      };
+
+      /*
+       * Deep-copy the local-to-global connection mapping.
+       */
+      if (other.connection_nodes_)
+      {
+        connection_nodes_ = std::make_unique<IdxT[]>(static_cast<size_t>(size_));
+
+        for (size_t i = 0; i < static_cast<size_t>(size_); ++i)
+        {
+          connection_nodes_[i] = other.connection_nodes_[i];
+        }
+      }
+
+      /*
+       * Deep-copy the COO Jacobian row indices.
+       */
+      if (other.jacobian_coo_rows_)
+      {
+        jacobian_coo_rows_ = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
+
+        for (size_t i = 0; i < static_cast<size_t>(nnz_); ++i)
+        {
+          jacobian_coo_rows_[i] = other.jacobian_coo_rows_[i];
+        }
+      }
+
+      /*
+       * Deep-copy the COO Jacobian column indices.
+       */
+      if (other.jacobian_coo_cols_)
+      {
+        jacobian_coo_cols_ = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
+
+        for (size_t i = 0; i < static_cast<size_t>(nnz_); ++i)
+        {
+          jacobian_coo_cols_[i] = other.jacobian_coo_cols_[i];
+        }
+      }
+
+      /*
+       * Deep-copy the COO Jacobian values.
+       */
+      if (other.jacobian_coo_values_)
+      {
+        jacobian_coo_values_ = std::make_unique<RealT[]>(static_cast<size_t>(nnz_));
+
+        for (size_t i = 0; i < static_cast<size_t>(nnz_); ++i)
+        {
+          jacobian_coo_values_[i] = other.jacobian_coo_values_[i];
+        }
+      }
+
+      if (size_ > 0)
+      {
+        y_ext_  = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
+        yp_ext_ = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
+        f_ext_  = std::make_unique<ScalarT*[]>(static_cast<size_t>(size_));
+
+        for (size_t i = 0; i < static_cast<size_t>(size_); ++i)
+        {
+          y_ext_[i]  = nullptr;
+          yp_ext_[i] = nullptr;
+          f_ext_[i]  = nullptr;
+        }
+      }
+
+      // State, state derivative, residual, and absolute tolerance.
+      copyVector(y_, other.y_);
+      copyVector(yp_, other.yp_);
+      copyVector(f_, other.f_);
+      copyVector(abs_tol_, other.abs_tol_);
+      copyVector(g_, other.g_);
+      copyVector(yB_, other.yB_);
+      copyVector(ypB_, other.ypB_);
+      copyVector(fB_, other.fB_);
+      copyVector(gB_, other.gB_);
+      copyVector(param_, other.param_);
+      copyVector(param_up_, other.param_up_);
+      copyVector(param_lo_, other.param_lo_);
+    }
+
+    virtual CircuitComponent<ScalarT, IdxT>* clone() const
+    {
+      return nullptr;
+    }
+
+    virtual bool isCloneable() const
+    {
+      return false;
+    }
+
     /**
      * @note Cannot be marked final, since it is overriden to recurse in the system model.
      */
@@ -51,7 +183,7 @@ namespace GridKit
       return this->n_intern_;
     }
 
-    std::set<size_t> getExternIndices()
+    std::set<IdxT> getExternIndices()
     {
       return this->extern_indices_;
     }
@@ -69,7 +201,7 @@ namespace GridKit
     int setInternalConnectionNodes(size_t local_index, IdxT global_index)
     {
       assert(!extern_indices_.contains(static_cast<IdxT>(local_index)));
-      connection_nodes_[local_index] = global_index;
+      setConnectionNodes(local_index, global_index);
       return 0;
     }
 
@@ -88,10 +220,27 @@ namespace GridKit
     int setExternalConnectionNodes(size_t local_index, ExternalConnection<ScalarT, IdxT> connection)
     {
       assert(extern_indices_.contains(local_index));
-      y_ext_[local_index]            = connection.y_;
-      yp_ext_[local_index]           = connection.yp_;
-      f_ext_[local_index]            = connection.f_;
-      connection_nodes_[local_index] = connection.idx_;
+      y_ext_[local_index]  = connection.y_;
+      yp_ext_[local_index] = connection.yp_;
+      f_ext_[local_index]  = connection.f_;
+      setConnectionNodes(local_index, connection.idx_);
+      return 0;
+    }
+
+    /**
+     * @brief Update the connection index for a variable.
+     *
+     * Sets only the connection index without modifying the variable's
+     * internal/external classification or its associated data pointers.
+     *
+     * @param local_index Index of the local variable.
+     * @param connection_index New connection index for the variable.
+     *
+     * @return int 0 if successful.
+     */
+    int setConnectionNodes(size_t local_index, IdxT connection_index)
+    {
+      connection_nodes_[local_index] = connection_index;
       return 0;
     }
 
@@ -132,9 +281,10 @@ namespace GridKit
       jacobian_coo_cols_   = std::make_unique<IdxT[]>(static_cast<size_t>(nnz_));
       jacobian_coo_values_ = std::make_unique<RealT[]>(static_cast<size_t>(nnz_));
 
-      y_ext_            = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
-      yp_ext_           = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
-      f_ext_            = std::make_unique<ScalarT*[]>(static_cast<size_t>(size_));
+      y_ext_  = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
+      yp_ext_ = std::make_unique<const ScalarT*[]>(static_cast<size_t>(size_));
+      f_ext_  = std::make_unique<ScalarT*[]>(static_cast<size_t>(size_));
+
       connection_nodes_ = std::make_unique<IdxT[]>(static_cast<size_t>(size_));
 
       tag_.resize(static_cast<size_t>(size_));
@@ -439,6 +589,16 @@ namespace GridKit
     IdxT getIDcomponent() const
     {
       return idc_;
+    }
+
+    /**
+     * @brief Check whether the component has already been allocated.
+     *
+     * @return true if allocate() has previously completed, false otherwise.
+     */
+    bool isAllocated() const
+    {
+      return allocated_;
     }
 
   protected:

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -50,11 +50,7 @@ namespace GridKit
         idc_(other.idc_),
         allocated_(other.allocated_)
     {
-      /*
-       * VectorT disables its normal copy constructor and copy-assignment
-       * operator. Use its provided copyFromExternal() operation to perform
-       * an independent copy of the vector data.
-       */
+
       auto copyVector = [](VectorT& destination, const VectorT& source)
       {
         const IdxT source_size = source.getSize();
@@ -149,11 +145,30 @@ namespace GridKit
       copyVector(param_lo_, other.param_lo_);
     }
 
+    /**
+     * @brief Create an independent copy of this component.
+     *
+     * The clone preserves the component's model configuration, parameters,
+     * topology, and structural data, but does not preserve bindings to
+     * system-owned state or residual storage.
+     *
+     * @note By default, the cloned component's state, state-derivative, and
+     * residual pointers are not set. The user is responsible for setting these
+     * pointers to the appropriate storage before evaluating the residual.
+     */
     virtual CircuitComponent<ScalarT, IdxT>* clone() const
     {
       return nullptr;
     }
 
+    /**
+     * @brief Indicates whether this component supports cloning.
+     *
+     * Derived components that implement clone() should override this method
+     * and return true.
+     *
+     * @return true if the component can be cloned, false otherwise.
+     */
     virtual bool isCloneable() const
     {
       return false;

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -29,7 +29,7 @@ namespace GridKit
     CircuitComponent() = default;
 
     /**
-     * @brief Constructs an independent copy of a circuit component.
+     * @brief Constructs a copy of a circuit component.
      *
      * Copies the component metadata, local vector data, connection-node mapping,
      * and COO Jacobian storage. Dynamically allocated component-owned data is
@@ -37,11 +37,11 @@ namespace GridKit
      * storage with @p other.
      *
      * Pointers to state, state-derivative, and residual storage supplied by a
-     * parent system are intentionally not copied. The internal pointers
-     * (`y_int_`, `yp_int_`, and `f_int_`) are initialized to `nullptr`, and the
-     * external variable pointers (`y_ext_`, `yp_ext_`, and `f_ext_`) are allocated
-     * but initialized to `nullptr`. The copied component must therefore be
-     * connected to the appropriate parent-system storage before it is evaluated.
+     * parent system are copied as-is. Consequently, the copied component initially
+     * references the same parent-system storage as @p other. The pointer arrays
+     * used for external variables are independently allocated, but their entries
+     * point to the same external state, state-derivative, and residual storage as
+     * the original component.
      *
      * Local vectors, including the state, state derivative, residual, tolerances,
      * quadrature data, adjoint data, and parameter vectors, retain the values of
@@ -49,9 +49,9 @@ namespace GridKit
      *
      * @param other Component to copy.
      *
-     * @note Copying a component reproduces its component-owned data and structural
-     *       information, but does not preserve its connections to parent-system
-     *       state or residual storage.
+     * @note If the copied component is subsequently attached to a different parent
+     *       system, its state, state-derivative, and residual pointers must be
+     *       reassigned to the storage provided by that system before evaluation.
      */
     CircuitComponent(const CircuitComponent& other)
       : n_extern_(other.n_extern_),
@@ -62,13 +62,9 @@ namespace GridKit
         size_quad_(other.size_quad_),
         size_opt_(other.size_opt_),
         current_jac_size_(other.current_jac_size_),
-
-        // These pointers refer to storage supplied by a parent system.
-        // The copied component must be connected to its own storage later.
-        y_int_(nullptr),
-        yp_int_(nullptr),
-        f_int_(nullptr),
-
+        y_int_(other.y_int_),
+        yp_int_(other.yp_int_),
+        f_int_(other.f_int_),
         tag_(other.tag_),
         time_(other.time_),
         alpha_(other.alpha_),
@@ -150,9 +146,9 @@ namespace GridKit
 
         for (size_t i = 0; i < static_cast<size_t>(size_); ++i)
         {
-          y_ext_[i]  = nullptr;
-          yp_ext_[i] = nullptr;
-          f_ext_[i]  = nullptr;
+          y_ext_[i]  = other.y_ext_[i];
+          yp_ext_[i] = other.yp_ext_[i];
+          f_ext_[i]  = other.f_ext_[i];
         }
       }
 

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <memory>
 #include <set>
+#include <stdexcept>
 #include <vector>
 
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
@@ -27,6 +28,31 @@ namespace GridKit
 
     CircuitComponent() = default;
 
+    /**
+     * @brief Constructs an independent copy of a circuit component.
+     *
+     * Copies the component metadata, local vector data, connection-node mapping,
+     * and COO Jacobian storage. Dynamically allocated component-owned data is
+     * deep-copied so that the new component does not share ownership of this
+     * storage with @p other.
+     *
+     * Pointers to state, state-derivative, and residual storage supplied by a
+     * parent system are intentionally not copied. The internal pointers
+     * (`y_int_`, `yp_int_`, and `f_int_`) are initialized to `nullptr`, and the
+     * external variable pointers (`y_ext_`, `yp_ext_`, and `f_ext_`) are allocated
+     * but initialized to `nullptr`. The copied component must therefore be
+     * connected to the appropriate parent-system storage before it is evaluated.
+     *
+     * Local vectors, including the state, state derivative, residual, tolerances,
+     * quadrature data, adjoint data, and parameter vectors, retain the values of
+     * the original component.
+     *
+     * @param other Component to copy.
+     *
+     * @note Copying a component reproduces its component-owned data and structural
+     *       information, but does not preserve its connections to parent-system
+     *       state or residual storage.
+     */
     CircuitComponent(const CircuitComponent& other)
       : n_extern_(other.n_extern_),
         n_intern_(other.n_intern_),
@@ -158,7 +184,7 @@ namespace GridKit
      */
     virtual CircuitComponent<ScalarT, IdxT>* clone() const
     {
-      return nullptr;
+      throw std::runtime_error("clone() is not supported for this component.");
     }
 
     /**

--- a/GridKit/Model/PowerElectronics/CircuitComponent.hpp
+++ b/GridKit/Model/PowerElectronics/CircuitComponent.hpp
@@ -28,6 +28,7 @@ namespace GridKit
 
     CircuitComponent() = default;
 
+  protected:
     /**
      * @brief Constructs a copy of a circuit component.
      *
@@ -167,6 +168,7 @@ namespace GridKit
       copyVector(param_lo_, other.param_lo_);
     }
 
+  public:
     /**
      * @brief Create an independent copy of this component.
      *
@@ -688,7 +690,6 @@ namespace GridKit
      */
     std::unique_ptr<IdxT[]> connection_nodes_;
 
-  protected:
     /// The number of variables in this component. Should be equal to \ref n_extern_ plus \ref n_intern_. \see size()
     IdxT size_{0};
     /// The number of nonzero elements in this component's Jacobian. \see nnz()

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
@@ -422,6 +422,18 @@ namespace GridKit
     return 0;
   }
 
+  template <class ScalarT, typename IdxT>
+  bool DistributedGenerator<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* DistributedGenerator<ScalarT, IdxT>::clone() const
+  {
+    return new DistributedGenerator<ScalarT, IdxT>(*this);
+  }
+
   // Available template instantiations
   template class DistributedGenerator<double, long int>;
   template class DistributedGenerator<double, size_t>;

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.cpp
@@ -423,12 +423,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool DistributedGenerator<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* DistributedGenerator<ScalarT, IdxT>::clone() const
   {
     return new DistributedGenerator<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
@@ -75,18 +75,21 @@ namespace GridKit
                          NodeT*                                      node_bus);
     virtual ~DistributedGenerator();
 
-    int initialize();
-    int allocate() final;
-    int tagDifferentiable();
-    int setAbsoluteTolerance(RealT);
-    int evaluateInternalResidual() final;
-    int evaluateExternalResidual() final;
-    int evaluateJacobian();
-    int evaluateIntegrand();
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initialize();
+    int  allocate() final;
+    int  tagDifferentiable();
+    int  setAbsoluteTolerance(RealT);
+    int  evaluateInternalResidual() final;
+    int  evaluateExternalResidual() final;
+    int  evaluateJacobian();
+    int  evaluateIntegrand();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT wb_;

--- a/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
+++ b/GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp
@@ -75,19 +75,18 @@ namespace GridKit
                          NodeT*                                      node_bus);
     virtual ~DistributedGenerator();
 
-    int  initialize();
-    int  allocate() final;
-    int  tagDifferentiable();
-    int  setAbsoluteTolerance(RealT);
-    int  evaluateInternalResidual() final;
-    int  evaluateExternalResidual() final;
-    int  evaluateJacobian();
-    int  evaluateIntegrand();
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initialize();
+    int allocate() final;
+    int tagDifferentiable();
+    int setAbsoluteTolerance(RealT);
+    int evaluateInternalResidual() final;
+    int evaluateExternalResidual() final;
+    int evaluateJacobian();
+    int evaluateIntegrand();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
@@ -66,6 +66,25 @@ namespace GridKit
   }
 
   /**
+   * @brief Compute the absolute tolerance for each variable in the model
+   *
+   * @param rel_tol The relative tolerance which can be used to pick the
+   *        absolute tolerance.
+   * @tparam ScalarT Scalar data type
+   * @tparam IdxT Index data type
+   * @return int 0 if successful, non-zero otherwise.
+   *
+   * This represents a "noise" level close to zero for which pure relative
+   * error cannot be used.
+   */
+  template <class ScalarT, typename IdxT>
+  int InductionMotor<ScalarT, IdxT>::setAbsoluteTolerance(RealT rel_tol)
+  {
+    abs_tol_.setToConst(static_cast<ScalarT>(rel_tol));
+    return 0;
+  }
+
+  /**
    * @brief Contributes to the resisdual
    *
    */
@@ -129,6 +148,18 @@ namespace GridKit
   int InductionMotor<ScalarT, IdxT>::evaluateAdjointIntegrand()
   {
     return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  bool InductionMotor<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* InductionMotor<ScalarT, IdxT>::clone() const
+  {
+    return new InductionMotor<ScalarT, IdxT>(*this);
   }
 
   // Available template instantiations

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.cpp
@@ -151,12 +151,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool InductionMotor<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* InductionMotor<ScalarT, IdxT>::clone() const
   {
     return new InductionMotor<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
@@ -29,6 +29,7 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::y_int_;
     using CircuitComponent<ScalarT, IdxT>::yp_ext_;
     using CircuitComponent<ScalarT, IdxT>::yp_int_;
+    using CircuitComponent<ScalarT, IdxT>::abs_tol_;
     using CircuitComponent<ScalarT, IdxT>::tag_;
     using CircuitComponent<ScalarT, IdxT>::f_ext_;
     using CircuitComponent<ScalarT, IdxT>::f_int_;
@@ -50,15 +51,19 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
+    int setAbsoluteTolerance(RealT);
     int evaluateInternalResidual() final;
     int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT Lls_;

--- a/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
+++ b/GridKit/Model/PowerElectronics/InductionMotor/InductionMotor.hpp
@@ -57,11 +57,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
@@ -149,6 +149,18 @@ namespace GridKit
     return 0;
   }
 
+  template <class ScalarT, typename IdxT>
+  bool Inductor<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* Inductor<ScalarT, IdxT>::clone() const
+  {
+    return new Inductor<ScalarT, IdxT>(*this);
+  }
+
   // Available template instantiations
   template class Inductor<double, long int>;
   template class Inductor<double, size_t>;

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.cpp
@@ -150,12 +150,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool Inductor<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* Inductor<ScalarT, IdxT>::clone() const
   {
     return new Inductor<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.hpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.hpp
@@ -60,10 +60,13 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT  L_;

--- a/GridKit/Model/PowerElectronics/Inductor/Inductor.hpp
+++ b/GridKit/Model/PowerElectronics/Inductor/Inductor.hpp
@@ -60,11 +60,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
@@ -68,6 +68,25 @@ namespace GridKit
   }
 
   /**
+   * @brief Compute the absolute tolerance for each variable in the model
+   *
+   * @param rel_tol The relative tolerance which can be used to pick the
+   *        absolute tolerance.
+   * @tparam ScalarT Scalar data type
+   * @tparam IdxT Index data type
+   * @return int 0 if successful, non-zero otherwise.
+   *
+   * This represents a "noise" level close to zero for which pure relative
+   * error cannot be used.
+   */
+  template <class ScalarT, typename IdxT>
+  int LinearTransformer<ScalarT, IdxT>::setAbsoluteTolerance(RealT rel_tol)
+  {
+    abs_tol_.setToConst(static_cast<ScalarT>(rel_tol));
+    return 0;
+  }
+
+  /**
    * @brief Computes the component resisdual
    */
   template <class ScalarT, typename IdxT>
@@ -114,6 +133,18 @@ namespace GridKit
   int LinearTransformer<ScalarT, IdxT>::evaluateAdjointIntegrand()
   {
     return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  bool LinearTransformer<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* LinearTransformer<ScalarT, IdxT>::clone() const
+  {
+    return new LinearTransformer<ScalarT, IdxT>(*this);
   }
 
   // Available template instantiations

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.cpp
@@ -136,12 +136,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool LinearTransformer<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* LinearTransformer<ScalarT, IdxT>::clone() const
   {
     return new LinearTransformer<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
@@ -29,6 +29,7 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::y_int_;
     using CircuitComponent<ScalarT, IdxT>::yp_ext_;
     using CircuitComponent<ScalarT, IdxT>::yp_int_;
+    using CircuitComponent<ScalarT, IdxT>::abs_tol_;
     using CircuitComponent<ScalarT, IdxT>::tag_;
     using CircuitComponent<ScalarT, IdxT>::f_ext_;
     using CircuitComponent<ScalarT, IdxT>::f_int_;
@@ -50,15 +51,19 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
+    int setAbsoluteTolerance(RealT);
     int evaluateInternalResidual() final;
     int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT L0_;

--- a/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
+++ b/GridKit/Model/PowerElectronics/LinearTransformer/LinearTransformer.hpp
@@ -57,11 +57,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
@@ -152,6 +152,18 @@ namespace GridKit
     return 0;
   }
 
+  template <class ScalarT, typename IdxT>
+  bool MicrogridBusDQ<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* MicrogridBusDQ<ScalarT, IdxT>::clone() const
+  {
+    return new MicrogridBusDQ<ScalarT, IdxT>(*this);
+  }
+
   // Available template instantiations
   template class MicrogridBusDQ<double, long int>;
   template class MicrogridBusDQ<double, size_t>;

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.cpp
@@ -153,12 +153,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool MicrogridBusDQ<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* MicrogridBusDQ<ScalarT, IdxT>::clone() const
   {
     return new MicrogridBusDQ<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
@@ -60,10 +60,13 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT  RN_;

--- a/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp
@@ -60,11 +60,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
@@ -184,6 +184,18 @@ namespace GridKit
     return 0;
   }
 
+  template <class ScalarT, typename IdxT>
+  bool MicrogridLine<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* MicrogridLine<ScalarT, IdxT>::clone() const
+  {
+    return new MicrogridLine<ScalarT, IdxT>(*this);
+  }
+
   // Available template instantiations
   template class MicrogridLine<double, long int>;
   template class MicrogridLine<double, size_t>;

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.cpp
@@ -185,12 +185,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool MicrogridLine<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* MicrogridLine<ScalarT, IdxT>::clone() const
   {
     return new MicrogridLine<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
@@ -60,10 +60,13 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT  R_;

--- a/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp
@@ -60,11 +60,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
@@ -175,6 +175,18 @@ namespace GridKit
     return 0;
   }
 
+  template <class ScalarT, typename IdxT>
+  bool MicrogridLoad<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* MicrogridLoad<ScalarT, IdxT>::clone() const
+  {
+    return new MicrogridLoad<ScalarT, IdxT>(*this);
+  }
+
   // Available template instantiations
   template class MicrogridLoad<double, long int>;
   template class MicrogridLoad<double, size_t>;

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.cpp
@@ -176,12 +176,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool MicrogridLoad<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* MicrogridLoad<ScalarT, IdxT>::clone() const
   {
     return new MicrogridLoad<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
@@ -60,10 +60,13 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT  R_;

--- a/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
+++ b/GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp
@@ -60,11 +60,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/NodeBase.hpp
+++ b/GridKit/Model/PowerElectronics/NodeBase.hpp
@@ -136,6 +136,23 @@ namespace GridKit
         };
       }
 
+      /**
+       * @brief Update the connection index for a variable.
+       *
+       * Changes only the connection index without modifying the variable's
+       * internal/external classification or its associated data pointers.
+       *
+       * @param local_index Index of the local variable.
+       * @param connection_index New connection index for the variable.
+       *
+       * @return int 0 if successful.
+       */
+      int setConnectionNodes(size_t local_index, IdxT connection_index)
+      {
+        connection_nodes_[local_index] = connection_index;
+        return 0;
+      }
+
       int allocate() override
       {
         size_t size = static_cast<size_t>(n_intern_ + n_extern_);
@@ -390,6 +407,16 @@ namespace GridKit
       {
         throw "ERROR: Method not implemented!\n";
         return gB_;
+      }
+
+      /**
+       * @brief Check whether the Node has already been allocated.
+       *
+       * @return true if allocate() has previously completed, false otherwise.
+       */
+      bool isAllocated() const
+      {
+        return allocated_;
       }
 
     private:

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
@@ -139,6 +139,18 @@ namespace GridKit
     return 0;
   }
 
+  template <class ScalarT, typename IdxT>
+  bool Resistor<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* Resistor<ScalarT, IdxT>::clone() const
+  {
+    return new Resistor<ScalarT, IdxT>(*this);
+  }
+
   // Available template instantiations
   template class Resistor<double, long int>;
   template class Resistor<double, size_t>;

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.cpp
@@ -140,12 +140,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool Resistor<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* Resistor<ScalarT, IdxT>::clone() const
   {
     return new Resistor<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.hpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.hpp
@@ -60,10 +60,13 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT  R_;

--- a/GridKit/Model/PowerElectronics/Resistor/Resistor.hpp
+++ b/GridKit/Model/PowerElectronics/Resistor/Resistor.hpp
@@ -60,11 +60,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
@@ -83,6 +83,25 @@ namespace GridKit
   }
 
   /**
+   * @brief Compute the absolute tolerance for each variable in the model
+   *
+   * @param rel_tol The relative tolerance which can be used to pick the
+   *        absolute tolerance.
+   * @tparam ScalarT Scalar data type
+   * @tparam IdxT Index data type
+   * @return int 0 if successful, non-zero otherwise.
+   *
+   * This represents a "noise" level close to zero for which pure relative
+   * error cannot be used.
+   */
+  template <class ScalarT, typename IdxT>
+  int SynchronousMachine<ScalarT, IdxT>::setAbsoluteTolerance(RealT rel_tol)
+  {
+    abs_tol_.setToConst(static_cast<ScalarT>(rel_tol));
+    return 0;
+  }
+
+  /**
    * @brief Compute the resisdual of the component.
    *
    * @todo not finished
@@ -163,6 +182,18 @@ namespace GridKit
   int SynchronousMachine<ScalarT, IdxT>::evaluateAdjointIntegrand()
   {
     return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  bool SynchronousMachine<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* SynchronousMachine<ScalarT, IdxT>::clone() const
+  {
+    return new SynchronousMachine<ScalarT, IdxT>(*this);
   }
 
   // Available template instantiations

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.cpp
@@ -185,12 +185,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool SynchronousMachine<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* SynchronousMachine<ScalarT, IdxT>::clone() const
   {
     return new SynchronousMachine<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
@@ -31,6 +31,7 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::y_int_;
     using CircuitComponent<ScalarT, IdxT>::yp_ext_;
     using CircuitComponent<ScalarT, IdxT>::yp_int_;
+    using CircuitComponent<ScalarT, IdxT>::abs_tol_;
     using CircuitComponent<ScalarT, IdxT>::tag_;
     using CircuitComponent<ScalarT, IdxT>::f_ext_;
     using CircuitComponent<ScalarT, IdxT>::f_int_;
@@ -52,15 +53,19 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
+    int setAbsoluteTolerance(RealT);
     int evaluateInternalResidual() final;
     int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT                    Lls_;

--- a/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
+++ b/GridKit/Model/PowerElectronics/SynchronousMachine/SynchronousMachine.hpp
@@ -59,11 +59,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
@@ -66,6 +66,25 @@ namespace GridKit
   }
 
   /**
+   * @brief Compute the absolute tolerance for each variable in the model
+   *
+   * @param rel_tol The relative tolerance which can be used to pick the
+   *        absolute tolerance.
+   * @tparam ScalarT Scalar data type
+   * @tparam IdxT Index data type
+   * @return int 0 if successful, non-zero otherwise.
+   *
+   * This represents a "noise" level close to zero for which pure relative
+   * error cannot be used.
+   */
+  template <class ScalarT, typename IdxT>
+  int TransmissionLine<ScalarT, IdxT>::setAbsoluteTolerance(RealT rel_tol)
+  {
+    abs_tol_.setToConst(static_cast<ScalarT>(rel_tol));
+    return 0;
+  }
+
+  /**
    * @brief Evaluate residual of transmission line
    *
    * The complex admittance matrix is:
@@ -184,6 +203,18 @@ namespace GridKit
   int TransmissionLine<ScalarT, IdxT>::evaluateAdjointIntegrand()
   {
     return 0;
+  }
+
+  template <class ScalarT, typename IdxT>
+  bool TransmissionLine<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* TransmissionLine<ScalarT, IdxT>::clone() const
+  {
+    return new TransmissionLine<ScalarT, IdxT>(*this);
   }
 
   // Available template instantiations

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.cpp
@@ -206,12 +206,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool TransmissionLine<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* TransmissionLine<ScalarT, IdxT>::clone() const
   {
     return new TransmissionLine<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
@@ -33,6 +33,7 @@ namespace GridKit
     using CircuitComponent<ScalarT, IdxT>::y_int_;
     using CircuitComponent<ScalarT, IdxT>::yp_ext_;
     using CircuitComponent<ScalarT, IdxT>::yp_int_;
+    using CircuitComponent<ScalarT, IdxT>::abs_tol_;
     using CircuitComponent<ScalarT, IdxT>::tag_;
     using CircuitComponent<ScalarT, IdxT>::f_ext_;
     using CircuitComponent<ScalarT, IdxT>::f_int_;
@@ -54,15 +55,19 @@ namespace GridKit
 
     int initialize();
     int tagDifferentiable();
+    int setAbsoluteTolerance(RealT);
     int evaluateInternalResidual() final;
     int evaluateExternalResidual() final;
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT R_;

--- a/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
+++ b/GridKit/Model/PowerElectronics/TransmissionLine/TransmissionLine.hpp
@@ -61,11 +61,10 @@ namespace GridKit
     int evaluateJacobian();
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
@@ -142,6 +142,18 @@ namespace GridKit
     return 0;
   }
 
+  template <class ScalarT, typename IdxT>
+  bool VoltageSource<ScalarT, IdxT>::isCloneable() const
+  {
+    return true;
+  }
+
+  template <class ScalarT, typename IdxT>
+  CircuitComponent<ScalarT, IdxT>* VoltageSource<ScalarT, IdxT>::clone() const
+  {
+    return new VoltageSource<ScalarT, IdxT>(*this);
+  }
+
   // Available template instantiations
   template class VoltageSource<double, long int>;
   template class VoltageSource<double, size_t>;

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.cpp
@@ -143,12 +143,6 @@ namespace GridKit
   }
 
   template <class ScalarT, typename IdxT>
-  bool VoltageSource<ScalarT, IdxT>::isCloneable() const
-  {
-    return true;
-  }
-
-  template <class ScalarT, typename IdxT>
   CircuitComponent<ScalarT, IdxT>* VoltageSource<ScalarT, IdxT>::clone() const
   {
     return new VoltageSource<ScalarT, IdxT>(*this);

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
@@ -60,10 +60,13 @@ namespace GridKit
     int evaluateJacobian() final;
     int evaluateIntegrand();
 
-    int initializeAdjoint();
-    int evaluateAdjointResidual();
+    int  initializeAdjoint();
+    int  evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int evaluateAdjointIntegrand();
+    int  evaluateAdjointIntegrand();
+    bool isCloneable() const;
+
+    CircuitComponent<ScalarT, IdxT>* clone() const;
 
   private:
     RealT  V_;

--- a/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
+++ b/GridKit/Model/PowerElectronics/VoltageSource/VoltageSource.hpp
@@ -60,11 +60,10 @@ namespace GridKit
     int evaluateJacobian() final;
     int evaluateIntegrand();
 
-    int  initializeAdjoint();
-    int  evaluateAdjointResidual();
+    int initializeAdjoint();
+    int evaluateAdjointResidual();
     // int evaluateAdjointJacobian();
-    int  evaluateAdjointIntegrand();
-    bool isCloneable() const;
+    int evaluateAdjointIntegrand();
 
     CircuitComponent<ScalarT, IdxT>* clone() const;
 

--- a/tests/UnitTests/PowerElectronics/CMakeLists.txt
+++ b/tests/UnitTests/PowerElectronics/CMakeLists.txt
@@ -13,7 +13,8 @@ target_link_libraries(
           GridKit::testing)
 
 add_test(NAME PowerElectronicsNodeTest COMMAND $<TARGET_FILE:test_power_electronics_node>)
-add_test(NAME PowerElectronicsComponentCloneTest COMMAND $<TARGET_FILE:test_power_electronics_component_clone>)
+add_test(NAME PowerElectronicsComponentCloneTest
+         COMMAND $<TARGET_FILE:test_power_electronics_component_clone>)
 
 install(TARGETS test_power_electronics_node RUNTIME DESTINATION bin)
 install(TARGETS test_power_electronics_component_clone RUNTIME DESTINATION bin)

--- a/tests/UnitTests/PowerElectronics/CMakeLists.txt
+++ b/tests/UnitTests/PowerElectronics/CMakeLists.txt
@@ -3,6 +3,17 @@ target_link_libraries(
   test_power_electronics_node
   PRIVATE GridKit::power_electronics_circuit_node GridKit::testing)
 
+add_executable(test_power_electronics_component_clone runComponentCloneTests.cpp)
+target_link_libraries(
+  test_power_electronics_component_clone
+  PRIVATE GridKit::power_elec_disgen
+          GridKit::power_elec_microline
+          GridKit::power_elec_microload
+          GridKit::power_elec_microbusdq
+          GridKit::testing)
+
 add_test(NAME PowerElectronicsNodeTest COMMAND $<TARGET_FILE:test_power_electronics_node>)
+add_test(NAME PowerElectronicsComponentCloneTest COMMAND $<TARGET_FILE:test_power_electronics_component_clone>)
 
 install(TARGETS test_power_electronics_node RUNTIME DESTINATION bin)
+install(TARGETS test_power_electronics_component_clone RUNTIME DESTINATION bin)

--- a/tests/UnitTests/PowerElectronics/ComponentCloneTests.hpp
+++ b/tests/UnitTests/PowerElectronics/ComponentCloneTests.hpp
@@ -1,0 +1,263 @@
+
+#include <GridKit/Model/PowerElectronics/Bus/MicrogridBus.hpp>
+#include <GridKit/Model/PowerElectronics/Bus/SignalNode.hpp>
+#include <GridKit/Model/PowerElectronics/DistributedGenerator/DistributedGenerator.hpp>
+#include <GridKit/Model/PowerElectronics/MicrogridBusDQ/MicrogridBusDQ.hpp>
+#include <GridKit/Model/PowerElectronics/MicrogridLine/MicrogridLine.hpp>
+#include <GridKit/Model/PowerElectronics/MicrogridLoad/MicrogridLoad.hpp>
+#include <GridKit/Testing/TestHelpers.hpp>
+#include <GridKit/Testing/Testing.hpp>
+
+namespace GridKit
+{
+  template <typename ComponentT, typename ScalarT, typename IdxT>
+  bool verifyComponentClone(ComponentT& component)
+  {
+    using RealT = typename CircuitComponent<ScalarT, IdxT>::RealT;
+
+    bool success = true;
+
+    auto* clone = dynamic_cast<ComponentT*>(component.clone());
+
+    if (clone == nullptr)
+    {
+      return false;
+    }
+
+    /**************************************************************************
+     * Verify the Clone Initially Matches the Original
+     **************************************************************************/
+
+    success &= clone != &component;
+    success &= clone->size() == component.size();
+    success &= clone->nnz() == component.nnz();
+    success &= clone->getInternalSize() == component.getInternalSize();
+    success &= clone->getExternSize() == component.getExternSize();
+    success &= clone->getExternIndices() == component.getExternIndices();
+    success &= clone->getIDcomponent() == component.getIDcomponent();
+
+    /**************************************************************************
+     * Verify Connection Independence
+     **************************************************************************/
+
+    for (IdxT i = 0; i < component.size(); ++i)
+    {
+      const IdxT connection = component.getNodeConnection(i);
+
+      success &= clone->getNodeConnection(i) == connection;
+
+      clone->setConnectionNodes(i, connection + 1);
+
+      success &= component.getNodeConnection(i) == connection;
+      success &= clone->getNodeConnection(i) == connection + 1;
+
+      clone->setConnectionNodes(i, connection);
+    }
+
+    /**************************************************************************
+     * Verify State Independence
+     **************************************************************************/
+
+    auto checkVectorIndependence = [&success](auto& original, auto& copy)
+    {
+      success &= original.getSize() == copy.getSize();
+
+      if (original.getSize() == 0)
+      {
+        return;
+      }
+
+      auto* original_data = original.getData();
+      auto* copy_data     = copy.getData();
+
+      success &= original_data != copy_data;
+
+      const auto original_value = original_data[0];
+
+      copy_data[0] = original_value + 1.0;
+
+      success &= original_data[0] == original_value;
+      success &= copy_data[0] == original_value + 1.0;
+
+      copy_data[0] = original_value;
+    };
+
+    checkVectorIndependence(component.y(), clone->y());
+    checkVectorIndependence(component.yp(), clone->yp());
+    checkVectorIndependence(component.getResidual(), clone->getResidual());
+    checkVectorIndependence(component.absoluteTolerance(), clone->absoluteTolerance());
+    checkVectorIndependence(component.param(), clone->param());
+
+    /**************************************************************************
+     * Verify Jacobian Independence
+     **************************************************************************/
+
+    if (component.nnz() > 0)
+    {
+      auto* original_rows   = component.jacobianCooRows();
+      auto* original_cols   = component.jacobianCooCols();
+      auto* original_values = component.jacobianCooValues();
+
+      auto* clone_rows   = clone->jacobianCooRows();
+      auto* clone_cols   = clone->jacobianCooCols();
+      auto* clone_values = clone->jacobianCooValues();
+
+      success &= clone_rows != original_rows;
+      success &= clone_cols != original_cols;
+      success &= clone_values != original_values;
+
+      for (IdxT i = 0; i < component.nnz(); ++i)
+      {
+        success &= clone_rows[i] == original_rows[i];
+        success &= clone_cols[i] == original_cols[i];
+        success &= clone_values[i] == original_values[i];
+      }
+
+      const IdxT  original_row   = original_rows[0];
+      const IdxT  original_col   = original_cols[0];
+      const RealT original_value = original_values[0];
+
+      clone_rows[0]   = original_row + 1;
+      clone_cols[0]   = original_col + 1;
+      clone_values[0] = original_value + 1.0;
+
+      success &= original_rows[0] == original_row;
+      success &= original_cols[0] == original_col;
+      success &= original_values[0] == original_value;
+
+      clone_rows[0]   = original_row;
+      clone_cols[0]   = original_col;
+      clone_values[0] = original_value;
+    }
+
+    delete clone;
+
+    return success;
+  }
+
+  namespace Testing
+  {
+    template <typename ScalarT, typename IdxT>
+    class CircuitComponentCloneTests
+    {
+      using SignalNode          = PowerElectronics::SignalNode<ScalarT, IdxT>;
+      using Bus                 = PowerElectronics::MicrogridBus<ScalarT, IdxT>;
+      using BusDQ               = MicrogridBusDQ<ScalarT, IdxT>;
+      using Generator           = DistributedGenerator<ScalarT, IdxT>;
+      using GeneratorParameters = DistributedGeneratorParameters<ScalarT, IdxT>;
+      using Line                = MicrogridLine<ScalarT, IdxT>;
+      using Load                = MicrogridLoad<ScalarT, IdxT>;
+
+    public:
+      CircuitComponentCloneTests()
+      {
+        /**************************************************************************
+         * Construct Network Nodes
+         **************************************************************************/
+
+        signal_.allocate();
+
+        bus1_.allocate();
+        bus2_.allocate();
+
+        /**************************************************************************
+         * Distributed Generator Parameters
+         **************************************************************************/
+
+        generator_parameters_.wb_  = 2.0 * M_PI * 50.0;
+        generator_parameters_.wc_  = 31.41;
+        generator_parameters_.mp_  = 9.4e-5;
+        generator_parameters_.Vn_  = 380.0;
+        generator_parameters_.nq_  = 1.3e-3;
+        generator_parameters_.F_   = 0.75;
+        generator_parameters_.Kiv_ = 420.0;
+        generator_parameters_.Kpv_ = 0.1;
+        generator_parameters_.Kic_ = 2.0e4;
+        generator_parameters_.Kpc_ = 15.0;
+        generator_parameters_.Cf_  = 5.0e-5;
+        generator_parameters_.rLf_ = 0.1;
+        generator_parameters_.Lf_  = 1.35e-3;
+        generator_parameters_.rLc_ = 0.03;
+        generator_parameters_.Lc_  = 0.35e-3;
+
+        /**************************************************************************
+         * Construct Components
+         **************************************************************************/
+
+        generator_ = new Generator(1, generator_parameters_, true, &signal_, &bus1_);
+
+        line_ = new Line(2, 0.23, 0.1 / (2.0 * M_PI * 50.0), &signal_, &bus1_, &bus2_);
+
+        load_ = new Load(3, 3.0, 2.0 / (2.0 * M_PI * 50.0), &signal_, &bus1_);
+
+        bus_dq_ = new BusDQ(4, 1.0e4, &bus1_);
+
+        /**************************************************************************
+         * Allocate Components
+         **************************************************************************/
+
+        generator_->allocate();
+        line_->allocate();
+        load_->allocate();
+        bus_dq_->allocate();
+      }
+
+      ~CircuitComponentCloneTests()
+      {
+        delete generator_;
+        delete line_;
+        delete load_;
+        delete bus_dq_;
+      }
+
+      TestOutcome distributedGeneratorClone()
+      {
+        TestStatus success = true;
+
+        success *= verifyComponentClone<Generator, ScalarT, IdxT>(*generator_);
+
+        return success.report(__func__);
+      }
+
+      TestOutcome microgridLineClone()
+      {
+        TestStatus success = true;
+
+        success *= verifyComponentClone<Line, ScalarT, IdxT>(*line_);
+
+        return success.report(__func__);
+      }
+
+      TestOutcome microgridLoadClone()
+      {
+        TestStatus success = true;
+
+        success *= verifyComponentClone<Load, ScalarT, IdxT>(*load_);
+
+        return success.report(__func__);
+      }
+
+      TestOutcome microgridBusDQClone()
+      {
+        TestStatus success = true;
+
+        success *= verifyComponentClone<BusDQ, ScalarT, IdxT>(*bus_dq_);
+
+        return success.report(__func__);
+      }
+
+    private:
+      SignalNode signal_;
+
+      Bus bus1_;
+      Bus bus2_;
+
+      GeneratorParameters generator_parameters_;
+
+      Generator* generator_{nullptr};
+      Line*      line_{nullptr};
+      Load*      load_{nullptr};
+      BusDQ*     bus_dq_{nullptr};
+    };
+  } // namespace Testing
+} // namespace GridKit

--- a/tests/UnitTests/PowerElectronics/ComponentCloneTests.hpp
+++ b/tests/UnitTests/PowerElectronics/ComponentCloneTests.hpp
@@ -10,131 +10,6 @@
 
 namespace GridKit
 {
-  template <typename ComponentT, typename ScalarT, typename IdxT>
-  bool verifyComponentClone(ComponentT& component)
-  {
-    using RealT = typename CircuitComponent<ScalarT, IdxT>::RealT;
-
-    bool success = true;
-
-    auto* clone = dynamic_cast<ComponentT*>(component.clone());
-
-    if (clone == nullptr)
-    {
-      return false;
-    }
-
-    /**************************************************************************
-     * Verify the Clone Initially Matches the Original
-     **************************************************************************/
-
-    success &= clone != &component;
-    success &= clone->size() == component.size();
-    success &= clone->nnz() == component.nnz();
-    success &= clone->getInternalSize() == component.getInternalSize();
-    success &= clone->getExternSize() == component.getExternSize();
-    success &= clone->getExternIndices() == component.getExternIndices();
-    success &= clone->getIDcomponent() == component.getIDcomponent();
-
-    /**************************************************************************
-     * Verify Connection Independence
-     **************************************************************************/
-
-    for (IdxT i = 0; i < component.size(); ++i)
-    {
-      const IdxT connection = component.getNodeConnection(i);
-
-      success &= clone->getNodeConnection(i) == connection;
-
-      clone->setConnectionNodes(i, connection + 1);
-
-      success &= component.getNodeConnection(i) == connection;
-      success &= clone->getNodeConnection(i) == connection + 1;
-
-      clone->setConnectionNodes(i, connection);
-    }
-
-    /**************************************************************************
-     * Verify State Independence
-     **************************************************************************/
-
-    auto checkVectorIndependence = [&success](auto& original, auto& copy)
-    {
-      success &= original.getSize() == copy.getSize();
-
-      if (original.getSize() == 0)
-      {
-        return;
-      }
-
-      auto* original_data = original.getData();
-      auto* copy_data     = copy.getData();
-
-      success &= original_data != copy_data;
-
-      const auto original_value = original_data[0];
-
-      copy_data[0] = original_value + 1.0;
-
-      success &= original_data[0] == original_value;
-      success &= copy_data[0] == original_value + 1.0;
-
-      copy_data[0] = original_value;
-    };
-
-    checkVectorIndependence(component.y(), clone->y());
-    checkVectorIndependence(component.yp(), clone->yp());
-    checkVectorIndependence(component.getResidual(), clone->getResidual());
-    checkVectorIndependence(component.absoluteTolerance(), clone->absoluteTolerance());
-    checkVectorIndependence(component.param(), clone->param());
-
-    /**************************************************************************
-     * Verify Jacobian Independence
-     **************************************************************************/
-
-    if (component.nnz() > 0)
-    {
-      auto* original_rows   = component.jacobianCooRows();
-      auto* original_cols   = component.jacobianCooCols();
-      auto* original_values = component.jacobianCooValues();
-
-      auto* clone_rows   = clone->jacobianCooRows();
-      auto* clone_cols   = clone->jacobianCooCols();
-      auto* clone_values = clone->jacobianCooValues();
-
-      success &= clone_rows != original_rows;
-      success &= clone_cols != original_cols;
-      success &= clone_values != original_values;
-
-      for (IdxT i = 0; i < component.nnz(); ++i)
-      {
-        success &= clone_rows[i] == original_rows[i];
-        success &= clone_cols[i] == original_cols[i];
-        success &= clone_values[i] == original_values[i];
-      }
-
-      const IdxT  original_row   = original_rows[0];
-      const IdxT  original_col   = original_cols[0];
-      const RealT original_value = original_values[0];
-
-      clone_rows[0]   = original_row + 1;
-      clone_cols[0]   = original_col + 1;
-      clone_values[0] = original_value + 1.0;
-
-      success &= original_rows[0] == original_row;
-      success &= original_cols[0] == original_col;
-      success &= original_values[0] == original_value;
-
-      clone_rows[0]   = original_row;
-      clone_cols[0]   = original_col;
-      clone_values[0] = original_value;
-    }
-
-    delete clone;
-
-    return success;
-  }
-
   namespace Testing
   {
     template <typename ScalarT, typename IdxT>
@@ -214,7 +89,7 @@ namespace GridKit
       {
         TestStatus success = true;
 
-        success *= verifyComponentClone<Generator, ScalarT, IdxT>(*generator_);
+        success *= verifyComponentClone<Generator>(*generator_);
 
         return success.report(__func__);
       }
@@ -223,7 +98,7 @@ namespace GridKit
       {
         TestStatus success = true;
 
-        success *= verifyComponentClone<Line, ScalarT, IdxT>(*line_);
+        success *= verifyComponentClone<Line>(*line_);
 
         return success.report(__func__);
       }
@@ -232,7 +107,7 @@ namespace GridKit
       {
         TestStatus success = true;
 
-        success *= verifyComponentClone<Load, ScalarT, IdxT>(*load_);
+        success *= verifyComponentClone<Load>(*load_);
 
         return success.report(__func__);
       }
@@ -241,12 +116,137 @@ namespace GridKit
       {
         TestStatus success = true;
 
-        success *= verifyComponentClone<BusDQ, ScalarT, IdxT>(*bus_dq_);
+        success *= verifyComponentClone<BusDQ>(*bus_dq_);
 
         return success.report(__func__);
       }
 
     private:
+      template <typename ComponentT>
+      bool verifyComponentClone(ComponentT& component)
+      {
+        using RealT = typename CircuitComponent<ScalarT, IdxT>::RealT;
+
+        bool success = true;
+
+        auto* clone = dynamic_cast<ComponentT*>(component.clone());
+
+        if (clone == nullptr)
+        {
+          return false;
+        }
+
+        /**************************************************************************
+         * Verify the Clone Initially Matches the Original
+         **************************************************************************/
+
+        success &= clone != &component;
+        success &= clone->size() == component.size();
+        success &= clone->nnz() == component.nnz();
+        success &= clone->getInternalSize() == component.getInternalSize();
+        success &= clone->getExternSize() == component.getExternSize();
+        success &= clone->getExternIndices() == component.getExternIndices();
+        success &= clone->getIDcomponent() == component.getIDcomponent();
+
+        /**************************************************************************
+         * Verify Connection Independence
+         **************************************************************************/
+
+        for (IdxT i = 0; i < component.size(); ++i)
+        {
+          const IdxT connection = component.getNodeConnection(i);
+
+          success &= clone->getNodeConnection(i) == connection;
+
+          clone->setConnectionNodes(i, connection + 1);
+
+          success &= component.getNodeConnection(i) == connection;
+          success &= clone->getNodeConnection(i) == connection + 1;
+
+          clone->setConnectionNodes(i, connection);
+        }
+
+        /**************************************************************************
+         * Verify State Independence
+         **************************************************************************/
+
+        auto checkVectorIndependence = [&success](auto& original, auto& copy)
+        {
+          success &= original.getSize() == copy.getSize();
+
+          if (original.getSize() == 0)
+          {
+            return;
+          }
+
+          auto* original_data = original.getData();
+          auto* copy_data     = copy.getData();
+
+          success &= original_data != copy_data;
+
+          const auto original_value = original_data[0];
+
+          copy_data[0] = original_value + 1.0;
+
+          success &= original_data[0] == original_value;
+          success &= copy_data[0] == original_value + 1.0;
+
+          copy_data[0] = original_value;
+        };
+
+        checkVectorIndependence(component.y(), clone->y());
+        checkVectorIndependence(component.yp(), clone->yp());
+        checkVectorIndependence(component.getResidual(), clone->getResidual());
+        checkVectorIndependence(component.absoluteTolerance(), clone->absoluteTolerance());
+        checkVectorIndependence(component.param(), clone->param());
+
+        /**************************************************************************
+         * Verify Jacobian Independence
+         **************************************************************************/
+
+        if (component.nnz() > 0)
+        {
+          auto* original_rows   = component.jacobianCooRows();
+          auto* original_cols   = component.jacobianCooCols();
+          auto* original_values = component.jacobianCooValues();
+
+          auto* clone_rows   = clone->jacobianCooRows();
+          auto* clone_cols   = clone->jacobianCooCols();
+          auto* clone_values = clone->jacobianCooValues();
+
+          success &= clone_rows != original_rows;
+          success &= clone_cols != original_cols;
+          success &= clone_values != original_values;
+
+          for (IdxT i = 0; i < component.nnz(); ++i)
+          {
+            success &= clone_rows[i] == original_rows[i];
+            success &= clone_cols[i] == original_cols[i];
+            success &= clone_values[i] == original_values[i];
+          }
+
+          const IdxT  original_row   = original_rows[0];
+          const IdxT  original_col   = original_cols[0];
+          const RealT original_value = original_values[0];
+
+          clone_rows[0]   = original_row + 1;
+          clone_cols[0]   = original_col + 1;
+          clone_values[0] = original_value + 1.0;
+
+          success &= original_rows[0] == original_row;
+          success &= original_cols[0] == original_col;
+          success &= original_values[0] == original_value;
+
+          clone_rows[0]   = original_row;
+          clone_cols[0]   = original_col;
+          clone_values[0] = original_value;
+        }
+
+        delete clone;
+
+        return success;
+      }
+
       SignalNode signal_;
 
       Bus bus1_;

--- a/tests/UnitTests/PowerElectronics/runComponentCloneTests.cpp
+++ b/tests/UnitTests/PowerElectronics/runComponentCloneTests.cpp
@@ -1,0 +1,15 @@
+#include "ComponentCloneTests.hpp"
+
+int main()
+{
+  GridKit::Testing::CircuitComponentCloneTests<double, size_t> tests;
+
+  GridKit::Testing::TestingResults result;
+
+  result += tests.distributedGeneratorClone();
+  result += tests.microgridLineClone();
+  result += tests.microgridLoadClone();
+  result += tests.microgridBusDQClone();
+
+  return result.summary();
+}


### PR DESCRIPTION
## Description
 
This pull request implements clone functionality for components in the ```PowerElectronics``` module. This gives us the ability to create independent copies of components such that modifications to one do not affect the other.
 
 ## Proposed changes
 
Each component implements the ```isCloneable``` and ```clone``` methods. The ```isCloneable``` method returns ```true``` if the component is cloneable and ```false``` otherwise. The ```clone``` method returns a pointer to a new object with the same state as the component from which it was cloned. After cloning a component, the user should set the data pointers for the clone. 

 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [ ] The [CHANGELOG.md](/CHANGELOG.md) has been updated to reflect the changes. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further Comments
This functionality is useful for the partitioning implementation. 
