### PR TITLE
Bus Fault Jacobian Bug

### DIFF
--- a/GridKit/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/BusFault/BusFaultEnzyme.cpp
@@ -66,14 +66,6 @@ namespace GridKit
                                                                                                        J_cols_buffer_,
                                                                                                        J_vals_buffer_,
                                                                                                        nnz_);
-      if (!status_) // Value contributions from DfDwb only when status_
-      {
-        for (IdxT i = nnz_tmp; i < nnz_; ++i)
-        {
-          J_vals_buffer_[i] = 0.0;
-        }
-      }
-
       GridKit::Enzyme::Sparse::DhDy<GridKit::PhasorDynamics::BusFault<ScalarT, IdxT>,
                                     GridKit::Enzyme::Sparse::MemberFunctions::BusResidual>::eval(this,
                                                                                                  static_cast<size_t>(bus_->size()),
@@ -87,6 +79,14 @@ namespace GridKit
                                                                                                  J_cols_buffer_,
                                                                                                  J_vals_buffer_,
                                                                                                  nnz_);
+
+      if (!status_) // Value contributions from DfDwb and DhDy only when status_
+      {
+        for (IdxT i = nnz_tmp; i < nnz_; ++i)
+        {
+          J_vals_buffer_[i] = 0.0;
+        }
+      }
 
       this->constructCoo();
 

--- a/tests/UnitTests/PhasorDynamics/BusFaultTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BusFaultTests.hpp
@@ -9,7 +9,6 @@
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp>
-#include <GridKit/Model/PhasorDynamics/SystemModel.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
 #include <GridKit/Utilities/MapFromCsr.hpp>
@@ -101,6 +100,17 @@ namespace GridKit
         // Jacobian via Enzyme
         auto enzyme_jacobian = EnzymeJacobian(R, X, status);
 
+        if (!status)
+        {
+          // HACK: Enzyme retains the fixed DfDwb/DhDy structure and masks its
+          // inactive values to exact zero, while DependencyTracking omits them.
+          for (auto& row : enzyme_jacobian)
+          {
+            std::erase_if(row, [](const auto& entry)
+                          { return entry.second == 0.0; });
+          }
+        }
+
         /// Compare DependencyTracking dependencies to Enzyme's
         for (size_t i = 0; i < dependency_tracking_jacobian.size(); ++i)
         {
@@ -110,77 +120,7 @@ namespace GridKit
         return success.report(__func__);
       }
 
-      /**
-       * A test case to verify a cleared fault drops out of the bus equations.
-       *
-       * After the fault clears it no longer injects current, so the Jacobian
-       * of the bus equations must not depend on the fault variables. A stale
-       * coupling left behind stalls the integrator at fault clearing.
-       */
-      TestOutcome jacobianAfterClearing()
-      {
-        TestStatus success = true;
-
-        PhasorDynamics::Bus<ScalarT, IdxT>      bus(1.0, 0.0);
-        PhasorDynamics::BusFault<ScalarT, IdxT> fault(&bus, 0.0, 0.01, 0);
-
-        PhasorDynamics::SystemModel<ScalarT, IdxT> system;
-        system.addBus(&bus);
-        system.addFault(&fault);
-        system.allocate();
-        system.initialize();
-
-        // Integrator callbacks before the fault
-        system.updateTime(0.0, 0.0);
-        system.evaluateResidual();
-        system.evaluateJacobian();
-
-        fault.setStatus(true);
-
-        // Integrator callbacks while the fault is on
-        system.updateTime(1.0, 0.0);
-        system.evaluateResidual();
-        system.evaluateJacobian();
-
-        fault.setStatus(false);
-
-        // Integrator callbacks after clearing
-        system.updateTime(2.0, 0.0);
-        system.evaluateResidual();
-        system.evaluateJacobian();
-
-        std::vector<DependencyTracking::Variable::DependencyMap> jacobian =
-            GridKit::Testing::MapFromCsr(system.getCsrJacobian());
-
-        // After clearing, the bus current balance should not depend on the
-        // fault current
-        success *= jacobianEntryIsZero(jacobian, 0, 2); // d(bus Ir eq)/d(fault Ir)
-        success *= jacobianEntryIsZero(jacobian, 0, 3); // d(bus Ir eq)/d(fault Ii)
-        success *= jacobianEntryIsZero(jacobian, 1, 2); // d(bus Ii eq)/d(fault Ir)
-        success *= jacobianEntryIsZero(jacobian, 1, 3); // d(bus Ii eq)/d(fault Ii)
-
-        return success.report(__func__);
-      }
-
     private:
