### PR TITLE
Fix IDA initial condition tol for fixed steps

### DIFF
--- a/GridKit/Solver/Dynamic/Ida.cpp
+++ b/GridKit/Solver/Dynamic/Ida.cpp
@@ -1312,6 +1312,11 @@ namespace AnalysisManager
          * "undo" the fac scaling. */
         retval = IDASetNonlinConvCoef(mem, 1 / FIXED_STEP_TOL_FAC);
         checkOutput(retval, "IDASetNonlinConvCoef");
+
+        static constexpr RealT DEFAULT_NONLIN_CONV_COEF_IC = 0.0033;
+
+        retval = IDASetNonlinConvCoefIC(mem, DEFAULT_NONLIN_CONV_COEF_IC / FIXED_STEP_TOL_FAC);
+        checkOutput(retval, "IDASetNonlinConvCoefIC");
       }
     }
 


### PR DESCRIPTION
## Description
 
Fixes a bug where tolerances were too loose when fixed step IDA solved for consistent initial conditions. Adaptive IDA was unaffected.
 
 
 ## Proposed changes
 
Adds missing `IDASetNonlinConvCoefIC` call.
 
 ## Checklist
 
- [x] All tests pass.
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows GridKit™ style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [ ] The [CHANGELOG.md](/CHANGELOG.md) has been updated to reflect the changes. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
