### PR TITLE
Classical Generator Updates and Completion

### DIFF
--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
@@ -13,29 +13,40 @@ if(GRIDKIT_ENABLE_ENZYME)
     HEADERS ${_install_headers}
     INCLUDE_DIRECTORIES PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
     LINK_LIBRARIES
-      PRIVATE
-      ClangEnzymeFlags
       PUBLIC
       GridKit::phasor_dynamics_core
+      PUBLIC
+      GridKit::phasor_dynamics_signal
+      PRIVATE
+      ClangEnzymeFlags
     COMPILE_OPTIONS
       PRIVATE
       -mllvm
       -enzyme-auto-sparsity=1
-      -fno-math-errno)
+      -fno-math-errno
+      -fno-vectorize)
 else()
   gridkit_add_library(
     phasor_dynamics_gen_classical
     SOURCES GenClassical.cpp
     HEADERS ${_install_headers}
-    LINK_LIBRARIES PUBLIC GridKit::phasor_dynamics_core
-    INCLUDE_DIRECTORIES PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+    INCLUDE_DIRECTORIES PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
+    LINK_LIBRARIES
+      PUBLIC
+      GridKit::phasor_dynamics_core
+      PUBLIC
+      GridKit::phasor_dynamics_signal)
 endif()
 
 gridkit_add_library(
   phasor_dynamics_gen_classical_dependency_tracking
   SOURCES GenClassicalDependencyTracking.cpp
-  LINK_LIBRARIES PUBLIC GridKit::phasor_dynamics_core
-  INCLUDE_DIRECTORIES PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include)
+  INCLUDE_DIRECTORIES PRIVATE ${GRIDKIT_THIRD_PARTY_DIR}/magic-enum/include
+  LINK_LIBRARIES
+    PUBLIC
+    GridKit::phasor_dynamics_core
+    PUBLIC
+    GridKit::phasor_dynamics_signal_dependency_tracking)
 
 # Link to interface target for all components
 target_link_libraries(

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/CMakeLists.txt
@@ -23,8 +23,7 @@ if(GRIDKIT_ENABLE_ENZYME)
       PRIVATE
       -mllvm
       -enzyme-auto-sparsity=1
-      -fno-math-errno
-      -fno-vectorize)
+      -fno-math-errno)
 else()
   gridkit_add_library(
     phasor_dynamics_gen_classical

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
@@ -1,3 +1,9 @@
+/**
+ * @file GenClassical.cpp
+ * @author Abdourahman Barry (abdourahman@vt.edu)
+ * @author Slaven Peles (peless@ornl.gov)
+ * @brief Definition of a classical generator model.
+ */
 
 #include "GenClassicalImpl.hpp"
 
@@ -6,7 +12,7 @@ namespace GridKit
   namespace PhasorDynamics
   {
     /**
-     * @brief Jacobian evaluation not implemented
+     * @brief Jacobian evaluation not implemented yet
      *
      * @return int - error code, 0 = success
      */
@@ -14,8 +20,7 @@ namespace GridKit
     int GenClassical<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for GenClassical..." << std::endl;
-      Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;
-
+      Log::misc() << "Jacobian evaluation not implemented!" << std::endl;
       return 0;
     }
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.cpp
@@ -12,7 +12,7 @@ namespace GridKit
   namespace PhasorDynamics
   {
     /**
-     * @brief Jacobian evaluation not implemented yet
+     * @brief Jacobian evaluation not implemented
      *
      * @return int - error code, 0 = success
      */
@@ -20,7 +20,8 @@ namespace GridKit
     int GenClassical<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for GenClassical..." << std::endl;
-      Log::misc() << "Jacobian evaluation not implemented!" << std::endl;
+      Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;
+
       return 0;
     }
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp
@@ -2,6 +2,7 @@
  * @file GenClassical.hpp
  * @author Abdourahman Barry (abdourahman@vt.edu)
  * @author Slaven Peles (peless@ornl.gov)
+ * @brief Declaration of a classical generator model.
  *
  */
 
@@ -29,6 +30,26 @@ namespace GridKit
 {
   namespace PhasorDynamics
   {
+    /// Internal variables of a `GenClassical`
+    enum class GenClassicalInternalVariables : size_t
+    {
+      DELTA, ///< \f$\delta\f$ rotor angle
+      OMEGA, ///< \f$\omega\f$ speed deviation
+      TE,    ///< \f$T_e\f$ electrical torque
+      IR,    ///< \f$I_r\f$ network real current
+      II,    ///< \f$I_i\f$ network imaginary current
+      MAXIMUM,
+    };
+
+    /// External variables of a `GenClassical`
+    enum class GenClassicalExternalVariables : size_t
+    {
+      VR,  ///< \f$V_r\f$ network real voltage
+      VI,  ///< \f$V_i\f$ network imaginary voltage
+      PM,  ///< \f$P_m\f$ mechanical power
+      EFD, ///< \f$E_{fd}\f$ field voltage
+      MAXIMUM,
+    };
 
     template <typename scalar_type, typename index_type>
     class GenClassical : public Component<scalar_type, index_type>
@@ -44,6 +65,8 @@ namespace GridKit
       using Component<scalar_type, index_type>::y_;
       using Component<scalar_type, index_type>::yp_;
       using Component<scalar_type, index_type>::wb_;
+      using Component<scalar_type, index_type>::ws_;
+      using Component<scalar_type, index_type>::ws_indices_;
       using Component<scalar_type, index_type>::h_;
       using Component<scalar_type, index_type>::J_rows_buffer_;
       using Component<scalar_type, index_type>::J_cols_buffer_;
@@ -62,45 +85,35 @@ namespace GridKit
       using ModelDataT = GenClassicalData<RealT, IdxT>;
       using MonitorT   = Model::VariableMonitor<GenClassical, GenClassicalData>;
 
-      GenClassical(BusT* bus);
-      GenClassical(BusT* bus,
-                   RealT p0,
-                   RealT q0,
-                   RealT H,
-                   RealT D,
-                   RealT Ra,
-                   RealT Xdp);
       GenClassical(BusT* bus, const ModelDataT& data);
       ~GenClassical();
 
       int setGridKitComponentID(IdxT) override final;
       int allocate() override final;
+      int verify() const override final;
       int initialize() override final;
       int tagDifferentiable() override final;
-      int setAbsoluteTolerance(RealT) override;
+      int setAbsoluteTolerance(RealT rel_tol) override final;
       int evaluateResidual() override final;
-
-      int verify() const override final
-      {
-        return 0;
-      }
 
       // Still to be implemented
       int evaluateJacobian() override final;
 
-      void setPmech(RealT pmech)
+      /// Get the `ComponentSignals` from this `GenClassical`
+      auto getSignals()
+          -> ComponentSignals<ScalarT,
+                              IdxT,
+                              GenClassicalInternalVariables,
+                              GenClassicalExternalVariables>&
       {
-        pmech_set_ = pmech;
-      }
-
-      void setEp(RealT ep)
-      {
-        ep_set_ = ep;
+        return signals_;
       }
 
       const Model::VariableMonitorBase* getMonitor() const override;
 
     private:
+      void initializeParameters(const ModelDataT& data);
+      /// Associate variable getter functions with enum values
       void initializeMonitor();
       void setDerivedParams();
 
@@ -146,34 +159,36 @@ namespace GridKit
 
     public:
       __attribute__((always_inline)) inline int evaluateInternalResidual(
-          const ScalarT*, const ScalarT*, const ScalarT*, ScalarT*);
+          const ScalarT*, const ScalarT*, const ScalarT*, const ScalarT*, ScalarT*);
       __attribute__((always_inline)) inline int evaluateBusResidual(
           const ScalarT*, const ScalarT*, const ScalarT*, ScalarT*);
 
     private:
       /* Identification */
       BusT* bus_;
-      IdxT  bus_id_{0};
+
+      /// Component signal extension
+      ComponentSignals<ScalarT, IdxT, GenClassicalInternalVariables, GenClassicalExternalVariables> signals_;
 
       /* Initial terminal conditions */
       RealT p0_{0.0};
       RealT q0_{0.0};
 
       /* Input parameters */
-      RealT H_{0.0};
+      RealT H_{3.0};
       RealT D_{0.0};
       RealT Ra_{0.0};
-      RealT Xdp_{0.0};
+      RealT Xdp_{0.2};
       RealT mva_base_{100.0};
 
-      /* Derivied parameters */
+      /* Derived parameters */
       RealT G_;
       RealT B_;
       RealT va_machine_base_;
 
       /* Setpoints for control variables (determined at initialization) */
-      ScalarT pmech_set_;
-      ScalarT ep_set_;
+      ScalarT pmech_set_{0.0};
+      ScalarT efd_set_{0.0};
 
       /// Variable monitor
       std::unique_ptr<MonitorT> monitor_;

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
@@ -1,7 +1,7 @@
 /**
  * @file GenClassicalData.hpp
  * @author Slaven Peles (peless@ornl.gov)
- * @brief Modeling data for branches (transmission lines)
+ * @brief Modeling data for a classical generator model.
  *
  */
 #pragma once
@@ -15,62 +15,56 @@ namespace GridKit
     /// Initial parameters for a classical generator model
     enum class GenClassicalParameters
     {
-      p0,  ///< Initial active power
-      q0,  ///< Initial reactive power
-      H,   ///< Rotor inertia
-      D,   ///< Damping coefficient
-      Ra,  ///< Winding resistance
-      Xdp, ///< Direct axis transient reactance
-      mva  ///< MVA Base of the generator
+      p0,  ///< \f$P_0\f$ Initial active power
+      q0,  ///< \f$Q_0\f$ Initial reactive power
+      H,   ///< \f$H\f$ Rotor inertia
+      D,   ///< \f$D\f$ Damping coefficient
+      Ra,  ///< \f$R_a\f$ Winding resistance
+      Xdp, ///< \f$X'_d\f$ Direct axis transient reactance
+      mva, ///< \f$S_\mathrm{mach}\f$ MVA base of the classical generator model
     };
 
-    /// Buses supported for a classical generator model
+    /// Buses for a classical generator model
     enum class GenClassicalBuses : size_t
     {
       bus, ///< Unique ID of the connecting bus
       SIZE
     };
 
-    /// Signal inputs supported for a classical generator model
-    ///
-    /// @warning GenClassical signal support is incomplete. These legacy signal
-    /// names are not wired by SystemModel today; the intended refactor is to
-    /// align this model with Genrou/Gensal by supporting `pmech`, `speed`, and
-    /// `efd` signals through ComponentSignals.
+    /// Signal inputs for a classical generator model
     enum class GenClassicalSignalInputs : size_t
     {
-      exciter_signal,  ///< Unique ID of the bus providing the exciter signal
-      governor_signal, ///< Unique ID of the bus providing the governor signal
+      pmech, ///< \f$P_m\f$ Unique ID of the signal providing mechanical power
+      efd,   ///< \f$E_{fd}\f$ Unique ID of the signal providing exciter field voltage
       SIZE
     };
 
-    /// Signal outputs supported for a classical generator model
+    /// Signal outputs for a classical generator model
     enum class GenClassicalSignalOutputs : size_t
     {
+      speed, ///< \f$\omega\f$ Unique ID of the signal receiving speed deviation
       SIZE
     };
 
     /// Variables able to be monitored for a classical generator model
     enum class GenClassicalMonitorableVariables
     {
-      ir,
-      ii,
-      p,
-      q,
-      delta,
-      omega,
-      speed
+      ir,    ///< \f$I_r\f$ Network-frame real terminal current
+      ii,    ///< \f$I_i\f$ Network-frame imaginary terminal current
+      p,     ///< \f$P\f$ Active power
+      q,     ///< \f$Q\f$ Reactive power
+      delta, ///< \f$\delta\f$ Rotor angle
+      omega, ///< \f$\omega\f$ Speed deviation
+      speed  ///< \f$1+\omega\f$ Per-unit machine speed
     };
 
     /**
-     * @brief Contains modeling data for a GenClassical generator model.
+     * @brief Contains modeling data for a classical generator model.
      *
      * @tparam real_type  Real parameter data type
      * @tparam index_type Integer parameter data type
      *
      * Integer parameters are of the same type as matrix and vector indices.
-     *
-     * @todo Decide on naming scheme for model parameters.
      */
     template <typename real_type, typename index_type>
     struct GenClassicalData : public ComponentData<real_type,

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp
@@ -19,9 +19,9 @@ namespace GridKit
       q0,  ///< \f$Q_0\f$ Initial reactive power
       H,   ///< \f$H\f$ Rotor inertia
       D,   ///< \f$D\f$ Damping coefficient
-      Ra,  ///< \f$R_a\f$ Winding resistance
-      Xdp, ///< \f$X'_d\f$ Direct axis transient reactance
-      mva, ///< \f$S_\mathrm{mach}\f$ MVA base of the classical generator model
+      Ra,  ///< \f$R_a\f$ Armature resistance
+      Xdp, ///< \f$X'_d\f$ Direct-axis transient reactance
+      mva, ///< \f$S^\mathrm{base}\f$ Component power base
     };
 
     /// Buses for a classical generator model

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalDependencyTracking.cpp
@@ -1,4 +1,3 @@
-
 #include "GenClassicalImpl.hpp"
 
 namespace GridKit
@@ -6,7 +5,7 @@ namespace GridKit
   namespace PhasorDynamics
   {
     /**
-     * @brief Jacobian evaluation not implemented
+     * @brief Jacobian evaluation not implemented yet
      *
      * @return int - error code, 0 = success
      */
@@ -14,14 +13,12 @@ namespace GridKit
     int GenClassical<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for GenClassical..." << std::endl;
-      Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;
-
+      Log::misc() << "Jacobian evaluation not implemented!" << std::endl;
       return 0;
     }
 
     // Available template instantiations
     template class GenClassical<DependencyTracking::Variable, long int>;
     template class GenClassical<DependencyTracking::Variable, size_t>;
-
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalDependencyTracking.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalDependencyTracking.cpp
@@ -1,3 +1,4 @@
+
 #include "GenClassicalImpl.hpp"
 
 namespace GridKit
@@ -5,7 +6,7 @@ namespace GridKit
   namespace PhasorDynamics
   {
     /**
-     * @brief Jacobian evaluation not implemented yet
+     * @brief Jacobian evaluation not implemented
      *
      * @return int - error code, 0 = success
      */
@@ -13,12 +14,14 @@ namespace GridKit
     int GenClassical<scalar_type, index_type>::evaluateJacobian()
     {
       Log::misc() << "Evaluate Jacobian for GenClassical..." << std::endl;
-      Log::misc() << "Jacobian evaluation not implemented!" << std::endl;
+      Log::misc() << "Jacobian evaluation is not implemented!" << std::endl;
+
       return 0;
     }
 
     // Available template instantiations
     template class GenClassical<DependencyTracking::Variable, long int>;
     template class GenClassical<DependencyTracking::Variable, size_t>;
+
   } // namespace PhasorDynamics
 } // namespace GridKit

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalEnzyme.cpp
@@ -30,7 +30,8 @@ namespace GridKit
         // Enyme will compute the appropriate nnz from sparsification.
         auto size        = static_cast<size_t>(size_);
         auto bus_size    = static_cast<size_t>(bus_->size());