-      /**
-       * Checks the Jacobian value at a row and column is zero, treating an
-       * absent entry as zero
-       */
-      bool jacobianEntryIsZero(const std::vector<DependencyTracking::Variable::DependencyMap>& jacobian,
-                               size_t                                                          row,
-                               size_t                                                          column) const
-      {
-        const auto entry = jacobian[row].find(column);
-        if (entry == jacobian[row].end() || isEqual(entry->second, 0.0))
-        {
-          return true;
-        }
-        std::cout << "Jacobian entry (" << row << ", " << column
-                  << ") = " << entry->second << " != 0\n";
-        return false;
-      }
-
       std::vector<DependencyTracking::Variable::DependencyMap> DependencyTrackingJacobian(
           const RealT R, const RealT X, const bool status)
       {
@@ -217,6 +157,10 @@ namespace GridKit
         std::vector<DependencyTracking::Variable> residual_y(
             residual_y_view.getData(),
             residual_y_view.getData() + residual_y_view.getSize());
+        auto&                                     bus_residual_y_view = bus.getResidual();
+        std::vector<DependencyTracking::Variable> bus_residual_y(
+            bus_residual_y_view.getData(),
+            bus_residual_y_view.getData() + bus_residual_y_view.getSize());
 
         // Get d/dy'
         bus.initialize();
@@ -249,7 +193,8 @@ namespace GridKit
         }
 
         // Extract the dependencies and add d/dy' to d/dy
-        std::vector<DependencyTracking::Variable::DependencyMap> dependencies(residual_y.size());
+        std::vector<DependencyTracking::Variable::DependencyMap> dependencies(
+            residual_y.size() + bus_residual_y.size());
         for (IdxT i = 0; i < residual_y.size(); ++i)
         {
           DependencyTracking::Variable::DependencyMap dependency_y  = (residual_y[i]).getDependencies();
@@ -282,6 +227,11 @@ namespace GridKit
               dependencies[i].insert(std::make_pair(index_yp, value_yp));
             }
           }
+        }
+
+        for (size_t i = 0; i < bus_residual_y.size(); ++i)
+        {
+          dependencies[residual_y.size() + i] = bus_residual_y[i].getDependencies();
         }
 
         return dependencies;

--- a/tests/UnitTests/PhasorDynamics/BusFaultTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/BusFaultTests.hpp
@@ -2,12 +2,14 @@
 
 #include <iomanip>
 #include <iostream>
+#include <vector>
 
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/Definitions.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp>
 #include <GridKit/Model/PhasorDynamics/BusFault/BusFault.hpp>
+#include <GridKit/Model/PhasorDynamics/SystemModel.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
 #include <GridKit/Testing/Testing.hpp>
 #include <GridKit/Utilities/MapFromCsr.hpp>
@@ -108,7 +110,77 @@ namespace GridKit
         return success.report(__func__);
       }
 
+      /**
+       * A test case to verify a cleared fault drops out of the bus equations.
+       *
+       * After the fault clears it no longer injects current, so the Jacobian
+       * of the bus equations must not depend on the fault variables. A stale
+       * coupling left behind stalls the integrator at fault clearing.
+       */
+      TestOutcome jacobianAfterClearing()
+      {
+        TestStatus success = true;
+
+        PhasorDynamics::Bus<ScalarT, IdxT>      bus(1.0, 0.0);
+        PhasorDynamics::BusFault<ScalarT, IdxT> fault(&bus, 0.0, 0.01, 0);
+
+        PhasorDynamics::SystemModel<ScalarT, IdxT> system;
+        system.addBus(&bus);
+        system.addFault(&fault);
+        system.allocate();
+        system.initialize();
+
+        // Integrator callbacks before the fault
+        system.updateTime(0.0, 0.0);
+        system.evaluateResidual();
+        system.evaluateJacobian();
+
+        fault.setStatus(true);
+
+        // Integrator callbacks while the fault is on
+        system.updateTime(1.0, 0.0);
+        system.evaluateResidual();
+        system.evaluateJacobian();
+
+        fault.setStatus(false);
+
+        // Integrator callbacks after clearing
+        system.updateTime(2.0, 0.0);
+        system.evaluateResidual();
+        system.evaluateJacobian();
+
+        std::vector<DependencyTracking::Variable::DependencyMap> jacobian =
+            GridKit::Testing::MapFromCsr(system.getCsrJacobian());
+
+        // After clearing, the bus current balance should not depend on the
+        // fault current
+        success *= jacobianEntryIsZero(jacobian, 0, 2); // d(bus Ir eq)/d(fault Ir)
+        success *= jacobianEntryIsZero(jacobian, 0, 3); // d(bus Ir eq)/d(fault Ii)
+        success *= jacobianEntryIsZero(jacobian, 1, 2); // d(bus Ii eq)/d(fault Ir)
+        success *= jacobianEntryIsZero(jacobian, 1, 3); // d(bus Ii eq)/d(fault Ii)
+
+        return success.report(__func__);
+      }
+
     private:
