### PR TITLE
Output the correct variable for TenGenGenrou example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Added cases and validation for ACTIVSg10k, ACTIVSg200, ACTIVSg500, and WECC240.
 - Added IDA option to choose the consistent initial condition calculation type.
 - Implemented `tagDifferentiable()` for `PowerElectronics` models.
+- Fixed the `TenGenGenrou` example to output the correct omega values.
 
 ## v0.1
 

--- a/examples/PhasorDynamics/Small/TenGen/Genrou/TenGenGenrou.cpp
+++ b/examples/PhasorDynamics/Small/TenGen/Genrou/TenGenGenrou.cpp
@@ -135,9 +135,8 @@ int main()
     for (size_t i = 0; i < 9; ++i)
     {
       // 18 is offset for variables of 9 buses.
-      // Each generator has 21 equations.
       // We are outputting second equation of each generator.
-      out << yval[18 + 21 * i + 1] << ",";
+      out << yval[18 + gen2.size() * i + 1] << ",";
     }
     out << "\n";
   };


### PR DESCRIPTION
## Description
 
The `Genrou` model was updated, and the number of equations was changed, after the `TenGen` example was created. Since the `TenGen` example wasn't updated with these changes, it was outputting the wrong values.
 
 ## Proposed changes
 
Change from a hard-coded magic number for the number of equations in a generator to querying the size at runtime.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [ ] The [CHANGELOG.md](/CHANGELOG.md) has been updated to reflect the changes. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments

 