-        auto buffer_size = 2 * size * size + 2 * size * bus_size;
+        auto signal_size = static_cast<size_t>(ws_.getSize());
+        auto buffer_size = 2 * size * size + size * signal_size + 2 * size * bus_size;
         J_rows_buffer_   = new IdxT[buffer_size];
         J_cols_buffer_   = new IdxT[buffer_size];
         J_vals_buffer_   = new RealT[buffer_size];
@@ -39,47 +40,65 @@ namespace GridKit
       nnz_ = 0;
 
       GridKit::Enzyme::Sparse::DfDy<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
-                                    GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual>::eval(this,
-                                                                                                      static_cast<size_t>(f_.getSize()),
-                                                                                                      static_cast<size_t>(y_.getSize()),
-                                                                                                      (this->getResidualIndices()).data(),
-                                                                                                      (this->getVariableIndices()).data(),
-                                                                                                      y_.getData(),
-                                                                                                      yp_.getData(),
-                                                                                                      wb_.getData(),
-                                                                                                      J_rows_buffer_,
-                                                                                                      J_cols_buffer_,
-                                                                                                      J_vals_buffer_,
-                                                                                                      nnz_);
+                                    GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal>::eval(this,
+                                                                                                                static_cast<size_t>(f_.getSize()),
+                                                                                                                static_cast<size_t>(y_.getSize()),
+                                                                                                                (this->getResidualIndices()).data(),
+                                                                                                                (this->getVariableIndices()).data(),
+                                                                                                                y_.getData(),
+                                                                                                                yp_.getData(),
+                                                                                                                wb_.getData(),
+                                                                                                                ws_.getData(),
+                                                                                                                J_rows_buffer_,
+                                                                                                                J_cols_buffer_,
+                                                                                                                J_vals_buffer_,
+                                                                                                                nnz_);
 
       GridKit::Enzyme::Sparse::DfDyp<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
-                                     GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual>::eval(this,
-                                                                                                       static_cast<size_t>(f_.getSize()),
-                                                                                                       static_cast<size_t>(y_.getSize()),
-                                                                                                       (this->getResidualIndices()).data(),
-                                                                                                       (this->getVariableIndices()).data(),
-                                                                                                       y_.getData(),
-                                                                                                       yp_.getData(),
-                                                                                                       wb_.getData(),
-                                                                                                       alpha_,
-                                                                                                       J_rows_buffer_,
-                                                                                                       J_cols_buffer_,
-                                                                                                       J_vals_buffer_,
-                                                                                                       nnz_);
+                                     GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal>::eval(this,
+                                                                                                                 static_cast<size_t>(f_.getSize()),
+                                                                                                                 static_cast<size_t>(y_.getSize()),
+                                                                                                                 (this->getResidualIndices()).data(),
+                                                                                                                 (this->getVariableIndices()).data(),
+                                                                                                                 y_.getData(),
+                                                                                                                 yp_.getData(),
+                                                                                                                 wb_.getData(),
+                                                                                                                 ws_.getData(),
+                                                                                                                 alpha_,
+                                                                                                                 J_rows_buffer_,
+                                                                                                                 J_cols_buffer_,
+                                                                                                                 J_vals_buffer_,
+                                                                                                                 nnz_);
 
       GridKit::Enzyme::Sparse::DfDwb<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