+      /**
+       * Checks the Jacobian value at a row and column is zero, treating an
+       * absent entry as zero
+       */
+      bool jacobianEntryIsZero(const std::vector<DependencyTracking::Variable::DependencyMap>& jacobian,
+                               size_t                                                          row,
+                               size_t                                                          column) const
+      {
+        const auto entry = jacobian[row].find(column);
+        if (entry == jacobian[row].end() || isEqual(entry->second, 0.0))
+        {
+          return true;
+        }
+        std::cout << "Jacobian entry (" << row << ", " << column
+                  << ") = " << entry->second << " != 0\n";
+        return false;
+      }
+
       std::vector<DependencyTracking::Variable::DependencyMap> DependencyTrackingJacobian(
           const RealT R, const RealT X, const bool status)
       {

--- a/tests/UnitTests/PhasorDynamics/CMakeLists.txt
+++ b/tests/UnitTests/PhasorDynamics/CMakeLists.txt
@@ -15,7 +15,6 @@ target_link_libraries(
   GridKit::phasor_dynamics_bus_fault_dependency_tracking
   GridKit::phasor_dynamics_bus
   GridKit::phasor_dynamics_bus_dependency_tracking
-  GridKit::phasor_dynamics_systemmodel
   GridKit::testing)
 
 add_executable(test_phasor_bustosignaladapter runBusToSignalAdapterTests.cpp)

--- a/tests/UnitTests/PhasorDynamics/CMakeLists.txt
+++ b/tests/UnitTests/PhasorDynamics/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(
   GridKit::phasor_dynamics_bus_fault_dependency_tracking
   GridKit::phasor_dynamics_bus
   GridKit::phasor_dynamics_bus_dependency_tracking
+  GridKit::phasor_dynamics_systemmodel
   GridKit::testing)
 
 add_executable(test_phasor_bustosignaladapter runBusToSignalAdapterTests.cpp)

--- a/tests/UnitTests/PhasorDynamics/runBusFaultTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runBusFaultTests.cpp
@@ -12,6 +12,7 @@ int main()
   result += test.zeroInitialResidual(true);
 #ifdef GRIDKIT_ENABLE_ENZYME
   result += test.jacobian(true);
+  result += test.jacobianAfterClearing();
 #endif
 
   return result.summary();

--- a/tests/UnitTests/PhasorDynamics/runBusFaultTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runBusFaultTests.cpp
@@ -10,6 +10,7 @@ int main()
 
   result += test.constructor();
   result += test.zeroInitialResidual(true);
+  result += test.zeroInitialResidual(false);
 #ifdef GRIDKIT_ENABLE_ENZYME
   result += test.jacobian(true);
   result += test.jacobian(false);

--- a/tests/UnitTests/PhasorDynamics/runBusFaultTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runBusFaultTests.cpp
@@ -12,7 +12,7 @@ int main()
   result += test.zeroInitialResidual(true);
 #ifdef GRIDKIT_ENABLE_ENZYME
   result += test.jacobian(true);
-  result += test.jacobianAfterClearing();
+  result += test.jacobian(false);
 #endif
 
   return result.summary();


### PR DESCRIPTION
## Description
 
The  implementation of the `BusFault` control signal, followed by unfortunate sequencing in `DynamicSimulation` , causes incorrect evaluation of the Enzyme Jacobian.

The problematic term is `DhDy`. When the fault is inactive, the bus residual contribution h is omitted, so `DhDy` must be zero. Enzyme still evaluates the structural `DhDy` block, and the existing status mask was applied before that block was generated. Moving the mask after `DhDy` correctly masks both `DfDwb` and `DhDy`, while leaving `DfDy` active to constrain the fault-current states to zero.
 
 ## Proposed changes
 
- Update tests to reproducing the issue
- Fix bug by updating the Jacobian logic
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- NA The [CHANGELOG.md](/CHANGELOG.md) has been updated to reflect the changes. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
I observed InitialCondition errors in IDA, and after some eyebrow-raising simulation results, a painful investigation led me to this. It is not clear to me how or why this does not significantly impact the working simulations.

Domain usability:

I think events/external controls need to be polished (i.e. the wart of requiring  `BusFault` at each `Bus` in the case file to use `ContingencyAnalysis`). Conceptually, it would be preferred if `BusFault` were added in `DynamicSimulation` so that `R` and `X` are configurable per simulation and not per case. (See #389 #382 #363 )