-                                     GridKit::Enzyme::Sparse::MemberFunctions::InternalResidual>::eval(this,
-                                                                                                       static_cast<size_t>(f_.getSize()),
-                                                                                                       static_cast<size_t>(bus_->size()),
-                                                                                                       (this->getResidualIndices()).data(),
-                                                                                                       (bus_->getVariableIndices()).data(),
-                                                                                                       y_.getData(),
-                                                                                                       yp_.getData(),
-                                                                                                       bus_->y().getData(),
-                                                                                                       J_rows_buffer_,
-                                                                                                       J_cols_buffer_,
-                                                                                                       J_vals_buffer_,
-                                                                                                       nnz_);
+                                     GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal>::eval(this,
+                                                                                                                 static_cast<size_t>(f_.getSize()),
+                                                                                                                 static_cast<size_t>(bus_->size()),
+                                                                                                                 (this->getResidualIndices()).data(),
+                                                                                                                 (bus_->getVariableIndices()).data(),
+                                                                                                                 y_.getData(),
+                                                                                                                 yp_.getData(),
+                                                                                                                 wb_.getData(),
+                                                                                                                 ws_.getData(),
+                                                                                                                 J_rows_buffer_,
+                                                                                                                 J_cols_buffer_,
+                                                                                                                 J_vals_buffer_,
+                                                                                                                 nnz_);
+
+      GridKit::Enzyme::Sparse::DfDws<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
+                                     GridKit::Enzyme::Sparse::MemberFunctions::InternalResidualWithSignal>::eval(this,
+                                                                                                                 static_cast<size_t>(f_.getSize()),
+                                                                                                                 static_cast<size_t>(ws_.getSize()),
+                                                                                                                 (this->getResidualIndices()).data(),
+                                                                                                                 ws_indices_.data(),
+                                                                                                                 y_.getData(),
+                                                                                                                 yp_.getData(),
+                                                                                                                 wb_.getData(),
+                                                                                                                 ws_.getData(),
+                                                                                                                 J_rows_buffer_,
+                                                                                                                 J_cols_buffer_,
+                                                                                                                 J_vals_buffer_,
+                                                                                                                 nnz_);
 
       GridKit::Enzyme::Sparse::DhDy<GridKit::PhasorDynamics::GenClassical<ScalarT, IdxT>,
                                     GridKit::Enzyme::Sparse::MemberFunctions::BusResidual>::eval(this,

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -2,8 +2,7 @@
  * @file GenClassicalImpl.hpp
  * @author Abdourahman Barry (abdourahman@vt.edu)
  * @author Slaven Peles (peless@ornl.gov)
- * @brief Definition of a Classical generator model.
- *
+ * @brief Definition of a classical generator model.
  *
  */
 
@@ -15,54 +14,13 @@
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalData.hpp>
 #include <GridKit/Model/VariableMonitorImpl.hpp>
+#include <GridKit/Utilities/Logger/Logger.hpp>
 
 namespace GridKit
 {
   namespace PhasorDynamics
   {
-    /**
-     * @brief Constructor for a classical generator model
-     */
-    template <typename scalar_type, typename index_type>
-    GenClassical<scalar_type, index_type>::GenClassical(BusT* bus)
-      : bus_(bus),
-        bus_id_(0),
-        p0_(0.0),
-        q0_(0.0),
-        H_(3.0),
-        D_(0.0),
-        Ra_(0.0),
-        Xdp_(0.5),
-        mva_base_(100.)
-    {
-      size_ = 5;
-      setDerivedParams();
-    }
-
-    /**
-     * @brief Constructor for a classical generator model
-     */
-    template <typename scalar_type, typename index_type>
-    GenClassical<scalar_type, index_type>::GenClassical(BusT* bus,
-                                                        RealT p0,
-                                                        RealT q0,
-                                                        RealT H,
-                                                        RealT D,
-                                                        RealT Ra,
-                                                        RealT Xdp)
-      : bus_(bus),
-        bus_id_(0),
-        p0_(p0),
-        q0_(q0),
-        H_(H),
-        D_(D),
-        Ra_(Ra),
-        Xdp_(Xdp),
-        mva_base_(100.)
-    {
-      size_ = 5;
-      setDerivedParams();
-    }
+    using Log = ::GridKit::Utilities::Logger;
 
     /**
      * @brief Constructor for a classical generator model
@@ -72,8 +30,24 @@ namespace GridKit
       : bus_(bus),
         monitor_(std::make_unique<MonitorT>(data))
     {
+      initializeParameters(data);
+      initializeMonitor();
+
+      size_ = 5;
+      setDerivedParams();
+    }
+
+    template <typename scalar_type, typename index_type>
+    GenClassical<scalar_type, index_type>::~GenClassical()
+    {
+    }
+
+    /// Helper function to extract and assign model parameters from the model's associated
+    /// data structure.
+    template <typename scalar_type, typename index_type>
+    void GenClassical<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
+    {
       using Parameter = typename ModelDataT::Parameters;
-      using Buses     = typename ModelDataT::Buses;
       if (data.parameters.contains(Parameter::p0))
       {
         p0_ = std::get<RealT>(data.parameters.at(Parameter::p0));
@@ -108,21 +82,6 @@ namespace GridKit
       {
         mva_base_ = std::get<RealT>(data.parameters.at(Parameter::mva));
       }
-
-      if (data.buses.contains(Buses::bus))
-      {
-        bus_id_ = data.buses.at(Buses::bus);
-      }
-
-      initializeMonitor();
-
-      size_ = 5;
-      setDerivedParams();
-    }
-
-    template <typename scalar_type, typename index_type>
-    GenClassical<scalar_type, index_type>::~GenClassical()
-    {
     }
 
     template <typename scalar_type, typename index_type>
@@ -131,14 +90,16 @@ namespace GridKit
       return monitor_.get();
     }
 
+    // System base -> machine base when reading system values.
     template <typename scalar_type, typename index_type>
-    GenClassical<scalar_type, index_type>::ScalarT GenClassical<scalar_type, index_type>::toMachineBase(ScalarT value) const
+    scalar_type GenClassical<scalar_type, index_type>::toMachineBase(ScalarT value) const
     {
       return value * va_system_base_ / va_machine_base_;
     }
 
+    // Machine base -> system base for network and signal output.
     template <typename scalar_type, typename index_type>
-    GenClassical<scalar_type, index_type>::ScalarT GenClassical<scalar_type, index_type>::toSystemBase(ScalarT value) const
+    scalar_type GenClassical<scalar_type, index_type>::toSystemBase(ScalarT value) const
     {
       return value / toMachineBase(static_cast<ScalarT>(ONE<RealT>));
     }
@@ -147,6 +108,7 @@ namespace GridKit
     void GenClassical<scalar_type, index_type>::initializeMonitor()
     {
       using Variable = typename ModelDataT::MonitorableVariables;
+      // Convert monitored terminal values to system base.
       monitor_->set(Variable::ir, [this]
                     { return toSystemBase(y_.getData()[3]); });
       monitor_->set(Variable::ii, [this]
@@ -173,7 +135,7 @@ namespace GridKit
       return 0;
     }
 
-    /**
+    /*!
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
     template <typename scalar_type, typename index_type>
@@ -195,47 +157,109 @@ namespace GridKit
         this->setResidualIndex(j, j);
       }
 
-      // Resize coupling data
+      // Resize bus data
       wb_.resize(2);
       h_.resize(2);
+
+      // Resize signal variable data
+      ws_.resize(2);
+      ws_indices_.resize(2);
+      ws_indices_[0] = INVALID_INDEX<IdxT>;
+      ws_indices_[1] = INVALID_INDEX<IdxT>;
+
+      // Set output signals
+      if (signals_.template isAssigned<GenClassicalInternalVariables::OMEGA>())
+      {
+        auto* y = y_.getData();
+        signals_.template getSignalNode<GenClassicalInternalVariables::OMEGA>()->set(&y[1], &(this->getVariableIndex(1)));
+      }
 
       allocated_ = true;
       return 0;
     }
 
     /**
+     * @brief verify method checks that attached signals are also linked
+     */
+    template <typename scalar_type, typename index_type>
+    int GenClassical<scalar_type, index_type>::verify() const
+    {
+      static constexpr auto PM  = GenClassicalExternalVariables::PM;
+      static constexpr auto EFD = GenClassicalExternalVariables::EFD;
+
+      int ret = 0;
+
+      if (signals_.template isAttached<PM>())
+      {
+        if (!signals_.template isLinked<PM>())
+        {
+          Log::error() << "GenClassical: pmech signal attached with no linked governor\n";
+          ret += 1;
+        }
+      }
+
+      if (signals_.template isAttached<EFD>())
+      {
+        if (!signals_.template isLinked<EFD>())
+        {
+          Log::error() << "GenClassical: efd signal attached with no linked exciter\n";
+          ret += 1;
+        }
+      }
+
+      return ret;
+    }
+
+    /**
      * Initialization of the generator model
+     *
      */
     template <typename scalar_type, typename index_type>
     int GenClassical<scalar_type, index_type>::initialize()
     {
-      ScalarT vr    = Vr();
-      ScalarT vi    = Vi();
-      ScalarT p     = toMachineBase(static_cast<ScalarT>(p0_));
-      ScalarT q     = toMachineBase(static_cast<ScalarT>(q0_));
-      ScalarT vm2   = vr * vr + vi * vi;
-      ScalarT ir    = (p * vr + q * vi) / vm2;
-      ScalarT ii    = (p * vi - q * vr) / vm2;
-      ScalarT Er    = Ra_ * ir - Xdp_ * ii + vr;
-      ScalarT Ei    = Ra_ * ii + Xdp_ * ir + vi;
+      // Network frame terminal values
+      ScalarT vr  = Vr();
+      ScalarT vi  = Vi();
+      ScalarT p   = toMachineBase(static_cast<ScalarT>(p0_));
+      ScalarT q   = toMachineBase(static_cast<ScalarT>(q0_));
+      ScalarT vm2 = vr * vr + vi * vi;
+      ScalarT ir  = (p * vr + q * vi) / vm2;
+      ScalarT ii  = (p * vi - q * vr) / vm2;
+
+      ScalarT Er    = vr + Ra_ * ir - Xdp_ * ii;
+      ScalarT Ei    = vi + Ra_ * ii + Xdp_ * ir;
       ScalarT delta = std::atan2(Ei, Er);
-      ScalarT omega = static_cast<ScalarT>(0.0);
-      ScalarT Ep    = std::sqrt(Er * Er + Ei * Ei);
-      ScalarT Te    = G_ * Ep * Ep - Ep * ((G_ * vr - B_ * vi) * std::cos(delta) + (B_ * vr + G_ * vi) * std::sin(delta));
+      ScalarT omega(0.0);
+
+      ScalarT efd = std::sqrt(Er * Er + Ei * Ei);
+      ScalarT Te  = G_ * efd * efd - efd * ((G_ * vr - B_ * vi) * std::cos(delta) + (B_ * vr + G_ * vi) * std::sin(delta));
 
       auto* y  = y_.getData();
       auto* yp = yp_.getData();
 
-      y[0]       = delta;
-      y[1]       = omega;
-      y[2]       = Te;
-      y[3]       = ir;
-      y[4]       = ii;
-      pmech_set_ = Te;
-      ep_set_    = Ep;
+      y[0] = delta;
+      y[1] = omega;
+      y[2] = Te;
+      y[3] = ir;
+      y[4] = ii;
 
-      for (size_t i = 0; i < static_cast<size_t>(size_); ++i)
-        yp[i] = 0.0;
+      // Convert Te to system base for governor PM signal.
+      pmech_set_ = toSystemBase(Te);
+      if (signals_.template isAttached<GenClassicalExternalVariables::PM>())
+      {
+        signals_.template writeExternalVariable<GenClassicalExternalVariables::PM>(pmech_set_);
+      }
+
+      efd_set_ = efd;
+      if (signals_.template isAttached<GenClassicalExternalVariables::EFD>())
+      {
+        signals_.template writeExternalVariable<GenClassicalExternalVariables::EFD>(efd_set_);
+      }
+
+      for (IdxT i = 0; i < size_; ++i)
+      {
+        yp[static_cast<size_t>(i)] = 0.0;
+      }
 
       y_.setDataUpdated();
       yp_.setDataUpdated();
@@ -280,40 +304,42 @@ namespace GridKit
      *
      */
     template <typename scalar_type, typename index_type>
-    __attribute__((always_inline)) int GenClassical<scalar_type, index_type>::evaluateInternalResidual(
+    __attribute__((always_inline)) inline int GenClassical<scalar_type, index_type>::evaluateInternalResidual(
         const ScalarT* y,
         const ScalarT* yp,
         const ScalarT* wb,
+        const ScalarT* ws,
         ScalarT*       f)
     {
-      // Set variable aliases for better readability.
-      const ScalarT delta = y[0];
-      const ScalarT omega = y[1];
-      const ScalarT telec = y[2];
-      const ScalarT ir    = y[3];
-      const ScalarT ii    = y[4];
-      const ScalarT pmech = pmech_set_; /* Later optionally acquire from governor */
-      const ScalarT ep    = ep_set_;    /* Later optionally acquire from exciter */
+      /* Read variables */
+      ScalarT delta = y[0];
+      ScalarT omega = y[1];
+      ScalarT telec = y[2];
+      ScalarT ir    = y[3];
+      ScalarT ii    = y[4];
 
-      // Set derivative aliases for better readability
-      const ScalarT delta_dot = yp[0];
-      const ScalarT omega_dot = yp[1];
+      /* Read derivatives */
+      ScalarT delta_dot = yp[0];
+      ScalarT omega_dot = yp[1];
 
       // Set coupling variable aliases
-      const ScalarT vr = wb[0];
-      const ScalarT vi = wb[1];
+      ScalarT vr = wb[0];
+      ScalarT vi = wb[1];
+
+      // Set signal variable aliases
+      ScalarT pmech = toMachineBase(ws[0]);
+      ScalarT efd   = ws[1];
 
       static constexpr auto pi = std::numbers::pi_v<RealT>;
 
-      // GenClassical differential equations
+      /* 2 GenClassical differential equations */
       f[0] = delta_dot - omega * (TWO<RealT> * pi * freq_system_base_);
       f[1] = omega_dot - (ONE<RealT> / (TWO<RealT> * H_)) * ((pmech - D_ * omega) / (ONE<RealT> + omega) - telec);
 
-      // GenClassical algebraic equations
-      f[2] = telec - (G_ * ep * ep - ep * ((G_ * vr - B_ * vi) * std::cos(delta) + (B_ * vr + G_ * vi) * std::sin(delta)));
-
-      f[3] = ir + G_ * vr - B_ * vi - ep * (G_ * std::cos(delta) - B_ * std::sin(delta));
-      f[4] = ii + B_ * vr + G_ * vi - ep * (B_ * std::cos(delta) + G_ * std::sin(delta));
+      /* 3 GenClassical algebraic equations */
+      f[2] = telec - (G_ * efd * efd - efd * ((G_ * vr - B_ * vi) * std::cos(delta) + (B_ * vr + G_ * vi) * std::sin(delta)));
+      f[3] = ir - (efd * (G_ * std::cos(delta) - B_ * std::sin(delta)) - G_ * vr + B_ * vi);
+      f[4] = ii - (efd * (B_ * std::cos(delta) + G_ * std::sin(delta)) - B_ * vr - G_ * vi);
 
       return 0;
     }
@@ -323,38 +349,61 @@ namespace GridKit
      *
      */
     template <typename scalar_type, typename index_type>
-    __attribute__((always_inline)) int GenClassical<scalar_type, index_type>::evaluateBusResidual(
+    __attribute__((always_inline)) inline int GenClassical<scalar_type, index_type>::evaluateBusResidual(
         const ScalarT*                  y,
         [[maybe_unused]] const ScalarT* yp,
         [[maybe_unused]] const ScalarT* wb,
         ScalarT*                        h)
     {
-      const ScalarT ir = y[3];
-      const ScalarT ii = y[4];
-      h[0]             = toSystemBase(ir);
-      h[1]             = toSystemBase(ii);
+      ScalarT ir = y[3];
+      ScalarT ii = y[4];
+
+      // Convert current injection to system base for the network.
+      h[0] = toSystemBase(ir);
+      h[1] = toSystemBase(ii);
 
       return 0;
     }
 
     /**
-     * \brief Residual for the generator model.
+     * \brief Residual evaluation and contribution to the connected bus
      *
      */
     template <typename scalar_type, typename index_type>
     int GenClassical<scalar_type, index_type>::evaluateResidual()
     {
+      auto* ws = ws_.getData();
+
+      // Mechanical Power
+      ws[0] = pmech_set_;
+      if (signals_.template isAttached<GenClassicalExternalVariables::PM>())
+      {
+        ws[0]          = signals_.template readExternalVariable<GenClassicalExternalVariables::PM>();
+        ws_indices_[0] = signals_.template readExternalVariableIndex<GenClassicalExternalVariables::PM>();
+      }
+
+      // Exciter Efield
+      ws[1] = efd_set_;
+      if (signals_.template isAttached<GenClassicalExternalVariables::EFD>())
+      {
+        ws[1]          = signals_.template readExternalVariable<GenClassicalExternalVariables::EFD>();
+        ws_indices_[1] = signals_.template readExternalVariableIndex<GenClassicalExternalVariables::EFD>();
+      }
+
+      // Bus voltages
       auto* wb = wb_.getData();
       wb[0]    = Vr();
       wb[1]    = Vi();
 
+      // Residual evaluation
       const auto* y  = y_.getData();
       const auto* yp = yp_.getData();
       auto*       f  = f_.getData();
       auto*       h  = h_.getData();
-      evaluateInternalResidual(y, yp, wb, f);
+      evaluateInternalResidual(y, yp, wb, ws, f);
       evaluateBusResidual(y, yp, wb, h);
 
+      // GenClassical contribution to bus algebraic equations
       Ir() += h[0];
       Ii() += h[1];
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassicalImpl.hpp
@@ -42,8 +42,7 @@ namespace GridKit
     {
     }
 
-    /// Helper function to extract and assign model parameters from the model's associated
-    /// data structure.
+    /// Read model parameters from the data structure
     template <typename scalar_type, typename index_type>
     void GenClassical<scalar_type, index_type>::initializeParameters(const ModelDataT& data)
     {
@@ -135,7 +134,7 @@ namespace GridKit
       return 0;
     }
 
-    /*!
+    /**
      * @brief allocate method computes sparsity pattern of the Jacobian.
      */
     template <typename scalar_type, typename index_type>
@@ -212,7 +211,6 @@ namespace GridKit
 
     /**
      * Initialization of the generator model
-     *
      */
     template <typename scalar_type, typename index_type>
     int GenClassical<scalar_type, index_type>::initialize()
@@ -229,7 +227,7 @@ namespace GridKit
       ScalarT Er    = vr + Ra_ * ir - Xdp_ * ii;
       ScalarT Ei    = vi + Ra_ * ii + Xdp_ * ir;
       ScalarT delta = std::atan2(Ei, Er);
-      ScalarT omega(0.0);
+      ScalarT omega = static_cast<ScalarT>(0.0);
 
       ScalarT efd = std::sqrt(Er * Er + Ei * Ei);
       ScalarT Te  = G_ * efd * efd - efd * ((G_ * vr - B_ * vi) * std::cos(delta) + (B_ * vr + G_ * vi) * std::sin(delta));
@@ -311,32 +309,32 @@ namespace GridKit
         const ScalarT* ws,
         ScalarT*       f)
     {
-      /* Read variables */
-      ScalarT delta = y[0];
-      ScalarT omega = y[1];
-      ScalarT telec = y[2];
-      ScalarT ir    = y[3];
-      ScalarT ii    = y[4];
+      // Set variable aliases for better readability.
+      const ScalarT delta = y[0];
+      const ScalarT omega = y[1];
+      const ScalarT telec = y[2];
+      const ScalarT ir    = y[3];
+      const ScalarT ii    = y[4];
 
-      /* Read derivatives */
-      ScalarT delta_dot = yp[0];
-      ScalarT omega_dot = yp[1];
+      // Set derivative aliases for better readability
+      const ScalarT delta_dot = yp[0];
+      const ScalarT omega_dot = yp[1];
 
       // Set coupling variable aliases
-      ScalarT vr = wb[0];
-      ScalarT vi = wb[1];
+      const ScalarT vr = wb[0];
+      const ScalarT vi = wb[1];
 
       // Set signal variable aliases
-      ScalarT pmech = toMachineBase(ws[0]);
-      ScalarT efd   = ws[1];
+      const ScalarT pmech = toMachineBase(ws[0]);
+      const ScalarT efd   = ws[1];
 
       static constexpr auto pi = std::numbers::pi_v<RealT>;
 
-      /* 2 GenClassical differential equations */
+      // GenClassical differential equations
       f[0] = delta_dot - omega * (TWO<RealT> * pi * freq_system_base_);
       f[1] = omega_dot - (ONE<RealT> / (TWO<RealT> * H_)) * ((pmech - D_ * omega) / (ONE<RealT> + omega) - telec);
 
-      /* 3 GenClassical algebraic equations */
+      // GenClassical algebraic equations
       f[2] = telec - (G_ * efd * efd - efd * ((G_ * vr - B_ * vi) * std::cos(delta) + (B_ * vr + G_ * vi) * std::sin(delta)));
       f[3] = ir - (efd * (G_ * std::cos(delta) - B_ * std::sin(delta)) - G_ * vr + B_ * vi);
       f[4] = ii - (efd * (B_ * std::cos(delta) + G_ * std::sin(delta)) - B_ * vr - G_ * vi);
@@ -355,18 +353,16 @@ namespace GridKit
         [[maybe_unused]] const ScalarT* wb,
         ScalarT*                        h)
     {
-      ScalarT ir = y[3];
-      ScalarT ii = y[4];
-
-      // Convert current injection to system base for the network.
-      h[0] = toSystemBase(ir);
-      h[1] = toSystemBase(ii);
+      const ScalarT ir = y[3];
+      const ScalarT ii = y[4];
+      h[0]             = toSystemBase(ir);
+      h[1]             = toSystemBase(ii);
 
       return 0;
     }
 
     /**
-     * \brief Residual evaluation and contribution to the connected bus
+     * \brief Residual for the generator model.
      *
      */
     template <typename scalar_type, typename index_type>
@@ -374,7 +370,6 @@ namespace GridKit
     {
       auto* ws = ws_.getData();
 
-      // Mechanical Power
       ws[0] = pmech_set_;
       if (signals_.template isAttached<GenClassicalExternalVariables::PM>())
       {
@@ -382,7 +377,6 @@ namespace GridKit
         ws_indices_[0] = signals_.template readExternalVariableIndex<GenClassicalExternalVariables::PM>();
       }
 
-      // Exciter Efield
       ws[1] = efd_set_;
       if (signals_.template isAttached<GenClassicalExternalVariables::EFD>())
       {
@@ -390,12 +384,10 @@ namespace GridKit
         ws_indices_[1] = signals_.template readExternalVariableIndex<GenClassicalExternalVariables::EFD>();
       }
 
-      // Bus voltages
       auto* wb = wb_.getData();
       wb[0]    = Vr();
       wb[1]    = Vi();
 
-      // Residual evaluation
       const auto* y  = y_.getData();
       const auto* yp = yp_.getData();
       auto*       f  = f_.getData();
@@ -403,7 +395,6 @@ namespace GridKit
       evaluateInternalResidual(y, yp, wb, ws, f);
       evaluateBusResidual(y, yp, wb, h);
 
-      // GenClassical contribution to bus algebraic equations
       Ir() += h[0];
       Ii() += h[1];
 

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
@@ -1,30 +1,57 @@
-# Classical Generator
+# **Classical Generator Model (GENCLS)**
 
-An electrical machine model with two differential variables (i.e. second-order
-model) is often called classical generator model. While its predictive ability
-is limited, it is useful for studies of grid network properties. Mathematically,
-it is equivalent to a driven damped pendulum model.
+GENCLS is the 2nd order synchronous machine model: a constant transient EMF
+behind the transient reactance. See the
+[General Synchronous Machine Model](../README.md) for general synchronous
+machine information.
+
+## Notes
+
+- No field dynamics: the `efd` input is the EMF behind $X'_d$ and is held
+  constant when unconnected.
+- No saliency and no saturation.
 
 ## Model Parameters
 
-Symbol      | Units   | Description                     | Note
-------------|---------|---------------------------------|----------------------
-$P_0$       | [p.u.]  | initial active power injection  |
-$Q_0$       | [p.u.]  | initial reactive power injection |
-$H$         | [s]     | rotor inertia                   |
-$D$         | [p.u.]  | damping coefficient             |
-$R_a$       | [p.u.]  | winding resistance              |
-$X_{dp}$    | [p.u.]  | machine reactance parameter     |
-$S_\mathrm{mach}$ | [MVA] | machine power base        |
+Symbol            | Units  | JSON  | Description                      | Typical Value | Note
+------------------|--------|-------|----------------------------------|---------------|------
+$P_0$             | [p.u.] | `p0`  | Initial active power injection   | 1.0           | System base; required initialization source
+$Q_0$             | [p.u.] | `q0`  | Initial reactive power injection | 0.0           | System base; required initialization source
+$S^\mathrm{base}$ | [MVA]  | `mva` | Machine component power base     | 100.0         |
+$H$               | [sec]  | `H`   | Rotor inertia                    | 3.0           |
+$D$               | [p.u.] | `D`   | Damping coefficient              | 0.0           |
+$R_a$             | [p.u.] | `Ra`  | Armature resistance              | 0.0           | Component base
+$X'_d$            | [p.u.] | `Xdp` | Direct-axis transient reactance  | 0.2           | Component base
+
+### Parameter Validation
+
+None.
 
 ### Model Derived Parameters
 
-- $G = \dfrac{R_a}{R_a^2 + X_{dp}^2} ~~~$ equivalent stator winding conductance
-- $B = \dfrac{-X_{dp}}{R_a^2 + X_{dp}^2} ~~~$ equivalent stator winding susceptance
-- $f_\mathrm{base} = f_\mathrm{sys} ~~~$ frequency base taken from the system at initialization
-- $S_\mathrm{mach,VA} = 10^6 S_\mathrm{mach} ~~~$ derived machine base used for machine-base/system-base conversions
+```math
+\begin{aligned}
+  G
+    &= \dfrac{R_a}{R_a^2+(X'_d)^2} \\
+  B
+    &= -\dfrac{X'_d}{R_a^2+(X'_d)^2} \\
+  k_\mathrm{base}
+    &= \dfrac{S^\mathrm{sys}}{S^\mathrm{base}}
+\end{aligned}
+```
 
-<br>
+Multiplying by $k_\mathrm{base}$ converts system base to component base;
+$S^\mathrm{sys}$ and $S^\mathrm{base}$ are stored in VA and $f^\mathrm{sys}$
+is the system frequency base in Hz.
+
+## Model Ports
+
+Name    | Port   | Init    | Description
+--------|--------|---------|------------
+`bus`   | Bus    | Known   | Terminal bus voltage
+`pmech` | Input  | Unknown | Mechanical-power input
+`efd`   | Input  | Unknown | Field-voltage input
+`speed` | Output | Known   | Speed-deviation output
 
 ## Model Variables
 
@@ -32,29 +59,20 @@ $S_\mathrm{mach}$ | [MVA] | machine power base        |
 
 #### Differential
 
-Symbol      | Units   | Description         | Note
-------------|---------|---------------------|----------------------
-$\delta$    | [rad]   | machine power angle |
-$\omega$    | [p.u]   | machine speed deviation       | Optionally read by a governor or a stabilizer component
+Symbol   | Units  | Description         | Note
+---------|--------|---------------------|------
+$\delta$ | [rad]  | Rotor angle         |
+$\omega$ | [p.u.] | Speed deviation     | Exported through `speed` when assigned
 
 #### Algebraic
 
-Symbol  | Units  | Description                         | Note
---------|--------|-------------------------------------|-------------
-$T_{e}$ | [p.u.] | electrical torque                   |
-$I_r$   | [p.u.] | machine real injection current      | read by bus
-$I_i$   | [p.u.] | machine imaginary injection current | read by bus
-
-Note: All three can be expressed as a function called by the model equations. We add
-these as variables as they are needed for outputs.
-
-<br>
+Symbol         | Units  | Description                           | Note
+---------------|--------|---------------------------------------|------
+$T_\mathrm{e}$ | [p.u.] | Electrical torque                     | Component base
+$I_\mathrm{r}$ | [p.u.] | Terminal current, real component      | Component base
+$I_\mathrm{i}$ | [p.u.] | Terminal current, imaginary component | Component base
 
 ### External Variables
-
-External variables enter component model equations but are owned by other
-components. The other components also provide equations needed to have a
-balanced system of equations. 
 
 #### Differential
 
@@ -62,115 +80,96 @@ None.
 
 #### Algebraic
 
-Symbol | Units   | Description                   | Note
--------|---------|-------------------------------|----------------------
-$V_r$  | [p.u.]  | machine bus real voltage      | owned by a bus object
-$V_i$  | [p.u.]  | machine bus imaginary voltage | owned by a bus object
-$P_m$  | [p.u.]  | mechanical power input        | owned by governor, constant if no governor is connected to the machine
-$E_p$  | [p.u.]  | field winding voltage         | owned by exciter, constant if no exciter is connected to the machine
-
-<br>
-
+Symbol          | Units  | Init    | Description                           | Note
+----------------|--------|---------|---------------------------------------|------
+$V_\mathrm{r}$  | [p.u.] | Known   | Terminal voltage, real component      | Bus input
+$V_\mathrm{i}$  | [p.u.] | Known   | Terminal voltage, imaginary component | Bus input
+$P_\mathrm{m}$  | [p.u.] | Unknown | Mechanical power                      | Optional signal port `pmech`; system base
+$E_\mathrm{fd}$ | [p.u.] | Unknown | Field voltage                         | Optional signal port `efd`; component base
 
 ## Model Equations
 
-### Differential Equations
+### Internal Equations
 
-```math 
-\begin{aligned}
-\dot{\delta} &= \omega \cdot 2\pi f_\mathrm{base} \\
-\dot{\omega} &= \frac{1}{2H}\left( \frac{P_{m} - D\omega}{1+\omega}   - T_{e}\right)
-\end{aligned}
-```
-
-### Algebraic Equations
+#### Differential
 
 ```math
 \begin{aligned}
-    0 &= T_{e} - \left( G E_p^2 - E_p \left[(G V_r - B V_i)\cos\delta + (B V_r + G V_i)\sin\delta \right]\right) \\
-    0 &= I_r + G V_r - B V_i - E_p(G \cos\delta - B \sin\delta) \\
-    0 &= I_i + B V_r + G V_i - E_p(B \cos\delta + G \sin\delta)
+  0 &= -\dot\delta + 2\pi f^\mathrm{sys}\omega \\
+  0 &= -\dot\omega + \dfrac{1}{2H}\left(\dfrac{k_\mathrm{base}P_\mathrm{m}-D\omega}{1+\omega}-T_\mathrm{e}\right)
 \end{aligned}
 ```
-As noted earlier, all three algebraic equations can be expressed as functions
-and substituted directly in the component and bus equations, respectively. We
-use redundant variables for modeling convenience.
 
-<br>
+#### Algebraic
+
+```math
+\begin{aligned}
+  0 &= -T_\mathrm{e} + GE_\mathrm{fd}^2 - E_\mathrm{fd}\left[(GV_\mathrm{r}-BV_\mathrm{i})\cos(\delta)+(BV_\mathrm{r}+GV_\mathrm{i})\sin(\delta)\right] \\
+  0 &= -I_\mathrm{r} + E_\mathrm{fd}(G\cos(\delta)-B\sin(\delta)) - GV_\mathrm{r} + BV_\mathrm{i} \\
+  0 &= -I_\mathrm{i} + E_\mathrm{fd}(B\cos(\delta)+G\sin(\delta)) - BV_\mathrm{r} - GV_\mathrm{i}
+\end{aligned}
+```
+
+### External Equations
+
+```math
+\begin{aligned}
+  \Delta I^\mathrm{bus}_\mathrm{r} &\mathrel{+}= \dfrac{I_\mathrm{r}}{k_\mathrm{base}} \\
+  \Delta I^\mathrm{bus}_\mathrm{i} &\mathrel{+}= \dfrac{I_\mathrm{i}}{k_\mathrm{base}}
+\end{aligned}
+```
 
 ## Initialization
 
-To initialize the model, given bus voltages $V_r$, $V_i$, and initial generator
-injection active and reactive power, $P$ and $Q$, we take following steps to
-initialize the system:
+### Input Initialization
 
-Complex power is defined as
-```math
-S=VI^{*}
-```
-or
-```math
-P + jQ = (V_r + j V_i)(I_r - j I_i).
-```
-From here, we compute injection currents from the initial power injection and bus
-voltages as
 ```math
 \begin{aligned}
-I_r &= \frac{PV_r + QV_i}{V_r^2 + V_i^2} \\
-I_i &= \frac{PV_i - QV_r}{V_r^2 + V_i^2}
-\end{aligned} 
-```
-
-We substitute the expressions above into equations for current injections and
-obtain
-```math
-\begin{aligned}
-E_p \sin\delta &= \dfrac{-B I_r + G I_i}{G^2 + B^2} + V_i \\
-E_p \cos\delta &= \dfrac{G I_r + B I_i}{G^2 + B^2} + V_r
-\end{aligned}
-```
-By dividing these two equations, we get an expression for the machine angle at the
-steady state:
-```math
-\delta = \arctan \dfrac{E_i}{E_r} \, ,
-```
-And by squaring and adding them, we get an expression for the field
-winding voltage at the steady state
-```math
-E_p = \sqrt{E_r^2 + E_i^2}   \, ,
-```
-where
-```math
-\begin{aligned}
-E_r &= \dfrac{G I_r + B I_i}{G^2 + B^2} + V_r \, ,\\
-E_i &= \dfrac{-B I_r + G I_i}{G^2 + B^2} + V_i \, .
+  V_\mathrm{r}, V_\mathrm{i}
+    &\leftarrow \text{terminal-bus voltage} \\
+  P_0, Q_0
+    &\leftarrow \text{power-flow injection on system base}
 \end{aligned}
 ```
 
-Next, we set the machine speed deviation to zero:
-```math
-\omega = 0
-```
+### Internal Initialization
 
-Now, we can compute the electrical torque and set the mechanical torque to be equal
-to the electrical:
+All internal derivatives are initialized to zero:
+
 ```math
 \begin{aligned}
-T_{e} &= G E_p^2 - E_p \left[ (G V_r - B V_i ) \cos\delta + (B V_r + G V_i )\sin\delta \right] \\
-P_{m} &= T_{e} 
-\end{aligned} 
+  I_\mathrm{r}
+    &\leftarrow k_\mathrm{base}\dfrac{V_\mathrm{r}P_0+V_\mathrm{i}Q_0}{V_\mathrm{r}^2+V_\mathrm{i}^2} \\
+  I_\mathrm{i}
+    &\leftarrow k_\mathrm{base}\dfrac{V_\mathrm{i}P_0-V_\mathrm{r}Q_0}{V_\mathrm{r}^2+V_\mathrm{i}^2} \\
+  \delta
+    &\leftarrow \text{arg}\left[V_\mathrm{r}+jV_\mathrm{i}+(R_a+jX'_d)(I_\mathrm{r}+jI_\mathrm{i})\right] \\
+  \omega
+    &\leftarrow 0 \\
+  T_\mathrm{e}
+    &\leftarrow V_\mathrm{r}I_\mathrm{r}+V_\mathrm{i}I_\mathrm{i}+R_a(I_\mathrm{r}^2+I_\mathrm{i}^2)
+\end{aligned}
 ```
 
-With this, we initialize the machine at a steady state.
+### Output Initialization
 
+```math
+\begin{aligned}
+  P_\mathrm{m}
+    &\leftarrow \dfrac{T_\mathrm{e}}{k_\mathrm{base}} \\
+  E_\mathrm{fd}
+    &\leftarrow \left|V_\mathrm{r}+jV_\mathrm{i}+(R_a+jX'_d)(I_\mathrm{r}+jI_\mathrm{i})\right|
+\end{aligned}
+```
 
-## Model Outputs
+## Monitors
 
-Symbol     | Units  | Description                       | Note
------------|--------|-----------------------------------|------
-$I_r$      | [p.u.] | Terminal current, real component on network reference frame | Oriented leaving the machine, system base
-$I_i$      | [p.u.] | Terminal current, imaginary component on network reference frame | Oriented leaving the machine, system base
-$P$        | [p.u.] | Active power, $V_rI_r+V_iI_i$     | Oriented leaving the machine, system base
-$Q$        | [p.u.] | Reactive power, $V_iI_r-V_rI_i$   | Oriented leaving the machine, system base
-$\delta$   | [rad]  | Machine internal rotor angle      |
-$\omega$   | [p.u.] | Machine speed deviation           | $\omega=0$ at synchronous speed
+Monitor | Units  | Description                           | Note
+--------|--------|---------------------------------------|------
+`ir`    | [p.u.] | Terminal current, real component      | System base; oriented leaving the machine
+`ii`    | [p.u.] | Terminal current, imaginary component | System base; oriented leaving the machine
+`p`     | [p.u.] | Active power                          | System base; $V_\mathrm{r}I_\mathrm{r}+V_\mathrm{i}I_\mathrm{i}$
+`q`     | [p.u.] | Reactive power                        | System base; $V_\mathrm{i}I_\mathrm{r}-V_\mathrm{r}I_\mathrm{i}$
+`delta` | [rad]  | Rotor angle                           |
+`omega` | [p.u.] | Speed deviation                       | $\omega=0$ at synchronous speed
+`speed` | [p.u.] | Per-unit machine speed                | $1+\omega$

--- a/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
+++ b/GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/README.md
@@ -17,7 +17,7 @@ Symbol            | Units  | JSON  | Description                      | Typical 
 ------------------|--------|-------|----------------------------------|---------------|------
 $P_0$             | [p.u.] | `p0`  | Initial active power injection   | 1.0           | System base; required initialization source
 $Q_0$             | [p.u.] | `q0`  | Initial reactive power injection | 0.0           | System base; required initialization source
-$S^\mathrm{base}$ | [MVA]  | `mva` | Machine component power base     | 100.0         |
+$S^\mathrm{base}$ | [MVA]  | `mva` | GENCLS component power base      | 100.0         |
 $H$               | [sec]  | `H`   | Rotor inertia                    | 3.0           |
 $D$               | [p.u.] | `D`   | Damping coefficient              | 0.0           |
 $R_a$             | [p.u.] | `Ra`  | Armature resistance              | 0.0           | Component base
@@ -40,9 +40,9 @@ None.
 \end{aligned}
 ```
 
-Multiplying by $k_\mathrm{base}$ converts system base to component base;
-$S^\mathrm{sys}$ and $S^\mathrm{base}$ are stored in VA and $f^\mathrm{sys}$
-is the system frequency base in Hz.
+Multiplying by $k_\mathrm{base}$ converts system base to component base.
+$S^\mathrm{sys}$ and $S^\mathrm{base}$ are stored in VA; $f^\mathrm{sys}$ is
+the system frequency base in Hz.
 
 ## Model Ports
 
@@ -104,7 +104,7 @@ $E_\mathrm{fd}$ | [p.u.] | Unknown | Field voltage                         | Opt
 
 ```math
 \begin{aligned}
-  0 &= -T_\mathrm{e} + GE_\mathrm{fd}^2 - E_\mathrm{fd}\left[(GV_\mathrm{r}-BV_\mathrm{i})\cos(\delta)+(BV_\mathrm{r}+GV_\mathrm{i})\sin(\delta)\right] \\
+  0 &= -T_\mathrm{e} + GE_\mathrm{fd}^2 - E_\mathrm{fd}[(GV_\mathrm{r}-BV_\mathrm{i})\cos(\delta)+(BV_\mathrm{r}+GV_\mathrm{i})\sin(\delta)] \\
   0 &= -I_\mathrm{r} + E_\mathrm{fd}(G\cos(\delta)-B\sin(\delta)) - GV_\mathrm{r} + BV_\mathrm{i} \\
   0 &= -I_\mathrm{i} + E_\mathrm{fd}(B\cos(\delta)+G\sin(\delta)) - BV_\mathrm{r} - GV_\mathrm{i}
 \end{aligned}
@@ -143,7 +143,7 @@ All internal derivatives are initialized to zero:
   I_\mathrm{i}
     &\leftarrow k_\mathrm{base}\dfrac{V_\mathrm{i}P_0-V_\mathrm{r}Q_0}{V_\mathrm{r}^2+V_\mathrm{i}^2} \\
   \delta
-    &\leftarrow \text{arg}\left[V_\mathrm{r}+jV_\mathrm{i}+(R_a+jX'_d)(I_\mathrm{r}+jI_\mathrm{i})\right] \\
+    &\leftarrow \text{arg}[V_\mathrm{r}+jV_\mathrm{i}+(R_a+jX'_d)(I_\mathrm{r}+jI_\mathrm{i})] \\
   \omega
     &\leftarrow 0 \\
   T_\mathrm{e}
@@ -158,7 +158,7 @@ All internal derivatives are initialized to zero:
   P_\mathrm{m}
     &\leftarrow \dfrac{T_\mathrm{e}}{k_\mathrm{base}} \\
   E_\mathrm{fd}
-    &\leftarrow \left|V_\mathrm{r}+jV_\mathrm{i}+(R_a+jX'_d)(I_\mathrm{r}+jI_\mathrm{i})\right|
+    &\leftarrow |V_\mathrm{r}+jV_\mathrm{i}+(R_a+jX'_d)(I_\mathrm{r}+jI_\mathrm{i})|
 \end{aligned}
 ```
 

--- a/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
+++ b/GridKit/Model/PhasorDynamics/SystemModelImpl.hpp
@@ -291,6 +291,28 @@ namespace GridKit
           bus_index = gendata.buses.at(GenClassicalBuses::bus);
         }
         auto* gen = new GenClassical<ScalarT, IdxT>(getBus(bus_index), gendata);
+
+        if (gendata.signal_outputs.contains(GenClassicalSignalOutputs::speed))
+        {
+          IdxT           speed = gendata.signal_outputs.at(GenClassicalSignalOutputs::speed);
+          constexpr auto OMEGA = GenClassicalInternalVariables::OMEGA;
+          gen->getSignals().template assignSignalNode<OMEGA>(getSignal(speed));
+        }
+
+        if (gendata.signal_inputs.contains(GenClassicalSignalInputs::pmech))
+        {
+          IdxT           pmech = gendata.signal_inputs.at(GenClassicalSignalInputs::pmech);
+          constexpr auto PM    = GenClassicalExternalVariables::PM;
+          gen->getSignals().template attachSignalNode<PM>(getSignal(pmech));
+        }
+
+        if (gendata.signal_inputs.contains(GenClassicalSignalInputs::efd))
+        {
+          IdxT           efd = gendata.signal_inputs.at(GenClassicalSignalInputs::efd);
+          constexpr auto EFD = GenClassicalExternalVariables::EFD;
+          gen->getSignals().template attachSignalNode<EFD>(getSignal(efd));
+        }
+
         addComponent(gen);
       }
 

--- a/examples/PhasorDynamics/Small/TenGen/Classical/TenGenClassical.cpp
+++ b/examples/PhasorDynamics/Small/TenGen/Classical/TenGenClassical.cpp
@@ -24,6 +24,22 @@ using scalar_type = double;
 using real_type   = double;
 using index_type  = size_t;
 
+/// Classical generator data sharing the machine parameters of the example
+GridKit::PhasorDynamics::GenClassicalData<real_type, index_type> genData(real_type p0, real_type q0)
+{
+  using Parameter = GridKit::PhasorDynamics::GenClassicalParameters;
+
+  GridKit::PhasorDynamics::GenClassicalData<real_type, index_type> data;
+  data.parameters[Parameter::p0]  = p0;
+  data.parameters[Parameter::q0]  = q0;
+  data.parameters[Parameter::H]   = 3.0;
+  data.parameters[Parameter::D]   = 0.1;
+  data.parameters[Parameter::Ra]  = 0.0;
+  data.parameters[Parameter::Xdp] = 0.2;
+
+  return data;
+}
+
 int main()
 {
   using namespace GridKit::PhasorDynamics;
@@ -52,15 +68,15 @@ int main()
   Branch<scalar_type, index_type> branch89(&bus8, &bus9, 0.001, 0.005, 0, 0);
   Branch<scalar_type, index_type> branch910(&bus9, &bus10, 0.001, 0.005, 0, 0);
 
-  GenClassical<scalar_type, index_type> gen2(&bus2, 0.5, -0.00442101, 3., 0.1, 0., 0.2);
-  GenClassical<scalar_type, index_type> gen3(&bus3, 0.5, -0.02510812, 3., 0.1, 0., 0.2);
-  GenClassical<scalar_type, index_type> gen4(&bus4, 0.5, -0.04339553, 3., 0.1, 0., 0.2);
-  GenClassical<scalar_type, index_type> gen5(&bus5, 0.5, -0.2334993, 3., 0.1, 0., 0.2);
-  GenClassical<scalar_type, index_type> gen6(&bus6, 0.5, 0.69907194, 3., 0.1, 0., 0.2);
-  GenClassical<scalar_type, index_type> gen7(&bus7, 0.5, -0.08318208, 3., 0.1, 0., 0.2);
-  GenClassical<scalar_type, index_type> gen8(&bus8, 0.5, -0.09123614, 3., 0.1, 0., 0.2);
-  GenClassical<scalar_type, index_type> gen9(&bus9, 0.5, -0.09662372, 3., 0.1, 0., 0.2);
-  GenClassical<scalar_type, index_type> gen10(&bus10, 0.5, -0.09932297, 3., 0.1, 0., 0.2);
+  GenClassical<scalar_type, index_type> gen2(&bus2, genData(0.5, -0.00442101));
+  GenClassical<scalar_type, index_type> gen3(&bus3, genData(0.5, -0.02510812));
+  GenClassical<scalar_type, index_type> gen4(&bus4, genData(0.5, -0.04339553));
+  GenClassical<scalar_type, index_type> gen5(&bus5, genData(0.5, -0.2334993));
+  GenClassical<scalar_type, index_type> gen6(&bus6, genData(0.5, 0.69907194));
+  GenClassical<scalar_type, index_type> gen7(&bus7, genData(0.5, -0.08318208));
+  GenClassical<scalar_type, index_type> gen8(&bus8, genData(0.5, -0.09123614));
+  GenClassical<scalar_type, index_type> gen9(&bus9, genData(0.5, -0.09662372));
+  GenClassical<scalar_type, index_type> gen10(&bus10, genData(0.5, -0.09932297));
 
   BusFault<scalar_type, index_type> fault(&bus10, 0, 1e-5, 0);
 

--- a/examples/PhasorDynamics/Small/TenGen/Classical/TenGenClassical.cpp
+++ b/examples/PhasorDynamics/Small/TenGen/Classical/TenGenClassical.cpp
@@ -24,7 +24,7 @@ using scalar_type = double;
 using real_type   = double;
 using index_type  = size_t;
 
-/// Classical generator data sharing the machine parameters of the example
+/// Machine data shared by the example generators
 GridKit::PhasorDynamics::GenClassicalData<real_type, index_type> genData(real_type p0, real_type q0)
 {
   using Parameter = GridKit::PhasorDynamics::GenClassicalParameters;

--- a/tests/UnitTests/PhasorDynamics/ComponentConnectionTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/ComponentConnectionTests.hpp
@@ -18,6 +18,7 @@
 #include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GENROU/Genrou.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GENSAL/Gensal.hpp>
+#include <GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp>
 #include <GridKit/Model/PhasorDynamics/SystemModel.hpp>
 #include <GridKit/Model/PhasorDynamics/SystemModelData.hpp>
 #include <GridKit/Testing/Testing.hpp>
@@ -111,6 +112,105 @@ namespace GridKit
             static_cast<ScalarT>(0.0));
         PhasorDynamics::SignalNode<ScalarT, IdxT> pmech;
         PhasorDynamics::Genrou<ScalarT, IdxT>     machine(&bus);
+
+        PhasorDynamics::Governor::HygovData<RealT, IdxT> governor_data;
+        governor_data.parameters[GovernorParams::Tnp] = static_cast<RealT>(1.0);
+
+        PhasorDynamics::Governor::Hygov<ScalarT, IdxT> governor(governor_data);
+
+        machine.getSignals().template attachSignalNode<MachineExternal::PM>(&pmech);
+        governor.getSignals().template assignSignalNode<GovernorInternal::PMECH>(&pmech);
+
+        system.addBus(&bus);
+        system.addComponent(&machine);
+        system.addComponent(&governor);
+
+        success *= system.allocate() == 0;
+        success *= pmech.linked();
+        success *= system.initialize() == 0;
+        success *= system.evaluateResidual() == 0;
+
+        // At zero machine power the required mechanical power is zero.
+        success *= isEqual(pmech.read(), static_cast<ScalarT>(0.0), kTol);
+
+        const auto* residual = governor.getResidual().getData();
+        for (IdxT row = 0; row < governor.size(); ++row)
+        {
+          success *= isEqual(residual[row], static_cast<ScalarT>(0.0), kTol);
+        }
+
+        return success.report(__func__);
+      }
+
+      /// GenClassical initializes first and writes the field voltage it needs
+      /// to the shared node. ESDC1A then initializes around that value and
+      /// must leave it unchanged at a steady state.
+      TestOutcome genClassicalEsdc1a()
+      {
+        using MachineExternal = PhasorDynamics::GenClassicalExternalVariables;
+        using ExciterInternal = PhasorDynamics::Exciter::Esdc1aInternalVariables;
+        using ExciterParams   = PhasorDynamics::Exciter::Esdc1aParameters;
+
+        TestStatus success = true;
+
+        PhasorDynamics::SystemModel<ScalarT, IdxT> system;
+        PhasorDynamics::BusInfinite<ScalarT, IdxT> bus(
+            static_cast<ScalarT>(1.0),
+            static_cast<ScalarT>(0.0));
+        PhasorDynamics::SignalNode<ScalarT, IdxT> efd;
+
+        PhasorDynamics::GenClassicalData<RealT, IdxT> machine_data;
+        PhasorDynamics::GenClassical<ScalarT, IdxT>   machine(&bus, machine_data);
+
+        PhasorDynamics::Exciter::Esdc1aData<RealT, IdxT> exciter_data;
+        exciter_data.parameters[ExciterParams::Tr] = static_cast<RealT>(0.02);
+        exciter_data.parameters[ExciterParams::Tb] = static_cast<RealT>(0.5);
+
+        PhasorDynamics::Exciter::Esdc1a<ScalarT, IdxT> exciter(&bus, exciter_data);
+
+        machine.getSignals().template attachSignalNode<MachineExternal::EFD>(&efd);
+        exciter.getSignals().template assignSignalNode<ExciterInternal::EFD>(&efd);
+
+        system.addBus(&bus);
+        system.addComponent(&machine);
+        system.addComponent(&exciter);
+
+        success *= system.allocate() == 0;
+        success *= efd.linked();
+        success *= system.initialize() == 0;
+        success *= system.evaluateResidual() == 0;
+
+        // At zero power the required field voltage equals the terminal voltage.
+        success *= isEqual(efd.read(), static_cast<ScalarT>(1.0), kTol);
+
+        const auto* residual = exciter.getResidual().getData();
+        for (IdxT row = 0; row < exciter.size(); ++row)
+        {
+          success *= isEqual(residual[row], static_cast<ScalarT>(0.0), kTol);
+        }
+
+        return success.report(__func__);
+      }
+
+      /// GenClassical initializes first and writes the mechanical power it
+      /// needs to the shared node. HYGOV then initializes around that value
+      /// and must leave it unchanged at a steady state.
+      TestOutcome genClassicalHygov()
+      {
+        using MachineExternal  = PhasorDynamics::GenClassicalExternalVariables;
+        using GovernorInternal = PhasorDynamics::Governor::HygovInternalVariables;
+        using GovernorParams   = PhasorDynamics::Governor::HygovParameters;
+
+        TestStatus success = true;
+
+        PhasorDynamics::SystemModel<ScalarT, IdxT> system;
+        PhasorDynamics::BusInfinite<ScalarT, IdxT> bus(
+            static_cast<ScalarT>(1.0),
+            static_cast<ScalarT>(0.0));
+        PhasorDynamics::SignalNode<ScalarT, IdxT> pmech;
+
+        PhasorDynamics::GenClassicalData<RealT, IdxT> machine_data;
+        PhasorDynamics::GenClassical<ScalarT, IdxT>   machine(&bus, machine_data);
 
         PhasorDynamics::Governor::HygovData<RealT, IdxT> governor_data;
         governor_data.parameters[GovernorParams::Tnp] = static_cast<RealT>(1.0);
@@ -365,6 +465,17 @@ namespace GridKit
                                                             __func__);
       }
 
+      /// Check production GASTPTI signal wiring to GenClassical.
+      TestOutcome genClassicalGastPti()
+      {
+        using namespace PhasorDynamics;
+
+        return checkConnection<GenClassical<ScalarT, IdxT>,
+                               GenClassicalInternalVariables::OMEGA,
+                               GenClassicalExternalVariables::PM>(makeGenClassicalGastPtiCase(),
+                                                                  __func__);
+      }
+
     private:
       using SystemDataT = PhasorDynamics::SystemModelData<RealT, IdxT>;
       using SystemT     = PhasorDynamics::SystemModel<ScalarT, IdxT>;
@@ -527,6 +638,23 @@ namespace GridKit
         machine.parameters[GensalParameters::p0]           = kInitialActivePower;
         machine.parameters[GensalParameters::q0]           = kInitialReactivePower;
         machine.parameters[GensalParameters::mva]          = kMachineBaseMva;
+
+        return data;
+      }
+
+      static SystemDataT makeGenClassicalGastPtiCase()
+      {
+        using namespace PhasorDynamics;
+
+        auto data = makeGastPtiCase();
+
+        auto& machine                                            = data.genclassical.emplace_back();
+        machine.buses[GenClassicalBuses::bus]                    = kBusId;
+        machine.signal_outputs[GenClassicalSignalOutputs::speed] = kSpeedSignalId;
+        machine.signal_inputs[GenClassicalSignalInputs::pmech]   = kPmechSignalId;
+        machine.parameters[GenClassicalParameters::p0]           = kInitialActivePower;
+        machine.parameters[GenClassicalParameters::q0]           = kInitialReactivePower;
+        machine.parameters[GenClassicalParameters::mva]          = kMachineBaseMva;
 
         return data;
       }

--- a/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/GenClassicalTests.hpp
@@ -5,7 +5,6 @@
  * @brief Tests for classical generator model.
  *
  */
-#include <iomanip>
 #include <iostream>
 #include <numbers>
 #include <sstream>
@@ -13,7 +12,7 @@
 #include <GridKit/AutomaticDifferentiation/DependencyTracking/Variable.hpp>
 #include <GridKit/Definitions.hpp>
 #include <GridKit/Model/PhasorDynamics/Bus/Bus.hpp>
-#include <GridKit/Model/PhasorDynamics/Bus/BusInfinite.hpp>
+#include <GridKit/Model/PhasorDynamics/SignalNode/SignalNode.hpp>
 #include <GridKit/Model/PhasorDynamics/SynchronousMachine/GenClassical/GenClassical.hpp>
 #include <GridKit/Model/VariableMonitorController.hpp>
 #include <GridKit/Testing/TestHelpers.hpp>
@@ -61,10 +60,11 @@ namespace GridKit
       {
         TestStatus success = true;
 
-        auto* bus = new PhasorDynamics::Bus<ScalarT, IdxT>(1.0, 0.0);
+        auto* bus  = new PhasorDynamics::Bus<ScalarT, IdxT>(1.0, 0.0);
+        auto  data = makeGenClassicalData();
 
         PhasorDynamics::Component<ScalarT, IdxT>* machine =
-            new PhasorDynamics::GenClassical<ScalarT, IdxT>(bus);
+            new PhasorDynamics::GenClassical<ScalarT, IdxT>(bus, data);
 
         success *= (machine != nullptr);
 
@@ -78,77 +78,165 @@ namespace GridKit
       }
 
       /**
-       * A test case to verify residual values
+       * @brief Checks initialized state against hand-computed values.
+       */
+      TestOutcome initial()
+      {
+        TestStatus success = true;
+
+        using Parameter = typename GenClassicalDataT::Parameters;
+
+        auto data                       = makeGenClassicalData();
+        data.parameters[Parameter::p0]  = RealT{3.0};
+        data.parameters[Parameter::q0]  = RealT{-1.0};
+        data.parameters[Parameter::H]   = RealT{1.0};
+        data.parameters[Parameter::D]   = RealT{1.0};
+        data.parameters[Parameter::Ra]  = RealT{0.1};
+        data.parameters[Parameter::Xdp] = RealT{2.3};
+
+        const std::vector<ScalarT> var_answer = {
+            3.0 * std::numbers::pi_v<RealT> / 4.0, // delta
+            0.0,                                   // omega
+            3.5,                                   // Te
+            1.0,                                   // Ir
+            2.0,                                   // Ii
+        };
+
+        PhasorDynamics::Bus<ScalarT, IdxT>          bus(1.0, 1.0);
+        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, data);
+
+        bus.allocate();
+        bus.initialize();
+        gen.allocate();
+        gen.initialize();
+
+        const auto* y  = gen.y().getData();
+        const auto* yp = gen.yp().getData();
+        for (size_t i = 0; i < var_answer.size(); ++i)
+        {
+          if (!isEqual(y[i], var_answer[i], tol_))
+          {
+            std::cout << "Incorrect result: "
+                      << y[i] << " != " << var_answer[i] << "\n";
+            success = false;
+            break;
+          }
+
+          if (!isEqual(yp[i], 0.0, tol_))
+          {
+            std::cout << "Incorrect result: "
+                      << yp[i] << " != 0\n";
+            success = false;
+            break;
+          }
+        }
+
+        return success.report(__func__);
+      }
+
+      /**
+       * @brief Checks residual evaluation at initialized steady state.
        */
       TestOutcome residual()
       {
         TestStatus success = true;
 
-        // Classical generator parameters
-        RealT H{0.5};
-        RealT D{-1.0};
-        RealT Ra{0.5};
-        RealT Xdp{0.5};
+        PhasorDynamics::Bus<ScalarT, IdxT>          bus(1.0, 0.0);
+        auto                                        data = makeGenClassicalData();
+        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, data);
 
-        // Classical generator inputs
-        RealT Pm{1.0};
-        RealT Ep{2.0};
-
-        ScalarT Vr1{1.0}; ///< Bus-1 real voltage
-        ScalarT Vi1{1.0}; ///< Bus-1 imaginary voltage
-
-        // Test answer keys
-        const std::vector<ScalarT> res_answer = {0.0,
-                                                 -0.5,
-                                                 -6.0,
-                                                 2.0,
-                                                 -6.0};
-
-        PhasorDynamics::Bus<ScalarT, IdxT>          bus(Vr1, Vi1);
-        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, 1.0, 1.0, H, D, Ra, Xdp);
         bus.allocate();
         bus.initialize();
+        bus.evaluateResidual();
 
-        // Allocate but not initialize genrator model
         gen.allocate();
-        gen.setPmech(Pm);
-        gen.setEp(Ep);
-
-        // Set variable values matching the answer key
-        auto* y  = gen.y().getData();
-        auto* yp = gen.yp().getData();
-
-        static constexpr auto pi = std::numbers::pi_v<RealT>;
-
-        y[0] = pi;   // delta
-        y[1] = 1.0;  // omega
-        y[2] = 2.0;  // telec
-        y[3] = -2.0; // ir
-        y[4] = -4.0; // ii
-
-        // Set derivative values matching the answer key
-        yp[0] = 2 * pi * 60.0; // delta_dot
-        yp[1] = -1.5;          // omega_dot
-        yp[2] = 0;
-        yp[3] = 0;
-        yp[4] = 0;
-
-        gen.y().setDataUpdated();
-        gen.yp().setDataUpdated();
+        gen.initialize();
         gen.evaluateResidual();
-        auto&       residual      = gen.getResidual();
-        const auto* residual_data = residual.getData();
 
-        for (size_t i = 0; i < res_answer.size(); ++i)
+        const auto& f      = gen.getResidual();
+        const auto* f_data = f.getData();
+        for (std::size_t i = 0; i < f.getSize(); ++i)
         {
-          if (!isEqual(residual_data[i], res_answer[i], tol_))
+          if (!isEqual(f_data[i], 0.0, tol_))
           {
-            std::cout << "Incorrect result for residual " << i << ": "
-                      << residual_data[i] << " != " << res_answer[i] << "\n";
             success = false;
             break;
           }
         }
+
+        return success.report(__func__);
+      }
+
+      /**
+       * @brief Checks initialized steady state with nonzero armature resistance.
+       */
+      TestOutcome residual_nonzero_ra()
+      {
+        TestStatus success = true;
+
+        using Parameter = typename GenClassicalDataT::Parameters;
+
+        auto data                       = makeGenClassicalData();
+        data.parameters[Parameter::p0]  = RealT{3.0};
+        data.parameters[Parameter::q0]  = RealT{-1.0};
+        data.parameters[Parameter::H]   = RealT{1.0};
+        data.parameters[Parameter::D]   = RealT{1.0};
+        data.parameters[Parameter::Ra]  = RealT{0.6};
+        data.parameters[Parameter::Xdp] = RealT{0.2};
+
+        PhasorDynamics::Bus<ScalarT, IdxT>          bus(1.0, 1.0);
+        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, data);
+
+        bus.allocate();
+        bus.initialize();
+        bus.evaluateResidual();
+
+        gen.allocate();
+        gen.initialize();
+        gen.evaluateResidual();
+
+        const auto& f      = gen.getResidual();
+        const auto* f_data = f.getData();
+        for (std::size_t i = 0; i < f.getSize(); ++i)
+        {
+          if (!isEqual(f_data[i], 0.0, tol_))
+          {
+            success = false;
+            break;
+          }
+        }
+
+        return success.report(__func__);
+      }
+
+      /**
+       * @brief Checks GenClassical uses the configured system frequency base.
+       */
+      TestOutcome frequency_base()
+      {
+        TestStatus success = true;
+
+        PhasorDynamics::Bus<ScalarT, IdxT>          bus(1.0, 0.0);
+        auto                                        data = makeGenClassicalData();
+        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, data);
+
+        bus.allocate();
+        bus.initialize();
+
+        gen.setSystemBase(50.0, 100.0e6);
+        gen.allocate();
+
+        auto* y  = gen.y().getData();
+        auto* yp = gen.yp().getData();
+        y[1]     = 1.0;
+        yp[0]    = TWO<RealT> * std::numbers::pi_v<RealT> * 50.0;
+
+        gen.y().setDataUpdated();
+        gen.yp().setDataUpdated();
+        gen.evaluateResidual();
+
+        const auto* f  = gen.getResidual().getData();
+        success       *= isEqual(f[0], 0.0, tol_);
 
         return success.report(__func__);
       }
@@ -203,99 +291,132 @@ namespace GridKit
       }
 
       /**
-       *
-       * Verifies correctness of the system initialization
+       * @brief Checks the speed output and the seeded pmech and efd inputs.
        */
-      TestOutcome initial()
+      TestOutcome signals()
       {
         TestStatus success = true;
 
-        // Classical generator parameters
-        RealT p0{3.0};
-        RealT q0{-1.0};
-        RealT H{1.0};
-        RealT D{1.0};
-        RealT Ra{0.1};
-        RealT Xdp{2.3};
+        using Parameter = typename GenClassicalDataT::Parameters;
+        using Internal  = PhasorDynamics::GenClassicalInternalVariables;
+        using External  = PhasorDynamics::GenClassicalExternalVariables;
 
-        ScalarT Vr1{1.0}; ///< Bus-1 real voltage
-        ScalarT Vi1{1.0}; ///< Bus-1 imaginary voltage
+        auto data                       = makeGenClassicalData();
+        data.parameters[Parameter::mva] = RealT{50.0};
 
-        // Test answer keys
-        const std::vector<ScalarT> var_answer = {
-            3.0 * std::numbers::pi_v<RealT> / 4.0, // delta
-            0.0,                                   // omega
-            3.5,                                   // Te
-            1.0,                                   // Ir
-            2.0,                                   // Ii
-        };
+        PhasorDynamics::Bus<ScalarT, IdxT>          bus(1.0, 0.0);
+        PhasorDynamics::SignalNode<ScalarT, IdxT>   speed;
+        PhasorDynamics::SignalNode<ScalarT, IdxT>   pmech;
+        PhasorDynamics::SignalNode<ScalarT, IdxT>   efd;
+        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, data);
 
-        PhasorDynamics::Bus<ScalarT, IdxT>          bus(Vr1, Vi1);
-        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, p0, q0, H, D, Ra, Xdp);
+        ScalarT pmech_value{0.0};
+        ScalarT efd_value{0.0};
+        IdxT    index{0};
+        pmech.set(&pmech_value, &index);
+        efd.set(&efd_value, &index);
+
+        gen.getSignals().template assignSignalNode<Internal::OMEGA>(&speed);
+        gen.getSignals().template attachSignalNode<External::PM>(&pmech);
+        gen.getSignals().template attachSignalNode<External::EFD>(&efd);
+
         bus.allocate();
         bus.initialize();
+        bus.evaluateResidual();
+
+        gen.setSystemBase(60.0, 100.0e6);
         gen.allocate();
+        success *= gen.verify() == 0;
+        success *= speed.linked();
+
         gen.initialize();
+        gen.evaluateResidual();
 
-        const auto* y  = gen.y().getData();
-        const auto* yp = gen.yp().getData();
-        for (size_t i = 0; i < var_answer.size(); ++i)
+        // With Ra = 0 the seeded system-base mechanical power equals p0.
+        success *= isEqual(speed.read(), 0.0, tol_);
+        success *= isEqual(pmech.read(), 1.0, tol_);
+        success *= isEqual(efd.read(), std::sqrt(RealT{2.0}), tol_);
+
+        const auto& f      = gen.getResidual();
+        const auto* f_data = f.getData();
+        for (std::size_t i = 0; i < f.getSize(); ++i)
         {
-          if (!isEqual(y[i], var_answer[i], tol_))
-          {
-            std::cout << "Incorrect result: "
-                      << y[i] << " != " << var_answer[i] << "\n";
-            success = false;
-            break;
-          }
-
-          if (!isEqual(yp[i], 0.0, tol_))
-          {
-            std::cout << "Incorrect result: "
-                      << yp[i] << " != 0\n";
-            success = false;
-            break;
-          }
+          success *= isEqual(f_data[i], 0.0, tol_);
         }
 
         return success.report(__func__);
       }
 
       /**
-       * Verifies the residual evaluates to zero for the initial conditions
+       * @brief Verifies residual equations against hard-coded values.
        */
-      TestOutcome zeroInitialResidual()
+      TestOutcome hard_coded_residual()
       {
         TestStatus success = true;
 
-        // Classical generator parameters
-        RealT p0{3.0};
-        RealT q0{-1.0};
-        RealT H{1.0};
-        RealT D{1.0};
-        RealT Ra{0.6};
-        RealT Xdp{0.2};
+        using Parameter = typename GenClassicalDataT::Parameters;
+        using External  = PhasorDynamics::GenClassicalExternalVariables;
 
-        ScalarT Vr1{1.0}; ///< Bus real voltage
-        ScalarT Vi1{1.0}; ///< Bus imaginary voltage
+        auto data                       = makeGenClassicalData();
+        data.parameters[Parameter::p0]  = RealT{1.0};
+        data.parameters[Parameter::q0]  = RealT{1.0};
+        data.parameters[Parameter::H]   = RealT{0.5};
+        data.parameters[Parameter::D]   = RealT{-1.0};
+        data.parameters[Parameter::Ra]  = RealT{0.5};
+        data.parameters[Parameter::Xdp] = RealT{0.5};
 
-        PhasorDynamics::Bus<ScalarT, IdxT>          bus(Vr1, Vi1);
-        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, p0, q0, H, D, Ra, Xdp);
+        PhasorDynamics::Bus<ScalarT, IdxT>          bus(1.0, 1.0);
+        PhasorDynamics::SignalNode<ScalarT, IdxT>   pmech;
+        PhasorDynamics::SignalNode<ScalarT, IdxT>   efd;
+        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, data);
+
+        ScalarT pmech_value{1.0};
+        ScalarT efd_value{2.0};
+        IdxT    index{0};
+        pmech.set(&pmech_value, &index);
+        efd.set(&efd_value, &index);
+
+        gen.getSignals().template attachSignalNode<External::PM>(&pmech);
+        gen.getSignals().template attachSignalNode<External::EFD>(&efd);
+
+        const std::vector<ScalarT> res_answer = {
+            0.0,
+            -0.5,
+            -6.0,
+            2.0,
+            -6.0};
+
         bus.allocate();
         bus.initialize();
-        gen.allocate();
-        gen.initialize();
-        gen.evaluateResidual();
-        auto&       res      = gen.getResidual();
-        const auto* res_data = res.getData();
-        const auto* yp       = gen.yp().getData();
 
-        for (size_t i = 0; i < res.getSize(); ++i)
+        gen.allocate();
+
+        auto* y  = gen.y().getData();
+        auto* yp = gen.yp().getData();
+
+        static constexpr auto pi = std::numbers::pi_v<RealT>;
+
+        y[0] = pi;   // delta
+        y[1] = 1.0;  // omega
+        y[2] = 2.0;  // telec
+        y[3] = -2.0; // ir
+        y[4] = -4.0; // ii
+
+        yp[0] = 2.0 * pi * 60.0; // delta_dot
+        yp[1] = -1.5;            // omega_dot
+
+        gen.y().setDataUpdated();
+        gen.yp().setDataUpdated();
+        gen.evaluateResidual();
+        auto&       residual      = gen.getResidual();
+        const auto* residual_data = residual.getData();
+
+        for (size_t i = 0; i < res_answer.size(); ++i)
         {
-          if (!isEqual(res_data[i], 0.0, tol_))
+          if (!isEqual(residual_data[i], res_answer[i], tol_))
           {
-            std::cout << "Incorrect result: "
-                      << yp[i] << " != 0\n";
+            std::cout << "Incorrect result for residual " << i << ": "
+                      << residual_data[i] << " != " << res_answer[i] << "\n";
             success = false;
             break;
           }
@@ -306,83 +427,70 @@ namespace GridKit
 
 #ifdef GRIDKIT_ENABLE_ENZYME
       /**
-       * A test case to verify Jacobian values
+       * @brief Checks Jacobian evaluation.
        */
       TestOutcome jacobian()
       {
         TestStatus success = true;
 
-        // Classical generator parameters
-        RealT H{0.5};
-        RealT D{-1.0};
-        RealT Ra{0.5};
-        RealT Xdp{0.5};
+        auto tol = 10 * std::numeric_limits<RealT>::epsilon();
 
-        // Jacobian via DependencyTracking
-        std::vector<DependencyTracking::Variable::DependencyMap> dependency_tracking_jacobian = DependencyTrackingJacobian(H, D, Ra, Xdp);
+        std::vector<DependencyTracking::Variable::DependencyMap> dependency_tracking_jacobian = DependencyTrackingJacobian();
+        std::vector<DependencyTracking::Variable::DependencyMap> enzyme_jacobian              = EnzymeJacobian();
 
-        // Jacobian via Enzyme
-        std::vector<DependencyTracking::Variable::DependencyMap> enzyme_jacobian = EnzymeJacobian(H, D, Ra, Xdp);
-
-        /// Compare DependencyTracking dependencies to Enzyme's
         for (size_t i = 0; i < dependency_tracking_jacobian.size(); ++i)
         {
-          success *= (GridKit::Testing::isEqual(dependency_tracking_jacobian[i], enzyme_jacobian[i]));
+          success *= (GridKit::Testing::isEqual(dependency_tracking_jacobian[i], enzyme_jacobian[i], tol));
         }
 
         return success.report(__func__);
       }
 
     private:
-      std::vector<DependencyTracking::Variable::DependencyMap> DependencyTrackingJacobian(
-          const RealT H, const RealT D, const RealT Ra, const RealT Xdp)
+      std::vector<DependencyTracking::Variable::DependencyMap> DependencyTrackingJacobian()
       {
-        DependencyTracking::Variable Vr1{1.0}; ///< Bus-1 real voltage
-        DependencyTracking::Variable Vi1{1.0}; ///< Bus-1 imaginary voltage
-
+        DependencyTracking::Variable                                     Vr1{1.0};
+        DependencyTracking::Variable                                     Vi1{1.0};
         PhasorDynamics::Bus<DependencyTracking::Variable, IdxT>          bus(Vr1, Vi1);
-        PhasorDynamics::GenClassical<DependencyTracking::Variable, IdxT> gen(&bus, 1.0, 1.0, H, D, Ra, Xdp);
+        auto                                                             data = makeGenClassicalData();
+        PhasorDynamics::GenClassical<DependencyTracking::Variable, IdxT> gen(&bus, data);
 
         bus.allocate();
         gen.allocate();
 
-        // Get d/dy
         bus.initialize();
         gen.initialize();
 
         auto* gen_y = gen.y().getData();
         for (size_t i = 0; i < gen.size(); ++i)
         {
-          gen_y[i].setVariableNumber(i); ///< Generator independent variables
+          gen_y[i].setVariableNumber(i);
         }
         gen.y().setDataUpdated();
         auto* bus_y = bus.y().getData();
         for (size_t i = 0; i < bus.size(); ++i)
         {
-          bus_y[i].setVariableNumber(i + gen.size()); // Bus independent variables
+          bus_y[i].setVariableNumber(i + gen.size());
         }
         bus.y().setDataUpdated();
 
         bus.evaluateResidual();
-        gen.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
-                                ///< the dependencies
+        gen.evaluateResidual();
         auto&                                     residual_y_view = gen.getResidual();
         std::vector<DependencyTracking::Variable> residual_y(residual_y_view.getData(), residual_y_view.getData() + residual_y_view.getSize());
 
-        // Get d/dy'
         bus.initialize();
         gen.initialize();
 
         auto* gen_yp = gen.yp().getData();
         for (size_t i = 0; i < gen.size(); ++i)
         {
-          gen_yp[i].setVariableNumber(i); ///< Generator independent variables
+          gen_yp[i].setVariableNumber(i);
         }
         gen.yp().setDataUpdated();
 
         bus.evaluateResidual();
-        gen.evaluateResidual(); ///< Computes the residual and the Jacobian values by tracking
-                                ///< the dependencies
+        gen.evaluateResidual();
         auto&                                     residual_yp_view = gen.getResidual();
         std::vector<DependencyTracking::Variable> residual_yp(residual_yp_view.getData(), residual_yp_view.getData() + residual_yp_view.getSize());
 
@@ -397,7 +505,6 @@ namespace GridKit
           std::cout << "\n";
         }
 
-        // Extract the dependencies and add d/dy' to d/dy
         std::vector<DependencyTracking::Variable::DependencyMap> dependencies(residual_y.size());
         for (IdxT i = 0; i < residual_y.size(); ++i)
         {
@@ -420,7 +527,6 @@ namespace GridKit
             }
           }
 
-          // Insert yp dependencies that did not exist in the y dependencies
           for (const auto& pair_yp : dependency_yp)
           {
             auto index_yp = pair_yp.first;
@@ -436,14 +542,13 @@ namespace GridKit
         return dependencies;
       }
 
-      std::vector<DependencyTracking::Variable::DependencyMap> EnzymeJacobian(
-          const RealT H, const RealT D, const RealT Ra, const RealT Xdp)
+      std::vector<DependencyTracking::Variable::DependencyMap> EnzymeJacobian()
       {
-        ScalarT Vr1{1.0}; ///< Bus-1 real voltage
-        ScalarT Vi1{1.0}; ///< Bus-1 imaginary voltage
-
+        ScalarT                                     Vr1{1.0};
+        ScalarT                                     Vi1{1.0};
         PhasorDynamics::Bus<ScalarT, IdxT>          bus(Vr1, Vi1);
-        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, 1.0, 1.0, H, D, Ra, Xdp);
+        auto                                        data = makeGenClassicalData();
+        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus, data);
 
         bus.allocate();
         gen.allocate();
@@ -455,8 +560,8 @@ namespace GridKit
 
         for (size_t i = 0; i < bus.size(); ++i)
         {
-          bus.setVariableIndex(i, i + gen.size()); // Reset bus variable indices
-          bus.setResidualIndex(i, i + gen.size()); // Reset bus residual indices
+          bus.setVariableIndex(i, i + gen.size());
+          bus.setResidualIndex(i, i + gen.size());
         }
 
         bus.evaluateResidual();
@@ -472,7 +577,6 @@ namespace GridKit
         return GridKit::Testing::MapFromCsr(model_jacobian);
       }
 #endif
-
     }; // class GenClassicalTests
 
   } // namespace Testing

--- a/tests/UnitTests/PhasorDynamics/SystemSingleComponentTests.hpp
+++ b/tests/UnitTests/PhasorDynamics/SystemSingleComponentTests.hpp
@@ -410,7 +410,8 @@ namespace GridKit
         PhasorDynamics::BusInfinite<ScalarT, IdxT> bus;
         system->addBus(&bus);
 
-        PhasorDynamics::GenClassical<ScalarT, IdxT> gen(&bus);
+        PhasorDynamics::GenClassicalData<RealT, IdxT> data;
+        PhasorDynamics::GenClassical<ScalarT, IdxT>   gen(&bus, data);
         system->addComponent(&gen);
 
         success *= system->allocate() == 0;

--- a/tests/UnitTests/PhasorDynamics/runComponentConnectionTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runComponentConnectionTests.cpp
@@ -10,9 +10,12 @@ int main()
 
   result += test.genrouEsdc1a();
   result += test.genrouHygov();
+  result += test.genClassicalEsdc1a();
+  result += test.genClassicalHygov();
   result += test.regcaRepca();
   result += gastpti.genrouGastPti();
   result += gastpti.gensalGastPti();
+  result += gastpti.genClassicalGastPti();
   result += test.regcaReecb();
 
   return result.summary();

--- a/tests/UnitTests/PhasorDynamics/runGenClassicalTests.cpp
+++ b/tests/UnitTests/PhasorDynamics/runGenClassicalTests.cpp
@@ -7,10 +7,13 @@ int main()
   GridKit::Testing::GenClassicalTests<double, size_t> test;
 
   result += test.constructor();
-  result += test.residual();
-  result += test.monitor_system_base();
   result += test.initial();
-  result += test.zeroInitialResidual();
+  result += test.residual();
+  result += test.residual_nonzero_ra();
+  result += test.frequency_base();
+  result += test.monitor_system_base();
+  result += test.signals();
+  result += test.hard_coded_residual();
 #ifdef GRIDKIT_ENABLE_ENZYME
   result += test.jacobian();
 #endif


### PR DESCRIPTION
## Description

Update `GenClassical` to have recent conventions and implementation. Adds functionality to the signal ports, so governors, exciters, and stabilizers now connect to it the same way they connect to other machines.

## Proposed changes

- Add `GenClassicalInternalVariables`/`GenClassicalExternalVariables` and `ComponentSignals` with `pmech` and `efd` inputs and a `speed` output.
- Replace the default and positional constructors with the data constructor; remove `setPmech`/`setEp`, `bus_id_`, and the dead `exciter_signal`/`governor_signal` inputs.
- Add the `DfDws` block to the Enzyme Jacobian and link the signal libraries.
- Rewrite the README to the current notation and section standard.

## Checklist

- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] Changelog changes are N/A; this is a focused cleanup of an existing model implementation.

## Further comments

Could not be connected to controllers before this PR because we started governor and exciter integration with `Genrou`
